### PR TITLE
content: reframe self-improving to corpus-gets-richer

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Claude has access to your full context: who you are, what you're building, your 
 A cascade scans the entire conversation and files everything to the right place: decisions to your decision log, to-dos to your task list, insights to your captures file, ideas to your ideas doc. Substack note candidates get drafted. Journal seeds get preserved verbatim for your next /journal session.
 
 ### Over weeks and months
-Weekly insight reports track your emotional floor patterns, flag avoidance, surface wins. Monthly reports go deeper. The /patterns skill (Instinct Engine) detects recurring friction and converts it into permanent rules and captures. Your corpus gets richer every week. Every conversation lands on a deeper substrate than the last one.
+Weekly insight reports track your emotional floor patterns, flag avoidance, surface wins. Monthly reports go deeper. The /patterns skill (Instinct Engine) detects recurring friction and converts it into permanent rules and captures. Your system literally gets smarter the more you use it.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Claude has access to your full context: who you are, what you're building, your 
 A cascade scans the entire conversation and files everything to the right place: decisions to your decision log, to-dos to your task list, insights to your captures file, ideas to your ideas doc. Substack note candidates get drafted. Journal seeds get preserved verbatim for your next /journal session.
 
 ### Over weeks and months
-Weekly insight reports track your emotional floor patterns, flag avoidance, surface wins. Monthly reports go deeper. The /patterns skill (Instinct Engine) detects recurring friction and converts it into permanent rules and captures. Your system literally gets smarter the more you use it.
+Weekly insight reports track your emotional floor patterns, flag avoidance, surface wins. Monthly reports go deeper. The /patterns skill (Instinct Engine) detects recurring friction and converts it into permanent rules and captures. Your corpus gets richer every week. Every conversation lands on a deeper substrate than the last one.
 
 ---
 

--- a/templates/CLOSED-LOOP-README.md
+++ b/templates/CLOSED-LOOP-README.md
@@ -250,13 +250,14 @@ share `entity_ids.github_pr` are very likely about the same workstream.
 
 The vault-as-ground-truth principle says the agent never trusts what it
 remembers between sessions. Every claim the agent makes must trace to a file
-the company controls. The closed loop turns that principle into a
-self-improving substrate: the agent's failures become episodic records, the
-records cluster into recognizable patterns, the patterns get human-reviewed
-into procedural memory, and the next agent reads the procedural memory
-before re-running the same task. Over time the procedural surface grows,
-the failure rate falls, and the agent's reliability becomes a function of
-the vault rather than the model's training-time priors.
+the company controls. The closed loop turns that principle into a substrate
+that compounds: the agent's failures become episodic records, the records
+cluster into recognizable patterns, the patterns get human-reviewed into
+procedural memory, and the next agent reads the procedural memory before
+re-running the same task. Over time the procedural surface grows, the
+failure rate falls, and the agent's reliability becomes a function of the
+vault rather than the model's training-time priors. The corpus gets richer
+every week. The model itself does not get smarter; the substrate does.
 
 The human review gate is the load-bearing piece. Without it, the loop
 amplifies noise (transient errors, environmental flakes, one-off network


### PR DESCRIPTION
## Summary
- Shifts two public surfaces from AI-hype framing to engineering-honest framing.
- README.md "Over weeks and months": replaces "your system literally gets smarter the more you use it" with "your corpus gets richer every week. Every conversation lands on a deeper substrate than the last one."
- templates/CLOSED-LOOP-README.md: replaces "self-improving substrate" with "substrate that compounds" and adds an explicit final clause: "The model itself does not get smarter; the substrate does."

## Why
"Self-improving / system gets smarter" reads as model self-improvement (which it isn't) and primes a sophisticated reader to discount the entire claim. The honest mechanism is corpus accumulation plus human-reviewed promotion to procedural memory. Naming that directly survives technical scrutiny in a way the original framing does not.

## Test plan
- [x] Reframe matches sister change on mycelium-site primitive 04 (EN + ES).
- [x] No factual claims changed; only framing.
- [x] Personal-data scrub clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)