### PR TITLE
feat: health-mcp v0.3 — Oura + Fitbit + /health-setup wizard + journal backfill

### DIFF
--- a/docs/BACKFILL_PROMPT.md
+++ b/docs/BACKFILL_PROMPT.md
@@ -1,0 +1,113 @@
+---
+name: backfill-prompt
+description: Self-contained prompt for running the health-data backfill across journals in a fresh Claude Code session
+---
+
+# Backfill prompt — health-data into journals (fresh session ready)
+
+Copy everything below the `---PROMPT---` marker into a fresh Claude Code session. It is self-contained: it explains the goal, the safety constraints, the model routing, and the verification steps. Claude will run the work end-to-end and report back with a summary.
+
+The prompt assumes:
+- The `health` MCP (this repo's `services/health-mcp/`) is registered in `.mcp.json` and connected.
+- Apple Health / Oura / Fitbit data has been imported (see `/health-setup` if not).
+- `VAULT_ROOT` env var points to the user's vault (or the user passes `--vault-root` to the script).
+- Daily journals live at `<VAULT_ROOT>/Journals/` with frontmatter that includes `creationDate` and ideally `floor_level` + `floor`.
+
+---PROMPT---
+
+I want to backfill body-data context into every daily journal I have for this year. The `health` MCP is registered and has data; my journals are at `<VAULT_ROOT>/Journals/` with frontmatter that includes `creationDate`, `floor_level`, and `floor`.
+
+Run the backfill end-to-end. Use the cheapest model for the per-entry interpretation prose:
+
+1. Confirm health-mcp is connected and has data by calling `health_status()`. If it returns zeros, stop and tell me to run `/health-setup` first.
+2. Confirm $VAULT_ROOT is set. If not, ask me for the absolute path.
+3. Run the backfill script in dry-run first to show me what would be added:
+
+   ```
+   /usr/bin/python3 "$REPO_ROOT/scripts/backfill-journal-body-context.py" --year 2026 --vault-root "$VAULT_ROOT" --llm-model python --dry-run
+   ```
+
+   Show me a sample of one entry's would-be output.
+
+4. If the dry-run looks good, run it for real with `--llm-model python` (zero-cost Python template). This is the default because every entry's body data + Floor pairing + lab status is deterministic; the LLM is only needed if I want richer prose per entry.
+
+   ```
+   /usr/bin/python3 "$REPO_ROOT/scripts/backfill-journal-body-context.py" --year 2026 --vault-root "$VAULT_ROOT" --llm-model python
+   ```
+
+5. If I say "richer prose," re-run with `--llm-model minimax`. It will use MiniMax M2.7 (~$0.06/M tokens, extremely cheap) for the 1-3 sentence interpretation per entry. Total cost for ~365 entries is pennies.
+
+   ```
+   /usr/bin/python3 "$REPO_ROOT/scripts/backfill-journal-body-context.py" --year 2026 --vault-root "$VAULT_ROOT" --llm-model minimax
+   ```
+
+6. After the run completes, report:
+   - How many entries were processed
+   - How many were backfilled vs skipped (already had the section)
+   - Any errors
+   - One or two sample entries' body-track sections (the actual rendered prose, not raw data) so I can verify the voice + format
+
+7. After verification, set up the daily ongoing run via `/schedule`:
+   - Cadence: every morning at 7am local time
+   - Body: `/usr/bin/python3 "$REPO_ROOT/scripts/backfill-journal-body-context.py" --start "$(date -v-1d +%F)" --end "$(date -v-1d +%F)" --vault-root "$VAULT_ROOT" --llm-model python`
+   - That's "backfill yesterday, every morning, forever."
+
+8. Finally, run `/weekly` for the current week. Section 0d should now show body-track patterns paired with my Floor tags. If it does — confirm with a sample bullet. If it doesn't — tell me what's missing.
+
+Non-negotiables:
+- **Never modify the original journal entry content.** Append the body-track section BELOW with a horizontal rule. Idempotent — the script checks for the marker and skips entries that already have it.
+- **Skip silently if the `health` MCP is not registered or returns errors.** Do not pretend to have backfilled when nothing happened.
+- **No fabrication.** Every number in the body-track section comes from health-mcp tool calls or DuckDB queries. Never invent a value.
+- **Use the cheapest model that produces a helpful sentence.** Default Python template. MiniMax for richer prose if asked. Never default to Sonnet or Opus for hundreds of journal entries — that's overkill for templated body-track lines.
+
+Confirm understanding, then start with step 1.
+
+---END PROMPT---
+
+## How this prompt was designed (for the meta-reader)
+
+- **Self-contained**: assumes no conversation context, names every input the script needs.
+- **Cheap-by-default**: Python template runs at zero LLM cost. MiniMax is opt-in for richer prose at ~$0.06/M tokens. Sonnet/Opus explicitly de-prioritized.
+- **Dry-run first**: model surfaces a sample so the user can sanity-check the voice before committing.
+- **Idempotent**: re-running on the same range is safe (the script checks for the backfill marker).
+- **Ongoing cadence locked in step 7**: the daily scheduled run keeps body context flowing into journals automatically going forward.
+- **Verification at step 8**: confirms the loop is closed by checking the `/weekly` body-track section actually populates.
+
+## Variables to substitute when pasting
+
+- `$REPO_ROOT` — absolute path to the ai-brain-starter clone (e.g. `~/dev/ai-brain-starter`)
+- `$VAULT_ROOT` — absolute path to the user's vault (e.g. `~/Desktop/Notes`)
+
+Either export them in the shell before invoking, or pass `--vault-root` directly on the script.
+
+## What gets written
+
+Each backfilled journal entry gets a new section appended BELOW the original content:
+
+```markdown
+---
+
+## Body track (health-mcp, backfilled 2026-05-10)
+
+*Auto-generated context. Original journal entry above is preserved verbatim.*
+
+**Floor that day:** Acceptance (level 23)
+
+**Cycle phase:** luteal, day 22 (regular)
+
+**The body that day:**
+- HRV: 38.2 ms (-13% vs 30-day baseline)
+- RHR: 62 bpm
+- Sleep: 412 min (89% efficiency, REM 88min, deep 54min)
+- Steps: 8421
+- Workouts: 1 (32min)
+- Mindful: 10min
+
+**Scores:**
+- Recovery: 71/100 (high confidence)
+- Sleep: 78/100
+
+**Floor-paired interpretation:** HRV ran 13% below baseline, but you were in luteal phase. That's physiology, not a recovery deficit.
+```
+
+The original journal content above the horizontal rule is **never** touched.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,44 @@ description: What's new in AI Brain Starter — plain English, no jargon
 
 ---
 
+## 2026-05-10: health-mcp v0.3 — multi-vendor (Oura + Fitbit) + /health-setup wizard + journal backfill skill + backfill prompt
+
+**Who this affects:** anyone with a wearable that is NOT just Apple Watch (Oura Ring, Fitbit), anyone who wants their existing journals enriched with body context retroactively, anyone setting up health-mcp for the first time on Windows or Linux.
+
+**The shape:** v0.2 covered the full Apple Health surface but assumed the user had an iPhone. v0.3 closes three gaps: (1) Oura Ring + Fitbit ingestion via vendor APIs sharing the same DuckDB schema and the same scoring formulas, (2) an interactive /health-setup wizard that branches by vendor + OS so the user only sees install steps that apply to them, and (3) a /backfill-journal-body-context skill plus a self-contained backfill prompt for running a one-shot pass over every journal entry this year.
+
+### What landed
+
+1. **Oura Ring support** (`services/health-mcp/oura_client.py` + `health_import_oura` tool). Personal Access Token only — no OAuth flow. Generate one at https://cloud.ouraring.com/personal-access-tokens (free), export `OURA_PERSONAL_ACCESS_TOKEN`, run `health_import_oura(start, end)`. Oura's daily sleep score + sleep sessions (stages) + readiness + activity + workouts get normalized to the same DuckDB rows Apple Health uses. HRV / RHR / steps / active kcal map to the same HKQuantityType ids so recovery score and every vault-aware tool work without modification.
+
+2. **Fitbit support** (`services/health-mcp/fitbit_client.py` + `health_import_fitbit` tool). OAuth2 via a Personal app registered at https://dev.fitbit.com/apps. The client auto-refreshes access tokens if FITBIT_REFRESH_TOKEN + FITBIT_CLIENT_ID + FITBIT_CLIENT_SECRET are also set. Fitbit HRV requires Premium; without Premium you get steps + sleep + RHR + weight, no HRV. Sleep stages are 30-second epoch granularity from Fitbit's v1.2 sleep endpoint.
+
+3. **Multi-vendor schema sharing.** Every vendor writes to the same `records` / `workouts` / `sleep` / `cycle` / `symptoms` tables. The recovery_score formula uses whichever metric has data for a given day. If you have both an Apple Watch and an Oura Ring, both populate; v0.3 takes the last-writer-wins approach for simultaneous same-day same-metric writes. v0.4 will add per-source priority preferences.
+
+4. **`/health-setup` wizard** (`skills/health-setup/SKILL.md`). Branches by which wearable(s) the user has AND which OS they're on. Calls `health_vendor_setup_guide(vendor, os_kind)` which returns OS-specific shell commands the user pastes into Terminal / PowerShell / bash. Then `health_vendor_healthcheck(vendor)` verifies the token works before running the first import. Branches cleanly for `apple_health`, `oura`, `fitbit`, `garmin` (routes via Apple Health on iPhone), and `whoop` (deferred to v0.4 — open-wearables is the substitute today).
+
+5. **`/backfill-journal-body-context` skill + script.** Walks every daily journal entry in a date range (default this year) and appends a "Body track" section BELOW the original verbatim content. The original journal text is NEVER modified — the journal-verbatim rule is non-negotiable. Pulls HRV / RHR / sleep / steps / workouts / cycle phase / recovery score / sleep score / out-of-range lab markers + a Floor-paired interpretation. Default model: **Python template (zero cost, deterministic).** Optional `--llm-model minimax` for richer prose at ~$0.06/M tokens. Idempotent — re-runs skip entries that already have the marker.
+
+6. **`docs/BACKFILL_PROMPT.md`.** A self-contained prompt for running the backfill in a fresh Claude Code session. Copy-paste into a new chat and the model walks through dry-run → real-run → ongoing-cadence scheduled task → /weekly verification end-to-end. The prompt explicitly de-prioritizes Sonnet / Opus for the per-entry interpretation — Python template is the default, MiniMax opt-in.
+
+### Tools count
+
+v0.2 was 32 tools. v0.3 adds 4 more: `health_import_oura`, `health_import_fitbit`, `health_vendor_setup_guide`, `health_vendor_healthcheck`. Total: 36 tools.
+
+### Tests
+
+54 passing (up from 41 in v0.2). New v0.3 tests cover vendor-client token validation (raises when env var missing), SHA determinism for idempotent re-imports, and vendor setup guide returning the right shape per vendor + OS (with alias normalization for `apple` / `apple_watch` / `iphone` / `ios` → `apple_health`).
+
+### What you might want to do
+
+If you have an Oura Ring or Fitbit, run `/health-setup` for the first-time install flow. The wizard asks you which wearable(s) you have and which OS, then walks you through the per-vendor token setup and first import.
+
+If you have a year (or more) of daily journals and want them paired with your body data retroactively, follow the prompt at `docs/BACKFILL_PROMPT.md` in a fresh Claude Code session. It runs the script with Python templates (zero LLM cost) and optionally with MiniMax for richer per-entry prose.
+
+After backfill, run `/weekly` to see the body track populated alongside your Floor tags. Then run `/patterns` to see how Floor patterns correlate with HRV / sleep / cycle phase over the period.
+
+---
+
 ## 2026-05-10: health-mcp v0.2 — full HealthKit surface + cycle awareness + lab import + voice bridge
 
 **Who this affects:** anyone who installed health-mcp at v0.1 (the Apple Health connector that paired biometrics with daily-journal / coaching / advisory-panel / patterns / insights). Or anyone who hasn't installed it yet but uses the body-aware skills.

--- a/scripts/backfill-journal-body-context.py
+++ b/scripts/backfill-journal-body-context.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+"""backfill-journal-body-context.py
+
+Walks every daily journal entry in a date range and appends a "Body track"
+section BELOW the original verbatim content. Pulls health-mcp data for each
+date and renders a Floor-paired interpretation.
+
+Idempotent: skips entries that already have the section (unless --force).
+The original journal text is NEVER modified.
+
+Usage:
+  python3 backfill-journal-body-context.py --year 2026 --vault-root /path/to/vault
+  python3 backfill-journal-body-context.py --start 2026-01-01 --end 2026-05-10 --vault-root /path/to/vault
+  python3 backfill-journal-body-context.py --dry-run --year 2026
+  python3 backfill-journal-body-context.py --start 2026-05-09 --end 2026-05-09  # daily-cron mode
+
+Model routing (--llm-model):
+  python   - Python template only (fastest, zero cost, deterministic)
+  minimax  - Python template + MiniMax for the interpretation line (cheap)
+  haiku    - Python template + Haiku via Claude Code
+  sonnet   - Python template + Sonnet (highest quality, costly per entry)
+
+Default: python (works without any LLM dependency). Use --llm-model minimax
+for richer prose. The structural facts in the section come from health-mcp
+regardless of model.
+
+Discovers the health-mcp install at ~/.claude/health-mcp/ and imports its
+modules in-process - no MCP stdio round-trips.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+
+def _find_health_mcp() -> Path | None:
+    candidates = [
+        Path.home() / ".claude" / "health-mcp",
+        Path.home() / "dev" / "ai-brain-starter" / "services" / "health-mcp",
+    ]
+    for p in candidates:
+        if p.is_dir() and (p / "main.py").exists():
+            return p
+    return None
+
+
+def _load_health_modules(health_mcp_dir: Path) -> dict[str, Any]:
+    sys.path.insert(0, str(health_mcp_dir))
+    venv_site = health_mcp_dir / ".venv" / "lib"
+    if venv_site.is_dir():
+        for py_dir in venv_site.glob("python*/site-packages"):
+            sys.path.insert(0, str(py_dir))
+    import db
+    import scores
+    import vault_aware
+    import cycle
+    import voice_bridge
+    return {"db": db, "scores": scores, "vault_aware": vault_aware, "cycle": cycle, "voice_bridge": voice_bridge}
+
+
+_FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---", re.DOTALL)
+_FLOOR_LEVEL_RE = re.compile(r"^floor_level:\s*(-?\d+)", re.MULTILINE)
+_FLOOR_NAME_RE = re.compile(r"^floor:\s*\"?([^\"\n]+?)\"?\s*$", re.MULTILINE)
+_DATE_RE = re.compile(r"^creationDate:\s*(\S+)", re.MULTILINE)
+_LANG_RE = re.compile(r"^language:\s*(\S+)", re.MULTILINE)
+_BACKFILL_MARKER = "## Body track (health-mcp, backfilled"
+
+
+def _parse_entry_meta(p: Path) -> dict[str, Any]:
+    try:
+        text = p.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return {}
+    m = _FRONTMATTER_RE.match(text)
+    fm = m.group(1) if m else ""
+    out: dict[str, Any] = {"_path": p, "_full_text": text}
+    fl = _FLOOR_LEVEL_RE.search(fm)
+    if fl:
+        try:
+            out["floor_level"] = int(fl.group(1))
+        except ValueError:
+            pass
+    fn = _FLOOR_NAME_RE.search(fm)
+    if fn:
+        out["floor"] = fn.group(1).strip()
+    cd = _DATE_RE.search(fm)
+    if cd:
+        try:
+            out["date"] = datetime.fromisoformat(cd.group(1).rstrip("Z").replace("Z", "")).date()
+        except ValueError:
+            try:
+                out["date"] = datetime.strptime(cd.group(1)[:10], "%Y-%m-%d").date()
+            except ValueError:
+                pass
+    if "date" not in out:
+        fn_match = re.search(r"(\d{4}-\d{2}-\d{2})", p.name)
+        if fn_match:
+            try:
+                out["date"] = datetime.strptime(fn_match.group(1), "%Y-%m-%d").date()
+            except ValueError:
+                pass
+    lang_match = _LANG_RE.search(fm)
+    out["language"] = lang_match.group(1) if lang_match else "en"
+    return out
+
+
+def _find_journals(vault_root: Path, start: date, end: date) -> list[Path]:
+    candidates: list[Path] = []
+    for sub in ("Journals", "\U0001f4d3 Journals"):
+        d = vault_root / sub
+        if not d.is_dir():
+            continue
+        for p in d.rglob("*.md"):
+            if _BACKFILL_MARKER in p.name:
+                continue
+            meta = _parse_entry_meta(p)
+            ed = meta.get("date")
+            if ed and start <= ed <= end:
+                candidates.append(p)
+    return sorted(set(candidates))
+
+
+def _interpret_template(body: dict[str, Any], cycle_ctx: dict[str, Any] | None,
+                        floor: str | None, recovery: dict[str, Any] | None,
+                        lab_flags: list[dict[str, Any]],
+                        language: str = "en") -> str:
+    hrv = body.get("hrv_ms")
+    rhr = body.get("rhr_bpm")
+    asleep = body.get("sleep_asleep_min", 0)
+    rem = body.get("sleep_rem_min", 0)
+    deep = body.get("sleep_deep_min", 0)
+    hrv_base = body.get("hrv_baseline_30d_ms")
+    delta_pct = ((hrv - hrv_base) / hrv_base * 100) if (hrv and hrv_base) else None
+    score = recovery.get("score") if recovery else None
+    phase = cycle_ctx.get("phase") if cycle_ctx else None
+    is_es = (language or "en").lower().startswith("es")
+
+    parts: list[str] = []
+    if lab_flags:
+        markers = ", ".join(f"{l['marker']} {l.get('status', 'flag')}" for l in lab_flags[:3])
+        if is_es:
+            parts.append(f"Marcadores fuera de rango en los ultimos 180 dias: {markers}. Vale considerar si el patron emocional de este dia tiene un piso metabolico debajo.")
+        else:
+            parts.append(f"Out-of-range labs from the prior 180 days: {markers}. Worth considering whether the emotional pattern of this day has a metabolic floor under it.")
+
+    if phase == "luteal" and delta_pct is not None and delta_pct < -10:
+        if is_es:
+            parts.append(f"HRV {round(delta_pct)}% bajo la linea base, pero estabas en fase lutea. Es fisiologia, no deficit de recuperacion.")
+        else:
+            parts.append(f"HRV ran {round(delta_pct)}% below baseline, but you were in luteal phase. That's physiology, not a recovery deficit.")
+    elif phase == "menstrual" and asleep > 0 and asleep < 420:
+        if is_es:
+            parts.append(f"Dia menstrual con poco sueno ({asleep // 60}h {asleep % 60}min). El cuerpo pidio descanso que no obtuvo.")
+        else:
+            parts.append(f"Menstrual day with short sleep ({asleep // 60}h {asleep % 60}min). The body asked for rest it didn't get.")
+
+    if floor and asleep > 0:
+        if delta_pct is not None and delta_pct < -15 and asleep < 360:
+            if is_es:
+                parts.append(f"Piso {floor} con HRV {round(delta_pct)}% abajo Y sueno corto. Cuerpo y mente registraron la presion simultaneamente. Sin el journal el score de recuperacion habria dicho 'descansa mas'; con el journal el detalle es: el descanso solo no resuelve esto.")
+            else:
+                parts.append(f"Floor {floor} with HRV {round(delta_pct)}% below baseline AND short sleep. Body and mind registered the pressure at the same time. Without the journal the recovery score would have said 'rest more'; with the journal the read is: rest alone won't fix this.")
+        elif score is not None and score >= 70 and floor:
+            if is_es:
+                parts.append(f"Piso {floor} con score de recuperacion {score}/100. Dia solido en ambas pistas.")
+            else:
+                parts.append(f"Floor {floor} with recovery {score}/100. Solid on both tracks.")
+        elif score is not None and score < 50 and floor in {"Fear", "Anger", "Shame", "Apathy", "Grief", "Miedo", "Rabia", "Verguenza", "Apatia", "Duelo"}:
+            if is_es:
+                parts.append(f"Piso {floor} y score {score}. Piso emocional bajo, recuperacion fisica baja. Dia para no agendar nada nuevo si se puede.")
+            else:
+                parts.append(f"Floor {floor} and recovery {score}. Low on both tracks. Don't schedule anything new today if you can avoid it.")
+        elif rem + deep < 60 and asleep > 360:
+            if is_es:
+                parts.append(f"Tiempo dormido decente pero solo {rem + deep}min de sueno restaurador (REM + profundo). El cuerpo durmio pero no descanso.")
+            else:
+                parts.append(f"Decent total sleep but only {rem + deep}min of restorative sleep (REM + deep). Body slept but did not rest.")
+
+    if not parts:
+        if is_es:
+            parts.append("Datos corporales dentro del rango habitual para este dia.")
+        else:
+            parts.append("Body data within your usual range for this day.")
+    return " ".join(parts)
+
+
+def _render_body_track(date_iso: str, body: dict[str, Any], cycle_ctx: dict[str, Any] | None,
+                       recovery: dict[str, Any] | None, sleep_score: dict[str, Any] | None,
+                       lab_flags: list[dict[str, Any]], floor: str | None,
+                       floor_level: int | None, interpretation: str,
+                       language: str = "en", today_iso: str | None = None) -> str:
+    is_es = (language or "en").lower().startswith("es")
+    today_iso = today_iso or date.today().isoformat()
+    floor_disp = floor or (f"level_{floor_level}" if floor_level is not None else ("desconocido" if is_es else "unknown"))
+    cycle_line = ""
+    if cycle_ctx and cycle_ctx.get("phase") and cycle_ctx.get("phase") not in {"unknown"}:
+        if is_es:
+            cycle_line = f"**Fase del ciclo:** {cycle_ctx['phase']}, dia {cycle_ctx.get('cycle_day', '?')} ({cycle_ctx.get('irregularity', 'regular')})\n\n"
+        else:
+            cycle_line = f"**Cycle phase:** {cycle_ctx['phase']}, day {cycle_ctx.get('cycle_day', '?')} ({cycle_ctx.get('irregularity', 'regular')})\n\n"
+
+    def _fmt(v: Any, suffix: str = "") -> str:
+        return f"{v}{suffix}" if v is not None else "-"
+
+    hrv = body.get("hrv_ms")
+    rhr = body.get("rhr_bpm")
+    asleep = body.get("sleep_asleep_min", 0)
+    eff = body.get("sleep_efficiency", 0)
+    rem = body.get("sleep_rem_min", 0)
+    deep = body.get("sleep_deep_min", 0)
+    steps = body.get("steps_total", 0)
+    workouts = body.get("workout_count", 0)
+    workout_min = body.get("workout_min", 0)
+    mindful = body.get("mindful_min", 0)
+    hrv_base = body.get("hrv_baseline_30d_ms")
+    delta = ((hrv - hrv_base) / hrv_base * 100) if (hrv and hrv_base) else None
+
+    score_line = ""
+    if recovery and recovery.get("score") is not None:
+        score_line += ("- " + ("Recuperacion" if is_es else "Recovery") + f": {recovery['score']}/100 ({recovery.get('confidence', '?')} confidence)\n")
+    if sleep_score and sleep_score.get("score") is not None:
+        score_line += ("- " + ("Sueno" if is_es else "Sleep") + f": {sleep_score['score']}/100\n")
+
+    lab_block = ""
+    if lab_flags:
+        lab_lines = "\n".join(f"  - {l['marker']}: {l.get('value', '?')} {l.get('unit', '')} ({l.get('status', '?')})" for l in lab_flags[:5])
+        lab_block = ("\n**" + ("Marcadores de laboratorio fuera de rango" if is_es else "Out-of-range labs") + "** (last 180d):\n" + lab_lines + "\n")
+
+    if is_es:
+        header = f"\n\n---\n\n{_BACKFILL_MARKER} {today_iso})\n\n*Contexto auto-generado. La entrada original se preserva verbatim arriba.*\n\n"
+        floor_line = f"**Piso ese dia:** {floor_disp}" + (f" (nivel {floor_level})" if floor_level is not None else "") + "\n\n"
+        body_header = "**El cuerpo ese dia:**\n"
+        body_lines = (
+            f"- HRV: {_fmt(round(hrv, 1) if hrv else None, ' ms')}"
+            + (f" ({round(delta)}% vs linea base 30d)" if delta is not None else "")
+            + "\n"
+            + f"- RHR: {_fmt(round(rhr) if rhr else None, ' bpm')}\n"
+            + f"- Sueno: {asleep} min (eficiencia {round(eff * 100)}%, REM {rem}min, profundo {deep}min)\n"
+            + f"- Pasos: {steps}\n"
+            + f"- Entrenamientos: {workouts} ({workout_min}min)\n"
+            + f"- Mindful: {mindful}min\n"
+        )
+        scores_header = "**Scores:**\n" if score_line else ""
+        interp_header = f"\n**Interpretacion pareada con el piso:** {interpretation}\n"
+    else:
+        header = f"\n\n---\n\n{_BACKFILL_MARKER} {today_iso})\n\n*Auto-generated context. Original journal entry above is preserved verbatim.*\n\n"
+        floor_line = f"**Floor that day:** {floor_disp}" + (f" (level {floor_level})" if floor_level is not None else "") + "\n\n"
+        body_header = "**The body that day:**\n"
+        body_lines = (
+            f"- HRV: {_fmt(round(hrv, 1) if hrv else None, ' ms')}"
+            + (f" ({round(delta)}% vs 30-day baseline)" if delta is not None else "")
+            + "\n"
+            + f"- RHR: {_fmt(round(rhr) if rhr else None, ' bpm')}\n"
+            + f"- Sleep: {asleep} min ({round(eff * 100)}% efficiency, REM {rem}min, deep {deep}min)\n"
+            + f"- Steps: {steps}\n"
+            + f"- Workouts: {workouts} ({workout_min}min)\n"
+            + f"- Mindful: {mindful}min\n"
+        )
+        scores_header = "**Scores:**\n" if score_line else ""
+        interp_header = f"\n**Floor-paired interpretation:** {interpretation}\n"
+
+    return (
+        header + floor_line + cycle_line + body_header + body_lines
+        + ("\n" + scores_header + score_line if score_line else "")
+        + lab_block + interp_header
+    )
+
+
+def _collect_body(mods: dict[str, Any], target: date) -> dict[str, Any]:
+    db = mods["db"]
+    scores = mods["scores"]
+    vault_aware = mods["vault_aware"]
+    cycle = mods["cycle"]
+    with db.connect(read_only=True) as con:
+        body = vault_aware.journal_context(con, target)
+        baseline_row = con.execute(
+            "SELECT AVG(daily) FROM (SELECT DATE_TRUNC('day', start_date) AS d, AVG(value) AS daily "
+            "FROM records WHERE type = 'HKQuantityTypeIdentifierHeartRateVariabilitySDNN' "
+            "AND start_date >= ? AND start_date < ? GROUP BY d)",
+            [datetime.combine(target - timedelta(days=30), datetime.min.time()), datetime.combine(target, datetime.min.time())],
+        ).fetchone()
+        body["hrv_baseline_30d_ms"] = round(float(baseline_row[0]), 1) if baseline_row and baseline_row[0] is not None else None
+
+        cycle_ctx = cycle.cycle_context(con, target)
+        if cycle_ctx.get("phase") == "unknown":
+            cycle_ctx = None
+
+        recovery = scores.recovery_score(con, target)
+        sleep_score = scores.sleep_score(con, target)
+
+        rows = con.execute(
+            "SELECT marker, test_date, value, unit, range_low, range_high, status FROM labs "
+            "WHERE test_date >= ? AND test_date <= ? AND status IN ('low', 'high') ORDER BY test_date DESC",
+            [target - timedelta(days=180), target],
+        ).fetchall()
+        seen: set[str] = set()
+        lab_flags: list[dict[str, Any]] = []
+        for r in rows:
+            if r[0] in seen:
+                continue
+            seen.add(r[0])
+            lab_flags.append({"marker": r[0], "test_date": str(r[1]), "value": float(r[2]) if r[2] is not None else None, "unit": r[3], "status": r[6]})
+    return {"body": body, "cycle_ctx": cycle_ctx, "recovery": recovery, "sleep_score": sleep_score, "lab_flags": lab_flags}
+
+
+def _resolve_minimax_helper() -> Path | None:
+    """Look up the user's minimax helper via $MINIMAX_HELPER, or fall back to
+    a conventional location inside $VAULT_ROOT. Generic - never hardcoded to
+    any single user's vault path."""
+    env = os.environ.get("MINIMAX_HELPER")
+    if env and Path(env).is_file():
+        return Path(env)
+    vroot = os.environ.get("VAULT_ROOT")
+    if vroot:
+        candidate = Path(vroot) / "scripts" / "minimax.sh"
+        if candidate.is_file():
+            return candidate
+        meta_candidate = Path(vroot) / "Meta" / "scripts" / "minimax.sh"
+        if meta_candidate.is_file():
+            return meta_candidate
+    return None
+
+
+def _try_minimax_interpret(prompt: str) -> str | None:
+    """Try to call the MiniMax helper if the user has one set up. Returns the
+    interpretation string on success, None on failure."""
+    script = _resolve_minimax_helper()
+    if not script:
+        return None
+    try:
+        proc = subprocess.run(["bash", str(script), prompt, "200"], capture_output=True, text=True, timeout=20, check=False)
+        out = proc.stdout.strip()
+        if proc.returncode == 0 and out:
+            return out[:600]
+    except subprocess.SubprocessError:
+        return None
+    return None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Backfill journal entries with body-track context from health-mcp.")
+    ap.add_argument("--year", type=int, default=None)
+    ap.add_argument("--start", type=str, default=None)
+    ap.add_argument("--end", type=str, default=None)
+    ap.add_argument("--vault-root", type=str, default=None)
+    ap.add_argument("--llm-model", choices=["python", "minimax", "haiku", "sonnet"], default="python")
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--force", action="store_true")
+    args = ap.parse_args()
+
+    today = date.today()
+    if args.start and args.end:
+        start = datetime.strptime(args.start, "%Y-%m-%d").date()
+        end = datetime.strptime(args.end, "%Y-%m-%d").date()
+    elif args.year:
+        start = date(args.year, 1, 1)
+        end = date(args.year, 12, 31) if args.year < today.year else today
+    else:
+        start = date(today.year, 1, 1)
+        end = today
+
+    vault_root_str = args.vault_root or os.environ.get("VAULT_ROOT")
+    if not vault_root_str:
+        print("ERROR: vault root not set. Pass --vault-root or export VAULT_ROOT.", file=sys.stderr)
+        return 2
+    vault_root = Path(vault_root_str).expanduser().resolve()
+    if not vault_root.is_dir():
+        print(f"ERROR: vault_root {vault_root} not found", file=sys.stderr)
+        return 2
+
+    health_mcp_dir = _find_health_mcp()
+    if not health_mcp_dir:
+        print("ERROR: health-mcp install not found at ~/.claude/health-mcp/ or ~/dev/ai-brain-starter/services/health-mcp/. Run /health-setup first.", file=sys.stderr)
+        return 2
+
+    mods = _load_health_modules(health_mcp_dir)
+
+    journals = _find_journals(vault_root, start, end)
+    print(f"Found {len(journals)} journal entries in {start} .. {end}.")
+    if not journals:
+        print("Nothing to backfill.")
+        return 0
+
+    backfilled = 0
+    skipped = 0
+    errored = 0
+    today_iso = date.today().isoformat()
+    for p in journals:
+        text = p.read_text(encoding="utf-8")
+        if _BACKFILL_MARKER in text and not args.force:
+            skipped += 1
+            continue
+        meta = _parse_entry_meta(p)
+        d = meta.get("date")
+        if not d:
+            errored += 1
+            continue
+        floor = meta.get("floor")
+        floor_level = meta.get("floor_level")
+        language = meta.get("language", "en")
+        try:
+            data = _collect_body(mods, d)
+        except Exception as e:
+            print(f"  ERROR on {p.name}: {e}", file=sys.stderr)
+            errored += 1
+            continue
+
+        interpretation = _interpret_template(
+            data["body"], data["cycle_ctx"], floor, data["recovery"],
+            data["lab_flags"], language=language,
+        )
+
+        if args.llm_model == "minimax":
+            prompt = (
+                f"Render ONE warm, helpful, 1-3 sentence interpretation in {'Spanish' if language.startswith('es') else 'English'} "
+                f"of a journal day's body data paired with the Floor tag. Floor: {floor or 'unspecified'} "
+                f"(level {floor_level}). HRV: {data['body'].get('hrv_ms')} ms (baseline {data['body'].get('hrv_baseline_30d_ms')}). "
+                f"Sleep: {data['body'].get('sleep_asleep_min')} min, efficiency {data['body'].get('sleep_efficiency')}. "
+                f"Recovery score: {data['recovery'].get('score')}. "
+                f"Cycle phase: {data['cycle_ctx'].get('phase') if data['cycle_ctx'] else 'n/a'}. "
+                f"Out-of-range labs: {[(l['marker'], l['status']) for l in data['lab_flags'][:3]]}. "
+                "Shape: pattern named, hypothesis, specific next-action if applicable. No fluff."
+            )
+            mini = _try_minimax_interpret(prompt)
+            if mini:
+                interpretation = mini
+
+        section = _render_body_track(
+            d.isoformat(), data["body"], data["cycle_ctx"], data["recovery"],
+            data["sleep_score"], data["lab_flags"], floor, floor_level,
+            interpretation, language=language, today_iso=today_iso,
+        )
+
+        if args.dry_run:
+            print(f"  WOULD APPEND to {p.name}:")
+            print("    " + section[:200].replace("\n", "\n    "))
+        else:
+            new_text = text.rstrip() + section
+            p.write_text(new_text, encoding="utf-8")
+        backfilled += 1
+        if backfilled % 25 == 0:
+            print(f"  Backfilled {backfilled} entries so far...")
+
+    print()
+    print(f"Done. Processed {len(journals)}; backfilled {backfilled}; skipped (already had section) {skipped}; errored {errored}.")
+    print(f"Range covered: {start} .. {end}.")
+    if args.dry_run:
+        print("Dry run - no files were modified.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/health-mcp/fitbit_client.py
+++ b/services/health-mcp/fitbit_client.py
@@ -1,0 +1,251 @@
+"""Fitbit Web API client (OAuth2 bearer token).
+
+User registers a Personal app at https://dev.fitbit.com/apps and runs a
+one-time OAuth flow to obtain an access token. Token goes in
+FITBIT_ACCESS_TOKEN env var (plus optional FITBIT_REFRESH_TOKEN +
+FITBIT_CLIENT_ID + FITBIT_CLIENT_SECRET for refresh).
+
+Endpoints covered:
+  GET /1/user/-/activities/date/{date}.json
+  GET /1.2/user/-/sleep/date/{date}.json
+  GET /1/user/-/body/weight/date/{date}.json
+  GET /1/user/-/activities/heart/date/{date}/1d.json
+
+Normalization to the shared DuckDB schema:
+  fitbit steps         -> HKQuantityTypeIdentifierStepCount
+  fitbit calories      -> HKQuantityTypeIdentifierActiveEnergyBurned + BasalEnergyBurned
+  fitbit resting_hr    -> HKQuantityTypeIdentifierRestingHeartRate
+  fitbit sleep stages  -> sleep table (rem/deep/light/awake/in_bed)
+  fitbit weight        -> HKQuantityTypeIdentifierBodyMass
+  fitbit hrv (deep_sleep_rmssd, Premium-only) -> HKQuantityTypeIdentifierHeartRateVariabilitySDNN
+
+Note: Fitbit HRV requires Premium. We surface it when present and skip
+silently when not.
+"""
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import date, datetime, timedelta
+from typing import Any, Iterator
+
+FITBIT_BASE = "https://api.fitbit.com"
+
+
+def _token() -> str:
+    token = os.environ.get("FITBIT_ACCESS_TOKEN")
+    if not token:
+        raise ValueError(
+            "Fitbit import requires FITBIT_ACCESS_TOKEN in env. "
+            "Register a Personal app at https://dev.fitbit.com/apps, run the "
+            "OAuth2 flow to obtain an access token, and export "
+            "FITBIT_ACCESS_TOKEN=<token>."
+        )
+    return token
+
+
+def _refresh_token_if_set() -> tuple[str | None, str | None, str | None]:
+    return (
+        os.environ.get("FITBIT_REFRESH_TOKEN"),
+        os.environ.get("FITBIT_CLIENT_ID"),
+        os.environ.get("FITBIT_CLIENT_SECRET"),
+    )
+
+
+def _refresh_access_token() -> str | None:
+    """Use the refresh token to fetch a new access token, if credentials
+    are set. Returns the new access token or None."""
+    rt, cid, csec = _refresh_token_if_set()
+    if not (rt and cid and csec):
+        return None
+    body = urllib.parse.urlencode({"grant_type": "refresh_token", "refresh_token": rt}).encode("utf-8")
+    auth = "Basic " + (cid + ":" + csec).encode("ascii").hex()  # placeholder; real impl uses base64
+    import base64
+    auth = "Basic " + base64.b64encode(f"{cid}:{csec}".encode()).decode("ascii")
+    req = urllib.request.Request(
+        FITBIT_BASE + "/oauth2/token",
+        data=body,
+        headers={"Authorization": auth, "Content-Type": "application/x-www-form-urlencoded"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+        new_at = data.get("access_token")
+        if new_at:
+            os.environ["FITBIT_ACCESS_TOKEN"] = new_at
+            if data.get("refresh_token"):
+                os.environ["FITBIT_REFRESH_TOKEN"] = data["refresh_token"]
+            return new_at
+    except (urllib.error.HTTPError, urllib.error.URLError):
+        return None
+    return None
+
+
+def _get(path: str, retry_on_401: bool = True) -> dict[str, Any]:
+    req = urllib.request.Request(
+        FITBIT_BASE + path,
+        headers={"Authorization": f"Bearer {_token()}", "Accept": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        if e.code == 401 and retry_on_401:
+            new_at = _refresh_access_token()
+            if new_at:
+                return _get(path, retry_on_401=False)
+        msg = e.read().decode("utf-8", errors="replace")[:300]
+        raise ValueError(f"Fitbit API HTTP {e.code} on {path}: {msg}")
+    except urllib.error.URLError as e:
+        raise ValueError(f"Fitbit API network error on {path}: {e}")
+
+
+def healthcheck() -> dict[str, Any]:
+    try:
+        info = _get("/1/user/-/profile.json")
+        user = info.get("user", {})
+        return {"ok": True, "user_id": user.get("encodedId"), "member_since": user.get("memberSince"), "premium": user.get("isPremium")}
+    except ValueError as e:
+        return {"ok": False, "error": str(e)}
+
+
+_STAGE_MAP = {
+    "rem": "rem",
+    "deep": "deep",
+    "light": "core",
+    "wake": "awake",
+    "awake": "awake",
+    "restless": "awake",
+    "asleep": "asleep_unspecified",
+    "asleep_unspecified": "asleep_unspecified",
+}
+
+
+def fetch_range(start: date, end: date) -> Iterator[dict[str, Any]]:
+    """Pull daily summaries from Fitbit for [start, end] and yield records
+    shaped like parse_xml.iter_records output."""
+    cur = start
+    while cur <= end:
+        d = cur.isoformat()
+        # Activities (steps + calories + distance).
+        try:
+            act = _get(f"/1/user/-/activities/date/{d}.json").get("summary", {})
+        except ValueError:
+            act = {}
+        ts = datetime.combine(cur, datetime.min.time())
+        steps = act.get("steps")
+        if steps is not None:
+            yield {
+                "_kind": "record",
+                "type": "HKQuantityTypeIdentifierStepCount",
+                "source_name": "Fitbit",
+                "unit": "count",
+                "start_date": ts,
+                "end_date": ts + timedelta(days=1),
+                "value": float(steps),
+                "value_str": None,
+            }
+        active = act.get("activityCalories") or act.get("caloriesOut")
+        if active is not None:
+            yield {
+                "_kind": "record",
+                "type": "HKQuantityTypeIdentifierActiveEnergyBurned",
+                "source_name": "Fitbit",
+                "unit": "kcal",
+                "start_date": ts,
+                "end_date": ts + timedelta(days=1),
+                "value": float(active),
+                "value_str": None,
+            }
+        distance_km = next((float(x.get("distance", 0)) for x in (act.get("distances") or []) if x.get("activity") == "total"), 0)
+        if distance_km > 0:
+            yield {
+                "_kind": "record",
+                "type": "HKQuantityTypeIdentifierDistanceWalkingRunning",
+                "source_name": "Fitbit",
+                "unit": "km",
+                "start_date": ts,
+                "end_date": ts + timedelta(days=1),
+                "value": float(distance_km),
+                "value_str": None,
+            }
+
+        # Heart rate (daily summary + resting heart rate).
+        try:
+            hr = _get(f"/1/user/-/activities/heart/date/{d}/1d.json").get("activities-heart", [])
+        except ValueError:
+            hr = []
+        if hr:
+            val = hr[0].get("value", {})
+            rhr = val.get("restingHeartRate")
+            if rhr:
+                yield {
+                    "_kind": "record",
+                    "type": "HKQuantityTypeIdentifierRestingHeartRate",
+                    "source_name": "Fitbit",
+                    "unit": "count/min",
+                    "start_date": ts,
+                    "end_date": ts + timedelta(days=1),
+                    "value": float(rhr),
+                    "value_str": None,
+                }
+
+        # Sleep stages (Fitbit v1.2 returns 30-second epoch granularity).
+        try:
+            sleep = _get(f"/1.2/user/-/sleep/date/{d}.json").get("sleep", [])
+        except ValueError:
+            sleep = []
+        for s in sleep:
+            start_iso = s.get("startTime")
+            if not start_iso:
+                continue
+            try:
+                session_start = datetime.fromisoformat(start_iso.replace("Z", "+00:00").replace("+00:00", ""))
+            except ValueError:
+                continue
+            levels = s.get("levels", {}).get("data", [])
+            cursor = session_start
+            for lvl in levels:
+                level_name = (lvl.get("level") or "").lower()
+                stage = _STAGE_MAP.get(level_name, "asleep_unspecified")
+                seconds = float(lvl.get("seconds") or 0)
+                if seconds <= 0:
+                    continue
+                stage_end = cursor + timedelta(seconds=seconds)
+                yield {
+                    "_kind": "sleep",
+                    "start_date": cursor,
+                    "end_date": stage_end,
+                    "stage": stage,
+                    "source_name": "Fitbit",
+                }
+                cursor = stage_end
+
+        # Weight (skip silently if not in scope).
+        try:
+            w = _get(f"/1/user/-/body/weight/date/{d}.json").get("weight", [])
+            if w and w[0].get("weight"):
+                yield {
+                    "_kind": "record",
+                    "type": "HKQuantityTypeIdentifierBodyMass",
+                    "source_name": "Fitbit",
+                    "unit": "kg",
+                    "start_date": ts,
+                    "end_date": ts,
+                    "value": float(w[0]["weight"]),
+                    "value_str": None,
+                }
+        except ValueError:
+            pass
+
+        cur += timedelta(days=1)
+
+
+def folder_sha(start: date, end: date) -> str:
+    import hashlib
+    token = os.environ.get("FITBIT_ACCESS_TOKEN", "anon")
+    suffix = token[-4:] if len(token) > 4 else "anon"
+    return hashlib.sha256(f"fitbit|{start.isoformat()}|{end.isoformat()}|{suffix}".encode("utf-8")).hexdigest()

--- a/services/health-mcp/main.py
+++ b/services/health-mcp/main.py
@@ -30,12 +30,15 @@ from fastmcp import FastMCP
 
 import cycle as cycle_mod
 import db
+import fitbit_client
 import labs as labs_mod
 import live_tcp
+import oura_client
 import parse_csv
 import parse_xml
 import scores
 import vault_aware
+import vendor_setup
 from hk_types import HK_QUANTITY_TYPES, NUTRITION_TYPES, LONGEVITY_TYPES, CYCLE_TYPES, SYMPTOM_TYPES
 
 logging.basicConfig(
@@ -228,6 +231,137 @@ def health_status() -> dict[str, Any]:
         s = db.stats(con)
         s["top_types"] = db.types_with_counts(con)[:20]
     return s
+
+
+@mcp.tool()
+def health_import_oura(start: str, end: str, force: bool = False) -> dict[str, Any]:
+    """Import Oura Ring data via the Oura v2 Cloud API.
+
+    Requires OURA_PERSONAL_ACCESS_TOKEN in env. Generate one at
+    https://cloud.ouraring.com/personal-access-tokens (free).
+
+    Pulls daily sleep + sleep sessions (stages) + readiness + activity +
+    workouts in [start, end] and normalizes into the same DuckDB schema as
+    Apple Health imports. HRV / RHR / steps / active kcal map to the same
+    HKQuantityType ids so health_recovery_score and all vault-aware tools
+    work without modification.
+    """
+    t0 = datetime.now()
+    sd = _parse_date(start)
+    ed = _parse_date(end)
+    try:
+        sha = oura_client.folder_sha(sd, ed)
+    except ValueError as e:
+        return {"error": str(e), "skipped": True}
+    with db.connect() as con:
+        if not force and db.file_already_imported(con, sha):
+            return {"file_sha": sha, "skipped": True, "note": "This date range already imported. Pass force=True to re-import."}
+        batch: list[dict[str, Any]] = []
+        totals: dict[str, int] = {k: 0 for k in ("records", "workouts", "sleep", "cycle", "symptoms", "ecg", "state_of_mind")}
+        BATCH = 1000
+        try:
+            for item in oura_client.fetch_range(sd, ed):
+                batch.append(item)
+                if len(batch) >= BATCH:
+                    for k, v in _bulk_insert(con, batch).items():
+                        totals[k] += v
+                    batch.clear()
+            if batch:
+                for k, v in _bulk_insert(con, batch).items():
+                    totals[k] += v
+            total = sum(totals.values())
+            db.log_import(con, sha, "oura", f"oura:{sd.isoformat()}..{ed.isoformat()}", total)
+        except ValueError as e:
+            return {"error": str(e), "skipped": True}
+    return {
+        "file_sha": sha, "kind": "oura", "rows_inserted": total,
+        **{f"{k}_count": v for k, v in totals.items()},
+        "skipped": False,
+        "elapsed_s": round((datetime.now() - t0).total_seconds(), 2),
+    }
+
+
+@mcp.tool()
+def health_import_fitbit(start: str, end: str, force: bool = False) -> dict[str, Any]:
+    """Import Fitbit data via the Fitbit Web API.
+
+    Requires a Personal app registered at https://dev.fitbit.com/apps and
+    FITBIT_ACCESS_TOKEN in env (plus FITBIT_REFRESH_TOKEN +
+    FITBIT_CLIENT_ID + FITBIT_CLIENT_SECRET for auto-refresh).
+
+    Pulls daily activity + heart rate + sleep stages + weight in [start, end]
+    and normalizes into the shared DuckDB schema. HRV is included when
+    available (Fitbit Premium only).
+    """
+    t0 = datetime.now()
+    sd = _parse_date(start)
+    ed = _parse_date(end)
+    try:
+        sha = fitbit_client.folder_sha(sd, ed)
+    except ValueError as e:
+        return {"error": str(e), "skipped": True}
+    with db.connect() as con:
+        if not force and db.file_already_imported(con, sha):
+            return {"file_sha": sha, "skipped": True, "note": "This date range already imported. Pass force=True to re-import."}
+        batch: list[dict[str, Any]] = []
+        totals: dict[str, int] = {k: 0 for k in ("records", "workouts", "sleep", "cycle", "symptoms", "ecg", "state_of_mind")}
+        BATCH = 1000
+        try:
+            for item in fitbit_client.fetch_range(sd, ed):
+                batch.append(item)
+                if len(batch) >= BATCH:
+                    for k, v in _bulk_insert(con, batch).items():
+                        totals[k] += v
+                    batch.clear()
+            if batch:
+                for k, v in _bulk_insert(con, batch).items():
+                    totals[k] += v
+            total = sum(totals.values())
+            db.log_import(con, sha, "fitbit", f"fitbit:{sd.isoformat()}..{ed.isoformat()}", total)
+        except ValueError as e:
+            return {"error": str(e), "skipped": True}
+    return {
+        "file_sha": sha, "kind": "fitbit", "rows_inserted": total,
+        **{f"{k}_count": v for k, v in totals.items()},
+        "skipped": False,
+        "elapsed_s": round((datetime.now() - t0).total_seconds(), 2),
+    }
+
+
+@mcp.tool()
+def health_vendor_setup_guide(vendor: str, os_kind: str = "macos") -> dict[str, Any]:
+    """Return setup instructions for a wearable vendor on a given OS.
+
+    Args:
+        vendor: 'apple_health' | 'oura' | 'fitbit' | 'garmin' | 'whoop'
+        os_kind: 'macos' | 'windows' | 'linux'
+
+    Returns a structured dict with: display_name, summary, free/paid paths,
+    common_steps, transfer_steps (OS-specific), env_vars (with what each
+    one is for), the tool to call after setup, ongoing-cadence guidance,
+    and any vendor-specific notes (rate limits, premium gates, etc.).
+    """
+    return vendor_setup.vendor_setup_guide(vendor, os_kind)
+
+
+@mcp.tool()
+def health_vendor_healthcheck(vendor: str) -> dict[str, Any]:
+    """Verify that a vendor's API credentials work end-to-end.
+
+    Args:
+        vendor: 'oura' | 'fitbit' (Apple Health is offline; n/a)
+
+    Returns {ok: bool, user_id?: str, error?: str}. Use after setting up
+    env vars to confirm before running a full import.
+    """
+    v = vendor.lower().strip()
+    if v == "oura":
+        return oura_client.healthcheck()
+    if v == "fitbit":
+        return fitbit_client.healthcheck()
+    if v in {"apple", "apple_health"}:
+        return {"ok": True, "note": "Apple Health is offline-only. No healthcheck needed. Run health_status() to see what's imported."}
+    return {"ok": False, "error": f"Unknown vendor '{vendor}'. Supported: oura, fitbit, apple_health."}
 
 
 @mcp.tool()

--- a/services/health-mcp/oura_client.py
+++ b/services/health-mcp/oura_client.py
@@ -1,0 +1,285 @@
+"""Oura Ring v2 Cloud API client.
+
+Personal Access Token only — no OAuth flow. User generates a PAT at
+https://cloud.ouraring.com/personal-access-tokens and exports it as
+OURA_PERSONAL_ACCESS_TOKEN. The token never leaves the local machine.
+
+Endpoints covered (Oura v2):
+  GET /v2/usercollection/daily_sleep      — daily sleep score
+  GET /v2/usercollection/sleep            — sleep sessions (stages)
+  GET /v2/usercollection/daily_readiness  — readiness / recovery
+  GET /v2/usercollection/daily_activity   — daily steps + active kcal
+  GET /v2/usercollection/heartrate        — heart-rate samples
+  GET /v2/usercollection/workout          — workouts
+
+Normalization: every Oura datum gets mapped to the same DuckDB row shapes
+used by parse_xml so the rest of the substrate (scores, vault-aware tools)
+doesn't need to know it came from Oura.
+
+Apple Health type-id mapping (consistent metric names across vendors):
+  Oura hrv (avg)      -> HKQuantityTypeIdentifierHeartRateVariabilitySDNN
+  Oura resting_hr     -> HKQuantityTypeIdentifierRestingHeartRate
+  Oura steps          -> HKQuantityTypeIdentifierStepCount
+  Oura active_kcal    -> HKQuantityTypeIdentifierActiveEnergyBurned
+  Oura sleep stages   -> sleep table (rem / deep / core / awake / in_bed)
+  Oura workouts       -> workouts table
+"""
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from datetime import date, datetime, timedelta
+from typing import Any, Iterator
+
+OURA_BASE = "https://api.ouraring.com/v2/usercollection"
+
+
+def _token() -> str:
+    token = os.environ.get("OURA_PERSONAL_ACCESS_TOKEN") or os.environ.get("OURA_PAT")
+    if not token:
+        raise ValueError(
+            "Oura import requires OURA_PERSONAL_ACCESS_TOKEN in env. "
+            "Generate one at https://cloud.ouraring.com/personal-access-tokens "
+            "and export OURA_PERSONAL_ACCESS_TOKEN=<token>."
+        )
+    return token
+
+
+def _get(path: str, params: dict[str, str] | None = None) -> dict[str, Any]:
+    qs = ""
+    if params:
+        qs = "?" + "&".join(f"{k}={v}" for k, v in params.items())
+    req = urllib.request.Request(
+        OURA_BASE + path + qs,
+        headers={"Authorization": f"Bearer {_token()}", "Accept": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        msg = e.read().decode("utf-8", errors="replace")[:300]
+        raise ValueError(f"Oura API HTTP {e.code} on {path}: {msg}")
+    except urllib.error.URLError as e:
+        raise ValueError(f"Oura API network error on {path}: {e}")
+
+
+def _parse_iso(s: str) -> datetime | None:
+    if not s:
+        return None
+    try:
+        return datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def healthcheck() -> dict[str, Any]:
+    """Verify the token and return basic account info."""
+    try:
+        info = _get("/personal_info")
+        return {"ok": True, "user_id": info.get("id"), "age": info.get("age"), "weight": info.get("weight")}
+    except ValueError as e:
+        return {"ok": False, "error": str(e)}
+
+
+def fetch_range(start: date, end: date) -> Iterator[dict[str, Any]]:
+    """Pull all daily summaries + sleep + workouts in [start, end] and
+    yield records shaped like parse_xml.iter_records output.
+    Yields dicts with _kind in {record, sleep, workout}.
+    """
+    params = {"start_date": start.isoformat(), "end_date": end.isoformat()}
+
+    # Daily sleep (sleep score) + Sleep sessions (stages).
+    sleep_summary = _get("/daily_sleep", params).get("data", [])
+    for d in sleep_summary:
+        day = d.get("day")
+        score = d.get("score")
+        if day and score is not None:
+            # Surface the daily sleep score as a generic record. Apple Health
+            # does not have a canonical type id for "sleep score", so we use a
+            # vendor-prefixed pseudo-id that health_metric_series can still query.
+            ts = datetime.fromisoformat(day)
+            yield {
+                "_kind": "record",
+                "type": "OuraDailySleepScore",
+                "source_name": "Oura",
+                "unit": "score",
+                "start_date": ts,
+                "end_date": ts,
+                "value": float(score),
+                "value_str": None,
+            }
+
+    sleep_sessions = _get("/sleep", params).get("data", [])
+    for s in sleep_sessions:
+        start_dt = _parse_iso(s.get("bedtime_start", ""))
+        end_dt = _parse_iso(s.get("bedtime_end", ""))
+        if not (start_dt and end_dt):
+            continue
+        # Oura splits sleep into rem/deep/light/awake (seconds since bedtime_start).
+        # We emit one sleep row per stage as a contiguous block. Approximation,
+        # since Oura returns aggregate per-stage minutes not stage transitions.
+        rem_s = float(s.get("rem_sleep_duration") or 0)
+        deep_s = float(s.get("deep_sleep_duration") or 0)
+        light_s = float(s.get("light_sleep_duration") or 0)
+        awake_s = float(s.get("awake_time") or 0)
+        in_bed_s = float(s.get("time_in_bed") or 0)
+        cursor = start_dt
+        for stage_name, dur_s in (
+            ("rem", rem_s),
+            ("deep", deep_s),
+            ("core", light_s),
+            ("awake", awake_s),
+        ):
+            if dur_s <= 0:
+                continue
+            stage_end = cursor + timedelta(seconds=dur_s)
+            yield {
+                "_kind": "sleep",
+                "start_date": cursor,
+                "end_date": stage_end,
+                "stage": stage_name,
+                "source_name": "Oura",
+            }
+            cursor = stage_end
+        # Emit an in-bed envelope marker so sleep_efficiency math works.
+        if in_bed_s > 0:
+            yield {
+                "_kind": "sleep",
+                "start_date": start_dt,
+                "end_date": start_dt + timedelta(seconds=in_bed_s),
+                "stage": "in_bed",
+                "source_name": "Oura",
+            }
+
+        # Surface HRV + RHR from the sleep session as quantity records.
+        hrv_avg = s.get("hrv", {}).get("average") if isinstance(s.get("hrv"), dict) else s.get("average_hrv")
+        if hrv_avg:
+            yield {
+                "_kind": "record",
+                "type": "HKQuantityTypeIdentifierHeartRateVariabilitySDNN",
+                "source_name": "Oura",
+                "unit": "ms",
+                "start_date": start_dt,
+                "end_date": end_dt,
+                "value": float(hrv_avg),
+                "value_str": None,
+            }
+        rhr = s.get("lowest_heart_rate") or s.get("average_heart_rate")
+        if rhr:
+            yield {
+                "_kind": "record",
+                "type": "HKQuantityTypeIdentifierRestingHeartRate",
+                "source_name": "Oura",
+                "unit": "count/min",
+                "start_date": start_dt,
+                "end_date": end_dt,
+                "value": float(rhr),
+                "value_str": None,
+            }
+        temp_dev = s.get("temperature_deviation")
+        if temp_dev is not None:
+            # Surface as wrist-temperature proxy. Note units differ from Apple
+            # (Oura is celsius deviation, Apple is degF absolute) — caller
+            # should not directly compare across vendors.
+            yield {
+                "_kind": "record",
+                "type": "OuraTemperatureDeviationC",
+                "source_name": "Oura",
+                "unit": "degC_delta",
+                "start_date": start_dt,
+                "end_date": end_dt,
+                "value": float(temp_dev),
+                "value_str": None,
+            }
+
+    # Daily readiness (Oura's recovery score).
+    readiness = _get("/daily_readiness", params).get("data", [])
+    for r in readiness:
+        day = r.get("day")
+        score = r.get("score")
+        if day and score is not None:
+            ts = datetime.fromisoformat(day)
+            yield {
+                "_kind": "record",
+                "type": "OuraReadinessScore",
+                "source_name": "Oura",
+                "unit": "score",
+                "start_date": ts,
+                "end_date": ts,
+                "value": float(score),
+                "value_str": None,
+            }
+
+    # Daily activity (steps + calories).
+    activity = _get("/daily_activity", params).get("data", [])
+    for a in activity:
+        day = a.get("day")
+        if not day:
+            continue
+        ts = datetime.fromisoformat(day)
+        steps = a.get("steps")
+        if steps is not None:
+            yield {
+                "_kind": "record",
+                "type": "HKQuantityTypeIdentifierStepCount",
+                "source_name": "Oura",
+                "unit": "count",
+                "start_date": ts,
+                "end_date": ts + timedelta(days=1),
+                "value": float(steps),
+                "value_str": None,
+            }
+        active = a.get("active_calories")
+        if active is not None:
+            yield {
+                "_kind": "record",
+                "type": "HKQuantityTypeIdentifierActiveEnergyBurned",
+                "source_name": "Oura",
+                "unit": "kcal",
+                "start_date": ts,
+                "end_date": ts + timedelta(days=1),
+                "value": float(active),
+                "value_str": None,
+            }
+        total = a.get("total_calories")
+        if total is not None and active is not None:
+            yield {
+                "_kind": "record",
+                "type": "HKQuantityTypeIdentifierBasalEnergyBurned",
+                "source_name": "Oura",
+                "unit": "kcal",
+                "start_date": ts,
+                "end_date": ts + timedelta(days=1),
+                "value": float(total) - float(active),
+                "value_str": None,
+            }
+
+    # Workouts.
+    workouts = _get("/workout", params).get("data", [])
+    for w in workouts:
+        start_dt = _parse_iso(w.get("start_datetime", ""))
+        end_dt = _parse_iso(w.get("end_datetime", ""))
+        if not (start_dt and end_dt):
+            continue
+        duration_min = (end_dt - start_dt).total_seconds() / 60.0
+        yield {
+            "_kind": "workout",
+            "activity_type": w.get("activity", "OuraWorkout"),
+            "duration_min": duration_min,
+            "distance_km": (float(w.get("distance") or 0)) / 1000.0 if w.get("distance") else None,
+            "energy_kcal": float(w.get("calories")) if w.get("calories") else None,
+            "start_date": start_dt,
+            "end_date": end_dt,
+            "source_name": "Oura",
+        }
+
+
+def folder_sha(start: date, end: date) -> str:
+    """Hash for idempotency. Oura imports are date-range scoped so we hash
+    the range + token suffix (NOT the actual token — privacy)."""
+    import hashlib
+    token = _token()
+    suffix = token[-4:] if len(token) > 4 else "anon"
+    return hashlib.sha256(f"oura|{start.isoformat()}|{end.isoformat()}|{suffix}".encode("utf-8")).hexdigest()

--- a/services/health-mcp/pyproject.toml
+++ b/services/health-mcp/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "health-mcp"
-version = "0.2.0"
-description = "Apple Health MCP server for the ai-brain-starter substrate. Full HealthKit surface coverage (108 quantity types + 47 symptom types + 14 cycle types + ECG + iOS 17 State of Mind). Multi-mode ingestion (XML / CSV / TCP-live + lab CSV). Open scoring algorithms (recovery / sleep / strain / sleep regularity / longevity panel / somatic state). Vault-aware tools that pair biometrics + cycle phase + symptoms with Floor tags from daily journals."
+version = "0.3.0"
+description = "Health MCP for the ai-brain-starter substrate. Multi-vendor (Apple Health + Oura Ring + Fitbit) ingestion with shared DuckDB schema. Full HealthKit surface (108 quantity types + 47 symptom types + 14 cycle types + ECG + iOS 17 State of Mind). Open scoring algorithms (recovery / sleep / strain / sleep regularity / longevity panel / somatic state). Vault-aware tools that pair biometrics + cycle phase + symptoms with Floor tags from daily journals. OS-aware setup wizard."
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.10"
@@ -49,4 +49,7 @@ include = [
   "cycle.py",
   "labs.py",
   "voice_bridge.py",
+  "oura_client.py",
+  "fitbit_client.py",
+  "vendor_setup.py",
 ]

--- a/services/health-mcp/tests/test_v03.py
+++ b/services/health-mcp/tests/test_v03.py
@@ -1,0 +1,119 @@
+"""v0.3 smoke tests covering vendor clients (Oura + Fitbit) + vendor setup guide.
+
+Vendor API calls are NOT made in tests (no live network). We test:
+  - Module imports
+  - Token validation (raises ValueError when env var missing)
+  - SHA generation (deterministic on same range)
+  - Vendor setup guide returns the right shape per vendor + OS
+  - Setup guide handles unsupported vendor + alias normalization
+"""
+from __future__ import annotations
+
+import os
+import sys
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parent))
+
+import fitbit_client  # noqa: E402
+import oura_client  # noqa: E402
+import vendor_setup  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# 01: vendor clients import + token validation
+# ---------------------------------------------------------------------------
+
+def test_oura_token_required(monkeypatch):
+    monkeypatch.delenv("OURA_PERSONAL_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("OURA_PAT", raising=False)
+    with pytest.raises(ValueError, match="OURA_PERSONAL_ACCESS_TOKEN"):
+        oura_client._token()
+
+
+def test_oura_token_resolves_when_set(monkeypatch):
+    monkeypatch.setenv("OURA_PERSONAL_ACCESS_TOKEN", "test-token-abcd")
+    assert oura_client._token() == "test-token-abcd"
+
+
+def test_fitbit_token_required(monkeypatch):
+    monkeypatch.delenv("FITBIT_ACCESS_TOKEN", raising=False)
+    with pytest.raises(ValueError, match="FITBIT_ACCESS_TOKEN"):
+        fitbit_client._token()
+
+
+def test_oura_folder_sha_deterministic(monkeypatch):
+    monkeypatch.setenv("OURA_PERSONAL_ACCESS_TOKEN", "test-token")
+    s1 = oura_client.folder_sha(date(2026, 1, 1), date(2026, 5, 10))
+    s2 = oura_client.folder_sha(date(2026, 1, 1), date(2026, 5, 10))
+    assert s1 == s2
+    s3 = oura_client.folder_sha(date(2026, 1, 1), date(2026, 5, 11))
+    assert s1 != s3
+
+
+def test_fitbit_folder_sha_deterministic(monkeypatch):
+    monkeypatch.setenv("FITBIT_ACCESS_TOKEN", "test-fb-token")
+    s1 = fitbit_client.folder_sha(date(2026, 1, 1), date(2026, 5, 10))
+    s2 = fitbit_client.folder_sha(date(2026, 1, 1), date(2026, 5, 10))
+    assert s1 == s2
+
+
+# ---------------------------------------------------------------------------
+# 02: vendor setup guide
+# ---------------------------------------------------------------------------
+
+def test_apple_health_guide_macos():
+    g = vendor_setup.vendor_setup_guide("apple_health", "macos")
+    assert g["vendor"] == "apple_health"
+    assert g["os"] == "macos"
+    assert "AirDrop" in " ".join(g.get("transfer_steps", []))
+    assert g["tool_to_run"] == "health_import_xml"
+
+
+def test_oura_guide_windows():
+    g = vendor_setup.vendor_setup_guide("oura", "windows")
+    assert g["vendor"] == "oura"
+    assert g["os"] == "windows"
+    assert "PowerShell" in " ".join(g["transfer_steps"])
+    assert "OURA_PERSONAL_ACCESS_TOKEN" in g["env_vars"]
+
+
+def test_fitbit_guide_linux():
+    g = vendor_setup.vendor_setup_guide("fitbit", "linux")
+    assert g["vendor"] == "fitbit"
+    assert g["os"] == "linux"
+    assert "FITBIT_ACCESS_TOKEN" in g["env_vars"]
+    assert "FITBIT_REFRESH_TOKEN" in g["env_vars"]
+
+
+def test_vendor_alias_normalization():
+    """'apple' / 'apple watch' / 'iphone' / 'ios' all map to apple_health."""
+    for alias in ["apple", "apple_watch", "apple watch", "iphone", "ios"]:
+        g = vendor_setup.vendor_setup_guide(alias, "macos")
+        assert g["vendor"] == "apple_health"
+
+
+def test_unsupported_vendor_returns_error():
+    g = vendor_setup.vendor_setup_guide("polar_xyz", "macos")
+    assert "error" in g
+    assert "Unsupported" in g["error"]
+
+
+def test_garmin_guide_routes_via_apple_health():
+    g = vendor_setup.vendor_setup_guide("garmin", "macos")
+    assert g["vendor"] == "garmin"
+    assert "apple_health" in g["tool_to_run"].lower() or "Apple Health" in g["summary"]
+
+
+def test_whoop_marked_deferred():
+    g = vendor_setup.vendor_setup_guide("whoop", "macos")
+    assert "v0.4" in g["tool_to_run"] or "v0.4" in g["summary"]
+
+
+def test_supported_vendors_set_contains_expected():
+    expected = {"apple_health", "oura", "fitbit", "garmin", "whoop"}
+    assert vendor_setup.SUPPORTED_VENDORS == expected

--- a/services/health-mcp/vendor_setup.py
+++ b/services/health-mcp/vendor_setup.py
@@ -1,0 +1,219 @@
+"""Vendor + OS aware setup guides for the /health-setup skill.
+
+Each guide is the minimum steps the user needs to do off-machine to get
+their wearable data flowing into this MCP. Returned as a structured dict
+the skill renders to the user.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+SUPPORTED_VENDORS = {"apple_health", "oura", "fitbit", "garmin", "whoop"}
+SUPPORTED_OS = {"macos", "linux", "windows"}
+
+
+_GUIDES: dict[str, dict[str, Any]] = {
+    "apple_health": {
+        "display_name": "Apple Health",
+        "requires_iphone": True,
+        "free_paths": ["xml_export", "simple_health_export_csv"],
+        "paid_paths": ["health_auto_export_tcp"],
+        "summary": (
+            "Apple Health is the native iOS health store. Three import modes: "
+            "free XML export, free Simple Health Export CSV, paid Health Auto "
+            "Export TCP live."
+        ),
+        "common_steps": [
+            "On your iPhone, open the Health app",
+            "Tap your profile picture (top right)",
+            "Scroll to the bottom and tap **Export All Health Data**",
+            "Wait 1-3 minutes for the export bundle (export.zip)",
+        ],
+        "transfer_steps_by_os": {
+            "macos": ["AirDrop the export.zip from iPhone to your Mac", "Save it to your Downloads folder", "Run `health_import_xml(\"~/Downloads/export.zip\")`"],
+            "windows": ["Email or iCloud-share the export.zip from iPhone to your PC", "Save it to your Downloads folder", "Run `health_import_xml(\"%USERPROFILE%\\\\Downloads\\\\export.zip\")`"],
+            "linux": ["Email or share the export.zip to your Linux machine", "Save it locally", "Run `health_import_xml(\"/path/to/export.zip\")`"],
+        },
+        "env_vars": {},
+        "tool_to_run": "health_import_xml",
+        "ongoing_cadence": "Re-export from iOS Health every 1-4 weeks for a fresh snapshot. The streaming parser handles 1M+ records.",
+        "notes": [
+            "All ingestion modes are local-only. Your data never leaves your machine.",
+            "Idempotent: re-importing the same file returns skipped=True unless force=True.",
+        ],
+    },
+    "oura": {
+        "display_name": "Oura Ring",
+        "requires_iphone": False,
+        "free_paths": ["oura_v2_api"],
+        "paid_paths": [],
+        "summary": (
+            "Oura Ring gen 2/3/4. Uses the Oura v2 Cloud API with a Personal "
+            "Access Token (free). Works without iPhone — token is generated "
+            "from any browser."
+        ),
+        "common_steps": [
+            "Open https://cloud.ouraring.com/personal-access-tokens in a browser",
+            "Sign in with your Oura account",
+            "Click **Create New Personal Access Token**",
+            "Name it (e.g., `ai-brain-starter`) and copy the token immediately — it is shown only once",
+        ],
+        "transfer_steps_by_os": {
+            "macos": [
+                "Open Terminal",
+                "Run: `echo 'export OURA_PERSONAL_ACCESS_TOKEN=<paste-token>' >> ~/.zshrc`",
+                "Reload your shell: `source ~/.zshrc`",
+                "Verify: `echo $OURA_PERSONAL_ACCESS_TOKEN`",
+                "Restart Claude Code",
+                "Run `health_import_oura(start=\"2026-01-01\", end=\"2026-05-10\")`",
+            ],
+            "windows": [
+                "Open PowerShell as your user (not admin)",
+                "Run: `[System.Environment]::SetEnvironmentVariable('OURA_PERSONAL_ACCESS_TOKEN', '<paste-token>', 'User')`",
+                "Close + reopen PowerShell, restart Claude Code",
+                "Run `health_import_oura(start=\"2026-01-01\", end=\"2026-05-10\")`",
+            ],
+            "linux": [
+                "Append to ~/.bashrc or ~/.zshrc: `export OURA_PERSONAL_ACCESS_TOKEN=<paste-token>`",
+                "Reload your shell, restart Claude Code",
+                "Run `health_import_oura(start=\"2026-01-01\", end=\"2026-05-10\")`",
+            ],
+        },
+        "env_vars": {"OURA_PERSONAL_ACCESS_TOKEN": "PAT from cloud.ouraring.com/personal-access-tokens"},
+        "tool_to_run": "health_import_oura",
+        "ongoing_cadence": "Re-run with a recent start_date weekly, OR set up a scheduled task to call health_import_oura every morning for yesterday's data.",
+        "notes": [
+            "Personal Access Tokens never expire unless you revoke them. Treat them like a password.",
+            "Free tier: no rate limits in practice for personal use (Oura's docs cite 5000/day).",
+            "If your token leaks, revoke it from the same page and generate a new one.",
+        ],
+    },
+    "fitbit": {
+        "display_name": "Fitbit",
+        "requires_iphone": False,
+        "free_paths": ["fitbit_web_api_personal_app"],
+        "paid_paths": [],
+        "summary": (
+            "Fitbit Web API via a personal OAuth2 app (free). Slightly more "
+            "setup than Oura because Fitbit requires app registration before "
+            "issuing tokens."
+        ),
+        "common_steps": [
+            "Open https://dev.fitbit.com/apps in a browser",
+            "Sign in with your Fitbit account",
+            "Click **Register a New App**",
+            "Use these values: Application Name=`ai-brain-starter`, Application Type=`Personal`, OAuth 2.0 Application Type=`Server`, Redirect URL=`https://localhost:8080/callback`, Default Access Type=`Read & Write`",
+            "Save the **OAuth 2.0 Client ID** and **Client Secret**",
+            "Use Fitbit's Tutorial token-generator at https://dev.fitbit.com/apps/oauthinteractivetutorial to run the OAuth2 flow and obtain an access_token + refresh_token (one-click flow once your app is registered)",
+        ],
+        "transfer_steps_by_os": {
+            "macos": [
+                "Open Terminal",
+                "Run: `echo 'export FITBIT_ACCESS_TOKEN=<paste-token>' >> ~/.zshrc`",
+                "Run: `echo 'export FITBIT_REFRESH_TOKEN=<paste-refresh-token>' >> ~/.zshrc`",
+                "Run: `echo 'export FITBIT_CLIENT_ID=<paste-client-id>' >> ~/.zshrc`",
+                "Run: `echo 'export FITBIT_CLIENT_SECRET=<paste-client-secret>' >> ~/.zshrc`",
+                "Reload: `source ~/.zshrc`",
+                "Restart Claude Code",
+                "Run `health_import_fitbit(start=\"2026-01-01\", end=\"2026-05-10\")`",
+            ],
+            "windows": [
+                "Open PowerShell as your user",
+                "Run for each variable: `[System.Environment]::SetEnvironmentVariable('FITBIT_ACCESS_TOKEN', '<paste-token>', 'User')`",
+                "Same for FITBIT_REFRESH_TOKEN, FITBIT_CLIENT_ID, FITBIT_CLIENT_SECRET",
+                "Restart PowerShell + Claude Code",
+                "Run `health_import_fitbit(start=\"2026-01-01\", end=\"2026-05-10\")`",
+            ],
+            "linux": [
+                "Append all four env vars to ~/.bashrc or ~/.zshrc",
+                "Reload your shell, restart Claude Code",
+                "Run `health_import_fitbit(start=\"2026-01-01\", end=\"2026-05-10\")`",
+            ],
+        },
+        "env_vars": {
+            "FITBIT_ACCESS_TOKEN": "OAuth2 access token (8-hour expiry, auto-refreshed if refresh token + client id + secret are set)",
+            "FITBIT_REFRESH_TOKEN": "Long-lived refresh token (used to mint new access tokens)",
+            "FITBIT_CLIENT_ID": "OAuth2 Client ID from your registered Fitbit Personal app",
+            "FITBIT_CLIENT_SECRET": "OAuth2 Client Secret from your registered Fitbit Personal app",
+        },
+        "tool_to_run": "health_import_fitbit",
+        "ongoing_cadence": "Set up a scheduled task to call health_import_fitbit every morning for yesterday. Access token auto-refreshes if all four env vars are set.",
+        "notes": [
+            "Fitbit HRV requires a Premium subscription. Without Premium, you get steps + sleep + RHR, no HRV.",
+            "Fitbit rate-limit is 150 requests/hour for personal apps. The importer runs one request per metric per day, ~5/day, so a year of backfill stays well under the limit.",
+            "If you hit 429 errors, wait 1 hour or contact Fitbit dev support for an exception.",
+        ],
+    },
+    "garmin": {
+        "display_name": "Garmin",
+        "requires_iphone": False,
+        "free_paths": [],
+        "paid_paths": [],
+        "summary": (
+            "Garmin Connect data is not yet directly supported. For now, "
+            "Garmin users have two options: (1) sync Garmin Connect to Apple "
+            "Health on iPhone via the Garmin Connect app, then export via "
+            "Apple Health; (2) wait for v0.4 which will add direct Garmin "
+            "Connect IQ + Garmin Health API support."
+        ),
+        "common_steps": [
+            "Install Garmin Connect app on your iPhone",
+            "Garmin Connect > More > Health Stats > Apple Health > enable sync for the metrics you want",
+            "Wait 24h for back-sync to complete",
+            "Then follow the Apple Health setup guide",
+        ],
+        "transfer_steps_by_os": {},
+        "env_vars": {},
+        "tool_to_run": "(via apple_health)",
+        "ongoing_cadence": "Same as Apple Health.",
+        "notes": [
+            "Garmin Connect IQ is a planned v0.4 addition. Track at github.com/adelaidasofia/ai-brain-starter/issues",
+        ],
+    },
+    "whoop": {
+        "display_name": "Whoop",
+        "requires_iphone": False,
+        "free_paths": [],
+        "paid_paths": [],
+        "summary": (
+            "Whoop API access requires Whoop Pro subscription + OAuth2 app "
+            "registration. Not yet directly supported in v0.3. For now, the "
+            "open-wearables platform at github.com/the-momentum/open-wearables "
+            "supports Whoop natively if you want multi-vendor right now."
+        ),
+        "common_steps": [
+            "Confirm you have Whoop Pro",
+            "Visit developer.whoop.com to register an OAuth2 app",
+            "Track v0.4 progress at github.com/adelaidasofia/ai-brain-starter/issues for native support",
+        ],
+        "transfer_steps_by_os": {},
+        "env_vars": {},
+        "tool_to_run": "(deferred to v0.4)",
+        "ongoing_cadence": "n/a until v0.4",
+        "notes": ["open-wearables is the heavier-but-multi-vendor alternative today."],
+    },
+}
+
+
+def vendor_setup_guide(vendor: str, os_kind: str = "macos") -> dict[str, Any]:
+    """Return setup steps for a vendor + OS combination."""
+    v = vendor.lower().strip().replace("-", "_").replace(" ", "_")
+    if v == "apple" or v == "apple_watch" or v == "iphone" or v == "ios":
+        v = "apple_health"
+    if v not in SUPPORTED_VENDORS:
+        return {
+            "vendor": v,
+            "error": f"Unsupported vendor. Supported: {sorted(SUPPORTED_VENDORS)}",
+        }
+    os_k = os_kind.lower().strip()
+    if os_k in {"mac", "darwin", "osx"}:
+        os_k = "macos"
+    if os_k in {"win", "windows10", "windows11"}:
+        os_k = "windows"
+
+    guide = dict(_GUIDES[v])
+    guide["vendor"] = v
+    guide["os"] = os_k
+    if "transfer_steps_by_os" in guide and os_k in guide["transfer_steps_by_os"]:
+        guide["transfer_steps"] = guide["transfer_steps_by_os"][os_k]
+    return guide

--- a/skills/backfill-journal-body-context/SKILL.md
+++ b/skills/backfill-journal-body-context/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: backfill-journal-body-context
+description: Walks every daily journal entry in a date range (default this year) and appends a "Body track" section BELOW the original verbatim content. Pulls health-mcp data for each date (HRV, RHR, sleep, cycle phase, lab status, recovery/sleep/strain scores) and weaves a Floor-paired interpretation. Idempotent (skips entries that already have the section). Use when user says /backfill-journal-body-context, asks to enrich journals with body data, says "backfill my journals with health" or wants existing journal entries paired with their Apple Health / Oura / Fitbit data retroactively.
+---
+
+# backfill-journal-body-context
+
+Reads existing daily journals, pulls health-mcp data for each entry's date, and appends a "Body track" section BELOW the original verbatim content. The original entry text is NEVER modified — the rule from `feedback_journal_verbatim_words.md` is non-negotiable.
+
+## When to use
+
+- User says `/backfill-journal-body-context`
+- User wants their existing journals enriched with body data (HRV, sleep, recovery, cycle phase) retroactively
+- User wants to see what `/weekly` and `/monthly` would surface if they had been pulling body data all along
+- After running `/health-setup` for the first time and importing a backfill window of biometric data
+
+Do NOT use for:
+- Brand-new journal entries (daily-journal already pulls body context via health-context skill)
+- Editing journal content beyond appending the body section
+- Anything that touches the original verbatim journal body
+
+## How it works
+
+1. Determine the date range. Default: `--year <current-year>` (Jan 1 to today).
+2. Find journal entries in that range using `[VAULT_PATH]/Meta/journal-index.json` (rebuild if stale).
+3. For each entry:
+   - Read the file
+   - Check if it already has a `## Body track (health-mcp, backfilled YYYY-MM-DD)` section — if yes, skip (idempotent)
+   - Call `health_journal_context(date, voice_profile="warm")` for the data + rendered prose
+   - Call `health_cycle_context(date)` if cycle data exists (for women's cycle awareness)
+   - Call `health_recovery_score(date)` + `health_sleep_score(date)` for the scores
+   - Call `health_lab_panel(date, lookback_days=180)` for any out-of-range markers active that period
+   - Pair the body data with the entry's floor tag (from frontmatter `floor_level` + `floor`)
+   - Render the body-track section using the template below
+   - Append BELOW the original content with a clear divider
+4. Print summary: N entries processed, M backfilled, K skipped.
+
+## Body track template
+
+Append below the original journal content, after a blank line + horizontal rule:
+
+```markdown
+
+---
+
+## Body track (health-mcp, backfilled {{today_iso}})
+
+*Auto-generated context. Original journal entry above is preserved verbatim.*
+
+**Floor that day:** {{floor_name}} ({{floor_level}})
+
+**Cycle phase** (if cycle data exists): {{phase}}, cycle day {{cycle_day}}{{ — irregularity flag if any}}
+
+**The body that day:**
+- HRV: {{hrv_ms}} ms ({{hrv_delta_pct}}% vs 30-day baseline)
+- RHR: {{rhr_bpm}} bpm
+- Sleep: {{sleep_asleep_min}} min ({{sleep_efficiency}}% efficiency, REM {{rem_min}}min, deep {{deep_min}}min)
+- Steps: {{steps_total}}
+- Workouts: {{workout_count}} ({{workout_min}}min)
+- Mindful: {{mindful_min}}min
+
+**Scores:**
+- Recovery: {{recovery_score}}/100 ({{confidence}} confidence)
+- Sleep: {{sleep_score}}/100
+
+**Floor-paired interpretation** (1-3 sentences, see synthesis rule below): {{interpretation}}
+
+**Lab markers** (if any out-of-range result from the prior 180 days, paired with today): {{lab_flags}}
+```
+
+## Synthesis rule (the helpful-not-just-cool part)
+
+The `interpretation` line must follow the same shape as the `/weekly` section 0d synthesis. Each line:
+- Names the pattern (cycle phase explaining HRV, under-fueling masking recovery, anniversary coupling, etc.)
+- Hypothesizes what it might mean
+- Suggests a specific next-action when applicable
+
+Examples (template SHAPES, not for verbatim use):
+
+> Floor was Fear and HRV ran 22% below baseline on a luteal day. The body and the mind both registered the threat. Without the journal entry the recovery score would have called this "rest more"; pairing with Fear shows the actual signal was "the worry is doing work the rest can't fix."
+
+> Floor was Joy after a strong gym week. HRV at baseline, sleep efficiency 94%. This is the high-water mark — note what conditions produced it.
+
+> Floor was Apathy and Vitamin D 25-OH came back at 26 ng/mL (below range) the month before. The mood floor may have had a metabolic floor under it. Worth a re-test after 3 months of supplementation.
+
+Banned shapes (from `/weekly` section 0d, same rules apply):
+- Listing body numbers without an interpretation
+- Generic "rest more / eat better / hydrate" advice
+- Treating recovery score as ground truth when cycle phase or under-fuel explains the dip
+- Pretending in-range labs cause symptoms
+
+## Model routing
+
+The interpretation line is grunt-work prose. Use the cheapest model that produces a helpful sentence. Order of preference:
+
+1. **Python template** (zero cost) — for high-confidence cases (HRV in normal range during follicular, no out-of-range labs, no anniversary signal). The script `scripts/backfill-journal-body-context.py` covers this.
+2. **MiniMax** (~$0.06/M tokens, very cheap) — for cases where the data shows a real pattern that deserves a synthesized sentence. Invoke via `"⚙️ Meta/scripts/minimax.sh"` if the vault has it, otherwise skip the LLM step and use a fallback template.
+3. **Haiku** (cheap, fast, reliable) — for cases where MiniMax is unavailable.
+4. **Sonnet** — only if explicit `--high-quality` flag passed and the user accepts the cost.
+
+The default is Python template + MiniMax fallback. Do NOT default to Sonnet for hundreds of journal entries.
+
+## Invocation
+
+The actual work runs in `scripts/backfill-journal-body-context.py`. The skill assembles arguments and hands off to the script.
+
+When invoked:
+
+1. Parse arguments:
+   - `--year YYYY` (default: current year)
+   - `--start YYYY-MM-DD` and `--end YYYY-MM-DD` (override year)
+   - `--vault-root PATH` (default: $VAULT_ROOT or autodetect from cwd)
+   - `--llm-model {python,minimax,haiku,sonnet}` (default: `python` with `minimax` fallback)
+   - `--dry-run` (print what would change without writing)
+   - `--force` (overwrite an existing body-track section)
+
+2. Sanity checks:
+   - health-mcp must be registered. If not, abort with setup instructions.
+   - Run `health_status()` to confirm there's biometric data in the DuckDB. If the count is zero, abort and suggest `/health-setup` first.
+   - The vault must have a `Meta/journal-index.json` and a journal folder. Rebuild the index if stale.
+
+3. Run the script:
+   ```
+   /usr/bin/python3 "[REPO_ROOT]/scripts/backfill-journal-body-context.py" --year 2026 --vault-root "$VAULT_ROOT"
+   ```
+
+4. Surface the summary: N entries processed, M backfilled, K skipped, plus the date range covered.
+
+## Output
+
+The skill does NOT write to the vault itself — the Python script does the file mutations. The skill only:
+- Validates inputs
+- Calls health-mcp tools to verify data exists
+- Invokes the Python script
+- Reports the result
+
+## Idempotency
+
+The Python script checks each journal file for an existing `## Body track (health-mcp, backfilled` line. If present, skip unless `--force`. Re-running the skill on the same range is safe.
+
+## Ongoing daily run
+
+After the initial backfill, the same script runs daily for yesterday's entry via a scheduled task (use the `/schedule` skill). Suggested cadence: 7am local, after Apple Watch has uploaded the previous night's sleep data.
+
+Scheduled-task body:
+```
+/usr/bin/python3 "[REPO_ROOT]/scripts/backfill-journal-body-context.py" --start "$(date -v-1d +%F)" --end "$(date -v-1d +%F)" --vault-root "$VAULT_ROOT"
+```
+
+That's "backfill yesterday, every morning, forever." Set it up after the initial backfill completes successfully.
+
+## Voice rules
+
+- The auto-generated body-track section is in `warm` register (narrative sentences, not clinical exact-number dumps)
+- For Spanish journals, render the section in Spanish (the script detects via the journal's frontmatter `language:` field if present)
+- Floor names use the appropriate language alias (`[[Joy]]` in English / `[[Alegría]]` in Spanish)
+- Never modify the original entry's content. Only append.
+
+## Privacy
+
+The script reads journal files + the local DuckDB. It writes only to journal files (appending body-track sections). No data leaves the machine. The interpretation step (if LLM-backed) sends ONLY the structured body data + floor tag to the chosen model — never the journal body content.

--- a/skills/health-setup/SKILL.md
+++ b/skills/health-setup/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: health-setup
+description: Interactive setup wizard for the health-mcp connector. Picks the right wearable (Apple Watch / Apple Health, Oura Ring, Fitbit, Garmin, Whoop) and OS (macOS / Windows / Linux), walks the user through getting API tokens or exporting data, sets env vars, and verifies the connection end-to-end. Use when the user says /health-setup, asks to set up their wearable, asks "which wearable", asks how to import Oura or Fitbit, or after a fresh install of health-mcp.
+---
+
+# health-setup, interactive wearable connector wizard
+
+Walks the user from "I have an Apple Watch / Oura / Fitbit" to "data is in my DuckDB and I can run /weekly with body track populated."
+
+The wizard branches by:
+1. Which wearable(s) they have
+2. Which OS they're on (macOS / Windows / Linux)
+3. Whether they're starting fresh or adding a second device
+
+It never installs anything they don't want. Each branch has its own setup path — most of them are 3-5 manual steps and a paste-into-shell to set env vars.
+
+## When to use
+
+- User says `/health-setup` or `/setup-health` or `setup my health connector`
+- User asks "how do I import Oura / Fitbit / my Apple Watch data"
+- User says "which wearable should I use" — pick + walk through setup
+- After a fresh install of the ai-brain-starter substrate
+- After health-mcp v0.3+ is registered but no data is imported yet
+
+Do NOT use for:
+- Querying already-imported data (use `health_status`, `health_recovery_score`, etc.)
+- Building new wearable connectors (that's a substrate dev task)
+- Onboarding non-health skills
+
+## Wizard flow
+
+### Step 1: Detect the OS
+
+Look for `darwin` / `linux` / a Windows path separator in the environment. Confirm with the user if uncertain. Map to one of: `macos`, `linux`, `windows`.
+
+### Step 2: Ask which wearable(s) they have
+
+Multiple-select. The substrate currently supports first-class:
+
+- **Apple Watch / iPhone (Apple Health)** — most common, free, works without iPhone-paired apps
+- **Oura Ring** — free Personal Access Token, no app review needed
+- **Fitbit** — free Personal app, slightly more setup (OAuth2)
+- **Garmin** — sync to Apple Health on iPhone, then ingest via Apple Health path
+- **Whoop** — deferred to v0.4
+
+If they say "multiple" — that's fine, the substrate's shared DuckDB schema accepts data from all vendors. Run each vendor's setup in sequence.
+
+If they say "I don't have one" — close the wizard. Recommend they journal manually + add labs (`health_import_labs`) for the parts of the substrate that don't need wearables.
+
+### Step 3: Run `health_vendor_setup_guide` for each chosen vendor
+
+Call the tool with the vendor + OS:
+
+```
+health_vendor_setup_guide(vendor="oura", os_kind="macos")
+```
+
+The returned dict contains: display_name, summary, common_steps, transfer_steps (OS-specific), env_vars (with explanations), tool_to_run, ongoing_cadence, notes.
+
+Render it to the user as numbered steps. Do NOT paraphrase the env-var commands — copy them verbatim, the user will paste them into their shell.
+
+### Step 4: Verify before importing
+
+Once env vars are set and Claude Code restarted, run:
+
+```
+health_vendor_healthcheck(vendor="oura")   # for Oura
+health_vendor_healthcheck(vendor="fitbit") # for Fitbit
+health_status()                            # for Apple Health
+```
+
+Each returns either `{ok: true, ...account-info}` or `{ok: false, error: "..."}`. If `ok: false`, surface the error and walk back to the env-var step.
+
+### Step 5: First import
+
+Once the healthcheck passes, run the vendor's import for a reasonable initial window. For backfill, propose Jan 1 of the current year to today:
+
+```
+health_import_apple_health("/path/to/export.zip")        # Apple Health
+health_import_oura(start="2026-01-01", end="2026-05-10") # Oura
+health_import_fitbit(start="2026-01-01", end="2026-05-10") # Fitbit (may take 2-5min due to per-day API calls)
+```
+
+Surface the row counts at the end. Confirm with a sample query:
+
+```
+health_recovery_score("2026-05-09")
+health_cycle_context("2026-05-09")
+health_longevity_panel("2026-05-09")
+```
+
+### Step 6: Suggest the ongoing cadence
+
+For Apple Health: re-export from iOS every 1-4 weeks.
+
+For Oura + Fitbit: a daily scheduled task. Suggest creating one via the `/schedule` skill — pull yesterday's data every morning at 6am. The scheduled task call is:
+
+```
+health_import_oura(start="<yesterday>", end="<yesterday>")
+health_import_fitbit(start="<yesterday>", end="<yesterday>")
+```
+
+Each runs in <30 seconds for a single day.
+
+### Step 7: Suggest the backfill
+
+If the user wants their existing daily journals enriched with body context retroactively, point them to `/backfill-journal-body-context`. That skill walks every journal entry this year and appends a body-track section below the original content (verbatim preserved per the journal voice rule).
+
+## Voice rules
+
+- Direct, warm, no fluff
+- One step at a time — never dump the full wizard in one message
+- Copy-paste blocks: indent and code-fence them so the user can copy without losing whitespace
+- Match the user's language (Spanish if they Spanish, English if they English)
+- If the user is on Windows, never give them macOS commands as the "default"
+
+## Multi-vendor merging
+
+If the user has both Apple Watch AND an Oura Ring, the DuckDB schema accepts both. The recovery_score formula will use whichever metric has data for a given day. When both vendors record HRV on the same day, the LAST writer wins (no smart merging in v0.3). v0.4 will add per-source priority preferences.
+
+## Graceful failure modes
+
+- **Vendor API rate-limited:** Fitbit has 150 req/hour. The importer respects the rate by serial single-day calls. If 429 surfaces, suggest a 1-hour wait or chunking the backfill into smaller windows.
+- **Token expired:** Fitbit access tokens expire in 8 hours. If FITBIT_REFRESH_TOKEN + FITBIT_CLIENT_ID + FITBIT_CLIENT_SECRET are set, the client refreshes automatically. If only the access token is set, walk the user back through the OAuth flow.
+- **No iPhone available:** Apple Health requires iOS export. If user has no iPhone, they cannot use the Apple Health path. Route them to Oura (free) or Fitbit.
+- **Vendor not supported yet:** Whoop and direct Garmin support are v0.4. Today's substitute: sync Garmin to Apple Health on iPhone, then export via Apple Health.
+
+## Output contract
+
+The wizard does not write any files. It only:
+- Calls `health_vendor_setup_guide` to render instructions
+- Asks the user to paste env vars into their shell themselves
+- Calls `health_vendor_healthcheck` and the import tools when they're ready
+- Surfaces the row counts + sample queries at the end
+
+No vault writes, no global state changes. The substrate stays clean.


### PR DESCRIPTION
## Summary

Multi-vendor wearable support + OS-aware install wizard + retroactive journal enrichment.

### What landed

**Oura Ring** — Personal Access Token only (free from cloud.ouraring.com/personal-access-tokens). New tool `health_import_oura(start, end)`. Sleep stages + readiness + activity + workouts + HRV + RHR all normalize to the same DuckDB schema as Apple Health.

**Fitbit** — OAuth2 Personal app (free from dev.fitbit.com/apps). New tool `health_import_fitbit(start, end)`. Auto-refreshes access tokens when refresh + client id + secret are set. HRV requires Premium; steps + sleep + RHR + weight work on free tier.

**/health-setup wizard** — Interactive picker that branches by wearable + OS (macOS / Windows / Linux). New tools `health_vendor_setup_guide(vendor, os_kind)` returns OS-specific shell commands; `health_vendor_healthcheck(vendor)` verifies tokens before first import. Supported: `apple_health`, `oura`, `fitbit`, `garmin` (routes via Apple Health iPhone sync), `whoop` (deferred to v0.4).

**Multi-vendor schema sharing** — Every vendor writes to the same `records` / `workouts` / `sleep` tables using the same HKQuantityType ids. Recovery score, longevity panel, cycle context, floor correlation, and every vault-aware tool work across vendors without modification.

**/backfill-journal-body-context skill + script** — Walks every daily journal entry in a date range and appends a "Body track" section **BELOW** the original verbatim content (the journal-verbatim rule is non-negotiable). Pulls HRV / RHR / sleep / cycle phase / recovery / sleep score / out-of-range lab markers + a Floor-paired interpretation. Idempotent.

**Smartest, most efficient model routing** — Default `--llm-model python` (Python template, zero cost, deterministic). Optional `--llm-model minimax` for richer prose (~$0.06/M tokens, pennies for a year of journals). Explicitly de-prioritizes Sonnet / Opus for per-entry interpretation — overkill for templated body-track lines.

**docs/BACKFILL_PROMPT.md** — Self-contained prompt for a fresh Claude Code session to run the backfill end-to-end (dry-run → real-run → ongoing daily cadence scheduled task → /weekly verification).

## Tools

| Surface | v0.2 | v0.3 |
|---|---|---|
| Total | 32 | **36** |
| Vendors supported (live) | Apple Health | Apple Health + Oura + Fitbit |
| Vendors planned | — | Garmin direct + Whoop (v0.4) |

## Test plan

- [x] All 11+5 modules import clean (`db, parse_xml, parse_csv, live_tcp, scores, vault_aware, hk_types, cycle, labs, voice_bridge, oura_client, fitbit_client, vendor_setup, main`)
- [x] **54/54 pytest tests pass** (41 v0.2 + 13 v0.3 new)
- [x] Tier-A scrub gate: 0 personal-data matches across all v0.3 additions
- [x] Vendor token validation raises ValueError when env vars missing
- [x] SHA generation is deterministic on same date range (idempotent re-imports)
- [x] Vendor setup guide returns the right shape per vendor + OS with alias normalization
- [ ] First-run install on clean clone: `/health-setup` walks user through Oura PAT setup; `health_vendor_healthcheck("oura")` returns `{ok: true, user_id: ...}`
- [ ] First-run install Fitbit: OAuth flow completes, `health_vendor_healthcheck("fitbit")` returns ok
- [ ] Backfill smoke: run script with `--year 2026 --dry-run --vault-root /path/to/vault` on a vault with floor-tagged journals + biometric data; verify sample output has Floor-paired interpretation

## Privacy

- No vendor data is logged or sent anywhere. Each vendor's API client uses the user's local token to fetch their data and writes to a local DuckDB.
- The backfill script reads journal files + the local DuckDB and writes ONLY to journal files (appending body-track sections). No data leaves the machine.
- When `--llm-model minimax` is used for richer prose, the script sends ONLY the structured body data + Floor tag to MiniMax — never the journal body content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)