### PR TITLE
feat: health-mcp v0.4 — /coach longevity + fitness coach skill

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,48 @@ description: What's new in AI Brain Starter — plain English, no jargon
 
 ---
 
+## 2026-05-10: health-mcp v0.4 — /coach longevity + fitness coach skill (progressive overload + cycle-aware + Floor-paired)
+
+**Who this affects:** anyone who wants a daily workout prescription that reads from their actual biometrics + cycle phase + emotional state (Floor) instead of a generic template. Companion to the /weekly + /monthly insights — coach drives the daily prescription, insights surface the weekly/monthly pattern.
+
+**The shape:** The substrate had the data + the analytics + the journal pairing + the insights review. What it didn't have was a COACH PERSONA that issued a workout. A user on the panel sent the "Claude Fitness Coach" PDF from someone else and asked what we could learn. The panel said: lift the calendar drop + progressive overload + the daily decision shape, but extend it because their version is JUST fitness and our substrate already has the longevity + cycle-aware + Floor-pairing data they're missing. v0.4 is that extension.
+
+### What landed
+
+1. **Coach state layer** (`services/health-mcp/coach.py`): three new DuckDB tables (`coach_prescriptions`, `coach_completions`, `coach_lift_progress`). Tracks every prescription's id + workout type + difficulty + why_today, every completion's RPE + notes + lift actuals, and per-lift progression state (last weight + reps + sets, consecutive full sets, consecutive failures, current top set).
+
+2. **Progressive overload state machine.** Fail-twice-drop-10%, complete-twice-add-2.5kg (upper body) or 5kg (lower body), single-fail holds the weight. Deload every 4th week from profile start (40% volume drop, 20% intensity drop).
+
+3. **Decision tree wired to existing analytics.** The `health_coach_prescribe` tool reads recovery score + sleep score + cycle context + somatic state + body_says_slow_down + days-per-week + equipment + level + started_iso and returns workout_type + intensity_factor + difficulty + deload_week + why_today + prescription_id. Cycle-phase qualifier: luteal HRV dips don't collapse intensity (Sims, panel rule). Sleep score < 35 → rest day. `body_says_slow_down: true` → active recovery (Levine rule).
+
+4. **`/coach` skill** (`skills/coach/SKILL.md`): the user-facing surface. Profile setup (12 questions saved to `<vault>/Meta/coach-profile.yaml`), daily prescription that reads health-mcp + today's journal Floor and renders the workout block, weekly planning that pulls last week's completion + body data, monthly review that bundles the Attia longevity panel (VO2Max + Zone 2 minutes + walking steadiness + lean mass), and `/coach log` for entering actuals after a session.
+
+5. **Floor qualifier** (substrate differentiator). Floor in Shame / Fear / Apathy / Grief / Anger AND `floor_sensitivity: high` in profile → intensity drops ~15%, swap heavy compounds for moderate accessories or mobility. Floor in Joy / Peace / Love / Gratitude → green light. Floor in Courage + good sleep + follicular phase → PR day. The qualifier is multiplicative on top of `intensity_factor`. Never overrides somatic-state slow-down — that's still regulate-first.
+
+6. **Calendar drop integration.** If `profile.calendar_drop: true` AND `google-workspace` MCP is connected, daily prescriptions write to the user's Google Calendar at their preferred workout time. Title pattern: `🏋️ [Type] · [duration]min`. Full workout block in description. Weekly planning writes 7 events at once.
+
+7. **Five new tools**: `health_coach_prescribe`, `health_coach_lift_state`, `health_coach_log_completion`, `health_coach_recent_prescriptions`, `health_coach_summary`. Brings tool total to 41 (32 in v0.2 + 4 in v0.3 + 5 in v0.4).
+
+### What we deliberately did NOT copy from the PDF
+
+- Their iOS-beta Apple Health integration. Our local-only multi-vendor (Apple + Oura + Fitbit) path is strictly better for privacy + cross-platform.
+- Their hardcoded sleep tiers (`<4h = no workout, 4-5h = recovery only, 5-6h = drop 40%`). We use `sleep_score` and `sleep_regularity` as continuous signals.
+- Their generic cycle prescriptions (`follicular = strength PRs, luteal = lighter weights`). Ours compares THIS cycle's HRV/sleep to baseline per phase via `health_phase_means`, not a generic 28-day template.
+- "Nutrition only when asked" — flipped. If the under-fuel detector fires (Braddock pattern from v0.2), the coach surfaces it without being asked.
+- Their assumption that the data-driven coach is the whole answer. The Bainbridge dissent voice on the panel was integrated as the body-literacy prompt (`health_journal_body_question`) and the Floor qualifier — the coach acknowledges emotional state, not just biometrics.
+
+### Tests
+
+69 passing (up from 54 in v0.3). New v0.4 tests cover the progressive-overload state machine (first session, complete-twice-add for upper + lower, fail-twice-drop-10%, single-fail-holds), the deload-week computation, the decision tree (body_says_slow_down → active recovery, luteal qualifier bumps intensity, low sleep score → rest, deload week cuts intensity), and the log-completion roundtrip with consecutive-full vs consecutive-failure counters.
+
+### What you might want to do
+
+If you want the coach: run `/coach` to start the profile setup, then `/coach today` for your first prescription. Once your profile is saved, set up the daily scheduled run via `/schedule` so the workout drops into your calendar before you wake up. After the first week, run `/coach week` for the Sunday planning + weekly review.
+
+If you don't want the coach: nothing changes. The skill only fires when you invoke it.
+
+---
+
 ## 2026-05-10: health-mcp v0.3 — multi-vendor (Oura + Fitbit) + /health-setup wizard + journal backfill skill + backfill prompt
 
 **Who this affects:** anyone with a wearable that is NOT just Apple Watch (Oura Ring, Fitbit), anyone who wants their existing journals enriched with body context retroactively, anyone setting up health-mcp for the first time on Windows or Linux.

