### PR TITLE
hooks: raise rotate-logs KEEP default 3 to 30

### DIFF
--- a/hooks/rotate-logs.sh
+++ b/hooks/rotate-logs.sh
@@ -3,11 +3,16 @@
 # Keeps last N rotated copies, gzipped. Safe to call every SessionStart.
 # Runs silently and fast (~10ms for small logs); exits 0 always.
 #
-# Policy: rotate at >500KB, keep 3 generations (.1.gz .2.gz .3.gz).
-# Total cap per log ~2MB on disk after compression.
+# Policy: rotate at >500KB, keep 30 generations (.1.gz ... .30.gz).
+# Total cap per log ~16MB on disk after compression.
+#
+# KEEP default raised from 3 → 30 so substrate-audit-style analyses
+# over a 90-day window have enough rotated history to count rule fires.
+# Override per-host via env var (KEEP=N bash rotate-logs.sh).
 #
 # Usage:
 #   LOG_DIR=~/.claude/hooks bash rotate-logs.sh
+#   KEEP=30 LOG_DIR=~/.claude/hooks bash rotate-logs.sh
 #
 # Or add specific log paths to LOGS array below.
 
@@ -15,7 +20,7 @@ set +e
 
 LOG_DIR="${LOG_DIR:-$HOME/.claude/hooks}"
 MAX_BYTES="${MAX_BYTES:-512000}"
-KEEP="${KEEP:-3}"
+KEEP="${KEEP:-30}"
 
 # Auto-collect all .log files in LOG_DIR, or override by setting LOGS explicitly.
 if [ ${#LOGS[@]:-0} -eq 0 ]; then


### PR DESCRIPTION
## Why

Substrate-audit-style analyses over a 90-day window need enough rotated history to validate rule-fire counts. The current default KEEP=3 retains roughly 3 days of hookify-blocks.log churn at typical use rates, which makes it impossible to confirm whether rules fire at the expected rates over a full audit window.

## Change

- KEEP default raised from 3 → 30
- Per-log disk cap goes from ~2MB compressed → ~16MB compressed
- Per-host override via KEEP env var remains supported for users on tight disk budgets

## Test plan

- [x] bash -n hooks/rotate-logs.sh passes
- [x] Backwards compatible: existing .gz archives untouched, eviction still respects KEEP
- [x] Override path KEEP=N bash rotate-logs.sh still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)