### PR TITLE
v1.3.1: vertical-healthcare actually-complete (5 missing files)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "ai-brain-starter",
       "source": "./",
       "description": "The operating system for Claude Code. Memory, accountability, journaling, knowledge graphs, pattern recognition, and first-principles analysis — one install, every session compounds.",
-      "version": "1.3.0"
+      "version": "1.3.1"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-brain-starter",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Set up or upgrade an AI-powered Obsidian vault with journaling, knowledge graphs, pattern recognition, and meeting workflows. Includes skills for daily journaling, weekly insights, graphify knowledge graphs, humanizer, and more.",
   "author": {
     "name": "Adelaida Diaz-Roa",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,26 @@ description: What's new in AI Brain Starter — plain English, no jargon
 
 ---
 
+## 2026-05-09: v1.3.1 vertical-healthcare actually-complete (5 missing files landed)
+
+**Who this affects:** anyone who installed v1.3.0 expecting `/vertical-healthcare init` to work end-to-end.
+
+**The shape:** v1.3.0 advertised "vertical-healthcare completion" and shipped the 4 files the description promised (retention, both decision-audit patterns, Salesforce Health Cloud connector). But the original 5 files from the v1.2.0 partial scaffold (README, SKILL, cerner-fhir, epic-fhir, schema/typed-memory-categories) were never staged. Without README and SKILL, skill discovery did not register the pack at all, so the v1.3.0 promise was vacuous on disk. v1.3.1 lands the 5 files so the pack is functionally installable.
+
+### Files added
+
+- `skills/vertical-healthcare/README.md` — entry point, who-this-is-for, what-is-in-the-box, install + read-first guidance.
+- `skills/vertical-healthcare/SKILL.md` — `name: vertical-healthcare`, `trigger: /vertical-healthcare`, full pack overview with HIPAA + state-add-on framing.
+- `skills/vertical-healthcare/connectors/epic-fhir.md` — Epic via FHIR R4, SMART-on-FHIR auth, resource type coverage.
+- `skills/vertical-healthcare/connectors/cerner-fhir.md` — Oracle Cerner via FHIR R4, SMART-on-FHIR auth, resource type coverage.
+- `skills/vertical-healthcare/schema/typed-memory-categories.md` — 7 typed-memory categories (patient-scoped-fact, clinical-decision, phi-tagged-doc, baa-counterparty, retention-policy, hipaa-incident, breach-notification).
+
+### What you might want to do
+
+If you are on v1.3.0 and tried `/vertical-healthcare init` and got nothing, run `git pull` to v1.3.1 and try again. If you are on a clean install, no action needed.
+
+---
+
 ## 2026-05-08: Scheduled-task naming convention + `/diagnose` lint check
 
 **Who this affects:** anyone who has scheduled tasks under `~/.claude/scheduled-tasks/`.

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -11,6 +11,14 @@ For full development history including internal refactors and bug fixes, see [`C
 
 ---
 
+## 2026-05-09 — v1.3.1: vertical-healthcare actually-complete
+
+v1.3.0 advertised "vertical-healthcare completion" but only landed 4 of the 9 files the pack needs. Without `README.md` and `SKILL.md`, skill discovery did not register the pack, so `/vertical-healthcare init` was inert. v1.3.1 lands the 5 missing files: README, SKILL, the Epic and Cerner FHIR connectors, and the typed-memory schema. The pack is now functionally installable.
+
+If you tried `/vertical-healthcare init` on v1.3.0 and got nothing, `git pull` to v1.3.1 and try again. Clean install, no action needed.
+
+---
+
 ## 2026-05-06 — vertical-healthcare completion + skill-overrides recipe
 
 The healthcare vertical pack is now complete. Three layers shipped that match what the pack's description has promised since launch:

--- a/skills/vertical-healthcare/README.md
+++ b/skills/vertical-healthcare/README.md
@@ -1,0 +1,49 @@
+# Vertical pack: healthcare
+
+A drop-in configuration pack that turns the ai-brain-starter substrate into a healthcare-ready system: PHI handling, clinical-decision trails, BAA counterparty tracking, and connectors for Epic, Cerner, and Salesforce Health Cloud.
+
+## Who this is for
+
+- Covered entities (hospitals, health systems, clinics, payers) installing the substrate.
+- Business associates handling PHI on behalf of covered entities.
+- Digital health vendors needing HIPAA-compliant memory for clinical workflows.
+
+## What is in the box
+
+| Layer | File | What it gives you |
+|---|---|---|
+| Schema | `schema/typed-memory-categories.md` | 7 typed-memory categories: patient-scoped-fact, clinical-decision, phi-tagged-doc, baa-counterparty, retention-policy, hipaa-incident, breach-notification. |
+| Connectors | `connectors/epic-fhir.md`, `connectors/cerner-fhir.md`, `connectors/salesforce-health-cloud.md` | FHIR R4 endpoints, SMART-on-FHIR auth, resource coverage. |
+| Retention | `retention/defaults.md` | HIPAA 6-year baseline plus per-state add-ons. |
+| Decision audit | `decision-audit/phi-handling.md`, `decision-audit/clinical-decision-trail.md` | 18-HIPAA-identifier firewall and clinical-decision evidence chains. |
+
+## Install
+
+```bash
+/vertical-healthcare init
+```
+
+Stages drafts, prints a review checklist, stops.
+
+## Read first
+
+If you only have time to skim one file, read `decision-audit/phi-handling.md`. PHI handling is the load-bearing rule; if it does not match your privacy officer's posture, the rest will not fit.
+
+## What this pack does NOT include
+
+- Clinical decision support algorithms.
+- Coding and billing workflows.
+- Pharmacy or DEA-controlled-substance tracking.
+- Clinical trial data handling.
+- 42 CFR Part 2 substance-use-disorder protections.
+
+## Roadmap
+
+- v2: 42 CFR Part 2 layer for substance-use-disorder protected records.
+- v2: DEA-controlled-substance tracking.
+- v2: Joint Commission accreditation evidence layer.
+- v3: Pharmacy and 340B compliance layer.
+
+## Support
+
+Issues and pack-specific questions belong on the ai-brain-starter repository. The pack is open source; HIPAA compliance remains the covered entity's obligation.

--- a/skills/vertical-healthcare/SKILL.md
+++ b/skills/vertical-healthcare/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: vertical-healthcare
+description: Pre-configured healthcare vertical pack for the ai-brain-starter substrate. Ships typed-memory categories for patient-scoped facts, clinical decisions, PHI-tagged docs, BAA counterparties, and breach notification; HIPAA-aligned retention defaults plus per-state add-ons; connectors for Epic FHIR, Cerner FHIR, and Salesforce Health Cloud; decision-audit patterns for PHI handling against the 18 HIPAA identifiers and clinical-decision evidence chains. Use when onboarding a covered entity, business associate, or health system that needs the substrate to come pre-shaped to HIPAA, BAA, and clinical-decision audit obligations.
+trigger: /vertical-healthcare
+argument-hint: "init | status | rebuild [--tenant <id>]"
+---
+
+# /vertical-healthcare
+
+A pre-configured pack that turns the empty substrate into a healthcare-ready system in one install. The pack ships typed-memory categories that match how patient data, clinical decisions, and BAA relationships move through a covered entity; FHIR connectors for the two dominant EHR vendors; HIPAA retention defaults plus per-state add-ons; and decision-audit patterns that enforce PHI handling at the 18-identifier level and produce a verifiable clinical-decision evidence chain.
+
+## Why this exists
+
+Healthcare organizations operate under the strictest data-handling regime in commercial software: HIPAA, the HITECH Act, state-level add-ons (California CMIA, Texas HB 300, New York SHIELD), plus a forest of payer and joint-commission rules. A blank substrate install forces every covered entity to re-derive the same PHI-handling firewall and the same retention rules.
+
+This pack ships the firewall and the rules so the org can spend day one on its own clinical workflows rather than on schema design and HIPAA mapping.
+
+## What this pack sets up
+
+| Layer | What ships | Where it lands |
+|---|---|---|
+| Schema | 7 typed-memory categories with frontmatter contracts | `schema/typed-memory-categories.md` |
+| Connectors | Epic FHIR, Cerner FHIR, Salesforce Health Cloud specs and SMART-on-FHIR auth | `connectors/*.md` |
+| Retention | HIPAA 6-year baseline, per-state add-ons, breach-notification log retention | `retention/defaults.md` |
+| Decision audit | PHI handling against 18 HIPAA identifiers, clinical-decision evidence chains | `decision-audit/*.md` |
+
+Nothing is auto-applied. Drafts stage under `drafts/`; the privacy officer, security officer, and clinical informatics lead review and merge.
+
+## Categories shipped
+
+- patient-scoped-fact
+- clinical-decision
+- phi-tagged-doc
+- baa-counterparty
+- retention-policy
+- hipaa-incident
+- breach-notification
+
+## Connectors shipped
+
+- `connectors/epic-fhir.md` : Epic via FHIR R4; SMART-on-FHIR auth; resource types covered
+- `connectors/cerner-fhir.md` : Oracle Cerner via FHIR R4; SMART-on-FHIR auth; resource types covered
+- `connectors/salesforce-health-cloud.md` : Salesforce Health Cloud connector; OAuth and Salesforce platform auth
+
+## Retention defaults shipped
+
+- HIPAA records: 6 years from creation or last effective date (45 CFR 164.530(j)).
+- California CMIA add-on: 7 years for medical records.
+- Minor patient records: until age of majority + retention floor (varies by state; California: age 18 + 7 years; Texas: age 18 + 7 years).
+- Breach-notification log: 6 years.
+- Decedent records: 50 years post-death (HIPAA decedent rule).
+
+See `retention/defaults.md`.
+
+## Decision-audit patterns shipped
+
+- `decision-audit/phi-handling.md` : every PHI tag is verified at write time against the 18 HIPAA identifiers; PHI cannot cross tenant boundaries; audit log is BAA-default; every PHI access is logged with role, matter (encounter or case), and disposition.
+- `decision-audit/clinical-decision-trail.md` : every clinical recommendation has a chain: input data, decision, decision-maker, supporting evidence, alternatives considered.
+
+## When to use this pack
+
+- A covered entity is installing the substrate.
+- A business associate handling PHI on behalf of a covered entity is installing.
+- A health system is consolidating across hospitals or clinics on a shared substrate.
+- A digital health vendor needs HIPAA-compliant memory for clinical workflows.
+
+## When NOT to use this pack
+
+- Pure life-sciences research without PHI (use a thinner subset).
+- Veterinary medicine (the schema would need extensive remapping).
+- Non-clinical health-tech without patient data (skip; use the generic substrate).
+
+## Install
+
+```bash
+/vertical-healthcare init
+```
+
+Stages drafts, prints a review checklist, stops.
+
+## Status
+
+```bash
+/vertical-healthcare status
+```
+
+Reports which categories are live, which connectors are configured, BAA execution status for each downstream counterparty, and any PHI access in the past 30 days that lacked a logged disposition.
+
+## What this pack does NOT include
+
+- Clinical decision support (CDS) algorithms (out of scope; the pack tracks decisions, it does not make them).
+- Coding and billing workflows (use the finance pack plus a healthcare-specific billing layer).
+- Pharmacy or DEA-controlled-substance tracking (out of scope for v1).
+- Clinical trial data (use a research-specific schema; HIPAA does not cover de-identified research data the same way).
+- 42 CFR Part 2 substance-use-disorder protections (these are stricter than HIPAA; v1 does not encode them).
+
+## Provenance
+
+Every retention default cites the rule. Every connector cites the FHIR or platform documentation URL. Every decision-audit pattern cites the HIPAA section, HITECH provision, or state law. Drafts without provenance are gaps.

--- a/skills/vertical-healthcare/connectors/cerner-fhir.md
+++ b/skills/vertical-healthcare/connectors/cerner-fhir.md
@@ -1,0 +1,68 @@
+# Connector: Cerner FHIR (Oracle Health)
+
+Oracle Cerner Millennium is the second-largest EHR at US health systems. This connector targets the FHIR R4 surface and uses SMART-on-FHIR for auth.
+
+## API surface
+
+- Base URL: per-tenant Cerner FHIR endpoint, varies (`https://fhir-myrecord.cerner.com/r4/` is a common shape for production tenants)
+- Documentation: https://fhir.cerner.com (Oracle Health Developers portal)
+- Auth: SMART-on-FHIR with OAuth 2.0 (backend services flow and authorization code flow)
+
+## Resources mapped to typed-memory categories
+
+| FHIR resource | Substrate category | Sync direction |
+|---|---|---|
+| Patient | patient identity store + reference | inbound only |
+| Encounter | encounter reference | inbound only |
+| Observation | patient-scoped-fact | inbound only |
+| Condition | patient-scoped-fact (diagnosis subtype) | inbound only |
+| MedicationRequest | patient-scoped-fact (medication subtype) | inbound only |
+| AllergyIntolerance | patient-scoped-fact (allergy subtype) | inbound only |
+| Procedure | patient-scoped-fact (procedure subtype) | inbound only |
+| DocumentReference | phi-tagged-doc | inbound only |
+| CarePlan | clinical-decision (care-plan subtype) | inbound only |
+| ServiceRequest | clinical-decision (referral subtype) | inbound only |
+
+Read-only. Cerner is the source of truth.
+
+## Auth setup
+
+1. Health system registers a SMART-on-FHIR app via Cerner's developer portal (https://code.cerner.com).
+2. Backend services flow with JWKS-signed assertions; substrate manages the keypair in the tenant secret store.
+3. Authorization code flow with standard SMART scopes for user-context queries.
+
+## Sync cadence
+
+Same defaults as the Epic connector:
+
+- Patient master: nightly.
+- Encounters: every 30 minutes.
+- Observations, Conditions, Medications, Allergies, Procedures: every hour.
+- DocumentReference: every 4 hours.
+- CarePlan, ServiceRequest: every 2 hours.
+
+## Privilege handling
+
+Cerner's privacy filters (sensitive-chart flags, behavioral-health markers, custodial restrictions) are honored. The connector reads only what the authorizing principal is entitled to. PHI markers stamp onto `phi_tagged` and `sensitive`.
+
+42 CFR Part 2 records are out of scope for v1; the connector skips charts with that marker.
+
+## Rate limits
+
+Cerner's FHIR API has tenant-scoped rate limits documented in the developer portal. The connector backs off on 429.
+
+## Failure modes
+
+Same shapes as Epic: JWKS rotation, chart access revocation, FHIR version drift.
+
+## What this connector does NOT do
+
+- Authoring back to Cerner.
+- Pulling 42 CFR Part 2 records.
+- Pulling psychotherapy notes.
+- Bulk historical backfill beyond 24 months without explicit request.
+
+## Cerner-specific notes
+
+- Cerner's `Patient.identifier` slice for MRN varies by tenant configuration. The connector reads the configured slice via the tenant's CapabilityStatement; if the slice is missing, the connector falls back to the system-level MRN identifier and surfaces a notice.
+- Cerner's terminology bindings (especially for Observation.code) frequently use proprietary code systems alongside LOINC. The connector preserves both; downstream queries against patient-scoped-fact can match on either.

--- a/skills/vertical-healthcare/connectors/epic-fhir.md
+++ b/skills/vertical-healthcare/connectors/epic-fhir.md
@@ -1,0 +1,66 @@
+# Connector: Epic FHIR
+
+Epic is the dominant EHR at large US health systems. This connector targets the FHIR R4 surface and uses SMART-on-FHIR for auth.
+
+## API surface
+
+- Base URL: per-tenant Epic FHIR endpoint, varies (`https://fhir.epic.com/interconnect-fhir-oauth/api/FHIR/R4/` is a common shape for Epic-hosted environments)
+- Documentation: https://fhir.epic.com
+- Auth: SMART-on-FHIR with OAuth 2.0 (backend services flow for system-level access; authorization code flow for user-context access)
+
+## Resources mapped to typed-memory categories
+
+| FHIR resource | Substrate category | Sync direction |
+|---|---|---|
+| Patient | patient identity store + reference | inbound only |
+| Encounter | encounter reference (used by patient-scoped-fact) | inbound only |
+| Observation | patient-scoped-fact | inbound only |
+| Condition | patient-scoped-fact (diagnosis subtype) | inbound only |
+| MedicationRequest | patient-scoped-fact (medication subtype) | inbound only |
+| AllergyIntolerance | patient-scoped-fact (allergy subtype) | inbound only |
+| Procedure | patient-scoped-fact (procedure subtype) | inbound only |
+| DocumentReference | phi-tagged-doc | inbound only |
+| CarePlan | clinical-decision (care-plan subtype) | inbound only |
+| ServiceRequest | clinical-decision (referral subtype) | inbound only |
+
+The connector is read-only. Epic is the EHR source of truth; the substrate mirrors structured FHIR data for memory and audit, never authors back.
+
+## Auth setup
+
+1. Health system registers a SMART-on-FHIR app via Epic's App Orchard or via direct Epic admin enrollment.
+2. Backend services flow uses asymmetric key (JWKS) signing; substrate stores the private key in a tenant-scoped secret store, publishes the public key at a JWKS endpoint Epic can reach.
+3. Authorization code flow (when user-context access is needed) uses standard SMART scopes (`patient/*.read`, `user/*.read`).
+4. Per-patient access is gated by the patient's chart context; the substrate does not bypass Epic's break-glass or chart-access controls.
+
+## Sync cadence
+
+- Patient master: nightly (patient demographics change rarely).
+- Encounters: every 30 minutes (active encounters drive most query volume).
+- Observations, Conditions, Medications, Allergies, Procedures: every hour.
+- DocumentReference: every 4 hours (document volume is high; metadata-only sync).
+- CarePlan, ServiceRequest: every 2 hours.
+
+The connector defaults conservatively; the health system tunes via config.
+
+## Privilege handling
+
+Epic's chart-access controls (break-glass, sensitive-chart, behavioral-health restrictions) are honored. The connector reads only what the authorizing user or system principal is entitled to read. PHI markers from Epic (sensitive-chart flags, 42 CFR Part 2 subset) are stamped onto the substrate's `phi_tagged` and `sensitive` fields.
+
+If Epic surfaces a chart with a 42 CFR Part 2 marker, the connector does NOT pull that chart's data unless the substrate has been explicitly configured for Part 2 handling; Part 2 is out of scope for v1, and the connector errs on the side of refusal.
+
+## Rate limits
+
+Epic's FHIR API has tenant-scoped rate limits. The connector backs off on 429 with exponential retry; chronic 429s pause sync and notify the administrator.
+
+## Failure modes
+
+- JWKS rotation: the connector publishes the new public key at the JWKS endpoint and rotates the private key in the secret store; Epic picks up the new key on next request.
+- Chart access revoked: the connector logs the access change, drops cached data for the affected chart from any non-audit-scoped store, continues sync for unaffected charts.
+- FHIR version drift: the connector targets R4; if the tenant moves to R5 or beyond, the connector updates per the FHIR migration guidance.
+
+## What this connector does NOT do
+
+- Authoring back to Epic (no MyChart messages, no order entry, no chart writes).
+- Pulling 42 CFR Part 2 records (out of scope for v1).
+- Pulling psychotherapy notes (HIPAA prohibits routine disclosure; the connector skips by default).
+- Bulk historical backfill beyond 24 months without explicit administrator request.

--- a/skills/vertical-healthcare/schema/typed-memory-categories.md
+++ b/skills/vertical-healthcare/schema/typed-memory-categories.md
@@ -1,0 +1,145 @@
+# Healthcare vertical: typed-memory categories
+
+Seven categories ship with the healthcare pack. Each lists the required frontmatter the substrate enforces at write time, plus optional frontmatter that downstream queries depend on.
+
+A document that does not match its declared category schema is rejected at write time and surfaced as a recoverable error.
+
+## patient-scoped-fact
+
+Any fact about a patient. Tagged with the patient's tenant-internal identifier (never a raw HIPAA identifier; identifiers are mapped into a separate identity store).
+
+```yaml
+type: patient-scoped-fact
+fact_id: required, unique within tenant
+patient_internal_id: required, FK to patient identity store
+encounter_id: optional, FK to encounter (when the fact is encounter-scoped)
+fact_type: required, one of [diagnosis, observation, medication, procedure, allergy, social-history, family-history, plan, communication, other]
+fact_text: required, plain text
+recorded_date: required, ISO 8601 datetime with timezone
+recorded_by: required, person reference
+source_system: required, one of [epic, cerner, salesforce-health-cloud, manual, other]
+source_resource_id: optional, the FHIR resource ID or equivalent
+phi_tagged: required, boolean, defaults true
+sensitive: required, boolean, defaults false (true for behavioral health, HIV, substance use, reproductive)
+```
+
+## clinical-decision
+
+A clinical recommendation, treatment decision, or care-plan change. Drives the decision trail in `decision-audit/clinical-decision-trail.md`.
+
+```yaml
+type: clinical-decision
+decision_id: required, unique within tenant
+patient_internal_id: required, FK to patient identity store
+encounter_id: required, FK to encounter
+decision_text: required, plain text
+decision_type: required, one of [diagnosis, treatment, medication, procedure, referral, discharge, care-plan, other]
+decision_date: required, ISO 8601 datetime with timezone
+decision_maker: required, person reference (the credentialed provider accountable)
+input_data_references: required, list of fact_id or doc_id (must be non-empty)
+alternatives_considered: optional, plain text or list
+supporting_evidence_references: optional, list of doc_id (clinical guidelines, prior cases, literature)
+shared_decision_making: optional, boolean (whether the patient or family participated in the decision)
+phi_tagged: required, boolean, defaults true
+```
+
+## phi-tagged-doc
+
+Any document containing PHI. Drives the firewall in `decision-audit/phi-handling.md`.
+
+```yaml
+type: phi-tagged-doc
+doc_id: required, unique within tenant
+patient_internal_id: optional, FK to patient identity store (omit only for de-identified docs)
+encounter_id: optional, FK to encounter
+title: required
+phi_identifiers_present: required, list of integers 1 through 18 (the HIPAA identifier catalog)
+created_date: required, ISO 8601 datetime with timezone
+created_by: required, person reference
+source_system: required
+storage_location: required, FK to connector storage path
+sensitive: required, boolean
+de_identification_status: required, one of [identified, limited-data-set, safe-harbor-deidentified, expert-determination-deidentified]
+external_share_blocked: required, boolean, defaults true
+```
+
+## baa-counterparty
+
+A business associate (or subcontractor of a business associate) bound by a BAA. Drives the BAA-execution status check.
+
+```yaml
+type: baa-counterparty
+counterparty_id: required, unique within tenant
+legal_name: required
+counterparty_type: required, one of [business-associate, subcontractor, hybrid-entity, other]
+ba_role: required, plain text describing the BA function (claims processing, IT services, transcription, etc.)
+baa_executed_date: required, ISO 8601 date
+baa_effective_date: required, ISO 8601 date
+baa_termination_date: optional, ISO 8601 date
+baa_doc_id: required, FK to phi-tagged-doc (the executed BAA)
+phi_categories_disclosed: required, list of strings (treatment, payment, operations, research, marketing, other)
+breach_notification_window_days: required, integer (defaults 60 per HIPAA, may be tighter per BAA)
+status: required, one of [active, terminated, suspended]
+```
+
+## retention-policy
+
+A retention rule.
+
+```yaml
+type: retention-policy
+policy_id: required, unique within tenant
+applies_to_category: required
+applies_to_state: optional, list of US state codes
+retention_trigger: required, one of [creation, last-touch, encounter-close, patient-deceased, age-of-majority, statutory-event]
+retention_period_days: required, integer (or symbolic identifier for "until age 18 plus N")
+basis: required, citation
+overrides_default: required, boolean
+created_date: required, ISO 8601 date
+```
+
+## hipaa-incident
+
+A HIPAA security or privacy incident. Tracked from detection through closure.
+
+```yaml
+type: hipaa-incident
+incident_id: required, unique within tenant
+incident_type: required, one of [unauthorized-access, unauthorized-disclosure, lost-device, malware, phishing, insider-misuse, vendor-incident, other]
+detection_date: required, ISO 8601 datetime with timezone
+detected_by: required, person reference
+description: required, plain text
+patients_affected_estimate: optional, integer
+investigation_status: required, one of [open, in-progress, closed-no-breach, closed-breach-confirmed, closed-other]
+investigation_lead: required, person reference (privacy or security officer)
+closure_date: optional, ISO 8601 date
+closure_disposition: optional, plain text
+breach_notification_id: optional, FK to breach-notification record (when the incident is determined to be a breach)
+```
+
+## breach-notification
+
+A breach notification under the HIPAA Breach Notification Rule.
+
+```yaml
+type: breach-notification
+notification_id: required, unique within tenant
+incident_id: required, FK to hipaa-incident
+breach_determination_date: required, ISO 8601 date
+patients_affected_count: required, integer
+phi_categories_breached: required, list of integers 1 through 18
+risk_assessment_doc_id: required, FK to phi-tagged-doc
+notification_to_individuals_date: optional, ISO 8601 date (required within 60 days of discovery)
+notification_to_hhs_date: optional, ISO 8601 date
+notification_to_media_required: required, boolean (true when 500+ residents of a state are affected)
+notification_to_media_date: optional, ISO 8601 date
+ocr_breach_report_id: optional, the HHS OCR submission identifier
+state_notifications_required: required, list of US state codes
+state_notifications_completed: optional, list of US state codes with dates
+```
+
+## Schema enforcement
+
+The substrate enforces required fields at write time. Documents missing required fields are rejected with recoverable errors. The PHI fields (`phi_tagged`, `phi_identifiers_present`, `external_share_blocked`) are load-bearing for the firewall in `decision-audit/phi-handling.md`; do not weaken them locally.
+
+The patient identity store is a separate component (not in this schema). Patient internal IDs in this schema are pointers; the actual identifier mapping (MRN, SSN partial, DOB) lives in a tightly-controlled identity service that the substrate does not directly query for ad-hoc operations.


### PR DESCRIPTION
## Summary

- v1.3.0 advertised "vertical-healthcare completion" but only landed 4 of the 9 files. Without `README.md` and `SKILL.md`, skill discovery did not register the pack at all, so `/vertical-healthcare init` was inert.
- This patch lands the 5 missing files so the pack is functionally installable end-to-end: README, SKILL, Epic + Cerner FHIR connectors, and the typed-memory schema.
- Version bumped to 1.3.1 in `plugin.json` + `marketplace.json`. CHANGELOG + RELEASES entries explain what v1.3.0 did and did not actually ship.

## Test plan

- [x] Personal-data scrub on all 5 new files (zero matches on `\bAdelaida\b|\bOnde\b|\bDiaz.Roa\b|\bBogot[aá]\b|\bSergio Perez\b|\bNatalia\b|\bPaola\b|\bAccenture\b|\bShark Tank\b|\bDiana\b|\bBeverly\b|\bSilvia\b|\bColombia\b|adelaida@|tech@onde|🚀 Onde Team`)
- [x] Em-dash scrub on all 5 new files (one violation in SKILL.md fixed before commit, all others clean)
- [x] Lint workflow green pre-merge (CI auto-runs)
- [ ] Sanity: clone fresh, `/vertical-healthcare init` registers + stages drafts (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)