### PR TITLE
feat: Claude Code config integrity guards (3 hooks, 5-layer defense)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,33 @@ description: What's new in AI Brain Starter — plain English, no jargon
 
 ---
 
+## 2026-04-28 — Claude Code config integrity guards (5-layer defense against silently corrupt settings.json)
+
+**Who this affects:** anyone who has ever hand-edited `~/.claude/settings.json` or `.mcp.json`. No breaking change — all three guards are additive and warn-only by default.
+
+**What changed:** Three new hooks land in `hooks/`, wired into PreToolUse and SessionStart in `hooks.json`. They form a layered defense against the most common silent failure mode in Claude Code config: a duplicate top-level key (especially a second `"permissions": {...}` block at the bottom of settings.json) that wipes the original allowlist because JSON's last-key-wins semantics are silently tolerated by `json.load()`. The user keeps re-approving the same gh/git push permissions every session, never realizing the config has been corrupt for weeks.
+
+- `lint-claude-settings.py` — detects duplicate keys at any depth, unknown enum values for `model` and `theme`, hooks pointing at files that don't exist on disk, and bare-command permissions missing the `Bash(...)` wrapper. Runs in three modes: warn-only (default, for SessionStart drift detection), `--strict` (exit 2 on BLOCK-severity issues, for the PreToolUse blocker), and `--test` (5 self-test fixtures including duplicate-key and false-positive guard, so the linter itself can't silently rot).
+- `pre-write-settings-lint.py` — PreToolUse Write|Edit blocker. If you (or Claude) try to write a config file that contains a duplicate top-level key, the write is blocked with a stderr explanation pointing at the exact issue. Edit operations are projected (current file + old/new substitution) before linting so the check matches the post-edit shape.
+- `check-claude-code-version.sh` — SessionStart-cached check (24h TTL) against `gh api repos/anthropics/claude-code/releases/latest`. Warns if you're behind by 3 or more patch versions. Catches the silent-drift class of bug: Claude Code has no built-in "you're behind" notification, so users routinely miss memory-leak fixes and reliability patches that ship every couple weeks.
+
+**Why it matters:** The duplicate-permissions bug is a real failure mode that's easy to introduce and hard to detect. JSON parsers don't complain. Claude Code doesn't complain. The only signal is "huh, why is this permission not working" weeks later. Catching it at the write boundary is cheap; debugging it cold is hours. The version check closes the same kind of gap on the upgrade axis — no nag, just a one-line surface at SessionStart if you've drifted enough that it matters.
+
+**The defense layers:**
+1. PreToolUse blocks bad writes (write boundary)
+2. FileChanged (if your Claude Code version supports it) warns at write-time
+3. SessionStart audits drift introduced by external editors
+4. SessionStart runs the linter's self-test so guard rot fails loud
+5. Wire the version-check output into your existing UserPromptSubmit hook to surface drift inline
+
+**Files touched:** `hooks/lint-claude-settings.py` (new), `hooks/pre-write-settings-lint.py` (new), `hooks/check-claude-code-version.sh` (new), `hooks.json` (PreToolUse Write|Edit chain extended, new SessionStart block).
+
+**Existing users:** the next sync run picks up the new hooks via your hooks.json. The new SessionStart block is gated on `[ -f ~/.claude/hooks/<file> ] && ... || true` so missing files exit silently — no breakage if a sync is incomplete.
+
+**Requires:** `gh` CLI for the version check (silently no-ops if missing).
+
+---
+
 ## 2026-04-25 — Framework expanded from 16 to 34 floors across templates, scripts, and phase docs
 
 **Who this affects:** anyone setting up a new AI Brain Starter vault, or anyone whose existing vault has the older 16-floor framework wired into templates and the graphify pipeline. No breaking change for users who already manually expanded their framework — this just makes the public repo match.

