### PR TITLE
feat(install): inline email path — ask once in chat, no browser, no token paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,31 +65,29 @@ Read the four problems the team version solves: [`for-teams/why-teams-are-differ
 
 ## Install
 
-### Step 1 — Get your install link
+### Step 1 — Open Claude Code
 
-Go to **[myceliumai.co/install](https://myceliumai.co/install)** (Spanish: **[myceliumai.co/es/install](https://myceliumai.co/es/install)**) and fill out the short form. Takes about 4 minutes.
+Open the [Claude Code desktop app](https://claude.ai/download) and sign in with a paid Claude account (Pro, Max, or Team).
 
-The form personalizes your install (so the system knows your role, your data, and which language to run in) and emails you a one-paste install command with your unique token. The same form is the path for paid cohorts, paid private installs, complimentary partner cohorts, and free open-source explorers.
+### Step 2 — Say "install ai-brain-starter"
 
-### Step 2 — Open Claude Code
+Paste this one-liner into the chat:
 
-Open the [Claude Code desktop app](https://claude.ai/download) and sign in with a paid Claude account (Pro, Max, or Team). The bootstrap installs everything else (Homebrew, Python, Node, Obsidian, all skills) for you.
+```
+Install ai-brain-starter for me. Use the in-chat install path: ask me my email and name once, then run bootstrap. Don't send me to a browser or have me copy a token from email.
+```
 
-### Step 3 — Paste the install command from your email
+Claude asks two questions: *"What's your email?"* and *"What name should I use?"* That's it. Bootstrap mints your token over the API, installs everything (Homebrew, Python, Node, Obsidian, all skills, all MCPs), and runs the setup interview in your chosen language. No browser tab, no terminal copy-paste, no token to fish out of your inbox.
 
-Your welcome email contains a personalized command with your token embedded. Paste it into Claude Code and approve the tool calls. Claude runs:
+**If pre-flight fails**, Claude reads the structured report and explains in plain English what to fix. Most common blockers: Claude Code not installed, a corporate VPN blocking GitHub, or a Mac that's not in the admin group.
 
-1. A 30-second pre-flight check (OS, network, Claude Code install, admin permissions, disk).
-2. The token-gated bootstrap (clones the skill, installs all tools).
-3. The setup interview (asks your language first, runs everything in your chosen language).
+**Existing users** (re-running bootstrap, e.g. after a `git pull`): the email-gate marker on disk means you skip the question entirely. Bootstrap just runs.
 
-One paste, no terminal commands to type. Mac, Windows, and Linux all use the same flow.
+*Local install. Your vault data never leaves your machine. The signup is the only piece that touches our servers, and it captures only what's listed in [`SECURITY.md`](SECURITY.md) and the [privacy policy](https://myceliumai.co/privacy).*
 
-**If pre-flight fails**, Claude reads the structured report and explains in plain English what to fix. The most common blockers are: Claude Code not installed (download from https://claude.ai/download), a corporate VPN blocking GitHub, or a Mac that's not in the admin group.
+### Alternative — Browser form (only if you can't open Claude Code yet)
 
-**Existing users** (anyone who installed before the email gate was live): your next bootstrap re-run will prompt you once to fill the same form. After that, you're never asked again.
-
-*Local install. Your vault data never leaves your machine. The signup form is the only piece that touches our servers, and it captures only what's listed in [`SECURITY.md`](SECURITY.md) and the [privacy policy](https://myceliumai.co/privacy).*
+If you'd rather sign up before installing Claude Code, use the form at **[myceliumai.co/install](https://myceliumai.co/install)** (Spanish: **[myceliumai.co/es/install](https://myceliumai.co/es/install)**). It emails you a one-paste install command with a token embedded. This path exists for paid cohorts, partner cohorts, and anyone who wants to read the privacy details before installing.
 
 ### Quick-try (existing Claude Code users)
 
@@ -105,27 +103,27 @@ This loads the plugin **for the current session only**, giving you the skills (j
 
 ## Instalar (Español)
 
-### Paso 1 — Conseguí tu link de instalación
+### Paso 1 — Abrí Claude Code
 
-Andá a **[myceliumai.co/es/install](https://myceliumai.co/es/install)** (English: **[myceliumai.co/install](https://myceliumai.co/install)**) y completá el formulario corto. Tarda unos 4 minutos.
+Abrí la [app de escritorio de Claude Code](https://claude.ai/download) y logueate con una cuenta paga de Claude (Pro, Max o Team).
 
-El formulario personaliza tu instalación (para que el sistema sepa tu rol, tus datos, y en qué idioma correr) y te manda por email un comando de un solo pegado con tu token único. El mismo formulario es la ruta para cohortes pagas, instalaciones privadas pagas, cohortes complementarias de partners, y exploradores open-source.
+### Paso 2 — Decí "instalá ai-brain-starter"
 
-### Paso 2 — Abrí Claude Code
+Pegá este one-liner en el chat:
 
-Abrí la [app de escritorio de Claude Code](https://claude.ai/download) y logueate con una cuenta paga de Claude (Pro, Max o Team). El bootstrap instala todo lo demás (Homebrew, Python, Node, Obsidian, todas las skills) por vos.
+```
+Instalá ai-brain-starter para mí. Usá la ruta in-chat: preguntame mi email y nombre una vez, después corré el bootstrap. No me mandes al navegador ni me hagas copiar un token del email.
+```
 
-### Paso 3 — Pegá el comando de instalación de tu email
+Claude te hace dos preguntas: *"¿Cuál es tu email?"* y *"¿Qué nombre uso?"*. Eso es todo. El bootstrap genera tu token vía la API, instala todo (Homebrew, Python, Node, Obsidian, todas las skills, todos los MCPs), y corre la entrevista de setup en el idioma que elijas. Sin pestaña del navegador, sin copiar y pegar en la terminal, sin pescar un token del inbox.
 
-Tu email de bienvenida contiene un comando personalizado con tu token. Pegalo en Claude Code y aprobá las acciones. Claude va a correr:
+**Si la verificación previa falla**, Claude lee el reporte estructurado y te explica en idioma claro qué arreglar. Lo más común: Claude Code no instalado, una VPN corporativa bloqueando GitHub, o una Mac fuera del grupo admin.
 
-1. Una verificación previa de 30 segundos (OS, red, instalación de Claude Code, permisos de admin, disco).
-2. El bootstrap con token (clona la skill, instala todas las herramientas).
-3. La entrevista de setup (te pregunta el idioma primero, corre todo en el idioma que elijas).
+**Usuarios existentes** (re-corriendo el bootstrap, por ejemplo después de un `git pull`): el marker del email-gate en disco hace que saltees la pregunta. El bootstrap corre directo.
 
-Un pegado, cero comandos que tipear. Mac, Windows y Linux usan el mismo flujo.
+### Alternativa — Formulario web (sólo si todavía no podés abrir Claude Code)
 
-**Usuarios existentes** (cualquiera que instaló antes de que el gate de email estuviera vivo): la próxima vez que corras el bootstrap te va a pedir una sola vez que completes el mismo formulario. Después, nunca más.
+Si preferís registrarte antes de instalar Claude Code, usá el formulario en **[myceliumai.co/es/install](https://myceliumai.co/es/install)** (English: **[myceliumai.co/install](https://myceliumai.co/install)**). Te manda por email un comando de un pegado con el token incrustado. Esta ruta existe para cohortes pagas, cohortes de partners, y cualquiera que quiera leer la privacidad antes de instalar.
 
 ---
 

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -80,30 +80,77 @@ $installApiBase = if ($env:MYCELIUM_INSTALL_API) { $env:MYCELIUM_INSTALL_API } e
 
 if ($env:EMAIL_GATE_BYPASS -ne "1" -and -not $DryRun -and -not (Test-Path $emailMarker)) {
     Hdr (T "Email gate (one-time)" "Verificación de email (una sola vez)")
+
+    # Inline path: EMAIL+NAME passed as env vars (typically by Claude Code
+    # after asking the user inline). POST to quick-mint to get a token
+    # without making the user leave the chat.
+    if (-not $env:TOKEN -and $env:EMAIL -and $env:NAME) {
+        $qmLang = if ($env:LANG_HINT) { $env:LANG_HINT } else { "en" }
+        if ($qmLang -ne "en" -and $qmLang -ne "es") { $qmLang = "en" }
+        $qmOs = "windows"
+        Log (T "Minting install token for $($env:EMAIL) via $installApiBase..." `
+              "Generando token para $($env:EMAIL) en $installApiBase...")
+        try {
+            $qmBody = @{
+                email = $env:EMAIL
+                name = $env:NAME
+                lang = $qmLang
+                os = $qmOs
+                consentRequired = $true
+            } | ConvertTo-Json -Compress
+            $qmResp = Invoke-RestMethod -Uri "$installApiBase/api/install/quick-mint" `
+                -Method Post -ContentType "application/json" -Body $qmBody -TimeoutSec 12 -ErrorAction Stop
+            if ($qmResp.ok -and $qmResp.token -match '^[a-f0-9]{32}$') {
+                Ok (T "Token minted inline. No browser needed." `
+                      "Token generado en línea. Sin navegador.")
+                $env:TOKEN = $qmResp.token
+            } else {
+                Err (T "Inline mint returned no token. Falling back." `
+                      "Mint inline no devolvió token. Caemos al formulario.")
+            }
+        } catch {
+            Err (T "Inline mint failed: $_. Falling back." `
+                  "Falló mint inline: $_. Caemos al formulario.")
+        }
+    }
+
     if (-not $env:TOKEN) {
+        if ($env:CLAUDE_CODE_ENTRYPOINT) {
+            Write-Host ""
+            Write-Host "[ai-brain-starter:NEEDS_EMAIL]"
+            Write-Host ""
+            Write-Host (T "Bootstrap needs an email before installing. To keep this in-chat:" `
+                         "El bootstrap necesita un email antes de instalar. Para mantenerlo en chat:")
+            Write-Host ""
+            Write-Host (T "1. Ask the user: 'What's your email?' and 'What name should I use?' Optional: language (en/es)." `
+                         "1. Preguntale: '¿Cuál es tu email?' y '¿Qué nombre uso?' Opcional: idioma (en/es).")
+            Write-Host (T "2. Re-invoke this script with those values pre-set:" `
+                         "2. Volvé a correr este script con esos valores ya cargados:")
+            Write-Host ""
+            Write-Host '   $env:EMAIL="user@example.com"; $env:NAME="Their Name"; $env:LANG_HINT="en"; & "$env:USERPROFILE\.claude\skills\ai-brain-starter\bootstrap.ps1"'
+            Write-Host ""
+            Write-Host (T "Bootstrap will POST to /api/install/quick-mint, get a token, and continue. The user never leaves Claude Code." `
+                         "El bootstrap llama a /api/install/quick-mint, obtiene el token y continúa. El usuario nunca sale de Claude Code.")
+            Write-Host ""
+            exit 3
+        }
+
         Write-Host ""
         Write-Host ("  " + (T "We need your email before installing the second brain." `
                               "Necesitamos tu email antes de instalar el segundo cerebro."))
         Write-Host ""
-        Write-Host ("  " + (T "This is a one-time gate. Once you submit the form, you get a token by" `
-                              "Esto es una sola vez. Una vez completes el formulario, recibís un token"))
-        Write-Host ("  " + (T "email; future re-runs skip this prompt." `
-                              "por email; las próximas corridas saltean este paso."))
+        Write-Host ("  " + (T "Easiest path: open Claude Code and say 'install ai-brain-starter'." `
+                              "Camino más fácil: abrí Claude Code y decí 'instalá ai-brain-starter'."))
+        Write-Host ("  " + (T "It asks for your email in chat and handles the rest. No browser." `
+                              "Te pide el email en el chat y se encarga del resto. Sin navegador."))
         Write-Host ""
+        Write-Host ("  " + (T "Or, if you'd rather use the form:" "O, si preferís el formulario:"))
         Write-Host ("  1. " + (T "Open this URL in your browser:" "Abrí este URL en tu navegador:"))
         Write-Host "     https://myceliumai.co/install"
         Write-Host ("     (" + (T "Spanish:" "Español:") + " https://myceliumai.co/es/install)")
         Write-Host ""
-        Write-Host ("  2. " + (T "Fill out the short form. Takes about 4 minutes." `
-                              "Completá el formulario corto. Tarda unos 4 minutos."))
-        Write-Host ""
-        Write-Host ("  3. " + (T "Check your email. You'll receive your personalized install command." `
-                              "Revisá tu email. Vas a recibir tu comando de instalación personalizado."))
-        Write-Host ""
-        Write-Host ("  4. " + (T "Either paste that full command into Claude Code (recommended)," `
-                              "Pegá ese comando completo en Claude Code (recomendado),"))
-        Write-Host ("     " + (T "OR re-run this script with the token:" `
-                              "O volvé a correr este script con el token:"))
+        Write-Host ("  2. " + (T "Check your email for the install command and paste it back into PowerShell." `
+                              "Revisá tu email para el comando y pegalo en PowerShell."))
         Write-Host ""
         Write-Host '         $env:TOKEN = "<your-token-from-email>"; pwsh bootstrap.ps1'
         Write-Host ""

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -263,31 +263,102 @@ INSTALL_API_BASE="${MYCELIUM_INSTALL_API:-https://myceliumai.co}"
 
 if [[ "${EMAIL_GATE_BYPASS:-0}" != "1" && $DRY_RUN -eq 0 && ! -f "$EMAIL_MARKER" ]]; then
   hdr "$(t "Email gate (one-time)" "Verificación de email (una sola vez)")"
+
+  # Inline path: EMAIL+NAME provided as env vars (typically by Claude Code
+  # after asking the user inline). POST to quick-mint to get a token without
+  # the user ever leaving the chat.
+  if [[ -z "${TOKEN:-}" && -n "${EMAIL:-}" && -n "${NAME:-}" ]]; then
+    QM_LANG="${LANG_HINT:-en}"
+    [[ "$QM_LANG" != "en" && "$QM_LANG" != "es" ]] && QM_LANG="en"
+    QM_OS="mac-arm"
+    case "$(uname -sm 2>/dev/null)" in
+      Darwin*arm64*) QM_OS="mac-arm" ;;
+      Darwin*x86_64*) QM_OS="mac-intel" ;;
+      Linux*) QM_OS="linux" ;;
+    esac
+    log "$(t "Minting install token for $EMAIL via $INSTALL_API_BASE..." \
+            "Generando token de instalación para $EMAIL en $INSTALL_API_BASE...")"
+    QM_PAYLOAD="$(EMAIL="$EMAIL" NAME="$NAME" QM_LANG="$QM_LANG" QM_OS="$QM_OS" python3 <<'PY'
+import json, os
+print(json.dumps({
+  "email": os.environ.get("EMAIL",""),
+  "name": os.environ.get("NAME",""),
+  "lang": os.environ.get("QM_LANG","en"),
+  "os": os.environ.get("QM_OS","mac-arm"),
+  "consentRequired": True,
+}))
+PY
+)"
+    set +e
+    QM_RESP="$(curl -sS -m 12 -X POST "$INSTALL_API_BASE/api/install/quick-mint" \
+      -H "content-type: application/json" \
+      -d "$QM_PAYLOAD" 2>/dev/null)"
+    set -e
+    QM_TOKEN="$(printf '%s' "${QM_RESP:-}" | python3 <<'PY' 2>/dev/null
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    print(d.get("token","") if d.get("ok") else "")
+except Exception:
+    print("")
+PY
+)"
+    if [[ -z "$QM_TOKEN" || ! "$QM_TOKEN" =~ ^[a-f0-9]{32}$ ]]; then
+      err "$(t "Inline mint failed. Falling back to form." \
+              "Falló la generación inline. Caemos al formulario.")"
+    else
+      ok "$(t "Token minted inline. No browser needed." \
+              "Token generado en línea. Sin navegador.")"
+      TOKEN="$QM_TOKEN"
+    fi
+  fi
+
   if [[ -z "${TOKEN:-}" ]]; then
