### PR TITLE
refactor: shared _meta_resolver fixes copy-pasted Meta detection bug

### DIFF
--- a/scripts/_meta_resolver.py
+++ b/scripts/_meta_resolver.py
@@ -1,0 +1,48 @@
+"""Shared Meta folder resolver for vault scripts.
+
+Background:
+    Vaults can have two folders ending in "Meta":
+        - "⚙️ Meta"  human-readable rules + decisions (Decisions/, RESOLVER.md, etc.)
+        - "Meta"     closed-loop machine memory (Learnings/, Promotion-Candidates/)
+    Naive `for child in sorted(vault_root.iterdir()): if child.name.endswith("Meta")`
+    picks plain "Meta" first because "M" sorts before emoji codepoints. Scripts
+    that walk Decisions/ then silently return zero rules.
+
+Fix:
+    Each caller passes the subfolder it actually reads from. The resolver picks
+    whichever Meta variant contains that subfolder. Falls back to first Meta
+    found if neither variant has it (single-Meta vaults still work).
+
+Usage:
+    from _meta_resolver import find_meta_dir
+    meta = find_meta_dir(vault_root)                            # default: Decisions
+    meta = find_meta_dir(vault_root, ("graphify-out",))         # graphify scripts
+    meta = find_meta_dir(vault_root, ("Workflows", "Exceptions", "Facts", "Decisions"))
+
+Don't use this in scripts that intentionally want plain Meta/ (e.g.
+promote-episodic-to-procedural reads Learnings/ which lives in plain Meta).
+"""
+
+from pathlib import Path
+
+
+def find_meta_dir(
+    vault_root: Path,
+    prefer_subfolders: tuple[str, ...] = ("Decisions",),
+) -> Path | None:
+    """Auto-detect the Meta folder, preferring the variant containing
+    `prefer_subfolders`.
+
+    Returns the matching Meta path, or the first Meta-suffixed dir as fallback,
+    or None if none exist.
+    """
+    if not vault_root.is_dir():
+        return None
+    candidates = [
+        c for c in sorted(vault_root.iterdir())
+        if c.is_dir() and c.name.endswith("Meta")
+    ]
+    for c in candidates:
+        if any((c / sub).exists() for sub in prefer_subfolders):
+            return c
+    return candidates[0] if candidates else None

--- a/scripts/check-claude-md-drift.py
+++ b/scripts/check-claude-md-drift.py
@@ -42,12 +42,12 @@ import sys
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _meta_resolver import find_meta_dir as _find_meta_dir_helper  # noqa: E402
+
 
 def find_meta_dir(vault: Path) -> Path:
-    for child in (vault.iterdir() if vault.is_dir() else []):
-        if child.is_dir() and child.name.endswith("Meta"):
-            return child
-    return vault / "Meta"
+    return _find_meta_dir_helper(vault) or (vault / "Meta")
 
 
 def find_journals_dir(vault: Path) -> Path | None:

--- a/scripts/curate-skills-surface.py
+++ b/scripts/curate-skills-surface.py
@@ -30,6 +30,9 @@ import time
 from collections import Counter
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _meta_resolver import find_meta_dir  # noqa: E402
+
 
 def load_records(log_paths: list[Path], since_epoch: int) -> list[dict]:
     """Load JSONL records from any of the given paths. Tolerant of multiple schemas."""
@@ -117,14 +120,18 @@ def main() -> int:
 
     home = Path.home()
     log_paths = [home / ".claude" / "logs" / "skill-usage.jsonl"]
-    # Also check vault Meta
+    # Also check vault Meta. Walks UP from cwd looking for a vault root with a
+    # Meta folder that contains skill-usage-log.jsonl. Prefers '⚙️ Meta' over
+    # plain 'Meta' when both exist (the log lives in the human-rules variant).
     cwd = Path.cwd()
     for parent in [cwd] + list(cwd.parents)[:5]:
-        for child in parent.iterdir() if parent.is_dir() else []:
-            if child.is_dir() and child.name.endswith("Meta"):
-                vault_log = child / "skill-usage-log.jsonl"
-                if vault_log.is_file():
-                    log_paths.append(vault_log)
+        meta = find_meta_dir(parent, prefer_subfolders=("skill-usage-log.jsonl", "Decisions"))
+        if meta is None:
+            continue
+        vault_log = meta / "skill-usage-log.jsonl"
+        if vault_log.is_file():
+            log_paths.append(vault_log)
+            break
 
     since = int(time.time()) - args.days * 86400
     records = load_records(log_paths, since)