--- a/hooks.json
+++ b/hooks.json
@@ -73,6 +73,32 @@
           {
             "type": "command",
             "command": "[ -f ~/.claude/hooks/validate-mcp-json.py ] && python3 ~/.claude/hooks/validate-mcp-json.py || echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"allow\"}}'"
+          },
+          {
+            "type": "command",
+            "command": "[ -f ~/.claude/hooks/pre-write-settings-lint.py ] && python3 ~/.claude/hooks/pre-write-settings-lint.py || true"
+          }
+        ]
+      }
+    ],
+
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -f ~/.claude/hooks/lint-claude-settings.py ] && python3 ~/.claude/hooks/lint-claude-settings.py || true",
+            "statusMessage": "Linting Claude Code settings..."
+          },
+          {
+            "type": "command",
+            "command": "[ -f ~/.claude/hooks/lint-claude-settings.py ] && python3 ~/.claude/hooks/lint-claude-settings.py --test || true",
+            "statusMessage": "Self-testing settings linter..."
+          },
+          {
+            "type": "command",
+            "command": "[ -f ~/.claude/hooks/check-claude-code-version.sh ] && bash ~/.claude/hooks/check-claude-code-version.sh || true",
+            "statusMessage": "Checking Claude Code version..."
           }
         ]
       }

--- a/hooks/check-claude-code-version.sh
+++ b/hooks/check-claude-code-version.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Check Claude Code installed version against the latest GitHub release.
+# Warns at SessionStart if behind by >=3 patch versions. Caches result for 24h
+# to avoid hammering the GitHub API on every session.
+#
+# Why: Claude Code drift is silent — there's no built-in "you're behind"
+# notification. Multi-version drift means you miss memory-leak fixes, bash-cwd
+# fixes, and other reliability improvements that ship every few weeks. This
+# hook surfaces the gap at SessionStart so it can't hide.
+#
+# Wiring: SessionStart (no matcher needed). Pairs with vault-context.py or any
+# UserPromptSubmit hook that wants to surface the warning inline by reading
+# the cache file.
+#
+# Requires `gh` CLI installed and authenticated. Exits silently if missing.
+
+set -uo pipefail
+
+CACHE_FILE="$HOME/.claude/.claude-code-version-check"
+CACHE_TTL_SEC=$((24 * 60 * 60))   # 24 hours
+WARN_VERSION_GAP=3                # warn if behind by N or more patch versions
+
+now=$(date +%s)
+if [[ -f "$CACHE_FILE" ]]; then
+  last=$(stat -f %m "$CACHE_FILE" 2>/dev/null || stat -c %Y "$CACHE_FILE" 2>/dev/null || echo 0)
+  age=$(( now - last ))
+  if (( age < CACHE_TTL_SEC )); then
+    cat "$CACHE_FILE"
+    exit 0
+  fi
+fi
+
+# Need gh CLI; if missing, exit silently
+if ! command -v gh >/dev/null 2>&1; then
+  exit 0
+fi
+
+current=$(claude --version 2>/dev/null | awk '{print $1}')
+[[ -z "$current" ]] && exit 0
+
+latest=$(gh api repos/anthropics/claude-code/releases/latest --jq .tag_name 2>/dev/null | sed 's/^v//')
+[[ -z "$latest" ]] && exit 0
+
+# Parse semver patch components (X.Y.Z)
+cur_patch=$(echo "$current" | awk -F. '{print $3}')
+lat_patch=$(echo "$latest" | awk -F. '{print $3}')
+
+if [[ "$current" == "$latest" ]]; then
+  msg=""
+elif [[ -n "$cur_patch" && -n "$lat_patch" ]] && (( lat_patch - cur_patch >= WARN_VERSION_GAP )); then
+  gap=$(( lat_patch - cur_patch ))
+  msg="[claude-code-version] $current -> latest $latest ($gap versions behind). Upgrade: npm i -g @anthropic-ai/claude-code@latest"
+else
+  msg="[claude-code-version] $current -> latest $latest. Upgrade when convenient: npm i -g @anthropic-ai/claude-code@latest"
+fi
+
+# Cache for 24h
+printf '%s\n' "$msg" > "$CACHE_FILE"
+[[ -n "$msg" ]] && echo "$msg" >&2
+exit 0