-    # No token. Print the form URL + how to re-run with the token.
+    # No token, no inline EMAIL+NAME. Two paths:
+    #   (a) Inside Claude Code → emit a sentinel telling Claude to collect
+    #       email + name inline and re-run with EMAIL= NAME= LANG= preset.
+    #   (b) Standalone shell → print the form URL fallback.
+    if [[ -n "${CLAUDE_CODE_ENTRYPOINT:-}" ]]; then
+      cat <<EOF
+
+[ai-brain-starter:NEEDS_EMAIL]
+
+$(t "Bootstrap needs an email before installing. To keep this in-chat (no browser, no terminal copy-paste):" \
+    "El bootstrap necesita un email antes de instalar. Para mantenerlo en chat (sin navegador, sin copiar y pegar):")
+
+$(t "1. Ask the user: 'What's your email?' and 'What name should I use?' Optional: language preference (en/es)." \
+    "1. Preguntale al usuario: '¿Cuál es tu email?' y '¿Qué nombre uso?' Opcional: idioma (en/es).")
+$(t "2. Re-invoke this script with those values pre-set:" \
+    "2. Volvé a correr este script con esos valores ya cargados:")
+
+   EMAIL="user@example.com" NAME="Their Name" LANG_HINT="en" bash $0
+
+$(t "Bootstrap will POST to /api/install/quick-mint, get a token, write the marker, and continue installing. The user never leaves Claude Code." \
+    "El bootstrap llama a /api/install/quick-mint, obtiene el token, escribe el marker y continúa. El usuario nunca sale de Claude Code.")
+
+EOF
+      exit 3
+    fi
+
+    # Standalone terminal fallback (curl-to-bash from a plain shell).
     cat <<EOF
 
   $(t "We need your email before installing the second brain." \
         "Necesitamos tu email antes de instalar el segundo cerebro.")
 
