### PR TITLE
hooks: ship sunday-review-nudge SessionStart hook

### DIFF
--- a/hooks/sunday-review-nudge.py
+++ b/hooks/sunday-review-nudge.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""SessionStart hook: nudge /sunday-review on Sundays.
+
+Reads `<vault>/⚙️ Meta/skill-usage-log.jsonl` and emits a nudge to
+stderr (which Claude Code SessionStart hooks treat as injected context)
+only when:
+
+  1. Today is Sunday (weekday() == 6)
+  2. No `sunday-review` or `insights` skill invocation is present in the
+     skill-usage log within the last 6 days
+
+Vault root resolution order:
+  1. SUNDAY_NUDGE_VAULT env var (explicit override)
+  2. CLAUDE_PROJECT_DIR env var (set by Claude Code in CWD-aware contexts)
+
+If neither is set, the hook silently no-ops (avoids accidental fires
+in a project that does not have a vault).
+
+Bypass: SUNDAY_NUDGE_BYPASS=1
+Skill log location override: SUNDAY_NUDGE_LOG_PATH
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+
+WEEKDAY_SUNDAY = 6
+LOOKBACK_DAYS = 6
+TRIGGER_SKILLS = {"sunday-review", "insights"}
+
+
+def resolve_log_path() -> Path | None:
+    explicit = os.environ.get("SUNDAY_NUDGE_LOG_PATH")
+    if explicit:
+        return Path(explicit)
+
+    vault_env = os.environ.get("SUNDAY_NUDGE_VAULT") or os.environ.get(
+        "CLAUDE_PROJECT_DIR"
+    )
+    if vault_env:
+        return Path(vault_env) / "⚙️ Meta" / "skill-usage-log.jsonl"
+
+    return None
+
+
+def fired_recently(log: Path, cutoff: datetime) -> bool:
+    try:
+        with log.open() as f:
+            for line in f:
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if rec.get("skill") not in TRIGGER_SKILLS:
+                    continue
+                try:
+                    rec_time = datetime.fromisoformat(rec.get("timestamp", ""))
+                except ValueError:
+                    continue
+                if rec_time >= cutoff:
+                    return True
+    except OSError:
+        pass
+    return False
+
+
+def main() -> int:
+    if os.environ.get("SUNDAY_NUDGE_BYPASS") == "1":
+        return 0
+
+    today = datetime.now()
+    if today.weekday() != WEEKDAY_SUNDAY:
+        return 0
+
+    log = resolve_log_path()
+    if log is None or not log.exists():
+        return 0
+
+    cutoff = today - timedelta(days=LOOKBACK_DAYS)
+    if fired_recently(log, cutoff):
+        return 0
+
+    print(
+        "[sunday-nudge] It is Sunday and /sunday-review (or /weekly) has not "
+        f"fired in the last {LOOKBACK_DAYS} days. Run /sunday-review to "
+        "orchestrate /weekly + /patterns + vault-hygiene + claude-md-drift + "
+        "decision-retrospective before drilling into other work.",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

Vault-substrate users who run /sunday-review weekly often skip a week, then a month, then forget the ritual exists. This SessionStart hook surfaces a one-line nudge on Sundays only, suppressed if /sunday-review or /insights already fired in the last 6 days. Real-world signal: in one installation, /insights fired only 6 of 13 Sundays in a 90-day window.

## How it works

- Fires on every SessionStart; silently no-ops 6 days a week and after the weekly run
- Reads the skill-usage log at `<vault>/⚙️ Meta/skill-usage-log.jsonl` for evidence the weekly review ran
- Vault root resolved from `SUNDAY_NUDGE_VAULT` or `CLAUDE_PROJECT_DIR` env var; silently no-ops if neither is set
- Bypass: `SUNDAY_NUDGE_BYPASS=1`
- Override log path: `SUNDAY_NUDGE_LOG_PATH`

## Wire-up

Append to settings.json SessionStart hooks (matcher empty string):

```json
{\"type\": \"command\", \"command\": \"/usr/bin/python3 \${CLAUDE_PLUGIN_ROOT}/hooks/sunday-review-nudge.py\", \"timeout\": 10}
```

## Test plan

- [x] python ast.parse passes
- [x] Silently no-ops with no env (substrate-default behavior)
- [x] Suppresses when skill fired within lookback window
- [x] Emits nudge when skill has not fired

🤖 Generated with [Claude Code](https://claude.com/claude-code)