--- a/hooks/lint-claude-settings.py
+++ b/hooks/lint-claude-settings.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""
+Lint Claude Code settings + MCP config files for silent breakage.
+
+Detects:
+  1. Duplicate keys at ANY depth (json.load tolerates them; last wins;
+     allowlists/hooks/permissions get nuked when a second `permissions: {...}`
+     block lands at the same depth)
+  2. Unknown enum values for known fields (model, theme)
+  3. Hooks/commands referencing files that don't exist on disk
+  4. Permissions/allow entries with bare commands (must be wrapped Bash(...))
+
+Why this hook exists: standard json.load() is silently tolerant of duplicate
+top-level keys. A common failure: a user appends a second `"permissions": {...}`
+block at the bottom of `~/.claude/settings.json` to grant a few launchctl perms,
+and the original gh/git push allowlist at the top is wiped — last value wins.
+The user keeps re-approving the same permissions every session, never realizing
+the config has been silently corrupt for weeks.
+
+Modes:
+  (default)   Warn-only, exit 0. For SessionStart + FileChanged (drift detection).
+  --strict    Exit 2 on any BLOCK-severity issue. For PreToolUse blocker.
+  --test      Run self-test against in-process bad fixtures. Exits 1 if a guard
+              fails its own test. Wire into SessionStart so guard rot fails loud.
+  --paths X Y Override which files to lint.
+  --content STR --label LABEL  Lint JSON content directly (used by the PreToolUse
+              wrapper hook on tool_input.content for Write).
+
+Coverage (default mode):
+  ~/.claude/settings.json
+  ~/.claude/settings.local.json
+  cwd/.claude/settings.json
+  cwd/.claude/settings.local.json
+  cwd/.mcp.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections import Counter
+from pathlib import Path
+
+HOME = Path(os.path.expanduser("~"))
+
+KNOWN_ENUMS = {
+    "model": {"sonnet", "opus", "haiku", "opusplan", "default"},
+    "theme": {"light", "dark", "dark-daltonized", "light-daltonized", "system"},
+}
+
+WARN: list[tuple[str, str]] = []  # (severity, msg) — severity in {"BLOCK", "WARN"}
+
+
+def _emit(sev: str, msg: str) -> None:
+    WARN.append((sev, msg))
+
+
+def collect_dups(pairs, path="$"):
+    keys = [k for k, _ in pairs]
+    counts = Counter(keys)
+    for k, c in counts.items():
+        if c > 1:
+            _emit("BLOCK", f"DUP-KEY at {path}: '{k}' appears {c}x — last value wins, earlier ones SILENTLY LOST")
+    out = {}
+    for k, v in pairs:
+        out[k] = v
+    return out
+
+
+def check_enums(obj, path="$"):
+    if not isinstance(obj, dict):
+        return
+    for field, allowed in KNOWN_ENUMS.items():
+        if field in obj and isinstance(obj[field], str) and obj[field] not in allowed:
+            _emit("WARN", f"UNKNOWN-ENUM at {path}.{field}: '{obj[field]}' not in {sorted(allowed)}")
+
+
+def check_hook_paths(obj, path="$"):
+    if not isinstance(obj, dict):
+        return
+    hooks = obj.get("hooks")
+    if not isinstance(hooks, dict):
+        return
+    for event, entries in hooks.items():
+        if not isinstance(entries, list):
+            continue
+        for i, entry in enumerate(entries):
+            for j, h in enumerate(entry.get("hooks", []) or []):
+                cmd = h.get("command", "")
+                if not cmd:
+                    continue
+                for tok in cmd.split():
+                    if tok.startswith("/") and not tok.startswith("//"):
+                        if not Path(tok).exists():
+                            _emit("WARN", f"MISSING-HOOK-FILE at hooks.{event}[{i}].hooks[{j}]: {tok}")
+                        break
+
+
+def check_perms(obj, path="$"):
+    perms = obj.get("permissions", {}) if isinstance(obj, dict) else {}
+    allow = perms.get("allow", []) if isinstance(perms, dict) else []
+    for i, rule in enumerate(allow if isinstance(allow, list) else []):
+        if not isinstance(rule, str):
+            continue
+        if rule.startswith(("git ", "gh ", "npm ", "ls ", "cat ", "find ")) and not rule.startswith("Bash("):
+            _emit("WARN", f"BAD-PERM at permissions.allow[{i}]: '{rule}' — bare command, must be wrapped Bash(...)")
+
+
+def lint_file(path: Path, label: str) -> None:
+    if not path.exists():
+        return
+    try:
+        with path.open() as f:
+            data = json.load(f, object_pairs_hook=lambda p: collect_dups(p, path=label))
+    except json.JSONDecodeError as e:
+        _emit("BLOCK", f"INVALID-JSON in {label}: {e}")
+        return
+    check_enums(data, path=label)
+    check_hook_paths(data, path=label)
+    check_perms(data, path=label)
+
+
+def lint_content(content: str, label: str) -> None:
+    """Lint a JSON string directly (used by the PreToolUse wrapper)."""
+    try:
+        data = json.loads(content, object_pairs_hook=lambda p: collect_dups(p, path=label))
+    except json.JSONDecodeError as e:
+        _emit("BLOCK", f"INVALID-JSON in {label}: {e}")
+        return
+    check_enums(data, path=label)
+    check_perms(data, path=label)
+
+
+def default_targets() -> list[tuple[Path, str]]:
+    candidates = [
+        (HOME / ".claude" / "settings.json", "~/.claude/settings.json"),
+        (HOME / ".claude" / "settings.local.json", "~/.claude/settings.local.json"),
+        (Path.cwd() / ".claude" / "settings.json", "cwd/.claude/settings.json"),
+        (Path.cwd() / ".claude" / "settings.local.json", "cwd/.claude/settings.local.json"),
+        (Path.cwd() / ".mcp.json", "cwd/.mcp.json"),
+    ]
+    seen = set()
+    out = []
+    for p, lbl in candidates:
+        rp = p.resolve() if p.exists() else p
+        if rp in seen:
+            continue
+        seen.add(rp)
+        out.append((p, lbl))
+    return out
+
+
+# ─── Self-test (guards must fail loudly on known-bad input) ────────────────
+
+SELF_TEST_FIXTURES = [
+    {
+        "name": "duplicate top-level key",
+        "json": '{"a": 1, "a": 2}',
+        "expects": "DUP-KEY",
+    },
+    {
+        "name": "duplicate nested key",
+        "json": '{"permissions": {"allow": [], "allow": []}}',
+        "expects": "DUP-KEY",
+    },
+    {
+        "name": "unknown model enum",
+        "json": '{"model": "gpt-4"}',
+        "expects": "UNKNOWN-ENUM",
+    },
+    {
+        "name": "invalid json",
+        "json": '{"a": ',
+        "expects": "INVALID-JSON",
+    },
+    {
+        "name": "valid config (must NOT trigger)",
+        "json": '{"model": "sonnet", "theme": "light"}',
+        "expects": None,
+    },
+]
+
+
+def run_self_test() -> int:
+    fails = []
+    for fx in SELF_TEST_FIXTURES:
+        WARN.clear()
+        lint_content(fx["json"], label=f"<self-test:{fx['name']}>")
+        msgs = " | ".join(m for _, m in WARN)
+        expected = fx["expects"]
+        if expected is None:
+            if WARN:
+                fails.append(f"FALSE POSITIVE on '{fx['name']}': got {msgs}")
+        else:
+            if not any(expected in m for _, m in WARN):
+                fails.append(f"MISSED on '{fx['name']}': expected {expected}, got '{msgs}'")
+    if fails:
+        print("[lint-claude-settings:self-test] FAILED:", file=sys.stderr)
+        for f in fails:
+            print(f"  x {f}", file=sys.stderr)
+        return 1
+    return 0
+
+
+# ─── Main ──────────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--strict", action="store_true", help="Exit 2 on BLOCK-severity issues")
+    ap.add_argument("--test", action="store_true", help="Run self-test against fixtures")
+    ap.add_argument("--paths", nargs="+", help="Specific files to lint")
+    ap.add_argument("--content", help="Lint JSON content directly (with --label)")
+    ap.add_argument("--label", default="<stdin>", help="Label for --content")
+    args = ap.parse_args()
+
+    if args.test:
+        return run_self_test()
+
+    if args.content is not None:
+        lint_content(args.content, label=args.label)
+    elif args.paths:
+        for p in args.paths:
+            lint_file(Path(p), label=p)
+    else:
+        for p, lbl in default_targets():
+            lint_file(p, label=lbl)
+
+    if WARN:
+        blocking = [m for sev, m in WARN if sev == "BLOCK"]
+        warning = [m for sev, m in WARN if sev == "WARN"]
+        print("=" * 60, file=sys.stderr)
+        print("[lint-claude-settings] issues detected:", file=sys.stderr)
+        for m in blocking:
+            print(f"  x BLOCK: {m}", file=sys.stderr)
+        for m in warning:
+            print(f"  ! WARN:  {m}", file=sys.stderr)
+        print("=" * 60, file=sys.stderr)
+        if args.strict and blocking:
+            return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/pre-write-settings-lint.py
+++ b/hooks/pre-write-settings-lint.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""
+PreToolUse blocker for Write/Edit on Claude Code config files.
+
+Fires on Write|Edit. If tool_input.file_path is a Claude Code config file
+(settings.json, settings.local.json, .mcp.json) AND the projected new content
+contains a BLOCK-severity issue (duplicate top-level key, invalid JSON), exit 2
+with stderr explanation. Claude Code treats exit 2 as deny.
+
+Why: warn-after-the-fact (FileChanged) means the bad config has already shipped
+to the next process that reads it. Block at the write boundary — the cost of a
+false positive on a config file is low; the cost of a silently-corrupt config
+is hours of "why isn't my permission working?" debugging.
+
+The lint logic itself lives in lint-claude-settings.py (same dir).
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+LINT_SCRIPT = Path(__file__).parent / "lint-claude-settings.py"
+
+CONFIG_BASENAMES = {"settings.json", "settings.local.json", ".mcp.json"}
+
+
+def _is_config_path(path: str) -> bool:
+    p = Path(path)
+    if p.name not in CONFIG_BASENAMES:
+        return False
+    parts = p.parts
+    return ".claude" in parts or p.name == ".mcp.json"
+
+
+def _project_edit(file_path: str, old: str, new: str, replace_all: bool) -> str | None:
+    p = Path(file_path)
+    if not p.exists():
+        return None
+    try:
+        current = p.read_text()
+    except OSError:
+        return None
+    if old not in current:
+        return None
+    if replace_all:
+        return current.replace(old, new)
+    return current.replace(old, new, 1)
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0
+
+    tool = payload.get("tool_name", "")
+    if tool not in ("Write", "Edit"):
+        return 0
+
+    inp = payload.get("tool_input") or {}
+    file_path = inp.get("file_path", "")
+    if not _is_config_path(file_path):
+        return 0
+
+    if tool == "Write":
+        projected = inp.get("content", "")
+    else:
+        old = inp.get("old_string", "")
+        new = inp.get("new_string", "")
+        replace_all = bool(inp.get("replace_all", False))
+        projected = _project_edit(file_path, old, new, replace_all)
+        if projected is None:
+            return 0
+
+    label = f"<pretooluse:{Path(file_path).name}>"
+    result = subprocess.run(
+        ["python3", str(LINT_SCRIPT), "--strict", "--content", projected, "--label", label],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 2:
+        print(
+            f"BLOCKED by pre-write-settings-lint: {file_path}\n"
+            f"{result.stderr.rstrip()}\n"
+            "This write would silently corrupt your Claude Code config. "
+            "Fix the issue above (most often: duplicate top-level key) and retry.",
+            file=sys.stderr,
+        )
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Three new hooks form a layered defense against silently corrupt settings.json / .mcp.json. The most common failure mode: a duplicate top-level key (often a second `"permissions": {...}` block) that JSON's last-key-wins silently tolerates, wiping the original allowlist. The user keeps re-approving the same gh/git push permissions every session, never knowing the config has been corrupt for weeks.

- **hooks/lint-claude-settings.py** — warn-mode (drift detection) + `--strict` (PreToolUse blocker) + `--test` (5 self-test fixtures so guard rot fails loud)
- **hooks/pre-write-settings-lint.py** — PreToolUse Write|Edit. Bad config writes exit 2 (deny) instead of warn-after-the-fact. Edits are projected (current file + old/new substitution) before linting.
- **hooks/check-claude-code-version.sh** — 24h-cached `gh api releases/latest` check, warns at SessionStart if 3+ patches behind.

`hooks.json` extended: PreToolUse Write|Edit chain gains the blocker, new SessionStart block runs lint + self-test + version-check (all opt-in via `[ -f X ]` gates so missing files exit silently).

## Test plan

- [x] JSON parse: `python3 -c "import json; json.load(open('hooks.json'))"` → OK
- [x] Linter self-test: 5/5 fixtures pass (dup-key top + nested, invalid-JSON, unknown-enum, false-positive guard)
- [x] PreToolUse blocker smoke: bad write → exit 2 with stderr, good write → exit 0, unrelated path → exit 0
- [x] Personal-data scrub: zero matches across all 21 patterns
- [x] Syntax: py_compile + bash -n all clean
- [x] Path resolution: hook references in hooks.json all use `~/.claude/hooks/X` form
- [ ] CI green
- [ ] Auto-merge after CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)