-  $(t "This is a one-time gate. Once you submit the form, you get a token by" \
-        "Esto es una sola vez. Una vez completes el formulario, recibís un token")
-  $(t "email; future re-runs skip this prompt." \
-        "por email; las próximas corridas saltean este paso.")
+  $(t "Easiest path: open Claude Code and say 'install ai-brain-starter'. It" \
+        "Camino más fácil: abrí Claude Code y decí 'instalá ai-brain-starter'.")
+  $(t "will ask for your email in chat and handle the rest. No browser." \
+        "Te pide el email en el chat y se encarga del resto. Sin navegador.")
+
+  $(t "Or, if you'd rather use the form:" "O, si preferís el formulario:")
 
   1. $(t "Open this URL in your browser:" "Abrí este URL en tu navegador:")
      https://myceliumai.co/install
      ($(t "Spanish:" "Español:") https://myceliumai.co/es/install)
 
-  2. $(t "Fill out the short form. Takes about 4 minutes." \
-          "Completá el formulario corto. Tarda unos 4 minutos.")
-
-  3. $(t "Check your email. You'll receive your personalized install command." \
-          "Revisá tu email. Vas a recibir tu comando de instalación personalizado.")
-
-  4. $(t "Either paste that full command into Claude Code (recommended)," \
-          "Pegá ese comando completo en Claude Code (recomendado),")
-     $(t "OR re-run this script with the token:" "O volvé a correr este script con el token:")
+  2. $(t "Check your email for the install command and paste it back into a shell." \
+          "Revisá tu email para el comando y pegalo en una terminal.")
 
          TOKEN=<your-token-from-email> bash $0
 

--- a/phases/phase-00-install.md
+++ b/phases/phase-00-install.md
@@ -16,11 +16,47 @@ As bootstrap prints its own check-mark lines per tool, you don't need to narrate
 
 ---
 
-### Step 0.1. Invoke the bootstrap
+### Step 0.1a. Email — ask once, in chat (skip if marker already on disk)
+
+Before invoking bootstrap, check whether the email gate is already satisfied:
+
+```bash
+test -f "$HOME/.claude/.ai-brain-starter-email-on-file" && echo on-file || echo missing
+```
+
+**If `on-file`**, skip ahead to Step 0.1b. Bootstrap will pass through silently.
+
+**If `missing`**, ask the user — once, in chat — exactly these two questions, in their detected language:
+
+> "What's your email? (Used once to send you a heads-up if anything changes; never spammed.)"
+>
+> "And what should I call you?"
+
+Optional: if you don't already know their language preference, ask "English or Spanish?" — default to whatever they've been speaking. Do NOT ask role / company / intent here; Phase 1 covers that.
+
+Once you have email + name (+ optional lang), invoke bootstrap with those pre-set so it mints the token inline via the API (no browser, no email round-trip, no terminal copy-paste):
+
+```bash
+EMAIL="user@example.com" NAME="Their Name" LANG_HINT="en" bash "$HOME/.claude/skills/ai-brain-starter/bootstrap.sh"
+```
+
+```powershell
+$env:EMAIL="user@example.com"; $env:NAME="Their Name"; $env:LANG_HINT="en"; & "$env:USERPROFILE\.claude\skills\ai-brain-starter\bootstrap.ps1"
+```
+
+Bootstrap POSTs to `/api/install/quick-mint`, gets a token, writes the marker, and continues. The user never leaves Claude Code.
+
+**If bootstrap prints `[ai-brain-starter:NEEDS_EMAIL]`** (no email was provided and no marker exists), that's the script telling you to do exactly the above. Re-invoke with `EMAIL=` `NAME=` set.
+
+**Never** send the user to `myceliumai.co/install` and tell them to copy a token from their inbox. That flow exists only as a fallback for users who run bootstrap from a plain shell outside Claude Code.
+
+---
+
+### Step 0.1b. Invoke the bootstrap
 
 By the time `/setup-brain` fires, the ai-brain-starter skill folder already exists at `~/.claude/skills/ai-brain-starter/` (that's how Claude Code found this phase file). So the bootstrap is always a local invocation, never a fresh curl. It is idempotent: safe on fresh machines and on re-runs. It skips anything already installed.
 
-Detect platform with `uname -s` (Mac/Linux) or `$PSVersionTable` (Windows), then run the matching bootstrap:
+Detect platform with `uname -s` (Mac/Linux) or `$PSVersionTable` (Windows), then run the matching bootstrap (with `EMAIL=` `NAME=` pre-set per Step 0.1a if the marker was missing):
 
 #### Mac / Linux
 


### PR DESCRIPTION
## Summary

The previous install flow sent users to a 4-minute browser form, made them check email, copy a 32-character token, and paste it into Claude Code. Non-tech users (the explicit target audience) abandoned at every step.

This wires up the in-chat path the server already supported via `/api/install/quick-mint`:

- **`bootstrap.sh` + `bootstrap.ps1`**: accept `EMAIL=`, `NAME=`, `LANG_HINT=` env vars. When set, POST to quick-mint, get a token back, write the marker, continue installing. Zero browser interaction.
- **Sentinel for Claude**: when run inside Claude Code with no email + no marker, bootstrap exits with `[ai-brain-starter:NEEDS_EMAIL]` so Claude knows to ask the user inline and re-invoke.
- **`phases/phase-00-install.md`** (Step 0.1a): explicit instruction to ask email + name once, never send the user to the form URL.
- **`README.md`**: install steps rewritten. Paste a one-liner into Claude Code, answer two questions, done. Browser form moved to "alternative path."

## What didn't change

- Server-side `/api/install/quick-mint` endpoint (already shipped, just unused by bootstrap).
- Existing users with the email marker on disk: gate short-circuits as before. `git pull` + re-run is unchanged for them.
- Form fallback for users running bootstrap from a plain shell (no `CLAUDE_CODE_ENTRYPOINT`): still works, just deprioritized.

## Test plan
- [ ] `bash bootstrap.sh` from a shell with `CLAUDE_CODE_ENTRYPOINT=cli`, no marker, no token: prints `[ai-brain-starter:NEEDS_EMAIL]` sentinel and exits 3
- [ ] `EMAIL=test@example.com NAME=Test LANG_HINT=en bash bootstrap.sh`: hits quick-mint, gets a token, writes marker, proceeds (or errors with a clear message if the API is unreachable)
- [ ] `pwsh bootstrap.ps1` parity on Windows: same two paths
- [ ] Existing user with `~/.claude/.ai-brain-starter-email-on-file`: gate skips silently
- [ ] No personal data leakage in diff (manual scrub passed)