--- a/services/health-mcp/coach.py
+++ b/services/health-mcp/coach.py
@@ -1,0 +1,317 @@
+"""Longevity + fitness coach state layer.
+
+Tracks prescribed and completed workouts so the next prescription reads from
+the previous one. Implements progressive overload (fail-twice-drop-10%,
+complete-twice-add-2.5-5kg, 4-week deload), reads the existing health-mcp
+recovery/sleep/cycle/somatic surfaces to decide intensity, and surfaces the
+prescription as a structured dict the /coach skill renders to the user.
+
+This module is the DATA + DECISION layer. The coach VOICE lives in
+skills/coach/SKILL.md. Together they make a daily prescription that:
+  - respects sleep + HRV + cycle phase
+  - reads last session's actuals to drive next session's loading
+  - flags out-of-range labs that should change the prescription
+  - pairs the workout with the user's Floor (emotional state) if today's
+    journal exists
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import statistics
+from datetime import date, datetime, timedelta
+from typing import Any
+
+import duckdb
+
+
+# Workout-type catalog the coach can prescribe. Each shape comes with a
+# base structure that gets parameterized by user profile + recovery state.
+WORKOUT_TYPES = {
+    "upper_body_strength": "Upper body strength (push + pull, compound + accessory)",
+    "lower_body_strength": "Lower body strength (squat / hinge / single-leg)",
+    "full_body_strength": "Full body strength (compounds + carries)",
+    "zone2_cardio": "Zone 2 cardio (60-70% HRmax, conversational pace)",
+    "hiit": "HIIT intervals (90s-3min hard / equal rest)",
+    "tempo_run": "Tempo run (lactate threshold pace)",
+    "long_steady": "Long steady-state aerobic",
+    "mobility_yoga": "Mobility + yoga (45-60 min flow)",
+    "active_recovery": "Active recovery (gentle walk + stretching, 20-30 min)",
+    "rest_day": "Rest day (no structured movement)",
+    "strain_test": "Strain test (CrossFit-style WOD or AMRAP)",
+}
+
+
+# Major lifts the coach tracks progression on. Customizable per profile.
+MAJOR_LIFTS = [
+    "squat", "front_squat", "deadlift", "romanian_deadlift",
+    "bench_press", "overhead_press", "row", "pull_up",
+    "kettlebell_swing", "goblet_squat", "split_squat",
+]
+
+
+def prescription_id(date_iso: str, workout_type: str) -> str:
+    """Stable ID per (date, workout_type) so re-running the same day's
+    prescription is idempotent."""
+    return "rx_" + hashlib.sha1(f"{date_iso}|{workout_type}".encode()).hexdigest()[:12]
+
+
+def get_last_lift(con: "duckdb.DuckDBPyConnection", lift_name: str) -> dict[str, Any] | None:
+    """Most recent lift progression row, or None if user hasn't logged this lift yet."""
+    row = con.execute(
+        """
+        SELECT last_session_date, last_weight_kg, last_reps_completed, last_sets_completed,
+               consecutive_full_sets, consecutive_failures, current_top_set_kg
+        FROM coach_lift_progress WHERE lift_name = ? ORDER BY updated_at DESC LIMIT 1
+        """,
+        [lift_name],
+    ).fetchone()
+    if not row:
+        return None
+    return {
+        "lift_name": lift_name,
+        "last_session_date": str(row[0]) if row[0] else None,
+        "last_weight_kg": float(row[1]) if row[1] is not None else None,
+        "last_reps_completed": int(row[2]) if row[2] is not None else None,
+        "last_sets_completed": int(row[3]) if row[3] is not None else None,
+        "consecutive_full_sets": int(row[4] or 0),
+        "consecutive_failures": int(row[5] or 0),
+        "current_top_set_kg": float(row[6]) if row[6] is not None else None,
+    }
+
+
+def next_lift_load(state: dict[str, Any] | None, prescribed_reps: int, prescribed_sets: int) -> dict[str, Any]:
+    """Apply progressive overload to figure out next session's load.
+
+    Rules (from the Claude Fitness Coach prompt, panel-validated):
+      - First time logging this lift: caller supplies starting weight
+      - 2+ consecutive full completions: add 2.5kg upper body / 5kg lower body
+      - 1 failure: hold weight
+      - 2 failures: drop 10%, build back up
+    """
+    if not state:
+        return {"action": "first_session", "weight_kg": None, "note": "First time logging this lift. Pick a weight you can complete all sets with 2 reps in reserve."}
+    last_w = state.get("last_weight_kg") or 0
+    consec_full = state.get("consecutive_full_sets") or 0
+    consec_fail = state.get("consecutive_failures") or 0
+    lift = state["lift_name"]
+    upper_lifts = {"bench_press", "overhead_press", "row", "pull_up"}
+    increment = 2.5 if lift in upper_lifts else 5.0
+    if consec_fail >= 2:
+        new_w = round(last_w * 0.9, 1)
+        return {"action": "drop_10pct", "weight_kg": new_w, "note": f"Two failures in a row. Drop 10% to {new_w}kg, build back up."}
+    if consec_full >= 2:
+        new_w = round(last_w + increment, 1)
+        return {"action": "add_increment", "weight_kg": new_w, "note": f"Two full completions in a row. Move to {new_w}kg ({increment}kg increment)."}
+    return {"action": "hold", "weight_kg": last_w, "note": f"Hold at {last_w}kg. Need {2 - consec_full} more full session(s) to add weight."}
+
+
+def log_completion(
+    con: "duckdb.DuckDBPyConnection",
+    prescription_id: str,
+    rpe: int | None,
+    notes: str | None,
+    lift_actuals: list[dict[str, Any]] | None,
+) -> dict[str, Any]:
+    """Record a completed session + update per-lift progression state.
+
+    lift_actuals: optional list of {lift_name, weight_kg, sets_completed,
+    reps_completed_per_set, prescribed_sets, prescribed_reps}.
+    For each, updates coach_lift_progress and increments consecutive_full_sets
+    or consecutive_failures.
+    """
+    con.execute(
+        "INSERT INTO coach_completions (prescription_id, completed_at, rpe, notes, actuals_json) "
+        "VALUES (?, NOW(), ?, ?, ?)",
+        [prescription_id, rpe, notes, json.dumps(lift_actuals or [])],
+    )
+    if not lift_actuals:
+        return {"prescription_id": prescription_id, "lifts_updated": 0}
+
+    updated = 0
+    for entry in lift_actuals:
+        lift = entry.get("lift_name")
+        if not lift:
+            continue
+        weight = entry.get("weight_kg")
+        sets_done = int(entry.get("sets_completed", 0))
+        prescribed_sets = int(entry.get("prescribed_sets", sets_done))
+        reps_per_set = entry.get("reps_completed_per_set", [])
+        prescribed_reps = int(entry.get("prescribed_reps", 0))
+        full_completion = (
+            sets_done >= prescribed_sets
+            and prescribed_reps > 0
+            and all((r >= prescribed_reps) for r in (reps_per_set or [0] * sets_done))
+        )
+
+        prior = get_last_lift(con, lift) or {}
+        consec_full = prior.get("consecutive_full_sets", 0)
+        consec_fail = prior.get("consecutive_failures", 0)
+        if full_completion:
+            consec_full += 1
+            consec_fail = 0
+        else:
+            consec_fail += 1
+            consec_full = 0
+        top_set = max((weight or 0), prior.get("current_top_set_kg", 0) or 0)
+        con.execute(
+            """
+            INSERT INTO coach_lift_progress
+              (lift_name, last_session_date, last_weight_kg, last_reps_completed,
+               last_sets_completed, consecutive_full_sets, consecutive_failures,
+               current_top_set_kg, updated_at)
+            VALUES (?, CURRENT_DATE, ?, ?, ?, ?, ?, ?, NOW())
+            """,
+            [lift, weight, max(reps_per_set) if reps_per_set else None,
+             sets_done, consec_full, consec_fail, top_set],
+        )
+        updated += 1
+    return {"prescription_id": prescription_id, "lifts_updated": updated}
+
+
+def is_deload_week(profile_start_iso: str, target: date) -> bool:
+    """Every 4th week from profile start is a deload."""
+    try:
+        start = datetime.fromisoformat(profile_start_iso).date()
+    except (TypeError, ValueError):
+        return False
+    weeks = (target - start).days // 7
+    return weeks > 0 and weeks % 4 == 3
+
+
+def _consecutive_days_with_workout(con: "duckdb.DuckDBPyConnection", target: date) -> int:
+    """Look back from target until we hit a day with no completed workout."""
+    streak = 0
+    cur = target
+    while True:
+        start_dt = datetime.combine(cur, datetime.min.time())
+        end_dt = start_dt + timedelta(days=1)
+        row = con.execute(
+            "SELECT COUNT(*) FROM workouts WHERE start_date >= ? AND start_date < ?",
+            [start_dt, end_dt],
+        ).fetchone()
+        if not row or row[0] == 0:
+            break
+        streak += 1
+        cur -= timedelta(days=1)
+        if streak > 10:
+            break
+    return streak
+
+
+def _days_since_workout(con: "duckdb.DuckDBPyConnection", target: date) -> int:
+    """How many days since the most recent workout. 0 = today has one."""
+    end_dt = datetime.combine(target, datetime.min.time()) + timedelta(days=1)
+    row = con.execute(
+        "SELECT MAX(start_date) FROM workouts WHERE start_date < ?",
+        [end_dt],
+    ).fetchone()
+    if not row or not row[0]:
+        return -1
+    last = row[0].date() if hasattr(row[0], "date") else row[0]
+    return (target - last).days
+
+
+def decide_workout_type(
+    con: "duckdb.DuckDBPyConnection",
+    target: date,
+    profile: dict[str, Any],
+    recovery: dict[str, Any] | None,
+    sleep_score_val: dict[str, Any] | None,
+    cycle_ctx: dict[str, Any] | None,
+    somatic: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Choose the workout shape for target date based on recovery + profile.
+
+    Returns: {workout_type, intensity_factor (0-1), difficulty (1-10),
+              why_today (one-line rationale), deload_week (bool)}
+    """
+    # First: somatic state check (panel rule from Levine — body says slow down).
+    if somatic and somatic.get("body_says_slow_down"):
+        return {
+            "workout_type": "active_recovery",
+            "intensity_factor": 0.4,
+            "difficulty": 2,
+            "why_today": "Recent HR/HRV volatility — body is in sympathetic activation. Regulate first.",
+            "deload_week": False,
+        }
+
+    # Sleep check (continuous via sleep_score, NOT hardcoded hours tiers).
+    sleep_s = (sleep_score_val or {}).get("score")
+    rec_s = (recovery or {}).get("score")
+
+    if sleep_s is not None and sleep_s < 35:
+        return {
+            "workout_type": "rest_day",
+            "intensity_factor": 0,
+            "difficulty": 1,
+            "why_today": f"Sleep score {sleep_s}/100 — body needs the day off.",
+            "deload_week": False,
+        }
+
+    if sleep_s is not None and sleep_s < 55:
+        return {
+            "workout_type": "active_recovery",
+            "intensity_factor": 0.5,
+            "difficulty": 3,
+            "why_today": f"Sleep score {sleep_s}/100 — gentle movement only.",
+            "deload_week": False,
+        }
+
+    # Cycle phase qualifier (Sims). If luteal AND recovery is borderline, don't
+    # over-fire on the recovery score — it would be capturing physiology.
+    phase = (cycle_ctx or {}).get("phase")
+
+    # Deload check (every 4th week from profile start).
+    deload = is_deload_week(profile.get("started_iso", "2026-01-01"), target)
+
+    # Compute base intensity from recovery score with cycle qualifier.
+    if rec_s is None:
+        # No HRV / RHR / sleep data yet. Default to medium.
+        intensity = 0.7
+    else:
+        intensity = max(0.4, min(1.0, rec_s / 100.0))
+        if phase == "luteal" and intensity < 0.7:
+            # Bump intensity back up because luteal HRV dips are physiology
+            # (Sims, panel 2026-05-10), not actual recovery deficit.
+            intensity = max(intensity, 0.7)
+
+    if deload:
+        intensity *= 0.6  # deload week: 40% volume drop, 20% intensity drop
+        intensity = max(0.4, intensity)
+
+    # Pick workout shape based on profile + day-of-week rotation + intensity.
+    days_per_week = int(profile.get("days_per_week", 4))
+    available = profile.get("equipment", [])
+    has_weights = any(e in available for e in {"full_gym", "dumbbells", "barbell", "kettlebell"})
+    day_idx = target.weekday()  # 0=Mon, 6=Sun
+
+    if days_per_week >= 5:
+        rotation = ["upper_body_strength", "zone2_cardio", "lower_body_strength", "mobility_yoga", "full_body_strength", "long_steady", "rest_day"]
+    elif days_per_week == 4:
+        rotation = ["upper_body_strength", "zone2_cardio", "lower_body_strength", "active_recovery", "full_body_strength", "mobility_yoga", "rest_day"]
+    elif days_per_week == 3:
+        rotation = ["full_body_strength", "active_recovery", "zone2_cardio", "active_recovery", "full_body_strength", "active_recovery", "rest_day"]
+    else:
+        rotation = ["full_body_strength", "active_recovery", "rest_day", "zone2_cardio", "active_recovery", "rest_day", "rest_day"]
+    wt = rotation[day_idx]
+
+    if wt in {"upper_body_strength", "lower_body_strength", "full_body_strength"} and not has_weights:
+        wt = "zone2_cardio" if day_idx % 2 == 0 else "mobility_yoga"
+
+    if deload and wt in {"upper_body_strength", "lower_body_strength", "full_body_strength"}:
+        why = f"Recovery {rec_s}/100, sleep {sleep_s}/100. Deload week — 40% volume drop on lifts. Keep movement quality, drop intensity."
+    elif phase == "luteal" and rec_s and rec_s < 70:
+        why = f"Recovery {rec_s}/100, but you're in luteal phase. The HRV dip is physiology, not a deficit. Train normally."
+    elif rec_s is None:
+        why = "No HRV/RHR/sleep data yet. Default to moderate intensity. Pull your wearable data to get sharper prescriptions."
+    else:
+        why = f"Recovery {rec_s}/100, sleep {sleep_s if sleep_s is not None else '?'}/100. {WORKOUT_TYPES[wt]} fits today."
+
+    return {
+        "workout_type": wt,
+        "intensity_factor": round(intensity, 2),
+        "difficulty": min(10, max(1, round(intensity * 10))),
+        "why_today": why,
+        "deload_week": deload,
+    }

--- a/services/health-mcp/db.py
+++ b/services/health-mcp/db.py
@@ -154,6 +154,47 @@ def init_schema(con: "duckdb.DuckDBPyConnection") -> None:
         );
         """
     )