--- a/scripts/decision-outcome-check.py
+++ b/scripts/decision-outcome-check.py
@@ -27,6 +27,9 @@ import re
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _meta_resolver import find_meta_dir  # noqa: E402
+
 
 def detect_vault_root() -> Path:
     """Detect vault root from $VAULT_ROOT env var or script location."""
@@ -168,14 +171,7 @@ def main() -> int:
     args = parser.parse_args()
 
     vault_root = (args.vault_root or detect_vault_root()).resolve()
-    # Auto-detect the Meta folder (with or without emoji prefix)
-    meta_dir = None
-    for candidate in vault_root.iterdir():
-        if candidate.is_dir() and candidate.name.endswith("Meta"):
-            meta_dir = candidate
-            break
-    if meta_dir is None:
-        meta_dir = vault_root / "Meta"
+    meta_dir = find_meta_dir(vault_root) or (vault_root / "Meta")
 
     decision_log = meta_dir / "Decision Log.md"
     priorities = meta_dir / "Current Priorities.md"

--- a/scripts/decision-retrospective.py
+++ b/scripts/decision-retrospective.py
@@ -30,12 +30,12 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _meta_resolver import find_meta_dir as _find_meta_dir_helper  # noqa: E402
+
 
 def find_meta_dir(vault: Path) -> Path:
-    for child in (vault.iterdir() if vault.is_dir() else []):
-        if child.is_dir() and child.name.endswith("Meta"):
-            return child
-    return vault / "Meta"
+    return _find_meta_dir_helper(vault) or (vault / "Meta")
 
 
 def parse_frontmatter(text: str) -> dict | None:

