### PR TITLE
ci: PR-scoped privacy scan greps added lines only

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -146,7 +146,7 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref }}
         run: git fetch origin "$BASE_REF" --depth=50
-      - name: scan changed files
+      - name: scan added lines only
         env:
           BASE_REF: ${{ github.base_ref }}
         run: |
@@ -164,7 +164,15 @@ jobs:
               *.md|*.sh|*.ps1|*.py|*.json|*.yml|*.yaml|*.txt|.env.example) ;;
               *) continue ;;
             esac
-            if matches=$(grep -nE "$P" "$f" 2>/dev/null); then
+            # Scan ONLY lines this PR adds (diff lines starting with `+`,
+            # excluding the `+++ b/path` file header). Pre-existing committed
+            # content is intentionally ignored: CI gates net-new private-context
+            # additions, not legacy text in files this PR happens to touch.
+            added_lines=$(git diff "$BASE"..HEAD -- "$f" | grep -E '^\+' | grep -vE '^\+\+\+' || true)
+            if [ -z "$added_lines" ]; then
+              continue
+            fi
+            if matches=$(echo "$added_lines" | grep -nE "$P" 2>/dev/null); then
               echo "::error file=$f::private-context token added in this PR"
               echo "$matches" | head -3 | sed 's|^|  |'
               fail=1
@@ -174,7 +182,7 @@ jobs:
             echo "::error::Private-context scan failed. Use placeholders or fictional names instead."
             exit 1
           fi
-          echo "Private-context scan passed (changed files only)."
+          echo "Private-context scan passed (added lines only)."
 
   references:
     name: phase docs reference real repo files


### PR DESCRIPTION
## Summary

- The 'private-context tokens (PR-scoped)' check was selecting changed FILES correctly but then greping each file's full content. Pre-existing committed text (maintainer name in plugin.json, older CHANGELOG entries about features intentionally shipped public) failed every PR that touched those files.
- Fix: grep only the lines this PR adds (diff lines starting with '+', excluding the '+++ b/path' file header).
- Step renamed and final success message updated to match the actual scope.

## Why this matters

Without this fix, any PR that touches plugin.json, marketplace.json, or CHANGELOG.md fails the privacy check on legacy maintainer-attribution + intentional-feature text. PR adelaidasofia/ai-brain-starter#20 hit this; PR #21 worked around it by dropping the version bump + CHANGELOG entry from scope. With this fix, the version-bump + docs PR can ship cleanly.

## Test plan

- [x] Regex pattern unchanged: real net-new violations still get flagged
- [ ] Smoke: this PR itself touches lint.yml only — should pass the PR-scoped check (no private-context tokens in the diff)
- [ ] Follow-up: re-stage v1.3.1 version bump + CHANGELOG/RELEASES entries in a separate PR after this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)