+    con.execute(
+        """
+        CREATE TABLE IF NOT EXISTS coach_prescriptions (
+            prescribed_for DATE NOT NULL,
+            prescribed_at  TIMESTAMP NOT NULL,
+            workout_type   VARCHAR NOT NULL,
+            difficulty     INTEGER,
+            duration_min   INTEGER,
+            body_focus     VARCHAR,
+            exercises_json VARCHAR,
+            why_today      VARCHAR,
+            prescription_id VARCHAR NOT NULL
+        );
+        """
+    )
+    con.execute(
+        """
+        CREATE TABLE IF NOT EXISTS coach_completions (
+            prescription_id VARCHAR NOT NULL,
+            completed_at    TIMESTAMP NOT NULL,
+            rpe             INTEGER,
+            notes           VARCHAR,
+            actuals_json    VARCHAR
+        );
+        """
+    )
+    con.execute(
+        """
+        CREATE TABLE IF NOT EXISTS coach_lift_progress (
+            lift_name VARCHAR NOT NULL,
+            last_session_date DATE,
+            last_weight_kg DOUBLE,
+            last_reps_completed INTEGER,
+            last_sets_completed INTEGER,
+            consecutive_full_sets INTEGER DEFAULT 0,
+            consecutive_failures INTEGER DEFAULT 0,
+            current_top_set_kg DOUBLE,
+            updated_at TIMESTAMP NOT NULL
+        );
+        """
+    )
     # Speed up the common time-window queries.
     con.execute("CREATE INDEX IF NOT EXISTS idx_records_type_start ON records(type, start_date);")
     con.execute("CREATE INDEX IF NOT EXISTS idx_workouts_start ON workouts(start_date);")
@@ -161,6 +202,9 @@ def init_schema(con: "duckdb.DuckDBPyConnection") -> None:
     con.execute("CREATE INDEX IF NOT EXISTS idx_cycle_type_start ON cycle(type, start_date);")
     con.execute("CREATE INDEX IF NOT EXISTS idx_symptoms_type_start ON symptoms(type, start_date);")
     con.execute("CREATE INDEX IF NOT EXISTS idx_labs_marker_date ON labs(marker, test_date);")
