### PR TITLE
ci: add Python 3.9 syntax check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -102,6 +102,32 @@ jobs:
           done < <(find . -name '*.ps1' -not -path './.git/*')
           exit $fail
 
+  python-syntax:
+    name: Python syntax (3.9 - macOS system default)
+    runs-on: ubuntu-latest
+    # macOS ships /usr/bin/python3 as Python 3.9. Many users invoke hooks via
+    # that exact path. PEP 604 union syntax (X | None) in annotations crashes
+    # 3.9 at module load time. `from __future__ import annotations` is the
+    # canonical fix and works on 3.7+. This job catches the regression class
+    # before merge. No untrusted input used in any run: command.
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.9"
+      - name: py_compile every .py
+        run: |
+          set -e
+          fail=0
+          while IFS= read -r f; do
+            if ! python3 -m py_compile "$f" 2>err; then
+              echo "::error file=$f::python3 -m py_compile failed on Python 3.9"
+              cat err | sed "s|^|  |"
+              fail=1
+            fi
+          done < <(find . -name '*.py' -not -path './.git/*' -not -path './node_modules/*' -not -path '*/__pycache__/*')
+          exit $fail
+
   json:
     name: JSON validity (hooks.json, *.mcp.json)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds a `python-syntax` job to the lint workflow that runs `py_compile` against every `.py` file under Python 3.9.

## Why

macOS ships `/usr/bin/python3` as 3.9.6. Many users invoke hooks at that exact path (it's what's in `~/.claude/settings.json` for several entries). PEP 604 union syntax (`X | None`) in type annotations crashes 3.9 at module load time, taking down whatever hook imports the module.

[#29](https://github.com/adelaidasofia/ai-brain-starter/pull/29) just cleaned up the existing offenders by adding `from __future__ import annotations`. This CI job prevents the regression class from re-landing.

## Test plan

- [x] Workflow syntax valid (PR creation passes GHA validation)
- [ ] CI runs `py_compile` against every `.py` and exits 0 on green main

🤖 Generated with [Claude Code](https://claude.com/claude-code)