--- a/scripts/demote-stale-procedural.py
+++ b/scripts/demote-stale-procedural.py
@@ -68,6 +68,9 @@ try:
 except ImportError:
     yaml = None
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _meta_resolver import find_meta_dir as _find_meta_dir_helper  # noqa: E402
+
 
 TYPED_FOLDERS = ("Workflows", "Exceptions", "Facts")
 TYPE_BY_FOLDER = {
@@ -78,12 +81,10 @@ TYPE_BY_FOLDER = {
 
 
 def find_meta_dir(vault_root: Path) -> Path | None:
-    if not vault_root.is_dir():
-        return None
-    for child in sorted(vault_root.iterdir()):
-        if child.is_dir() and child.name.endswith("Meta"):
-            return child
-    return None
+    return _find_meta_dir_helper(
+        vault_root,
+        prefer_subfolders=("Workflows", "Exceptions", "Facts", "Decisions"),
+    )
 
 
 def parse_frontmatter(text: str) -> dict[str, Any] | None:

--- a/scripts/entity-disambiguator.py
+++ b/scripts/entity-disambiguator.py
@@ -82,14 +82,15 @@ STOPWORDS = {
 }
 
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _meta_resolver import find_meta_dir as _find_meta_dir_helper  # noqa: E402
+
+
 def find_meta_dir(vault_root: Path) -> Path | None:
-    """Auto-detect the Meta folder. Supports plain and emoji-prefixed names."""
-    if not vault_root.is_dir():
-        return None
-    for child in sorted(vault_root.iterdir()):
-        if child.is_dir() and child.name.endswith("Meta"):
-            return child
-    return None
+    return _find_meta_dir_helper(
+        vault_root,
+        prefer_subfolders=("RESOLVER.md", "Decisions"),
+    )
 
 
 def normalize_key(value: str) -> str:

--- a/scripts/graphify_prep.py
+++ b/scripts/graphify_prep.py
@@ -32,6 +32,9 @@ import sys
 from collections import Counter
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _meta_resolver import find_meta_dir  # noqa: E402
+
 # --- regex patterns ---
 WIKILINK_RE = re.compile(r"\[\[([^\[\]|#]+?)(?:\|([^\[\]]+?))?(?:#[^\[\]]*)?\]\]")
 YAML_FENCE_RE = re.compile(r"^---\n(.*?)\n---\n", re.DOTALL)
@@ -484,16 +487,11 @@ def main():
     # Auto-detect whitelist path if not provided
     whitelist_path = args.whitelist_path
     if whitelist_path is None:
-        # Try to find it relative to input dir's vault
-        for candidate_name in ["concept_whitelist.txt"]:
-            for meta_candidate in input_dir.parent.iterdir():
-                if meta_candidate.is_dir() and meta_candidate.name.endswith("Meta"):
-                    wl = meta_candidate / candidate_name
-                    if wl.exists():
-                        whitelist_path = wl
-                        break
-            if whitelist_path:
-                break
+        meta = find_meta_dir(input_dir.parent, prefer_subfolders=("concept_whitelist.txt",))
+        if meta is not None:
+            wl = meta / "concept_whitelist.txt"
+            if wl.exists():
+                whitelist_path = wl
 
     if args.no_dedupe:
         print("[1/2] Dedupe SKIPPED (--no-dedupe set; input is treated as read-only)")

--- a/scripts/resolver-build.py
+++ b/scripts/resolver-build.py
@@ -50,6 +50,9 @@ import sys
 from pathlib import Path
 from typing import Any
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _meta_resolver import find_meta_dir  # noqa: E402
+
 
 # Folder names the aggregator walks. The auto-detect supports both
 # emoji-prefixed ("⚙️ Meta") and plain ("Meta") layouts.
@@ -66,16 +69,6 @@ TYPE_BY_FOLDER = {
 # (rather than a clean supersession) when they share `pattern`, contradict
 # in outcome, and their last_verified dates are within this many days.
 BRANCH_MERGE_WINDOW_DAYS = 30
-
-
-def find_meta_dir(vault_root: Path) -> Path | None:
-    """Auto-detect the Meta folder. Supports '⚙️ Meta' and 'Meta'."""
-    if not vault_root.is_dir():
-        return None
-    for child in sorted(vault_root.iterdir()):
-        if child.is_dir() and child.name.endswith("Meta"):
-            return child
-    return None
 
 
 def parse_frontmatter(text: str) -> dict[str, Any] | None:

--- a/scripts/rotate-last-session.py
+++ b/scripts/rotate-last-session.py
@@ -31,6 +31,9 @@ import re
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _meta_resolver import find_meta_dir as _find_meta_dir_helper  # noqa: E402
+
 
 def detect_vault_root() -> Path:
     """Detect vault root from $VAULT_ROOT env var or script location."""
@@ -45,11 +48,7 @@ def detect_vault_root() -> Path:
 
 
 def find_meta_dir(vault_root: Path) -> Path:
-    """Auto-detect the Meta folder (with or without emoji prefix)."""
-    for candidate in vault_root.iterdir():
-        if candidate.is_dir() and candidate.name.endswith("Meta"):
-            return candidate
-    return vault_root / "Meta"
+    return _find_meta_dir_helper(vault_root) or (vault_root / "Meta")
 
 
 # Sessions start with "# Session —" at column 0.

--- a/scripts/rotate_graphify_backups.py
+++ b/scripts/rotate_graphify_backups.py
@@ -11,19 +11,20 @@ Usage:
 """
 
 import argparse
+import sys
 import time
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _meta_resolver import find_meta_dir as _find_meta_dir_helper  # noqa: E402
 
 DEFAULT_KEEP = 3
 DEFAULT_BAK_MAX_AGE_DAYS = 7
 
 
 def find_meta_dir(vault_root: Path) -> Path:
-    """Auto-detect the Meta folder (with or without emoji prefix)."""
-    for candidate in vault_root.iterdir():
-        if candidate.is_dir() and candidate.name.endswith("Meta"):
-            return candidate
-    return vault_root / "Meta"
+    return _find_meta_dir_helper(vault_root, prefer_subfolders=("graphify-out", "Decisions")) \
+        or (vault_root / "Meta")
 
 
 def rotate_graphify(vault_root: Path, keep: int) -> list[str]:

--- a/scripts/stale-rule-check.py
+++ b/scripts/stale-rule-check.py
@@ -33,6 +33,9 @@ import sys
 from pathlib import Path
 from typing import Any
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _meta_resolver import find_meta_dir  # noqa: E402
+
 
 TYPED_FOLDERS = ("Decisions", "Workflows", "Exceptions", "Facts")
 TYPE_BY_FOLDER = {
@@ -41,15 +44,6 @@ TYPE_BY_FOLDER = {
     "Exceptions": "exception",
     "Facts": "fact",
 }
-
-
-def find_meta_dir(vault_root: Path) -> Path | None:
-    if not vault_root.is_dir():
-        return None
-    for child in sorted(vault_root.iterdir()):
-        if child.is_dir() and child.name.endswith("Meta"):
-            return child
-    return None
 
 
 def parse_frontmatter(text: str) -> dict[str, Any] | None:

--- a/scripts/undo-last-close.py
+++ b/scripts/undo-last-close.py
@@ -32,12 +32,12 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _meta_resolver import find_meta_dir as _find_meta_dir_helper  # noqa: E402
+
 
 def find_meta_dir(vault: Path) -> Path:
-    for child in sorted(vault.iterdir()):
-        if child.is_dir() and child.name.endswith("Meta"):
-            return child
-    return vault / "Meta"
+    return _find_meta_dir_helper(vault) or (vault / "Meta")
 
 
 def derive_worktree() -> str:

--- a/scripts/vault-hygiene.py
+++ b/scripts/vault-hygiene.py
@@ -32,6 +32,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _meta_resolver import find_meta_dir as _find_meta_dir_helper  # noqa: E402
+
+
 SKIP_FOLDERS = {
     ".obsidian", ".trash", ".smart-env", "node_modules", ".git", "Archive",
     ".DS_Store", "__pycache__",
@@ -39,10 +43,8 @@ SKIP_FOLDERS = {
 
 
 def find_meta_dir(vault: Path) -> Path:
-    for child in (vault.iterdir() if vault.is_dir() else []):
-        if child.is_dir() and child.name.endswith("Meta"):
-            return child
-    return vault / "Meta"
+    return _find_meta_dir_helper(vault, prefer_subfolders=("graphify-out", "Decisions")) \
+        or (vault / "Meta")
 
 
 def walk_md_files(vault: Path):

--- a/scripts/vault-schema-validator.py
+++ b/scripts/vault-schema-validator.py
@@ -73,11 +73,12 @@ def load_schema(schema_path: Path) -> dict:
         return json.load(f)
 
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _meta_resolver import find_meta_dir as _find_meta_dir_helper  # noqa: E402
+
+
 def find_meta_dir(vault: Path) -> Path:
-    for child in sorted(vault.iterdir()) if vault.is_dir() else []:
-        if child.is_dir() and child.name.endswith("Meta"):
-            return child
-    return vault / "Meta"
+    return _find_meta_dir_helper(vault) or (vault / "Meta")
 
 
 def find_journals_dir(vault: Path) -> Path | None:

--- a/scripts/vault_maintenance.py
+++ b/scripts/vault_maintenance.py
@@ -25,9 +25,13 @@ The report is written to {vault-root}/Meta/Maintenance Report.md
 import argparse
 import os
 import subprocess
+import sys
 import time
 from datetime import datetime
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _meta_resolver import find_meta_dir as _find_meta_dir_helper  # noqa: E402
 
 SKIP_DIRS = {".git", ".claude", "node_modules", "graphify-input", ".obsidian"}
 
@@ -49,11 +53,7 @@ INBOX_MAX_AGE_DAYS = 7
 
 
 def find_meta_dir(vault_root: Path) -> Path:
-    """Auto-detect the Meta folder (with or without emoji prefix)."""
-    for candidate in vault_root.iterdir():
-        if candidate.is_dir() and candidate.name.endswith("Meta"):
-            return candidate
-    return vault_root / "Meta"
+    return _find_meta_dir_helper(vault_root) or (vault_root / "Meta")
 
 
 def find_inbox_dir(vault_root: Path) -> Path:


### PR DESCRIPTION
## Summary

- 17 scripts had a copy-pasted `find_meta_dir()` that silently picked the wrong folder when a vault has both `⚙️ Meta` (human-readable rules) and plain `Meta/` (closed-loop machine memory). Naive first-match by sorted `iterdir()` picks plain Meta because `M` sorts before emoji codepoints — `resolver-build` then writes zero rules to RESOLVER.md.
- New `scripts/_meta_resolver.py` exports `find_meta_dir(vault_root, prefer_subfolders=("Decisions",))`. Caller passes whichever subfolder the script actually reads from. Falls back to first Meta found if neither variant has the preferred subfolder, so single-Meta vaults still work.
- 15 scripts refactored to import from the helper. `resolver-conflict-report.py` and `resolver-branch-merge-prompt.py` inherit through `resolver-build.py`'s importlib aggregator and need no direct edit. `promote-episodic-to-procedural.py` intentionally untouched: it correctly wants plain `Meta/` where `Learnings/` lives.

## Why now

Per the permanent-fix pattern, every recurring corruption gets an automated guard the same session. The inline patches shipped earlier today on 4 daily-cron scripts; this refactor closes the door on the buggy function being copy-pasted into a future script.

## Test plan

- [x] Unit-tested helper across 6 cases: both-exist-prefer-Decisions, only-plain-Meta, only-emoji-Meta, missing-root, no-Meta-at-all, custom prefer_subfolders. All pass.
- [x] Smoke-tested every refactored script's `find_meta_dir` against a vault with both Meta variants. All 15 return `⚙️ Meta`. The two inheritors confirmed by inspection.
- [x] End-to-end: `resolver-build.py --dry-run` collects 115 rules. The buggy version returned 0.
- [x] Personal-data scrub on the diff and the new helper file: zero findings.