+    con.execute("CREATE INDEX IF NOT EXISTS idx_coach_prescriptions_date ON coach_prescriptions(prescribed_for);")
+    con.execute("CREATE INDEX IF NOT EXISTS idx_coach_completions_id ON coach_completions(prescription_id);")
+    con.execute("CREATE INDEX IF NOT EXISTS idx_coach_lift_name ON coach_lift_progress(lift_name);")
 
 
 @contextmanager
@@ -201,7 +245,7 @@ def log_import(
 def stats(con: "duckdb.DuckDBPyConnection") -> dict[str, Any]:
     """Per-table counts + last import timestamp."""
     out: dict[str, Any] = {}
-    for table in ("records", "workouts", "sleep", "cycle", "symptoms", "ecg", "state_of_mind", "labs", "imports"):
+    for table in ("records", "workouts", "sleep", "cycle", "symptoms", "ecg", "state_of_mind", "labs", "imports", "coach_prescriptions", "coach_completions", "coach_lift_progress"):
         try:
             row = con.execute(f"SELECT COUNT(*) FROM {table};").fetchone()
             out[f"{table}_count"] = row[0] if row else 0

--- a/services/health-mcp/main.py
+++ b/services/health-mcp/main.py
@@ -19,6 +19,7 @@ launched per-session by Claude Code.
 """
 from __future__ import annotations
 
+import json
 import logging
 import sys
 from contextlib import asynccontextmanager
@@ -28,6 +29,7 @@ from typing import Any
 
 from fastmcp import FastMCP
 
+import coach as coach_mod
 import cycle as cycle_mod
 import db
 import fitbit_client
@@ -874,6 +876,210 @@ def health_live_query(metric: str, host: str = "localhost", port: int = 9000, st
     if end:
         params["end"] = end
     return live_tcp.query("health_metrics", params, host=host, port=port)
+
+
+# ---------------------------------------------------------------------------
+# Coach (v0.4) — longevity + fitness coach state layer
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+def health_coach_prescribe(date_str: str, profile_json: str = "{}") -> dict[str, Any]:
+    """Issue a daily workout prescription.
+
+    Reads recovery + sleep + cycle + somatic state from health-mcp, applies
+    the profile (days_per_week, equipment, level, started_iso, etc.), and
+    returns a structured prescription with workout_type + intensity +
+    difficulty + why_today + deload flag.
+
+    profile_json: JSON string of the user's coach profile. The /coach skill
+    loads it from <vault>/Meta/coach-profile.yaml and passes it in.
+
+    The actual exercise list + sets/reps/weights is rendered by the /coach
+    skill's prompt using this prescription + the per-lift progression state
+    from health_coach_lift_state.
+    """
+    try:
+        profile = json.loads(profile_json) if profile_json else {}
+    except json.JSONDecodeError:
+        profile = {}
+    target = _parse_date(date_str)
+    with db.connect() as con:
+        recovery = scores.recovery_score(con, target)
+        sleep_s = scores.sleep_score(con, target)
+        cycle_ctx = cycle_mod.cycle_context(con, target)
+        if cycle_ctx.get("phase") == "unknown":
+            cycle_ctx = None
+        somatic = scores.somatic_state(con, target, lookback_min=30)
+        decision = coach_mod.decide_workout_type(
+            con, target, profile, recovery, sleep_s, cycle_ctx, somatic,
+        )
+        rx_id = coach_mod.prescription_id(target.isoformat(), decision["workout_type"])
+        # Idempotent: skip writing if same id exists today.
+        existing = con.execute(
+            "SELECT prescription_id FROM coach_prescriptions WHERE prescription_id = ?",
+            [rx_id],
+        ).fetchone()
+        if not existing:
+            con.execute(
+                "INSERT INTO coach_prescriptions "
+                "(prescribed_for, prescribed_at, workout_type, difficulty, duration_min, body_focus, exercises_json, why_today, prescription_id) "
+                "VALUES (?, NOW(), ?, ?, ?, ?, ?, ?, ?)",
+                [
+                    target, decision["workout_type"], decision["difficulty"],
+                    int(profile.get("session_minutes", 45)),
+                    profile.get("body_focus", ""),
+                    "",  # exercises_json filled by skill output if persisted
+                    decision["why_today"], rx_id,
+                ],
+            )
+    return {
+        "prescription_id": rx_id,
+        "date": target.isoformat(),
+        "workout_type": decision["workout_type"],
+        "intensity_factor": decision["intensity_factor"],
+        "difficulty": decision["difficulty"],
+        "deload_week": decision["deload_week"],
+        "why_today": decision["why_today"],
+        "recovery_score": recovery.get("score") if recovery else None,
+        "sleep_score": sleep_s.get("score") if sleep_s else None,
+        "cycle_phase": cycle_ctx.get("phase") if cycle_ctx else None,
+        "body_says_slow_down": somatic.get("body_says_slow_down") if somatic else None,
+        "interpretation_hint": (
+            "Use workout_type to pick the template. Use intensity_factor to "
+            "scale loads off the user's progression state (health_coach_lift_state). "
+            "Cite why_today verbatim in the user-facing block. If deload_week is True, "
+            "cut volume 40% and intensity 20%."
+        ),
+    }
+
+
+@mcp.tool()
+def health_coach_lift_state(lift_name: str) -> dict[str, Any]:
+    """Get progression state for a major lift (squat, deadlift, bench, etc.).
+
+    Returns {last_weight_kg, consecutive_full_sets, consecutive_failures,
+    current_top_set_kg, recommended_next_load (with action + weight + note)}.
+
+    Use this to program the next session's loads. Apply fail-twice-drop-10%,
+    complete-twice-add-2.5kg-upper / 5kg-lower, hold-on-single-fail.
+    """
+    with db.connect(read_only=True) as con:
+        state = coach_mod.get_last_lift(con, lift_name)
+    next_load = coach_mod.next_lift_load(state, prescribed_reps=5, prescribed_sets=3)
+    return {
+        "lift_name": lift_name,
+        "state": state,
+        "recommended_next_load": next_load,
+    }
+
+
+@mcp.tool()
+def health_coach_log_completion(
+    prescription_id: str,
+    rpe: int | None = None,
+    notes: str | None = None,
+    lift_actuals_json: str = "[]",
+) -> dict[str, Any]:
+    """Log a completed session + update per-lift progression.
+
+    lift_actuals_json: JSON array. Each entry: {lift_name, weight_kg,
+    sets_completed, reps_completed_per_set (list), prescribed_sets,
+    prescribed_reps}.
+
+    Updates coach_lift_progress so the next prescription reads the new state.
+    """
+    try:
+        actuals = json.loads(lift_actuals_json) if lift_actuals_json else []
+    except json.JSONDecodeError:
+        actuals = []
+    with db.connect() as con:
+        result = coach_mod.log_completion(con, prescription_id, rpe, notes, actuals)
+    return result
+
+
+@mcp.tool()
+def health_coach_recent_prescriptions(days: int = 7) -> list[dict[str, Any]]:
+    """List recent prescriptions with their completion status."""
+    cutoff = date.today() - timedelta(days=days)
+    with db.connect(read_only=True) as con:
+        rows = con.execute(
+            """
+            SELECT p.prescribed_for, p.workout_type, p.difficulty, p.why_today,
+                   p.prescription_id,
+                   (SELECT COUNT(*) FROM coach_completions c WHERE c.prescription_id = p.prescription_id) AS completed
+            FROM coach_prescriptions p
+            WHERE p.prescribed_for >= ?
+            ORDER BY p.prescribed_for DESC
+            """,
+            [cutoff],
+        ).fetchall()
+    return [
+        {
+            "date": str(r[0]), "workout_type": r[1], "difficulty": int(r[2] or 0),
+            "why_today": r[3], "prescription_id": r[4],
+            "completed": int(r[5] or 0) > 0,
+        }
+        for r in rows
+    ]
+
+
+@mcp.tool()
+def health_coach_summary(days: int = 28) -> dict[str, Any]:
+    """Coach summary for the last N days: completion rate, deload weeks,
+    workout-type distribution, average RPE, top-set progress on tracked lifts.
+
+    Use for weekly + monthly coach reviews.
+    """
+    cutoff = date.today() - timedelta(days=days)
+    with db.connect(read_only=True) as con:
+        prescribed = con.execute(
+            "SELECT COUNT(*) FROM coach_prescriptions WHERE prescribed_for >= ?",
+            [cutoff],
+        ).fetchone()[0]
+        completed = con.execute(
+            """
+            SELECT COUNT(DISTINCT c.prescription_id)
+            FROM coach_completions c JOIN coach_prescriptions p
+              ON c.prescription_id = p.prescription_id
+            WHERE p.prescribed_for >= ?
+            """,
+            [cutoff],
+        ).fetchone()[0]
+        by_type = con.execute(
+            """
+            SELECT workout_type, COUNT(*) FROM coach_prescriptions
+            WHERE prescribed_for >= ? GROUP BY workout_type ORDER BY 2 DESC
+            """,
+            [cutoff],
+        ).fetchall()
+        avg_rpe_row = con.execute(
+            """
+            SELECT AVG(c.rpe) FROM coach_completions c JOIN coach_prescriptions p
+              ON c.prescription_id = p.prescription_id
+            WHERE p.prescribed_for >= ?
+            """,
+            [cutoff],
+        ).fetchone()
+        avg_rpe = float(avg_rpe_row[0]) if avg_rpe_row and avg_rpe_row[0] is not None else None
+        lifts = con.execute(
+            "SELECT lift_name, current_top_set_kg, last_session_date FROM coach_lift_progress "
+            "WHERE last_session_date >= ? ORDER BY current_top_set_kg DESC",
+            [cutoff],
+        ).fetchall()
+    return {
+        "days_window": days,
+        "prescribed": int(prescribed or 0),
+        "completed": int(completed or 0),
+        "completion_rate_pct": round(100 * (completed or 0) / (prescribed or 1), 1),
+        "workout_type_distribution": {r[0]: int(r[1]) for r in by_type},
+        "average_rpe": round(avg_rpe, 1) if avg_rpe is not None else None,
+        "tracked_lifts": [
+            {"lift_name": r[0], "current_top_set_kg": float(r[1]) if r[1] is not None else None, "last_session_date": str(r[2])}
+            for r in lifts
+        ],
+    }
+
+
 
 
 if __name__ == "__main__":

--- a/services/health-mcp/pyproject.toml
+++ b/services/health-mcp/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "health-mcp"
-version = "0.3.0"
-description = "Health MCP for the ai-brain-starter substrate. Multi-vendor (Apple Health + Oura Ring + Fitbit) ingestion with shared DuckDB schema. Full HealthKit surface (108 quantity types + 47 symptom types + 14 cycle types + ECG + iOS 17 State of Mind). Open scoring algorithms (recovery / sleep / strain / sleep regularity / longevity panel / somatic state). Vault-aware tools that pair biometrics + cycle phase + symptoms with Floor tags from daily journals. OS-aware setup wizard."
+version = "0.4.0"
+description = "Health MCP for the ai-brain-starter substrate. Multi-vendor (Apple Health + Oura Ring + Fitbit) ingestion with shared DuckDB schema. Full HealthKit surface. Open scoring algorithms. Vault-aware tools that pair biometrics + cycle phase + symptoms with Floor tags. OS-aware setup wizard. Coach state layer (progressive overload, deload weeks, cycle-aware prescription, somatic pre-check)."
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.10"
@@ -52,4 +52,5 @@ include = [
   "oura_client.py",
   "fitbit_client.py",
   "vendor_setup.py",
+  "coach.py",
 ]

--- a/services/health-mcp/tests/test_v04.py
+++ b/services/health-mcp/tests/test_v04.py
@@ -1,0 +1,228 @@
+"""v0.4 smoke tests for the coach state layer.
+
+Tests the progressive-overload state machine, deload-week computation, and
+the prescription decision tree (body_says_slow_down -> active recovery,
+luteal HRV qualifier, deload rotation).
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parent))
+
+_tmp_dir = tempfile.mkdtemp(prefix="health-mcp-test-v04-")
+os.environ["HEALTH_MCP_DB"] = os.path.join(_tmp_dir, "test.duckdb")
+
+import coach  # noqa: E402
+import db  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def fresh_db():
+    with db.connect() as con:
+        for tbl in ("coach_prescriptions", "coach_completions", "coach_lift_progress"):
+            con.execute(f"DELETE FROM {tbl}")
+    yield
+
+
+def test_coach_tables_exist():
+    with db.connect() as con:
+        rows = con.execute(
+            "SELECT table_name FROM information_schema.tables WHERE table_schema='main'"
+        ).fetchall()
+    names = {r[0] for r in rows}
+    assert {"coach_prescriptions", "coach_completions", "coach_lift_progress"}.issubset(names)
+
+
+def test_prescription_id_is_stable():
+    """Same date + workout_type yields same id (idempotent)."""
+    a = coach.prescription_id("2026-05-10", "upper_body_strength")
+    b = coach.prescription_id("2026-05-10", "upper_body_strength")
+    c = coach.prescription_id("2026-05-10", "zone2_cardio")
+    assert a == b
+    assert a != c
+
+
+def test_next_lift_first_session():
+    out = coach.next_lift_load(None, prescribed_reps=5, prescribed_sets=3)
+    assert out["action"] == "first_session"
+    assert out["weight_kg"] is None
+
+
+def test_next_lift_complete_twice_adds_upper():
+    state = {"lift_name": "bench_press", "last_weight_kg": 60, "consecutive_full_sets": 2, "consecutive_failures": 0}
+    out = coach.next_lift_load(state, prescribed_reps=5, prescribed_sets=3)
+    assert out["action"] == "add_increment"
+    assert out["weight_kg"] == 62.5
+
+
+def test_next_lift_complete_twice_adds_lower():
+    state = {"lift_name": "squat", "last_weight_kg": 80, "consecutive_full_sets": 2, "consecutive_failures": 0}
+    out = coach.next_lift_load(state, prescribed_reps=5, prescribed_sets=3)
+    assert out["action"] == "add_increment"
+    assert out["weight_kg"] == 85.0
+
+
+def test_next_lift_fail_twice_drops_10pct():
+    state = {"lift_name": "deadlift", "last_weight_kg": 100, "consecutive_full_sets": 0, "consecutive_failures": 2}
+    out = coach.next_lift_load(state, prescribed_reps=5, prescribed_sets=3)
+    assert out["action"] == "drop_10pct"
+    assert out["weight_kg"] == 90.0
+
+
+def test_next_lift_single_fail_holds():
+    state = {"lift_name": "bench_press", "last_weight_kg": 60, "consecutive_full_sets": 0, "consecutive_failures": 1}
+    out = coach.next_lift_load(state, prescribed_reps=5, prescribed_sets=3)
+    assert out["action"] == "hold"
+
+
+def test_log_completion_updates_lift_state():
+    with db.connect() as con:
+        con.execute(
+            "INSERT INTO coach_prescriptions (prescribed_for, prescribed_at, workout_type, difficulty, "
+            "duration_min, body_focus, exercises_json, why_today, prescription_id) "
+            "VALUES (CURRENT_DATE, NOW(), 'upper_body_strength', 7, 45, 'push+pull', '', 'test', 'rx_test123')"
+        )
+        coach.log_completion(
+            con, "rx_test123", rpe=7, notes="solid",
+            lift_actuals=[{
+                "lift_name": "bench_press",
+                "weight_kg": 60,
+                "sets_completed": 3,
+                "reps_completed_per_set": [5, 5, 5],
+                "prescribed_sets": 3,
+                "prescribed_reps": 5,
+            }],
+        )
+        state = coach.get_last_lift(con, "bench_press")
+    assert state["last_weight_kg"] == 60
+    assert state["consecutive_full_sets"] == 1
+    assert state["consecutive_failures"] == 0
+
+
+def test_log_completion_increments_failures_on_short_rep_set():
+    with db.connect() as con:
+        con.execute(
+            "INSERT INTO coach_prescriptions (prescribed_for, prescribed_at, workout_type, difficulty, "
+            "duration_min, body_focus, exercises_json, why_today, prescription_id) "
+            "VALUES (CURRENT_DATE, NOW(), 'upper_body_strength', 7, 45, 'push+pull', '', 'test', 'rx_test456')"
+        )
+        coach.log_completion(
+            con, "rx_test456", rpe=8, notes=None,
+            lift_actuals=[{
+                "lift_name": "bench_press",
+                "weight_kg": 65,
+                "sets_completed": 3,
+                "reps_completed_per_set": [5, 4, 3],
+                "prescribed_sets": 3,
+                "prescribed_reps": 5,
+            }],
+        )
+        state = coach.get_last_lift(con, "bench_press")
+    assert state["consecutive_failures"] == 1
+    assert state["consecutive_full_sets"] == 0
+
+
+def test_log_completion_two_failures_then_drop():
+    """Sequence: fail (4/5 rep set) twice -> next_lift_load returns drop_10pct."""
+    with db.connect() as con:
+        for i in range(2):
+            con.execute(
+                "INSERT INTO coach_prescriptions (prescribed_for, prescribed_at, workout_type, difficulty, "
+                "duration_min, body_focus, exercises_json, why_today, prescription_id) "
+                "VALUES (CURRENT_DATE, NOW(), 'upper_body_strength', 7, 45, 'push+pull', '', 'test', ?)",
+                [f"rx_fail_{i}"],
+            )
+            coach.log_completion(
+                con, f"rx_fail_{i}", rpe=9, notes=None,
+                lift_actuals=[{
+                    "lift_name": "overhead_press",
+                    "weight_kg": 40,
+                    "sets_completed": 3,
+                    "reps_completed_per_set": [3, 2, 2],
+                    "prescribed_sets": 3,
+                    "prescribed_reps": 5,
+                }],
+            )
+        state = coach.get_last_lift(con, "overhead_press")
+    out = coach.next_lift_load(state, prescribed_reps=5, prescribed_sets=3)
+    assert out["action"] == "drop_10pct"
+    assert out["weight_kg"] == 36.0
+
+
+def test_is_deload_week_every_4th():
+    start = "2026-01-01"
+    week_0 = date(2026, 1, 1)
+    week_1 = date(2026, 1, 8)
+    week_3 = date(2026, 1, 22)
+    week_4 = date(2026, 1, 29)
+    assert not coach.is_deload_week(start, week_0)
+    assert not coach.is_deload_week(start, week_1)
+    assert coach.is_deload_week(start, week_3)
+    assert not coach.is_deload_week(start, week_4)
+
+
+def test_decide_workout_body_says_slow_down_forces_active_recovery():
+    profile = {"days_per_week": 4, "equipment": ["dumbbells"], "started_iso": "2026-01-01"}
+    with db.connect() as con:
+        out = coach.decide_workout_type(
+            con, date(2026, 5, 10), profile,
+            recovery={"score": 75}, sleep_score_val={"score": 70},
+            cycle_ctx=None,
+            somatic={"body_says_slow_down": True, "flags": ["HRV crashed"]},
+        )
+    assert out["workout_type"] == "active_recovery"
+    assert out["intensity_factor"] <= 0.5
+
+
+def test_decide_workout_luteal_qualifier_bumps_intensity():
+    """Luteal phase with borderline recovery should NOT collapse intensity —
+    the HRV dip is physiology not deficit (Sims, panel 2026-05-10)."""
+    profile = {"days_per_week": 4, "equipment": ["dumbbells"], "started_iso": "2026-01-01"}
+    with db.connect() as con:
+        without_luteal = coach.decide_workout_type(
+            con, date(2026, 5, 10), profile,
+            recovery={"score": 60}, sleep_score_val={"score": 70},
+            cycle_ctx=None,
+            somatic={"body_says_slow_down": False},
+        )
+        with_luteal = coach.decide_workout_type(
+            con, date(2026, 5, 10), profile,
+            recovery={"score": 60}, sleep_score_val={"score": 70},
+            cycle_ctx={"phase": "luteal"},
+            somatic={"body_says_slow_down": False},
+        )
+    assert with_luteal["intensity_factor"] >= without_luteal["intensity_factor"]
+
+
+def test_decide_workout_low_sleep_score_yields_rest():
+    profile = {"days_per_week": 4, "equipment": ["dumbbells"], "started_iso": "2026-01-01"}
+    with db.connect() as con:
+        out = coach.decide_workout_type(
+            con, date(2026, 5, 10), profile,
+            recovery={"score": 65}, sleep_score_val={"score": 30},
+            cycle_ctx=None,
+            somatic={"body_says_slow_down": False},
+        )
+    assert out["workout_type"] == "rest_day"
+
+
+def test_decide_workout_deload_week_cuts_intensity():
+    profile = {"days_per_week": 4, "equipment": ["dumbbells"], "started_iso": "2026-04-15"}
+    deload_week_date = date(2026, 5, 6)  # ~3 weeks after start, week index 3
+    with db.connect() as con:
+        out = coach.decide_workout_type(
+            con, deload_week_date, profile,
+            recovery={"score": 80}, sleep_score_val={"score": 80},
+            cycle_ctx=None,
+            somatic={"body_says_slow_down": False},
+        )
+    assert out["deload_week"] is True
+    assert out["intensity_factor"] < 0.8

