### PR TITLE
chore(v1.3.1): version bump + CHANGELOG/RELEASES

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "ai-brain-starter",
       "source": "./",
       "description": "The operating system for Claude Code. Memory, accountability, journaling, knowledge graphs, pattern recognition, and first-principles analysis — one install, every session compounds.",
-      "version": "1.3.0"
+      "version": "1.3.1"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-brain-starter",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Set up or upgrade an AI-powered Obsidian vault with journaling, knowledge graphs, pattern recognition, and meeting workflows. Includes skills for daily journaling, weekly insights, graphify knowledge graphs, humanizer, and more.",
   "author": {
     "name": "Adelaida Diaz-Roa",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,23 @@ description: What's new in AI Brain Starter — plain English, no jargon
 
 ---
 
+## 2026-05-09: v1.3.1 vertical-healthcare actually-complete + CI privacy scanner fix
+
+**Who this affects:** anyone who installed v1.3.0 expecting `/vertical-healthcare init` to register and stage drafts.
+
+**The shape:** v1.3.0 advertised "vertical-healthcare completion" and committed the four files that release described as missing (retention, both decision-audit patterns, the third connector). But the original five files from the v1.2.0 partial scaffold were never staged either. Without README and SKILL, skill discovery did not register the pack at all, so the v1.3.0 promise was vacuous on disk. v1.3.1 lands the five missing files so the pack is functionally installable.
+
+### Two changes
+
+1. **`skills/vertical-healthcare/` is now installable.** Five files added: README, SKILL, the Epic and Cerner FHIR connectors, and `schema/typed-memory-categories.md`. Combined with the four files already on main since v1.3.0 (retention defaults, PHI-handling firewall, clinical-decision evidence chain, Salesforce Health Cloud connector), the pack covers all four substrate extension surfaces (typed-memory schema, retention defaults, connector configs, decision-audit patterns).
+2. **CI privacy scanner now scans only added lines, not whole files.** The `private-context tokens (PR-scoped)` check was selecting changed FILES correctly but then greping each file's full content. Pre-existing committed text (maintainer-attribution in plugin.json's author block, older CHANGELOG entries about features intentionally shipped public) failed every PR that touched those files. Fix: grep only the lines this PR adds (diff lines starting with `+`, excluding the `+++ b/path` file header). Net-new private-context additions still fail; legacy text is now correctly ignored.
+
+### What you might want to do
+
+If you tried `/vertical-healthcare init` on v1.3.0 and got nothing, run `git pull` to v1.3.1 and try again. If you are on a clean install or are not in the healthcare vertical, no action needed.
+
+---
+
 ## 2026-05-08: Scheduled-task naming convention + `/diagnose` lint check
 
 **Who this affects:** anyone who has scheduled tasks under `~/.claude/scheduled-tasks/`.

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -11,6 +11,14 @@ For full development history including internal refactors and bug fixes, see [`C
 
 ---
 
+## 2026-05-09 — v1.3.1: vertical-healthcare actually-complete
+
+v1.3.0 advertised "vertical-healthcare completion" but only landed 4 of the 9 files the pack needs. Without `README.md` and `SKILL.md`, skill discovery did not register the pack, so `/vertical-healthcare init` was inert. v1.3.1 lands the 5 missing files: README, SKILL, the Epic and Cerner FHIR connectors, and the typed-memory schema. The pack is now functionally installable.
+
+If you tried `/vertical-healthcare init` on v1.3.0 and got nothing, `git pull` to v1.3.1 and try again. Clean install, no action needed.
+
+---
+
 ## 2026-05-06 — vertical-healthcare completion + skill-overrides recipe
 
 The healthcare vertical pack is now complete. Three layers shipped that match what the pack's description has promised since launch:


### PR DESCRIPTION
## Summary

- Version bumped to 1.3.1 in `plugin.json` and `marketplace.json` to match the vertical-healthcare-actually-complete patch shipped via PR #21.
- CHANGELOG and RELEASES entries cover both v1.3.1 changes: the 5 missing healthcare pack files (PR #21) and the CI privacy scanner diff-only fix (PR #22).

## Why this is a separate PR

PR #21 deferred this version bump because the pre-fix CI scanner was greping whole files for pre-existing maintainer-attribution and historical CHANGELOG content. PR #22 fixed that. With the scanner now scoped to added lines only, this PR ships cleanly.

## Test plan

- [x] Lint workflow + private-context PR-scoped scan green pre-merge (PR's added lines have no private-context tokens)
- [ ] Post-merge: `git pull` on a fresh install, confirm `~/.claude/plugins/marketplaces/.../ai-brain-starter/.claude-plugin/plugin.json` reads 1.3.1
- [ ] Post-merge: tag `v1.3.1` on main once the release workflow is set up

🤖 Generated with [Claude Code](https://claude.com/claude-code)