### PR TITLE
feat: message-channel extractors + healthcare vertical completion

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "ai-brain-starter",
       "source": "./",
       "description": "The operating system for Claude Code. Memory, accountability, journaling, knowledge graphs, pattern recognition, and first-principles analysis — one install, every session compounds.",
-      "version": "1.3.0"
+      "version": "1.3.1"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-brain-starter",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Set up or upgrade an AI-powered Obsidian vault with journaling, knowledge graphs, pattern recognition, and meeting workflows. Includes skills for daily journaling, weekly insights, graphify knowledge graphs, humanizer, and more.",
   "author": {
     "name": "Adelaida Diaz-Roa",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,26 @@ description: What's new in AI Brain Starter — plain English, no jargon
 
 ---
 
+## 2026-05-09: v1.3.1 vertical-healthcare actually-complete (5 missing files landed)
+
+**Who this affects:** anyone who installed v1.3.0 expecting `/vertical-healthcare init` to work end-to-end.
+
+**The shape:** v1.3.0 advertised "vertical-healthcare completion" and shipped the 4 files the description promised (retention, both decision-audit patterns, Salesforce Health Cloud connector). But the original 5 files from the v1.2.0 partial scaffold (README, SKILL, cerner-fhir, epic-fhir, schema/typed-memory-categories) were never staged. Without README and SKILL, skill discovery did not register the pack at all, so the v1.3.0 promise was vacuous on disk. v1.3.1 lands the 5 files so the pack is functionally installable.
+
+### Files added
+
+- `skills/vertical-healthcare/README.md` — entry point, who-this-is-for, what-is-in-the-box, install + read-first guidance.
+- `skills/vertical-healthcare/SKILL.md` — `name: vertical-healthcare`, `trigger: /vertical-healthcare`, full pack overview with HIPAA + state-add-on framing.
+- `skills/vertical-healthcare/connectors/epic-fhir.md` — Epic via FHIR R4, SMART-on-FHIR auth, resource type coverage.
+- `skills/vertical-healthcare/connectors/cerner-fhir.md` — Oracle Cerner via FHIR R4, SMART-on-FHIR auth, resource type coverage.
+- `skills/vertical-healthcare/schema/typed-memory-categories.md` — 7 typed-memory categories (patient-scoped-fact, clinical-decision, phi-tagged-doc, baa-counterparty, retention-policy, hipaa-incident, breach-notification).
+
+### What you might want to do
+
+If you are on v1.3.0 and tried `/vertical-healthcare init` and got nothing, run `git pull` to v1.3.1 and try again. If you are on a clean install, no action needed.
+
+---
+
 ## 2026-05-08: Scheduled-task naming convention + `/diagnose` lint check
 
 **Who this affects:** anyone who has scheduled tasks under `~/.claude/scheduled-tasks/`.

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -11,6 +11,14 @@ For full development history including internal refactors and bug fixes, see [`C
 
 ---
 
+## 2026-05-09 — v1.3.1: vertical-healthcare actually-complete
+
+v1.3.0 advertised "vertical-healthcare completion" but only landed 4 of the 9 files the pack needs. Without `README.md` and `SKILL.md`, skill discovery did not register the pack, so `/vertical-healthcare init` was inert. v1.3.1 lands the 5 missing files: README, SKILL, the Epic and Cerner FHIR connectors, and the typed-memory schema. The pack is now functionally installable.
+
+If you tried `/vertical-healthcare init` on v1.3.0 and got nothing, `git pull` to v1.3.1 and try again. Clean install, no action needed.
+
+---
+
 ## 2026-05-06 — vertical-healthcare completion + skill-overrides recipe
 
 The healthcare vertical pack is now complete. Three layers shipped that match what the pack's description has promised since launch:

--- a/scripts/extractors/external_input.py
+++ b/scripts/extractors/external_input.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""
+extractors/external_input.py — structured metadata for ingested external inputs.
+
+Type: `external-input` (hyphenated; dispatcher normalizes to `external_input`).
+
+Routes by `source:` frontmatter field. Currently implements: slack.
+Stubs for: notion, github, gmail, linear, whatsapp_ingest.
+
+Each source has its own field prefix (slack_*, notion_*, etc.) so cross-source
+queries work and field names never collide.
+
+File shape (slack example):
+    ---
+    type: external-input
+    source: slack
+    channel: <channel-name>
+    channel_id: <C064...>
+    date_range: <YYYY-MM-DD..YYYY-MM-DD>
+    message_count: <int>
+    ingested_at: <ISO>
+    ---
+    # Slack #<channel> — <date> to <date>
+    ## YYYY-MM-DD HH:MM <Sender Full Name>
+    <message body>
+
+Zero LLM. All fields regex / count / passthrough / arithmetic.
+"""
+import datetime as _dt
+import os
+import re
+from collections import Counter
+
+from _base import (
+    count_words, iso_date_from, wikilinks_in, match_people,
+    ExtractionResult,
+)
+
+# ────────────────────────────────────────────────────────────────────────
+# AUTO_FIELDS: union across all source variants. The dispatcher uses this
+# for idempotency. Each source's extract() function only writes its own
+# subset of fields; missing values are skipped at render time (_base
+# render_fields drops None/empty/[]).
+# ────────────────────────────────────────────────────────────────────────
+AUTO_FIELDS = (
+    # Common across all sources
+    "external_source",
+    "external_dormancy_days",
+    "word_count",
+    # Slack
+    "slack_channel",
+    "slack_channel_id",
+    "slack_workspace",
+    "slack_date_start_iso",
+    "slack_date_end_iso",
+    "slack_message_count",
+    "slack_unique_senders",
+    "slack_top_senders",
+    "slack_my_msg_count",
+    "slack_their_msg_count",
+    "slack_my_share_pct",
+    "slack_channel_mention_count",
+    "slack_link_count",
+    "slack_concepts_extracted",
+    "slack_people_mentioned",
+    "slack_decision_signal",
+)
+
+# Sender names treated as "me" for the my/their split. Reads MY_NAMES env
+# (comma-separated). Defaults to {"You"} which matches WhatsApp + iMessage
+# bridge convention. For Slack: configure MY_NAMES with your real Slack
+# display name(s). Without configuration, Slack `_my_msg_count` will be 0.
+def _my_names_from_env() -> set[str]:
+    raw = os.environ.get("MY_NAMES", "").strip()
+    if not raw:
+        return {"You"}
+    return {n.strip() for n in raw.split(",") if n.strip()}
+
+
+MY_NAMES = _my_names_from_env()
+# Backwards-compat alias for the old name.
+ADELAIDA_NAMES = MY_NAMES
+
+# Decision-stub trigger words (mirror the rule in CLAUDE.md and the WA/iMessage extractors)
+DECISION_KEYWORDS = re.compile(
+    r"(?i)\b(exception|incident|pricing|escalation|outage|edge\s*case|refund)\b"
+)
+
+# Slack message header: "## YYYY-MM-DD HH:MM <Sender Name>"
+SLACK_MSG_HEADER_RE = re.compile(
+    r"^##\s+(\d{4}-\d{2}-\d{2})\s+(\d{1,2}:\d{2})\s+(.+?)\s*$",
+    re.MULTILINE,
+)
+# <!channel> mention
+SLACK_CHANNEL_MENTION_RE = re.compile(r"<!channel>")
+# URL detection
+URL_RE = re.compile(r"https?://\S+")
+
+
+def _dormancy_from_iso(last_iso):
+    if not last_iso:
+        return None
+    try:
+        last = _dt.date.fromisoformat(last_iso)
+        delta = (_dt.date.today() - last).days
+        return delta if delta >= 0 else 0
+    except Exception:
+        return None
+
+
+def _safe_int(v, default=0):
+    if isinstance(v, int):
+        return v
+    if isinstance(v, str) and v.strip().lstrip("-").isdigit():
+        return int(v.strip())
+    return default
+
+
+def _parse_date_range(raw):
+    """Parse 'YYYY-MM-DD..YYYY-MM-DD' to (start_iso, end_iso) or (None, None)."""
+    if not raw:
+        return None, None
+    s = str(raw).strip()
+    parts = s.split("..")
+    if len(parts) != 2:
+        # single date as both start and end
+        only = iso_date_from(s)
+        return only, only
+    return iso_date_from(parts[0]), iso_date_from(parts[1])
+
+
+def _slack_workspace_from_path(filepath):
+    """Detect workspace from path. Returns None if not embedded.
+
+    Two known layouts:
+      - /ingest-slack:    External Inputs/Slack/<channel>/<date>.md     (NO workspace)
+      - slack MCP export: 🤖 AI Chats/Slack/<workspace>/<channel>.md    (workspace at index after Slack)
+
+    Only the AI-Chats pattern carries a workspace. /ingest-slack does not.
+    """
+    parts = filepath.split(os.sep)
+    for i, p in enumerate(parts):
+        if p == "🤖 AI Chats" and i + 2 < len(parts) and parts[i + 1] == "Slack":
+            ws = parts[i + 2]
+            return ws if not ws.endswith(".md") else None
+    return None
+
+
+def _extract_slack(filepath, body, fm, context):
+    crm_names = context.get("crm_names", set())
+
+    channel = (fm.get("channel") or "").strip() or None
+    channel_id = (fm.get("channel_id") or "").strip() or None
+    workspace = _slack_workspace_from_path(filepath)
+
+    start_iso, end_iso = _parse_date_range(fm.get("date_range"))
+    fm_msg_count = _safe_int(fm.get("message_count"), default=0)
+
+    # Scan ## headers for senders
+    senders = []
+    for m in SLACK_MSG_HEADER_RE.finditer(body):
+        senders.append(m.group(3).strip())
+
+    scan_total = len(senders)
+    message_count = fm_msg_count if fm_msg_count > 0 else scan_total
+
+    sender_counts = Counter(senders)
+    unique_senders = len(sender_counts)
+    top_senders = [
+        f"{name} ({cnt})" for name, cnt in sender_counts.most_common(5)
+    ]
+
+    mine = sum(c for n, c in sender_counts.items() if n in MY_NAMES)
+    theirs = scan_total - mine
+    my_share = round(100.0 * mine / scan_total, 1) if scan_total else None
+
+    chan_mentions = len(SLACK_CHANNEL_MENTION_RE.findall(body))
+    link_count = len(URL_RE.findall(body))
+
+    fields = {
+        "external_source": "slack",
+        "external_dormancy_days": _dormancy_from_iso(end_iso),
+        "word_count": count_words(body),
+        "slack_channel": channel,
+        "slack_channel_id": channel_id,
+        "slack_workspace": workspace,
+        "slack_date_start_iso": start_iso,
+        "slack_date_end_iso": end_iso,
+        "slack_message_count": message_count,
+        "slack_unique_senders": unique_senders,
+        "slack_top_senders": top_senders,
+        "slack_my_msg_count": mine,
+        "slack_their_msg_count": theirs,
+        "slack_my_share_pct": my_share,
+        "slack_channel_mention_count": chan_mentions,
+        "slack_link_count": link_count,
+        "slack_concepts_extracted": wikilinks_in(body)[:25],
+        "slack_people_mentioned": match_people(body, crm_names, cap=20),
+        "slack_decision_signal": bool(DECISION_KEYWORDS.search(body)),
+    }
+    return ExtractionResult(fields, AUTO_FIELDS, auto_fields=AUTO_FIELDS)
+
+
+# Future sources (each returns ExtractionResult or None for now).
+def _extract_notion(filepath, body, fm, context):
+    return None
+
+
+def _extract_github(filepath, body, fm, context):
+    return None
+
+
+def _extract_gmail(filepath, body, fm, context):
+    return None
+
+
+def _extract_linear(filepath, body, fm, context):
+    return None
+
+
+def _extract_whatsapp_ingest(filepath, body, fm, context):
+    # /ingest-whatsapp output. Different shape from the bridge's per-contact
+    # files in 🤖 AI Chats/WhatsApp (which use type: whatsapp-chat).
+    return None
+
+
+SOURCE_HANDLERS = {
+    "slack": _extract_slack,
+    "notion": _extract_notion,
+    "github": _extract_github,
+    "gmail": _extract_gmail,
+    "linear": _extract_linear,
+    "whatsapp": _extract_whatsapp_ingest,
+}
+
+
+def extract(filepath, body, fm, context):
+    source = (fm.get("source") or "").strip().lower()
+    handler = SOURCE_HANDLERS.get(source)
+    if handler is None:
+        return None
+    return handler(filepath, body, fm, context)

--- a/scripts/extractors/imessage_chat.py
+++ b/scripts/extractors/imessage_chat.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""
+extractors/imessage_chat.py — structured metadata for iMessage chat exports
+written by the bridge wrapper at ~/.local/bin/imessage-export-vault.sh.
+
+Type: `imessage-chat` (hyphenated in source; dispatcher normalizes to
+`imessage_chat` for module lookup).
+
+Each chat file shape:
+    ---
+    chat_guids: [...]
+    chat_rowids: [...]
+    contact: <display name>
+    emails: <single str OR list>
+    phones: [...]
+    kind: direct | group
+    service: iMessage | SMS | Mixed | RCS
+    message_count: <int>
+    first_message: '<YYYY-MM-DD>'
+    last_message: '<YYYY-MM-DD>'
+    last_message_ts: <unix>
+    last_sync: '<YYYY-MM-DD>'
+    type: imessage-chat
+    ---
+    ## YYYY-MM-DD
+    **HH:MM AM/PM** <Sender>: <text>          # outgoing sender == "You"
+    **HH:MM AM/PM** <Sender>: [Voice note] <transcript>
+      [attachment expired: <filename>]
+      [file: [[Attachments/...]]]
+    > <Sender>: <quoted text>                  # reply-quote line
+
+Field naming intentionally mirrors whatsapp_chat (s/whatsapp_/imessage_/) so
+cross-channel Dataview queries work. Adds three iMessage-specific fields:
+imessage_service, imessage_attachment_count, imessage_attachment_expired_count,
+imessage_reply_quote_count. Zero LLM. All fields regex / count / passthrough.
+"""
+import datetime as _dt
+import re
+
+from _base import (
+    count_words, iso_date_from, wikilinks_in, match_people,
+    ExtractionResult,
+)
+
+AUTO_FIELDS = (
+    "imessage_chat_kind",
+    "imessage_contact_name",
+    "imessage_service",
+    "imessage_message_count",
+    "imessage_my_msg_count",
+    "imessage_their_msg_count",
+    "imessage_first_iso",
+    "imessage_last_iso",
+    "imessage_days_active",
+    "imessage_dormancy_days",
+    "imessage_density_per_day",
+    "imessage_voice_note_count",
+    "imessage_voice_note_transcribed_count",
+    "imessage_attachment_count",
+    "imessage_attachment_expired_count",
+    "imessage_reply_quote_count",
+    "imessage_concepts_extracted",
+    "imessage_people_mentioned",
+    "imessage_decision_signal",
+    "word_count",
+)
+
+# **HH:MM AM/PM** Sender: rest
+MSG_LINE_RE = re.compile(
+    r"^\*\*(\d{1,2}:\d{2}(?:\s*[AP]M)?)\*\*\s+([^:]+):\s*(.*)$",
+    re.MULTILINE,
+)
+DAY_HEADER_RE = re.compile(r"^##\s+(\d{4}-\d{2}-\d{2})\s*$", re.MULTILINE)
+VOICE_NOTE_RE = re.compile(r"\[Voice note\]")
+VOICE_NOTE_TRANSCRIBED_RE = re.compile(r"\[Voice note\][ \t]+[^\s\n]")
+# Resolved attachment: "[file: [[Attachments/...]]]"
+ATTACHMENT_RE = re.compile(r"\[file:\s*\[\[Attachments/")
+# Expired attachment: "[attachment expired: <filename>]"
+ATTACHMENT_EXPIRED_RE = re.compile(r"\[attachment expired:")
+# Reply-quote line: "> Sender: text"
+REPLY_QUOTE_RE = re.compile(r"^>\s+[A-Za-z][^:\n]{0,80}:", re.MULTILINE)
+# Decision-stub trigger words (mirror the WhatsApp + bridge auto-stub rule)
+DECISION_KEYWORDS = re.compile(
+    r"(?i)\b(exception|incident|pricing|escalation|outage|edge\s*case|refund)\b"
+)
+
+VALID_SERVICES = {"imessage", "sms", "mixed", "rcs"}
+
+
+def _chat_kind(fm):
+    raw = (fm.get("kind") or fm.get("chat_type") or "").strip().lower()
+    if raw in ("direct", "group"):
+        return raw
+    # group iMessage chats have multiple chat_guids OR a chat_id starting with "chat"
+    guids = fm.get("chat_guids")
+    if isinstance(guids, list):
+        for g in guids:
+            if isinstance(g, str) and g.startswith("chat") and ";chat" in g:
+                return "group"
+    return "direct"
+
+
+def _service(fm):
+    raw = (fm.get("service") or "").strip()
+    if not raw:
+        return None
+    low = raw.lower()
+    return raw if low in VALID_SERVICES else raw  # passthrough; preserves casing
+
+
+def _msg_counts(body):
+    total = mine = theirs = 0
+    for m in MSG_LINE_RE.finditer(body):
+        total += 1
+        sender = m.group(2).strip()
+        if sender == "You":
+            mine += 1
+        else:
+            theirs += 1
+    return total, mine, theirs
+
+
+def _days_active(body):
+    return len(set(DAY_HEADER_RE.findall(body)))
+
+
+def _dormancy(last_iso):
+    if not last_iso:
+        return None
+    try:
+        last = _dt.date.fromisoformat(last_iso)
+        delta = (_dt.date.today() - last).days
+        return delta if delta >= 0 else 0
+    except Exception:
+        return None
+
+
+def _density(msg_count, days_active):
+    if not msg_count or not days_active:
+        return None
+    return round(msg_count / days_active, 2)
+
+
+def _safe_int(v, default=0):
+    if isinstance(v, int):
+        return v
+    if isinstance(v, str) and v.strip().lstrip("-").isdigit():
+        return int(v.strip())
+    return default
+
+
+def extract(filepath, body, fm, context):
+    crm_names = context.get("crm_names", set())
+
+    first_iso = iso_date_from(fm.get("first_message"))
+    last_iso = iso_date_from(fm.get("last_message"))
+
+    scan_total, mine, theirs = _msg_counts(body)
+    fm_msg_count = _safe_int(fm.get("message_count"), default=scan_total)
+    message_count = fm_msg_count if fm_msg_count > 0 else scan_total
+
+    days = _days_active(body)
+    voice_total = len(VOICE_NOTE_RE.findall(body))
+    voice_transcribed = len(VOICE_NOTE_TRANSCRIBED_RE.findall(body))
+    attachments_resolved = len(ATTACHMENT_RE.findall(body))
+    attachments_expired = len(ATTACHMENT_EXPIRED_RE.findall(body))
+    reply_quotes = len(REPLY_QUOTE_RE.findall(body))
+
+    fields = {
+        "imessage_chat_kind": _chat_kind(fm),
+        "imessage_contact_name": fm.get("contact") or None,
+        "imessage_service": _service(fm),
+        "imessage_message_count": message_count,
+        "imessage_my_msg_count": mine,
+        "imessage_their_msg_count": theirs,
+        "imessage_first_iso": first_iso,
+        "imessage_last_iso": last_iso,
+        "imessage_days_active": days,
+        "imessage_dormancy_days": _dormancy(last_iso),
+        "imessage_density_per_day": _density(message_count, days),
+        "imessage_voice_note_count": voice_total,
+        "imessage_voice_note_transcribed_count": voice_transcribed,
+        "imessage_attachment_count": attachments_resolved,
+        "imessage_attachment_expired_count": attachments_expired,
+        "imessage_reply_quote_count": reply_quotes,
+        "imessage_concepts_extracted": wikilinks_in(body)[:25],
+        "imessage_people_mentioned": match_people(body, crm_names, cap=20),
+        "imessage_decision_signal": bool(DECISION_KEYWORDS.search(body)),
+        "word_count": count_words(body),
+    }
+    return ExtractionResult(fields, AUTO_FIELDS, auto_fields=AUTO_FIELDS)

--- a/scripts/extractors/schemas.yaml
+++ b/scripts/extractors/schemas.yaml
@@ -236,3 +236,114 @@ reference:
     - reference_topic
     - reference_last_updated_iso
     - reference_related         # wikilinks to related docs
+
+# ── Tier 5: message-channel exports ────────────────────────────────
+# Structured metadata from per-contact / per-channel chat files written
+# by the WhatsApp + iMessage MCP bridges and the /ingest-* skills.
+# slack_export and external_input honor MY_NAMES env (comma-separated)
+# for the my/their split. Defaults to {"You"} if unset (matches WhatsApp +
+# iMessage bridge convention). For Slack, configure MY_NAMES with your
+# actual display name(s) since Slack uses real names, not "You".
+
+whatsapp_chat:
+  folder_hint: "🤖 AI Chats/WhatsApp"
+  fields:
+    - whatsapp_chat_kind                        # direct|group from chat_type or jid (@g.us → group)
+    - whatsapp_contact_name                     # passthrough fm.contact
+    - whatsapp_message_count
+    - whatsapp_my_msg_count                     # outgoing (sender == "You")
+    - whatsapp_their_msg_count
+    - whatsapp_first_iso
+    - whatsapp_last_iso
+    - whatsapp_days_active                      # unique day-headers
+    - whatsapp_dormancy_days                    # today − last_iso, runtime
+    - whatsapp_density_per_day                  # message_count / days_active
+    - whatsapp_voice_note_count
+    - whatsapp_voice_note_transcribed_count
+    - whatsapp_reaction_count
+    - whatsapp_concepts_extracted               # wikilinks
+    - whatsapp_people_mentioned                 # CRM-matched names
+    - whatsapp_decision_signal                  # bool — exception|incident|pricing|escalation|outage|edge case|refund
+    - word_count
+  example_query: |
+    TABLE whatsapp_contact_name, whatsapp_message_count, whatsapp_dormancy_days
+    FROM "🤖 AI Chats/WhatsApp"
+    WHERE whatsapp_chat_kind = "direct" AND whatsapp_dormancy_days > 30
+    SORT whatsapp_message_count DESC
+
+imessage_chat:
+  folder_hint: "🤖 AI Chats/iMessage"
+  fields:
+    - imessage_chat_kind
+    - imessage_contact_name
+    - imessage_service                          # iMessage|SMS|Mixed|RCS
+    - imessage_message_count
+    - imessage_my_msg_count
+    - imessage_their_msg_count
+    - imessage_first_iso
+    - imessage_last_iso
+    - imessage_days_active
+    - imessage_dormancy_days
+    - imessage_density_per_day
+    - imessage_voice_note_count
+    - imessage_voice_note_transcribed_count
+    - imessage_attachment_count                 # `[file: [[Attachments/...]]]` resolved
+    - imessage_attachment_expired_count         # `[attachment expired: ...]`
+    - imessage_reply_quote_count                # > Sender: lines
+    - imessage_concepts_extracted
+    - imessage_people_mentioned
+    - imessage_decision_signal
+    - word_count
+
+slack_export:
+  folder_hint: "🤖 AI Chats/Slack/<workspace>/<channel>.md"
+  description: |
+    Per-channel cumulative file written by the Slack MCP `read_channel` tool.
+    Distinct from `external-input` + `source: slack` (per-day files).
+  fields:
+    - slack_export_workspace
+    - slack_export_channel
+    - slack_export_channel_id
+    - slack_export_last_sync_iso
+    - slack_export_dormancy_days
+    - slack_export_message_count
+    - slack_export_unique_senders
+    - slack_export_top_senders                  # top 5 with counts
+    - slack_export_my_msg_count                 # configure MY_NAMES env
+    - slack_export_their_msg_count
+    - slack_export_my_share_pct
+    - slack_export_attachment_count
+    - slack_export_link_count
+    - slack_export_concepts_extracted
+    - slack_export_people_mentioned
+    - slack_export_decision_signal
+    - word_count
+
+external_input:
+  folder_hint: "External Inputs/"
+  description: |
+    Files written by /ingest-* skills (slack, notion, github, gmail, linear, whatsapp).
+    Routes by `source:` field; each source emits its own prefix (slack_*, etc.).
+    Currently implemented: slack. Stubs for: notion, github, gmail, linear, whatsapp.
+  fields:
+    # Common
+    - external_source                           # slack|notion|github|gmail|linear|whatsapp
+    - external_dormancy_days
+    - word_count
+    # Slack-specific
+    - slack_channel
+    - slack_channel_id
+    - slack_workspace
+    - slack_date_start_iso
+    - slack_date_end_iso
+    - slack_message_count
+    - slack_unique_senders
+    - slack_top_senders
+    - slack_my_msg_count                        # configure MY_NAMES env
+    - slack_their_msg_count
+    - slack_my_share_pct
+    - slack_channel_mention_count               # <!channel> markers
+    - slack_link_count
+    - slack_concepts_extracted
+    - slack_people_mentioned
+    - slack_decision_signal

--- a/scripts/extractors/slack_export.py
+++ b/scripts/extractors/slack_export.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""
+extractors/slack_export.py — structured metadata for the per-channel
+cumulative Slack export written by the slack MCP's `read_channel` tool.
+
+Type: `slack-export` (hyphenated; dispatcher normalizes to `slack_export`).
+
+Distinct from `type: external-input` + `source: slack` (which the
+ingest-slack skill writes per-day at `External Inputs/Slack/<channel>/<date>.md`).
+This format is per-channel cumulative at `🤖 AI Chats/Slack/<workspace>/<channel>.md`,
+overwritten on every MCP read_channel call.
+
+File shape (from slack_mcp/_shared/markdown.py:channel_to_markdown):
+    ---
+    workspace: <alias>
+    channel: <name>
+    channel_id: <C...>
+    exported: <YYYY-MM-DD>
+    type: slack-export
+    ---
+    # #<name> — <YYYY-MM-DD>
+
+    ## <user_name> — <when>
+    <!-- ts: <ts> | iso: <iso> -->
+
+    <message text>
+
+Field prefix `slack_export_*` distinguishes from the external_input
+extractor's `slack_*` fields. Cross-source queries can join on
+`whatsapp_contact_name` / `imessage_contact_name` / `slack_export_channel`
+or filter by file path.
+
+Zero LLM. All fields regex / count / passthrough / arithmetic.
+"""
+import datetime as _dt
+import os
+import re
+from collections import Counter
+
+from _base import (
+    count_words, iso_date_from, wikilinks_in, match_people,
+    ExtractionResult,
+)
+
+
+def _my_names_from_env() -> set[str]:
+    """Sender names treated as 'me' for the my/their split.
+
+    Reads `MY_NAMES` env var (comma-separated list). Falls back to a
+    common literal "You" so vaults that haven't configured the env still
+    produce reasonable my/their splits when the source format uses "You"
+    (e.g. WhatsApp + iMessage exports). Slack exports always use real
+    display names, so without MY_NAMES configured, slack files report
+    `slack_export_my_msg_count: 0` and `slack_export_their_msg_count: <total>`.
+
+    To configure: `export MY_NAMES="Your Full Name,Your Display Name"`
+    in your shell profile. The vault-metadata-extract script inherits.
+    """
+    raw = os.environ.get("MY_NAMES", "").strip()
+    if not raw:
+        return {"You"}
+    return {n.strip() for n in raw.split(",") if n.strip()}
+
+
+MY_NAMES = _my_names_from_env()
+
+AUTO_FIELDS = (
+    "slack_export_workspace",
+    "slack_export_channel",
+    "slack_export_channel_id",
+    "slack_export_last_sync_iso",
+    "slack_export_dormancy_days",
+    "slack_export_message_count",
+    "slack_export_unique_senders",
+    "slack_export_top_senders",
+    "slack_export_my_msg_count",
+    "slack_export_their_msg_count",
+    "slack_export_my_share_pct",
+    "slack_export_attachment_count",
+    "slack_export_link_count",
+    "slack_export_concepts_extracted",
+    "slack_export_people_mentioned",
+    "slack_export_decision_signal",
+    "word_count",
+)
+
+# Slack export message header: "## <Sender Name> — <when>"
+# (note: <when> is human-readable like "Jan 5 2026, 3:45 PM" or similar; we
+# just count the headers and split on " — " to extract sender)
+MSG_HEADER_RE = re.compile(r"^##\s+(.+?)\s+—\s+.+?$", re.MULTILINE)
+ATTACHMENT_RE = re.compile(r"^- 📎", re.MULTILINE)
+URL_RE = re.compile(r"https?://\S+")
+DECISION_KEYWORDS = re.compile(
+    r"(?i)\b(exception|incident|pricing|escalation|outage|edge\s*case|refund)\b"
+)
+
+# Backwards-compat: callers that still reference the old name keep working.
+ADELAIDA_NAMES = MY_NAMES
+
+
+def _workspace_from_path(filepath):
+    """Path: 🤖 AI Chats/Slack/<workspace>/<channel>.md → workspace."""
+    parts = filepath.split(os.sep)
+    for i, p in enumerate(parts):
+        if p == "🤖 AI Chats" and i + 2 < len(parts) and parts[i + 1] == "Slack":
+            return parts[i + 2] if not parts[i + 2].endswith(".md") else None
+    return None
+
+
+def _dormancy(iso):
+    if not iso:
+        return None
+    try:
+        d = _dt.date.fromisoformat(iso)
+        delta = (_dt.date.today() - d).days
+        return delta if delta >= 0 else 0
+    except Exception:
+        return None
+
+
+def _msg_counts(body):
+    """Returns (total, mine, theirs, sender_counter) by scanning ## headers."""
+    senders = []
+    for m in MSG_HEADER_RE.finditer(body):
+        senders.append(m.group(1).strip())
+    sender_counts = Counter(senders)
+    total = sum(sender_counts.values())
+    mine = sum(c for n, c in sender_counts.items() if n in MY_NAMES)
+    theirs = total - mine
+    return total, mine, theirs, sender_counts
+
+
+def extract(filepath, body, fm, context):
+    crm_names = context.get("crm_names", set())
+
+    workspace = (fm.get("workspace") or "").strip() or _workspace_from_path(filepath)
+    channel = (fm.get("channel") or "").strip() or None
+    channel_id = (fm.get("channel_id") or "").strip() or None
+    last_sync = iso_date_from(fm.get("exported"))
+
+    total, mine, theirs, sender_counts = _msg_counts(body)
+    unique_senders = len(sender_counts)
+    top_senders = [
+        f"{name} ({cnt})" for name, cnt in sender_counts.most_common(5)
+    ]
+    my_share = round(100.0 * mine / total, 1) if total else None
+
+    fields = {
+        "slack_export_workspace": workspace,
+        "slack_export_channel": channel,
+        "slack_export_channel_id": channel_id,
+        "slack_export_last_sync_iso": last_sync,
+        "slack_export_dormancy_days": _dormancy(last_sync),
+        "slack_export_message_count": total,
+        "slack_export_unique_senders": unique_senders,
+        "slack_export_top_senders": top_senders,
+        "slack_export_my_msg_count": mine,
+        "slack_export_their_msg_count": theirs,
+        "slack_export_my_share_pct": my_share,
+        "slack_export_attachment_count": len(ATTACHMENT_RE.findall(body)),
+        "slack_export_link_count": len(URL_RE.findall(body)),
+        "slack_export_concepts_extracted": wikilinks_in(body)[:25],
+        "slack_export_people_mentioned": match_people(body, crm_names, cap=20),
+        "slack_export_decision_signal": bool(DECISION_KEYWORDS.search(body)),
+        "word_count": count_words(body),
+    }
+    return ExtractionResult(fields, AUTO_FIELDS, auto_fields=AUTO_FIELDS)

--- a/scripts/extractors/whatsapp_chat.py
+++ b/scripts/extractors/whatsapp_chat.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""
+extractors/whatsapp_chat.py — structured metadata for WhatsApp chat exports
+written by the bridge wrapper at ~/.local/bin/whatsapp-export-vault.sh.
+
+Type: `whatsapp-chat` (hyphenated in source; dispatcher normalizes to
+`whatsapp_chat` for module lookup).
+
+Each chat file shape:
+    ---
+    type: whatsapp-chat
+    contact: "<display name>"
+    phone: "<E.164>"
+    jid: "<wa-jid>"                   # optional, group chats end with @g.us
+    chat_type: "direct" | "group"     # missing on older exports
+    message_count: <int>
+    first_message: <YYYY-MM-DD>
+    last_message: <YYYY-MM-DD>
+    last_sync: <YYYY-MM-DD>
+    ---
+    # WhatsApp: <contact>
+
+    ## YYYY-MM-DD
+    **HH:MM AM/PM** <Sender>: <text>       # outgoing sender == "You"
+    **HH:MM AM/PM** <Sender>: [Voice note] <transcript>
+    **HH:MM AM/PM** <Sender>: [Reaction: 😂]
+    **HH:MM AM/PM** <Sender>: [Sticker]
+    **HH:MM AM/PM** <Sender>: [Location]
+
+Zero LLM. All fields are regex / count / passthrough / arithmetic.
+"""
+import datetime as _dt
+import re
+
+from _base import (
+    count_words, iso_date_from, wikilinks_in, match_people,
+    ExtractionResult,
+)
+
+AUTO_FIELDS = (
+    "whatsapp_chat_kind",
+    "whatsapp_contact_name",
+    "whatsapp_message_count",
+    "whatsapp_my_msg_count",
+    "whatsapp_their_msg_count",
+    "whatsapp_first_iso",
+    "whatsapp_last_iso",
+    "whatsapp_days_active",
+    "whatsapp_dormancy_days",
+    "whatsapp_density_per_day",
+    "whatsapp_voice_note_count",
+    "whatsapp_voice_note_transcribed_count",
+    "whatsapp_reaction_count",
+    "whatsapp_concepts_extracted",
+    "whatsapp_people_mentioned",
+    "whatsapp_decision_signal",
+    "word_count",
+)
+
+# **HH:MM AM/PM** Sender: rest
+MSG_LINE_RE = re.compile(
+    r"^\*\*(\d{1,2}:\d{2}(?:\s*[AP]M)?)\*\*\s+([^:]+):\s*(.*)$",
+    re.MULTILINE,
+)
+# ## YYYY-MM-DD day header
+DAY_HEADER_RE = re.compile(r"^##\s+(\d{4}-\d{2}-\d{2})\s*$", re.MULTILINE)
+# Voice notes (with or without transcript)
+VOICE_NOTE_RE = re.compile(r"\[Voice note\]")
+# Voice note followed by transcript on the SAME line. \s matches \n, so the
+# original `\s+\S` over-counted by matching the next message line. Pin to
+# horizontal whitespace + non-newline content.
+VOICE_NOTE_TRANSCRIBED_RE = re.compile(r"\[Voice note\][ \t]+[^\s\n]")
+# Reaction marker
+REACTION_RE = re.compile(r"\[Reaction:")
+# Decision-stub trigger words (mirrors the bridge auto-stub rule in CLAUDE.md)
+DECISION_KEYWORDS = re.compile(
+    r"(?i)\b(exception|incident|pricing|escalation|outage|edge\s*case|refund)\b"
+)
+
+
+def _chat_kind(fm):
+    raw = (fm.get("chat_type") or "").strip().lower()
+    if raw in ("direct", "group"):
+        return raw
+    jid = str(fm.get("jid") or "")
+    if "@g.us" in jid:
+        return "group"
+    return "direct"
+
+
+def _msg_counts(body):
+    """(total, mine, theirs) from **HH:MM** Sender: lines."""
+    total = mine = theirs = 0
+    for m in MSG_LINE_RE.finditer(body):
+        total += 1
+        sender = m.group(2).strip()
+        if sender == "You":
+            mine += 1
+        else:
+            theirs += 1
+    return total, mine, theirs
+
+
+def _days_active(body):
+    return len(set(DAY_HEADER_RE.findall(body)))
+
+
+def _dormancy(last_iso):
+    if not last_iso:
+        return None
+    try:
+        last = _dt.date.fromisoformat(last_iso)
+        delta = (_dt.date.today() - last).days
+        return delta if delta >= 0 else 0
+    except Exception:
+        return None
+
+
+def _density(msg_count, days_active):
+    if not msg_count or not days_active:
+        return None
+    return round(msg_count / days_active, 2)
+
+
+def _safe_int(v, default=0):
+    if isinstance(v, int):
+        return v
+    if isinstance(v, str) and v.strip().lstrip("-").isdigit():
+        return int(v.strip())
+    return default
+
+
+def extract(filepath, body, fm, context):
+    crm_names = context.get("crm_names", set())
+
+    first_iso = iso_date_from(fm.get("first_message"))
+    last_iso = iso_date_from(fm.get("last_message"))
+
+    scan_total, mine, theirs = _msg_counts(body)
+    fm_msg_count = _safe_int(fm.get("message_count"), default=scan_total)
+    # Bridge frontmatter is authoritative when present; otherwise trust the scan.
+    message_count = fm_msg_count if fm_msg_count > 0 else scan_total
+
+    days = _days_active(body)
+    voice_total = len(VOICE_NOTE_RE.findall(body))
+    voice_transcribed = len(VOICE_NOTE_TRANSCRIBED_RE.findall(body))
+    reactions = len(REACTION_RE.findall(body))
+
+    fields = {
+        "whatsapp_chat_kind": _chat_kind(fm),
+        "whatsapp_contact_name": fm.get("contact") or None,
+        "whatsapp_message_count": message_count,
+        "whatsapp_my_msg_count": mine,
+        "whatsapp_their_msg_count": theirs,
+        "whatsapp_first_iso": first_iso,
+        "whatsapp_last_iso": last_iso,
+        "whatsapp_days_active": days,
+        "whatsapp_dormancy_days": _dormancy(last_iso),
+        "whatsapp_density_per_day": _density(message_count, days),
+        "whatsapp_voice_note_count": voice_total,
+        "whatsapp_voice_note_transcribed_count": voice_transcribed,
+        "whatsapp_reaction_count": reactions,
+        "whatsapp_concepts_extracted": wikilinks_in(body)[:25],
+        "whatsapp_people_mentioned": match_people(body, crm_names, cap=20),
+        "whatsapp_decision_signal": bool(DECISION_KEYWORDS.search(body)),
+        "word_count": count_words(body),
+    }
+    return ExtractionResult(fields, AUTO_FIELDS, auto_fields=AUTO_FIELDS)

--- a/skills/vertical-healthcare/README.md
+++ b/skills/vertical-healthcare/README.md
@@ -1,0 +1,49 @@
+# Vertical pack: healthcare
+
+A drop-in configuration pack that turns the ai-brain-starter substrate into a healthcare-ready system: PHI handling, clinical-decision trails, BAA counterparty tracking, and connectors for Epic, Cerner, and Salesforce Health Cloud.
+
+## Who this is for
+
+- Covered entities (hospitals, health systems, clinics, payers) installing the substrate.
+- Business associates handling PHI on behalf of covered entities.
+- Digital health vendors needing HIPAA-compliant memory for clinical workflows.
+
+## What is in the box
+
+| Layer | File | What it gives you |
+|---|---|---|
+| Schema | `schema/typed-memory-categories.md` | 7 typed-memory categories: patient-scoped-fact, clinical-decision, phi-tagged-doc, baa-counterparty, retention-policy, hipaa-incident, breach-notification. |
+| Connectors | `connectors/epic-fhir.md`, `connectors/cerner-fhir.md`, `connectors/salesforce-health-cloud.md` | FHIR R4 endpoints, SMART-on-FHIR auth, resource coverage. |
+| Retention | `retention/defaults.md` | HIPAA 6-year baseline plus per-state add-ons. |
+| Decision audit | `decision-audit/phi-handling.md`, `decision-audit/clinical-decision-trail.md` | 18-HIPAA-identifier firewall and clinical-decision evidence chains. |
+
+## Install
+
+```bash
+/vertical-healthcare init
+```
+
+Stages drafts, prints a review checklist, stops.
+
+## Read first
+
+If you only have time to skim one file, read `decision-audit/phi-handling.md`. PHI handling is the load-bearing rule; if it does not match your privacy officer's posture, the rest will not fit.
+
+## What this pack does NOT include
+
+- Clinical decision support algorithms.
+- Coding and billing workflows.
+- Pharmacy or DEA-controlled-substance tracking.
+- Clinical trial data handling.
+- 42 CFR Part 2 substance-use-disorder protections.
+
+## Roadmap
+
+- v2: 42 CFR Part 2 layer for substance-use-disorder protected records.
+- v2: DEA-controlled-substance tracking.
+- v2: Joint Commission accreditation evidence layer.
+- v3: Pharmacy and 340B compliance layer.
+
+## Support
+
+Issues and pack-specific questions belong on the ai-brain-starter repository. The pack is open source; HIPAA compliance remains the covered entity's obligation.

--- a/skills/vertical-healthcare/SKILL.md
+++ b/skills/vertical-healthcare/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: vertical-healthcare
+description: Pre-configured healthcare vertical pack for the ai-brain-starter substrate. Ships typed-memory categories for patient-scoped facts, clinical decisions, PHI-tagged docs, BAA counterparties, and breach notification; HIPAA-aligned retention defaults plus per-state add-ons; connectors for Epic FHIR, Cerner FHIR, and Salesforce Health Cloud; decision-audit patterns for PHI handling against the 18 HIPAA identifiers and clinical-decision evidence chains. Use when onboarding a covered entity, business associate, or health system that needs the substrate to come pre-shaped to HIPAA, BAA, and clinical-decision audit obligations.
+trigger: /vertical-healthcare
+argument-hint: "init | status | rebuild [--tenant <id>]"
+---
+
+# /vertical-healthcare
+
+A pre-configured pack that turns the empty substrate into a healthcare-ready system in one install. The pack ships typed-memory categories that match how patient data, clinical decisions, and BAA relationships move through a covered entity; FHIR connectors for the two dominant EHR vendors; HIPAA retention defaults plus per-state add-ons; and decision-audit patterns that enforce PHI handling at the 18-identifier level and produce a verifiable clinical-decision evidence chain.
+
+## Why this exists
+
+Healthcare organizations operate under the strictest data-handling regime in commercial software: HIPAA, the HITECH Act, state-level add-ons (California CMIA, Texas HB 300, New York SHIELD), plus a forest of payer and joint-commission rules. A blank substrate install forces every covered entity to re-derive the same PHI-handling firewall and the same retention rules.
+
+This pack ships the firewall and the rules so the org can spend day one on its own clinical workflows rather than on schema design and HIPAA mapping.
+
+## What this pack sets up
+
+| Layer | What ships | Where it lands |
+|---|---|---|
+| Schema | 7 typed-memory categories with frontmatter contracts | `schema/typed-memory-categories.md` |
+| Connectors | Epic FHIR, Cerner FHIR, Salesforce Health Cloud specs and SMART-on-FHIR auth | `connectors/*.md` |
+| Retention | HIPAA 6-year baseline, per-state add-ons, breach-notification log retention | `retention/defaults.md` |
+| Decision audit | PHI handling against 18 HIPAA identifiers, clinical-decision evidence chains | `decision-audit/*.md` |
+
+Nothing is auto-applied. Drafts stage under `drafts/`; the privacy officer, security officer, and clinical informatics lead review and merge.
+
+## Categories shipped
+
+- patient-scoped-fact
+- clinical-decision
+- phi-tagged-doc
+- baa-counterparty
+- retention-policy
+- hipaa-incident
+- breach-notification
+
+## Connectors shipped
+
+- `connectors/epic-fhir.md` : Epic via FHIR R4; SMART-on-FHIR auth; resource types covered
+- `connectors/cerner-fhir.md` : Oracle Cerner via FHIR R4; SMART-on-FHIR auth; resource types covered
+- `connectors/salesforce-health-cloud.md` : Salesforce Health Cloud connector; OAuth and Salesforce platform auth
+
+## Retention defaults shipped
+
+- HIPAA records: 6 years from creation or last effective date (45 CFR 164.530(j)).
+- California CMIA add-on: 7 years for medical records.
+- Minor patient records: until age of majority + retention floor (varies by state; California: age 18 + 7 years; Texas: age 18 + 7 years).
+- Breach-notification log: 6 years.
+- Decedent records: 50 years post-death (HIPAA decedent rule).
+
+See `retention/defaults.md`.
+
+## Decision-audit patterns shipped
+
+- `decision-audit/phi-handling.md` : every PHI tag is verified at write time against the 18 HIPAA identifiers; PHI cannot cross tenant boundaries; audit log is BAA-default; every PHI access is logged with role, matter (encounter or case), and disposition.
+- `decision-audit/clinical-decision-trail.md` : every clinical recommendation has a chain: input data, decision, decision-maker, supporting evidence, alternatives considered.
+
+## When to use this pack
+
+- A covered entity is installing the substrate.
+- A business associate handling PHI on behalf of a covered entity is installing.
+- A health system is consolidating across hospitals or clinics on a shared substrate.
+- A digital health vendor needs HIPAA-compliant memory for clinical workflows.
+
+## When NOT to use this pack
+
+- Pure life-sciences research without PHI (use a thinner subset).
+- Veterinary medicine (the schema would need extensive remapping).
+- Non-clinical health-tech without patient data (skip; use the generic substrate).
+
+## Install
+
+```bash
+/vertical-healthcare init
+```
+
+Stages drafts, prints a review checklist, stops.
+
+## Status
+
+```bash
+/vertical-healthcare status
+```
+
+Reports which categories are live, which connectors are configured, BAA execution status for each downstream counterparty, and any PHI access in the past 30 days that lacked a logged disposition.
+
+## What this pack does NOT include
+
+- Clinical decision support (CDS) algorithms (out of scope; the pack tracks decisions, it does not make them).
+- Coding and billing workflows (use the finance pack plus a healthcare-specific billing layer).
+- Pharmacy or DEA-controlled-substance tracking (out of scope for v1).
+- Clinical trial data (use a research-specific schema; HIPAA does not cover de-identified research data the same way).
+- 42 CFR Part 2 substance-use-disorder protections (these are stricter than HIPAA; v1 does not encode them).
+
+## Provenance
+
+Every retention default cites the rule. Every connector cites the FHIR or platform documentation URL. Every decision-audit pattern cites the HIPAA section, HITECH provision, or state law. Drafts without provenance are gaps.

--- a/skills/vertical-healthcare/connectors/cerner-fhir.md
+++ b/skills/vertical-healthcare/connectors/cerner-fhir.md
@@ -1,0 +1,68 @@
+# Connector: Cerner FHIR (Oracle Health)
+
+Oracle Cerner Millennium is the second-largest EHR at US health systems. This connector targets the FHIR R4 surface and uses SMART-on-FHIR for auth.
+
+## API surface
+
+- Base URL: per-tenant Cerner FHIR endpoint, varies (`https://fhir-myrecord.cerner.com/r4/` is a common shape for production tenants)
+- Documentation: https://fhir.cerner.com (Oracle Health Developers portal)
+- Auth: SMART-on-FHIR with OAuth 2.0 (backend services flow and authorization code flow)
+
+## Resources mapped to typed-memory categories
+
+| FHIR resource | Substrate category | Sync direction |
+|---|---|---|
+| Patient | patient identity store + reference | inbound only |
+| Encounter | encounter reference | inbound only |
+| Observation | patient-scoped-fact | inbound only |
+| Condition | patient-scoped-fact (diagnosis subtype) | inbound only |
+| MedicationRequest | patient-scoped-fact (medication subtype) | inbound only |
+| AllergyIntolerance | patient-scoped-fact (allergy subtype) | inbound only |
+| Procedure | patient-scoped-fact (procedure subtype) | inbound only |
+| DocumentReference | phi-tagged-doc | inbound only |
+| CarePlan | clinical-decision (care-plan subtype) | inbound only |
+| ServiceRequest | clinical-decision (referral subtype) | inbound only |
+
+Read-only. Cerner is the source of truth.
+
+## Auth setup
+
+1. Health system registers a SMART-on-FHIR app via Cerner's developer portal (https://code.cerner.com).
+2. Backend services flow with JWKS-signed assertions; substrate manages the keypair in the tenant secret store.
+3. Authorization code flow with standard SMART scopes for user-context queries.
+
+## Sync cadence
+
+Same defaults as the Epic connector:
+
+- Patient master: nightly.
+- Encounters: every 30 minutes.
+- Observations, Conditions, Medications, Allergies, Procedures: every hour.
+- DocumentReference: every 4 hours.
+- CarePlan, ServiceRequest: every 2 hours.
+
+## Privilege handling
+
+Cerner's privacy filters (sensitive-chart flags, behavioral-health markers, custodial restrictions) are honored. The connector reads only what the authorizing principal is entitled to. PHI markers stamp onto `phi_tagged` and `sensitive`.
+
+42 CFR Part 2 records are out of scope for v1; the connector skips charts with that marker.
+
+## Rate limits
+
+Cerner's FHIR API has tenant-scoped rate limits documented in the developer portal. The connector backs off on 429.
+
+## Failure modes
+
+Same shapes as Epic: JWKS rotation, chart access revocation, FHIR version drift.
+
+## What this connector does NOT do
+
+- Authoring back to Cerner.
+- Pulling 42 CFR Part 2 records.
+- Pulling psychotherapy notes.
+- Bulk historical backfill beyond 24 months without explicit request.
+
+## Cerner-specific notes
+
+- Cerner's `Patient.identifier` slice for MRN varies by tenant configuration. The connector reads the configured slice via the tenant's CapabilityStatement; if the slice is missing, the connector falls back to the system-level MRN identifier and surfaces a notice.
+- Cerner's terminology bindings (especially for Observation.code) frequently use proprietary code systems alongside LOINC. The connector preserves both; downstream queries against patient-scoped-fact can match on either.

--- a/skills/vertical-healthcare/connectors/epic-fhir.md
+++ b/skills/vertical-healthcare/connectors/epic-fhir.md
@@ -1,0 +1,66 @@
+# Connector: Epic FHIR
+
+Epic is the dominant EHR at large US health systems. This connector targets the FHIR R4 surface and uses SMART-on-FHIR for auth.
+
+## API surface
+
+- Base URL: per-tenant Epic FHIR endpoint, varies (`https://fhir.epic.com/interconnect-fhir-oauth/api/FHIR/R4/` is a common shape for Epic-hosted environments)
+- Documentation: https://fhir.epic.com
+- Auth: SMART-on-FHIR with OAuth 2.0 (backend services flow for system-level access; authorization code flow for user-context access)
+
+## Resources mapped to typed-memory categories
+
+| FHIR resource | Substrate category | Sync direction |
+|---|---|---|
+| Patient | patient identity store + reference | inbound only |
+| Encounter | encounter reference (used by patient-scoped-fact) | inbound only |
+| Observation | patient-scoped-fact | inbound only |
+| Condition | patient-scoped-fact (diagnosis subtype) | inbound only |
+| MedicationRequest | patient-scoped-fact (medication subtype) | inbound only |
+| AllergyIntolerance | patient-scoped-fact (allergy subtype) | inbound only |
+| Procedure | patient-scoped-fact (procedure subtype) | inbound only |
+| DocumentReference | phi-tagged-doc | inbound only |
+| CarePlan | clinical-decision (care-plan subtype) | inbound only |
+| ServiceRequest | clinical-decision (referral subtype) | inbound only |
+
+The connector is read-only. Epic is the EHR source of truth; the substrate mirrors structured FHIR data for memory and audit, never authors back.
+
+## Auth setup
+
+1. Health system registers a SMART-on-FHIR app via Epic's App Orchard or via direct Epic admin enrollment.
+2. Backend services flow uses asymmetric key (JWKS) signing; substrate stores the private key in a tenant-scoped secret store, publishes the public key at a JWKS endpoint Epic can reach.
+3. Authorization code flow (when user-context access is needed) uses standard SMART scopes (`patient/*.read`, `user/*.read`).
+4. Per-patient access is gated by the patient's chart context; the substrate does not bypass Epic's break-glass or chart-access controls.
+
+## Sync cadence
+
+- Patient master: nightly (patient demographics change rarely).
+- Encounters: every 30 minutes (active encounters drive most query volume).
+- Observations, Conditions, Medications, Allergies, Procedures: every hour.
+- DocumentReference: every 4 hours (document volume is high; metadata-only sync).
+- CarePlan, ServiceRequest: every 2 hours.
+
+The connector defaults conservatively; the health system tunes via config.
+
+## Privilege handling
+
+Epic's chart-access controls (break-glass, sensitive-chart, behavioral-health restrictions) are honored. The connector reads only what the authorizing user or system principal is entitled to read. PHI markers from Epic (sensitive-chart flags, 42 CFR Part 2 subset) are stamped onto the substrate's `phi_tagged` and `sensitive` fields.
+
+If Epic surfaces a chart with a 42 CFR Part 2 marker, the connector does NOT pull that chart's data unless the substrate has been explicitly configured for Part 2 handling; Part 2 is out of scope for v1, and the connector errs on the side of refusal.
+
+## Rate limits
+
+Epic's FHIR API has tenant-scoped rate limits. The connector backs off on 429 with exponential retry; chronic 429s pause sync and notify the administrator.
+
+## Failure modes
+
+- JWKS rotation: the connector publishes the new public key at the JWKS endpoint and rotates the private key in the secret store; Epic picks up the new key on next request.
+- Chart access revoked: the connector logs the access change, drops cached data for the affected chart from any non-audit-scoped store, continues sync for unaffected charts.
+- FHIR version drift: the connector targets R4; if the tenant moves to R5 or beyond, the connector updates per the FHIR migration guidance.
+
+## What this connector does NOT do
+
+- Authoring back to Epic (no MyChart messages, no order entry, no chart writes).
+- Pulling 42 CFR Part 2 records (out of scope for v1).
+- Pulling psychotherapy notes (HIPAA prohibits routine disclosure; the connector skips by default).
+- Bulk historical backfill beyond 24 months without explicit administrator request.

--- a/skills/vertical-healthcare/schema/typed-memory-categories.md
+++ b/skills/vertical-healthcare/schema/typed-memory-categories.md
@@ -1,0 +1,145 @@
+# Healthcare vertical: typed-memory categories
+
+Seven categories ship with the healthcare pack. Each lists the required frontmatter the substrate enforces at write time, plus optional frontmatter that downstream queries depend on.
+
+A document that does not match its declared category schema is rejected at write time and surfaced as a recoverable error.
+
+## patient-scoped-fact
+
+Any fact about a patient. Tagged with the patient's tenant-internal identifier (never a raw HIPAA identifier; identifiers are mapped into a separate identity store).
+
+```yaml
+type: patient-scoped-fact
+fact_id: required, unique within tenant
+patient_internal_id: required, FK to patient identity store
+encounter_id: optional, FK to encounter (when the fact is encounter-scoped)
+fact_type: required, one of [diagnosis, observation, medication, procedure, allergy, social-history, family-history, plan, communication, other]
+fact_text: required, plain text
+recorded_date: required, ISO 8601 datetime with timezone
+recorded_by: required, person reference
+source_system: required, one of [epic, cerner, salesforce-health-cloud, manual, other]
+source_resource_id: optional, the FHIR resource ID or equivalent
+phi_tagged: required, boolean, defaults true
+sensitive: required, boolean, defaults false (true for behavioral health, HIV, substance use, reproductive)
+```
+
+## clinical-decision
+
+A clinical recommendation, treatment decision, or care-plan change. Drives the decision trail in `decision-audit/clinical-decision-trail.md`.
+
+```yaml
+type: clinical-decision
+decision_id: required, unique within tenant
+patient_internal_id: required, FK to patient identity store
+encounter_id: required, FK to encounter
+decision_text: required, plain text
+decision_type: required, one of [diagnosis, treatment, medication, procedure, referral, discharge, care-plan, other]
+decision_date: required, ISO 8601 datetime with timezone
+decision_maker: required, person reference (the credentialed provider accountable)
+input_data_references: required, list of fact_id or doc_id (must be non-empty)
+alternatives_considered: optional, plain text or list
+supporting_evidence_references: optional, list of doc_id (clinical guidelines, prior cases, literature)
+shared_decision_making: optional, boolean (whether the patient or family participated in the decision)
+phi_tagged: required, boolean, defaults true
+```
+
+## phi-tagged-doc
+
+Any document containing PHI. Drives the firewall in `decision-audit/phi-handling.md`.
+
+```yaml
+type: phi-tagged-doc
+doc_id: required, unique within tenant
+patient_internal_id: optional, FK to patient identity store (omit only for de-identified docs)
+encounter_id: optional, FK to encounter
+title: required
+phi_identifiers_present: required, list of integers 1 through 18 (the HIPAA identifier catalog)
+created_date: required, ISO 8601 datetime with timezone
+created_by: required, person reference
+source_system: required
+storage_location: required, FK to connector storage path
+sensitive: required, boolean
+de_identification_status: required, one of [identified, limited-data-set, safe-harbor-deidentified, expert-determination-deidentified]
+external_share_blocked: required, boolean, defaults true
+```
+
+## baa-counterparty
+
+A business associate (or subcontractor of a business associate) bound by a BAA. Drives the BAA-execution status check.
+
+```yaml
+type: baa-counterparty
+counterparty_id: required, unique within tenant
+legal_name: required
+counterparty_type: required, one of [business-associate, subcontractor, hybrid-entity, other]
+ba_role: required, plain text describing the BA function (claims processing, IT services, transcription, etc.)
+baa_executed_date: required, ISO 8601 date
+baa_effective_date: required, ISO 8601 date
+baa_termination_date: optional, ISO 8601 date
+baa_doc_id: required, FK to phi-tagged-doc (the executed BAA)
+phi_categories_disclosed: required, list of strings (treatment, payment, operations, research, marketing, other)
+breach_notification_window_days: required, integer (defaults 60 per HIPAA, may be tighter per BAA)
+status: required, one of [active, terminated, suspended]
+```
+
+## retention-policy
+
+A retention rule.
+
+```yaml
+type: retention-policy
+policy_id: required, unique within tenant
+applies_to_category: required
+applies_to_state: optional, list of US state codes
+retention_trigger: required, one of [creation, last-touch, encounter-close, patient-deceased, age-of-majority, statutory-event]
+retention_period_days: required, integer (or symbolic identifier for "until age 18 plus N")
+basis: required, citation
+overrides_default: required, boolean
+created_date: required, ISO 8601 date
+```
+
+## hipaa-incident
+
+A HIPAA security or privacy incident. Tracked from detection through closure.
+
+```yaml
+type: hipaa-incident
+incident_id: required, unique within tenant
+incident_type: required, one of [unauthorized-access, unauthorized-disclosure, lost-device, malware, phishing, insider-misuse, vendor-incident, other]
+detection_date: required, ISO 8601 datetime with timezone
+detected_by: required, person reference
+description: required, plain text
+patients_affected_estimate: optional, integer
+investigation_status: required, one of [open, in-progress, closed-no-breach, closed-breach-confirmed, closed-other]
+investigation_lead: required, person reference (privacy or security officer)
+closure_date: optional, ISO 8601 date
+closure_disposition: optional, plain text
+breach_notification_id: optional, FK to breach-notification record (when the incident is determined to be a breach)
+```
+
+## breach-notification
+
+A breach notification under the HIPAA Breach Notification Rule.
+
+```yaml
+type: breach-notification
+notification_id: required, unique within tenant
+incident_id: required, FK to hipaa-incident
+breach_determination_date: required, ISO 8601 date
+patients_affected_count: required, integer
+phi_categories_breached: required, list of integers 1 through 18
+risk_assessment_doc_id: required, FK to phi-tagged-doc
+notification_to_individuals_date: optional, ISO 8601 date (required within 60 days of discovery)
+notification_to_hhs_date: optional, ISO 8601 date
+notification_to_media_required: required, boolean (true when 500+ residents of a state are affected)
+notification_to_media_date: optional, ISO 8601 date
+ocr_breach_report_id: optional, the HHS OCR submission identifier
+state_notifications_required: required, list of US state codes
+state_notifications_completed: optional, list of US state codes with dates
+```
+
+## Schema enforcement
+
+The substrate enforces required fields at write time. Documents missing required fields are rejected with recoverable errors. The PHI fields (`phi_tagged`, `phi_identifiers_present`, `external_share_blocked`) are load-bearing for the firewall in `decision-audit/phi-handling.md`; do not weaken them locally.
+
+The patient identity store is a separate component (not in this schema). Patient internal IDs in this schema are pointers; the actual identifier mapping (MRN, SSN partial, DOB) lives in a tightly-controlled identity service that the substrate does not directly query for ad-hoc operations.


### PR DESCRIPTION
## Summary

Two stacked feature commits ahead of main:

- **`feat: add four message-channel extractors`** — adds `whatsapp_chat`, `imessage_chat`, `slack_export`, `external_input` extractors to the substrate. Mirrors the four-channel ingestion pattern already used by ingest-* skills; substrate now has the typed-memory category coverage to match.
- **`feat(v1.3.1): vertical-healthcare actually-complete`** — fills the 5 missing files in the healthcare vertical pack so it is no longer a half-shipped vertical.

## Test plan

- [ ] CI green (substrate test suite)
- [ ] Personal-data scrub passed locally (zero matches against the canonical scrub regex)
- [ ] No new heavy deps; substrate-style stdlib-only extractors

## Notes

Auto-merge enabled per `feedback_auto_push_repo` rule (public-repo PRs auto-merge when CI green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)