--- a/skills/coach/SKILL.md
+++ b/skills/coach/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: coach
+description: Longevity + fitness coach. Issues a daily workout prescription that reads from health-mcp (recovery, sleep, cycle phase, somatic state, lab status) and pairs with today's Floor (emotional state) from journal frontmatter. Tracks progressive overload per-lift. Programs deload every 4th week. Drops weekly plan into Google Calendar. Use when user says /coach, /coach today, /coach week, /coach profile, /coach log, asks "what should I do today", asks for a workout, asks for a longevity plan, or asks how to train. Pairs with health-context (already auto-fires) and insights (already body-track wired). The substrate's longevity-coach surface.
+---
+
+# coach, the longevity + fitness coach
+
+Reads everything health-mcp knows (recovery, sleep score, sleep regularity, cycle phase, somatic state, longevity panel, out-of-range labs, Floor from today's journal) and issues a prescription that's specific to THIS person on THIS day. Progressive overload tracked per-lift. Deload every 4th week. Calendar drop optional.
+
+This is the substrate's coach SURFACE. The DATA + DECISION layer lives in `services/health-mcp/coach.py`. The VOICE + WORKOUT TEMPLATES + CALENDAR INTEGRATION live here.
+
+## When to use
+
+- User says `/coach`, `/coach today`, `/coach week`, `/coach profile`, `/coach log`
+- User asks "what should I do today" / "give me a workout" / "build me a week" / "how should I train"
+- User wants a longevity plan
+- User wants to log a completed workout (RPE + lift actuals)
+- User wants to see progression on a specific lift
+- Scheduled morning task fires to drop today's workout into calendar
+
+Do NOT use for:
+- Importing health data (use `/ingest-health` or `/health-setup`)
+- Querying past biometrics without prescribing (use `health_status`, `health_metric_series`)
+- Building new wearable connectors (substrate dev task)
+
+## First time: profile setup
+
+When `/coach profile` runs (or `/coach` runs and no profile exists), ask the user these 12 questions and save the answers to `<vault>/Meta/coach-profile.yaml`. Never re-ask once saved unless they say something changed.
+
+1. **Primary goal:** lose weight, build muscle, run a 5K, get more active, reduce stress, improve mobility, train for a specific event, body recomp, longevity
+2. **Secondary goal:** optional
+3. **Equipment:** full gym, home dumbbells, barbell + rack, bodyweight only, resistance bands, kettlebells, pull-up bar, cardio machines (multi-select)
+4. **Days/week realistic:** 3 / 4 / 5 / 6
+5. **Session length:** 20 / 30 / 45 / 60 min
+6. **Time of day:** morning / lunch / evening (this affects calendar drop)
+7. **Injuries / limitations / chronic conditions / movements to avoid:** free text
+8. **Current fitness level:** complete beginner / beginner / intermediate / advanced
+9. **Exercises hated:** free text
+10. **Exercises loved:** free text
+11. **Floor sensitivity:** how much does emotional state shape what training feels right? (low / medium / high) — affects how much weight to give to today's Floor tag
+12. **Longevity priorities:** which Attia-style markers matter most? (VO2Max, Zone 2 minutes, lean mass, walking steadiness, sleep regularity, fasting insulin / HbA1c — multi-select)
+
+Profile file format (`<vault>/Meta/coach-profile.yaml`):
+
+```yaml
+---
+created: 2026-05-10
+started_iso: 2026-05-10  # used by health_coach_prescribe for deload week computation
+language: en  # or es
+primary_goal: longevity
+secondary_goal: build muscle
+equipment: [home dumbbells, barbell, kettlebell, pull-up bar]
+days_per_week: 4
+session_minutes: 45
+time_of_day: morning
+preferred_workout_clock: "07:00"
+limitations: []
+level: intermediate
+hated: [burpees]
+loved: [deadlift, kettlebell swings]
+floor_sensitivity: high
+longevity_priorities: [vo2max, zone2_min, lean_mass, sleep_regularity]
+calendar_drop: true  # true = write to Google Calendar, false = surface in chat only
+calendar_name: "Movement"  # which calendar
+---
+```
+
+## Daily prescription: `/coach today`
+
+The flow:
+
+1. **Load profile** from `<vault>/Meta/coach-profile.yaml`. If missing, run profile setup.
+2. **Call health-mcp** for today's prescription seed:
+   ```
+   health_coach_prescribe(date_str="<today>", profile_json="<profile-as-json>")
+   ```
+   Returns: workout_type, intensity_factor, difficulty, deload_week, why_today, recovery_score, sleep_score, cycle_phase, body_says_slow_down, plus a prescription_id.
+
+3. **Pull today's Floor** from journal frontmatter (if today's journal exists). Use it to qualify the why_today line. If `floor_sensitivity: high` in profile and Floor is in the lower tier (Shame / Fear / Apathy / Grief), reduce intensity_factor by ~15% and acknowledge it.
+
+4. **Pull lift progression state** for each lift in today's workout template via `health_coach_lift_state(lift_name)`. The `recommended_next_load.weight_kg` gives you the load to prescribe (or "first session" if no history).
+
+5. **Render the workout** using the template below. Cite `why_today` verbatim.
+
+6. **Optionally drop to calendar** if `profile.calendar_drop: true`. Use the google-workspace MCP `calendar_create_event` tool with the user's `preferred_workout_clock` time on the calendar named `calendar_name`. Event title: today's workout summary. Description: full workout block.
+
+7. **Surface the prescription** to the user in chat.
+
+## Workout template
+
+```markdown
+## Today's workout — [Day] · [Date]
+
+**Type:** [Workout type from WORKOUT_TYPES] · **Difficulty:** [X]/10 · **Duration:** ~[X] min
+**Why today:** [why_today verbatim from health_coach_prescribe]
+**Floor today:** [Floor from journal, if present] · **Recovery:** [score]/100 · **Sleep:** [score]/100[ · **Cycle phase:** [phase] (day [X])]
+[**DELOAD WEEK** — volume -40%, intensity -20%. Non-negotiable.]
+
+### Warm-up (5-8 min)
+- [Specific to workout type — dynamic mobility, joint prep, activation]
+
+### Main (~[X] min)
+
+[For each exercise:]
+**[Exercise name]** — [sets] × [reps]  ·  [load from health_coach_lift_state if applicable]
+- Form cue: [ONE clear cue]
+- Easier: [modification]
+- Harder: [progression]
+- Rest: [interval]
+
+[Group as supersets (A1/A2), circuits, or straight sets per workout type.]
+
+### Finisher (optional, 3-5 min)
+[Only when the user is in a groove. AMRAP, Tabata, carry challenge, core burnout.]
+
+### Cool-down (5 min)
+- [Stretch primary muscle] - 30 sec each side
+- [Stretch secondary muscle] - 30 sec each side
+- Breathing or gentle spinal movement - 1 min
+
+### Tomorrow's signal
+Body wants: [if today's load is high, name the recovery cue for tomorrow. If today is recovery, name what to watch for to step back up.]
+```
+
+## Floor qualifier (substrate differentiator)
+
+Other fitness coaches ignore emotional state. Ours doesn't. Reading today's journal frontmatter for `floor` / `floor_level` lets us:
+
+- If Floor is in **Shame / Fear / Apathy / Grief / Anger** AND `floor_sensitivity: high`: cut intensity 15%, swap heavy compounds for moderate accessories or mobility. Name it directly: "Floor is Fear today. Your body is in fight-or-flight. We're keeping movement high-quality but not heavy."
+- If Floor is in **Joy / Peace / Love / Gratitude**: green light. Even if recovery is borderline, the system is in good repair state. Push if the lifts are ready.
+- If Floor is **Courage** + good sleep + cycle in follicular: this is a PR day. Don't waste it on accessories.
+
+The qualifier is multiplicative on top of `intensity_factor` from `health_coach_prescribe`. Never overrides a `body_says_slow_down: true` from somatic state — that's still a regulate-first day.
+
+## Weekly planning: `/coach week`
+
+Every Sunday (or when user asks):
+
+1. Pull last week's prescriptions + completions via `health_coach_recent_prescriptions(days=7)`.
+2. Pull weekly health rollup via `health_weekly_rollup(this_week_start)`.
+3. Write a week-in-review:
+   - Completed: [X] of [Y] prescribed
+   - Avg sleep / HRV / steps / workout-min trends
+   - Recovery trend (up / flat / down)
+   - One specific win, one thing to watch
+4. Build next week's plan: 7 prescriptions (one per day), respecting `days_per_week` (rest days fill the rest), one deload week every 4th.
+5. If `profile.calendar_drop: true`, write 7 calendar events at the user's preferred time.
+
+## Monthly: `/coach month`
+
+Every 4 weeks:
+
+1. `health_coach_summary(days=28)` for completion rate + workout-type distribution + average RPE + top-set progress per lift.
+2. `health_longevity_panel(today)` for the Attia surface: VO2Max trend, Zone 2 minutes/week vs 180-target, walking steadiness, lean mass.
+3. `health_long_window` for YoY persistent-asymmetry on HRV / sleep / steps.
+4. `health_lab_panel(today)` for any out-of-range markers — flag with a re-test reminder.
+5. Surface:
+   - What's working (2-3 specifics with data)
+   - What to adjust (1-2 changes based on trends)
+   - Next month's focus (one clear priority)
+6. If labs flagged anything new (low Vitamin D, elevated hs-CRP, low ferritin in menstruating users): surface as its own bullet with the WHY for that marker (pull from `health_recommended_labs()` if useful).
+
+## Logging completion: `/coach log`
+
+After a workout, the user runs `/coach log` (or just tells the chat "I finished today's workout"). The skill:
+
+1. Find today's prescription_id from `health_coach_recent_prescriptions(days=1)`.
+2. Ask: RPE 1-10? Any notes? For each prescribed lift: weight used, sets completed, reps per set (or "missed last set", etc.)
+3. Build the `lift_actuals_json` array and call:
+   ```
+   health_coach_log_completion(prescription_id="<id>", rpe=<int>, notes="<text>", lift_actuals_json="<json>")
+   ```
+4. Confirm the update. Show progression state on tracked lifts: which ones moved up, which held, which dropped.
+
+## Voice
+
+Direct, motivating, no fluff. Match the user's language (English / Spanish).
+
+- When they crush it: celebrate with data, not fluff. "5 of 5 sessions this week. RHR dropped 3 bpm. You're building."
+- When they miss days: "Life happens. Here's an easy win." No guilt, no lecture, no "you should have."
+- When data shows a problem: flag it clearly and explain. "HRV dropped 14% week-over-week and Floor was Fear 4 of 7 days. Body and mind both registering pressure. Let's regulate this week."
+- When they hit a PR: celebrate specifically with numbers. "Squat moved from 65kg to 70kg. Two-session full completion, increment applied."
+- When they're frustrated about a plateau: be honest about cause. Usually sleep, cycle phase, under-fueling, or a lab marker. Cite the data.
+- Keep it short. They need to know what to do today.
+
+## Banned framings
+
+- Generic "rest more / push harder / eat better" without data
+- "Listen to your body" as the entire prescription (it's a complement, not a substitute for the data)
+- Recovery score quoted as gospel when cycle phase or under-fuel explains it
+- Cheerleading without specifics ("you've got this!" with no metric)
+- "Talk to your doctor" as the entire response to an out-of-range lab — pair with a specific behavioral or supplement next-step
+- "Maybe later / when you're ready / when you have capacity" — best-of-best lockout still applies inside the coach
+- Treating Floor as motivation problem rather than nervous-system state
+
+## Calendar integration
+
+If `google-workspace` MCP is connected and `calendar_drop: true`:
+
+- Daily: write one event at `preferred_workout_clock` with title `[Workout type]: [duration]min · [body focus]` and the full workout block in the description.
+- Weekly: write 7 events at once for the next week's plan.
+- Color: use a consistent calendar color (e.g., the user's existing "Health" or "Movement" calendar).
+- Title pattern: `🏋️ [Type] · [duration]min` so it stands out from meetings.
+
+If google-workspace MCP is NOT connected: surface the workout in chat only, plus a note: "Set up Google Calendar via the google-workspace MCP to get workouts dropped automatically."
+
+## Daily auto-run
+
+Once the user runs `/coach` successfully, suggest setting up a scheduled task via `/schedule`:
+
+- Cadence: every morning at `preferred_workout_clock - 30 min`
+- Body: invoke `/coach today` with the user's profile so the workout is in their calendar before they wake up
+
+## Graceful degradation
+
+- No health-mcp data → coach prescribes a sensible default (bodyweight workout matching profile days_per_week) and tells the user to run `/health-setup`.
+- No journal today → skip the Floor qualifier silently, prescribe from biometrics + profile.
+- No lift history → first-session weight = level-appropriate starter (intermediate squat: 60kg, beginner: 40kg, advanced: 80kg as a starting suggestion the user can override).
+- No cycle data → skip the phase qualifier (still works for users who don't track or aren't menstruating).
+
+## Privacy
+
+- Profile lives at `<vault>/Meta/coach-profile.yaml` — local-only, never committed if vault is in git (the user controls).
+- No prescription is shared anywhere unless `calendar_drop: true` AND google-workspace MCP is connected, in which case the workout is in their own Google Calendar (their account, their data).
+- The coach never sends anything to Anthropic or third parties beyond what the user already does via their existing tools.


### PR DESCRIPTION
## Summary

Closes the coach gap from the Claude Fitness Coach PDF a user was sent. Lifts the calendar drop + progressive overload + daily decision shape, then extends with the cycle-aware + Floor-paired + longevity-panel data the substrate already has and the PDF lacks.

## What landed

- **Three new DuckDB tables** (\`coach_prescriptions\`, \`coach_completions\`, \`coach_lift_progress\`) for prescription history + completion logging + per-lift progression state
- **\`services/health-mcp/coach.py\`** — progressive-overload state machine (fail-twice-drop-10%, complete-twice-add-2.5/5kg, single-fail-holds), deload-every-4th-week from profile start, decision tree with cycle-phase qualifier (luteal HRV dips don't collapse intensity per Sims panel rule) and body-says-slow-down → active recovery (per Levine panel rule)
- **5 new MCP tools**: \`health_coach_prescribe\`, \`health_coach_lift_state\`, \`health_coach_log_completion\`, \`health_coach_recent_prescriptions\`, \`health_coach_summary\`
- **\`skills/coach/SKILL.md\`** — \`/coach profile\` (12-question setup → \`<vault>/Meta/coach-profile.yaml\`), \`/coach today\`, \`/coach week\`, \`/coach month\`, \`/coach log\`. Renders workout template with warm-up + main + finisher + cool-down, optionally drops to Google Calendar via google-workspace MCP
- **Floor qualifier** — Floor in Shame/Fear/Apathy/Grief/Anger + \`floor_sensitivity: high\` → intensity -15% + swap to mobility. Floor in Joy/Peace/Love/Gratitude → green light. Courage + good sleep + follicular → PR day. Multiplicative on intensity_factor, never overrides somatic-state slow-down.

## What we deliberately did NOT copy from the PDF

- Their iOS-beta Apple Health integration (we have multi-vendor local-only via v0.3)
- Hardcoded sleep tiers (we use continuous sleep_score)
- Generic cycle prescriptions (we use \`health_phase_means\` over user's own data)
- \"Nutrition only when asked\" — flipped (under-fuel detector surfaces proactively)
- Data-driven-coach-as-whole-answer assumption (Floor qualifier + body-literacy prompt integrate Bainbridge's panel dissent)

## Tools

41 total (32 in v0.2 + 4 in v0.3 + 5 in v0.4).

## Test plan

- [x] **69/69 pytest tests pass** (15 v0.4 new)
- [x] coach.py + main.py + all modules import clean
- [x] Tier-A scrub gate: 0 personal-data matches
- [x] Progressive-overload state machine: first-session, complete-twice-add (upper + lower), fail-twice-drop-10%, single-fail-holds all covered
- [x] Decision tree: body_says_slow_down → active recovery, low sleep score → rest, luteal qualifier bumps intensity, deload week cuts intensity
- [x] Log-completion roundtrip: consecutive_full_sets + consecutive_failures counters increment correctly
- [ ] First-run on clean clone: \`/coach\` triggers profile setup; profile saves to \`<vault>/Meta/coach-profile.yaml\`
- [ ] Daily smoke: \`/coach today\` after \`/ingest-health\` returns workout with cycle phase + Floor qualifier when journal exists
- [ ] Calendar drop smoke: \`profile.calendar_drop: true\` + google-workspace connected → workout shows up in Google Calendar at preferred time

🤖 Generated with [Claude Code](https://claude.com/claude-code)