### PR TITLE
fix: Python 3.9 compat — add `from __future__ import annotations`

### DIFF
--- a/hooks/reconcile-worktree-shared.py
+++ b/hooks/reconcile-worktree-shared.py
@@ -33,6 +33,8 @@ CONFIG (per user, once):
 BYPASS: WORKTREE_RECONCILE_BYPASS=1
 """
 
+from __future__ import annotations
+
 import json
 import os
 import subprocess

--- a/hooks/route-suggest.py
+++ b/hooks/route-suggest.py
@@ -25,6 +25,8 @@ Wire into settings.json:
     }]
   }]
 """
+from __future__ import annotations
+
 import json
 import re
 import sys

--- a/scripts/_meta_resolver.py
+++ b/scripts/_meta_resolver.py
@@ -23,6 +23,8 @@ Don't use this in scripts that intentionally want plain Meta/ (e.g.
 promote-episodic-to-procedural reads Learnings/ which lives in plain Meta).
 """
 
+from __future__ import annotations
+
 from pathlib import Path
 
 

--- a/scripts/extractors/_dispatcher.py
+++ b/scripts/extractors/_dispatcher.py
@@ -12,6 +12,8 @@ Each extractor module must expose:
 Registry convention: module filename == type name. `book.py` handles `type: book`.
 Modules starting with _ are infrastructure, not extractors.
 """
+from __future__ import annotations
+
 import argparse
 import glob
 import importlib

--- a/scripts/extractors/article.py
+++ b/scripts/extractors/article.py
@@ -3,6 +3,8 @@
 extractors/article.py — structured metadata for saved articles / essays.
 Type: `article`.
 """
+from __future__ import annotations
+
 import re
 
 from _base import (

--- a/scripts/extractors/book.py
+++ b/scripts/extractors/book.py
@@ -3,6 +3,8 @@
 extractors/book.py — structured metadata for book notes.
 Type: `book`. Verbatim only, no LLM.
 """
+from __future__ import annotations
+
 import re
 
 from _base import (

--- a/scripts/extractors/company.py
+++ b/scripts/extractors/company.py
@@ -3,6 +3,8 @@
 extractors/company.py — structured metadata for company notes.
 Type: `company`.
 """
+from __future__ import annotations
+
 import re
 
 from _base import (

--- a/scripts/extractors/negotiation_prep.py
+++ b/scripts/extractors/negotiation_prep.py
@@ -7,6 +7,8 @@ Note: Python module names can't have hyphens, so the module is named with
 an underscore but the `type:` field in frontmatter uses `negotiation-prep`.
 The dispatcher matches by lowercasing + normalizing.
 """
+from __future__ import annotations
+
 import re
 
 from _base import (

--- a/scripts/extractors/playbook.py
+++ b/scripts/extractors/playbook.py
@@ -3,6 +3,8 @@
 extractors/playbook.py — structured metadata for playbook docs.
 Type: `playbook`. Usually Pao contractor playbooks (Source/Location/Shape/Channel).
 """
+from __future__ import annotations
+
 import re
 
 from _base import (

--- a/scripts/extractors/travel.py
+++ b/scripts/extractors/travel.py
@@ -3,6 +3,8 @@
 extractors/travel.py — structured metadata for travel entries.
 Type: `travel`, also `trip`, `place`.
 """
+from __future__ import annotations
+
 import re
 
 from _base import (

--- a/scripts/graphify_apply_wikilinks.py
+++ b/scripts/graphify_apply_wikilinks.py
@@ -55,6 +55,8 @@ Maintenance runbook:
        once you've identified era/company/role markers per person.
 """
 
+from __future__ import annotations
+
 import argparse
 import re
 import sys

--- a/scripts/graphify_coverage_audit.py
+++ b/scripts/graphify_coverage_audit.py
@@ -33,6 +33,8 @@ Usage:
     python3 graphify_coverage_audit.py --vault-root "$(pwd)" --json-only
     python3 graphify_coverage_audit.py --vault-root "$(pwd)" --skip "Archive,Drafts"
 """
+from __future__ import annotations
+
 import argparse
 import hashlib
 import json

--- a/scripts/graphify_wikilink_gaps.py
+++ b/scripts/graphify_wikilink_gaps.py
@@ -20,6 +20,8 @@ Options:
     --exclude LABEL [...]   Labels to skip entirely (e.g. your own name)
 """
 
+from __future__ import annotations
+
 import argparse
 import json
 import re

--- a/scripts/mcps/rescuetime-server.py
+++ b/scripts/mcps/rescuetime-server.py
@@ -13,6 +13,8 @@ Tools exposed:
   - get_productivity_trend — pulse trend over N days
 """
 
+from __future__ import annotations
+
 import os
 import httpx
 from datetime import date, timedelta

--- a/scripts/stub_audit.py
+++ b/scripts/stub_audit.py
@@ -21,6 +21,8 @@ Usage:
     python3 stub_audit.py --vault-root "$(pwd)" --skip "Drafts,Personal"
     python3 stub_audit.py --vault-root "$(pwd)" --out-dir "/tmp/audit"
 """
+from __future__ import annotations
+
 import argparse
 import json
 import os

--- a/scripts/whatsapp/rename-contacts.py
+++ b/scripts/whatsapp/rename-contacts.py
@@ -17,6 +17,8 @@ Usage:
   python3 rename-contacts.py --vault /path/to/vault --output "Notes/WhatsApp"
 """
 
+from __future__ import annotations
+
 import os
 import re
 import sys


### PR DESCRIPTION
## Summary

PEP 604 union syntax (`X | None`, `str | None`) in type annotations crashed on Python 3.9 with `TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'`. Adding `from __future__ import annotations` makes all annotations lazy strings — works on Python 3.7+, no runtime behavior change.

Caught when `lint-vault-frontmatter.py` (PreToolUse hook) crashed on every Write call because `_meta_resolver.py` used `Path | None` in a function signature, evaluated at module load time.

## Changes

Added `from __future__ import annotations` to 16 files:

- `hooks/reconcile-worktree-shared.py`, `hooks/route-suggest.py`
- `scripts/_meta_resolver.py`, `scripts/graphify_apply_wikilinks.py`, `scripts/graphify_coverage_audit.py`, `scripts/graphify_wikilink_gaps.py`, `scripts/stub_audit.py`
- `scripts/extractors/*.py` (7 files)
- `scripts/mcps/rescuetime-server.py`, `scripts/whatsapp/rename-contacts.py`

## Test plan

- [x] Every patched file compiles cleanly under `/usr/bin/python3` (3.9.6, macOS system Python)
- [x] `_meta_resolver.find_meta_dir()` imports + runs on 3.9
- [x] No runtime use of `X | Y` outside annotations (verified via grep for `isinstance(x, A | B)` / `case A() | B():`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)