### PR TITLE
fix(bootstrap): install helpers return 0 on failure (set -e abort fix)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,29 @@ Same thing — open an issue. Describe the problem you're trying to solve, not j
 
 ---
 
+## Testing bootstrap.sh changes safely
+
+Editing `bootstrap.sh` is risky to test against your real machine — it touches `~/.claude/`, registers plugin marketplaces, edits `settings.json`, and installs system tools. The fix: a sandbox HOME.
+
+`HOME` is what every Claude Code path resolves against (`~/.claude/`, skill clones, plugin installs, `settings.json`). Set `HOME` to a fresh empty directory, run bootstrap from there, and everything writes into the sandbox while your real config stays untouched.
+
+```bash
+SANDBOX=$(mktemp -d)
+cd /path/to/your/local/ai-brain-starter
+HOME="$SANDBOX" EMAIL_GATE_BYPASS=1 PREFLIGHT_BYPASS=1 bash bootstrap.sh
+```
+
+After the run, inspect `$SANDBOX/.claude/` to see what got created. To reset and re-test: `rm -rf "$SANDBOX"` and start over.
+
+**Two flags worth knowing for tests:**
+
+- `--dry-run` — shows what would be installed without making changes. Every install path respects this; if you add a new install step, wrap it in `do_cmd`, `git_clone_safe`, `claude_install_safe`, `claude_marketplace_safe`, or `pipx_install_safe` to keep dry-run actually dry.
+- `--uninstall` — removes everything bootstrap installed (with a confirmation prompt). Useful for leaving a clean machine after testing.
+
+**System tools (Brew, Node, Python, pipx, gh, Obsidian) are global**, so they short-circuit if already present on the host even with `HOME` redirected. That's fine — bootstrap's job is to install user-level Claude Code content, not duplicate system installs.
+
+---
+
 ## What's welcome
 
 - Bug fixes

--- a/README.md
+++ b/README.md
@@ -65,6 +65,44 @@ Read the four problems the team version solves: [`for-teams/why-teams-are-differ
 
 ## Install
 
+> **Requires Claude Code 2.1.133 or newer.** Bootstrap will refuse to run on older versions and tell you the upgrade command. To check, run `claude --version`. To upgrade: `npm i -g @anthropic-ai/claude-code@latest`.
+
+### Before you paste — what gets installed
+
+Bootstrap touches your `~/.claude/` directory and registers third-party content. Here's the full surface so you can opt in with eyes open.
+
+**Skill repos cloned to `~/.claude/skills/`:**
+
+| Repo | License | What it does |
+|---|---|---|
+| `ai-brain-starter` (this repo) | MIT | The substrate itself — vault setup, hooks, session lifecycle |
+| `humanizer` | MIT | De-AI-ifies writing, scores against your voice corpus |
+| `obra/superpowers` | MIT | Engineering discipline (TDD, brainstorming, debugging) |
+| `yvgude/lean-ctx` | Apache 2.0 | Context compression — shell patterns + AST-aware reads |
+| `CyberZenithX/Rich-Elicitation-Skill` | MIT | Multi-round clarifying questions before ambiguous tasks |
+| `vercel-labs/agent-skills` | No license — read-only reference | Next.js / React patterns; cloned but not auto-loaded |
+
+**Plugin marketplaces added (and the plugins enabled from each):**
+
+| Marketplace | Plugins enabled | License |
+|---|---|---|
+| `getsentry/sentry-skills` | sentry-skills (28+ SDK + AI monitoring sub-skills) | Apache 2.0 |
+| `trailofbits/skills` | modern-python, insecure-defaults, sharp-edges, property-based-testing, static-analysis, testing-handbook-skills, differential-review, ask-questions-if-underspecified | CC-BY-SA-4.0 |
+| `stripe/agent-toolkit` | stripe (best-practices, upgrade-stripe) | MIT |
+| `cloudflare/skills` | cloudflare (workers, durable-objects, agents-sdk, web-perf, wrangler, sandbox-sdk) | Apache 2.0 |
+| `AgriciDaniel/claude-seo` | claude-seo (25 sub-skills + 18 sub-agents) | MIT |
+| `obra/superpowers` | superpowers (engineering discipline as plugin) | MIT |
+| `coreyhaines31/marketingskills` | marketing-skills (41 marketing sub-skills) | MIT |
+| `kepano/obsidian-skills` | obsidian, context7, playwright | MIT |
+
+**MCP servers wired in `~/.claude/.mcp.json`:** `granola` (meeting transcription), `chatprd` (PRD drafting). Existing MCPs you wired yourself are preserved.
+
+**System tools (skipped if already present):** Homebrew, Python 3.10+, Node, npm, pipx, gh, fastmcp, graphify (via pipx), skill-seekers (via pipx), Obsidian.
+
+**Settings + backups:** every edit to `~/.claude/settings.json` and `~/.claude/.mcp.json` writes a `.bak-YYYY-MM-DD-HHMM` backup first. Existing custom marketplaces, plugins, hooks, env vars, and permissions are preserved (`setdefault` semantics, never overwrites).
+
+**Don't want all of it?** Set `SKIP_VENDOR_SKILLS=1` to skip third-party plugin marketplaces. The core ai-brain-starter substrate still installs. Removing later: `bash bootstrap.sh --uninstall` (asks for confirmation, then removes everything bootstrap installed; preserves your vault and your customizations).
+
 ### Step 1 — Open Claude Code
 
 Open the [Claude Code desktop app](https://claude.ai/download) and sign in with a paid Claude account (Pro, Max, or Team).
@@ -196,6 +234,8 @@ Full catalog with attribution and source links: [`docs/POWER_TOOLS.md`](docs/POW
 
 ## What Gets Created
 
+**In your vault** (the markdown side — what you see in Obsidian):
+
 ```
 Your Vault/
   CLAUDE.md                    # Your memory file — loaded every session
@@ -217,6 +257,20 @@ Your Vault/
   Books/                       # Book notes
   Psychology/                  # Inner work, therapy, growth
 ```
+
+**In Claude Code** (the tooling side — new commands you can invoke):
+
+```
+~/.claude/
+  skills/                      # 6 cloned skill repos (see "Before you paste" inventory)
+  plugins/                     # 8 plugin marketplaces, ~40+ installed plugins
+  settings.json                # +8 marketplace registrations, +3 enabled plugins
+  .mcp.json                    # +2 MCP servers (granola, chatprd)
+  .bootstrap.log               # Forensic log of every bootstrap run
+  .bootstrap-state             # Last successful run timestamp
+```
+
+The full inventory is in [Before you paste](#before-you-paste--what-gets-installed) above and [`docs/POWER_TOOLS.md`](docs/POWER_TOOLS.md). To remove cleanly: `bash bootstrap.sh --uninstall`.
 
 Plus custom folders based on your interview.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A verification harness around your AI agent. So memory compounds instead of corr
 
 ---
 
+You have a smart assistant that forgets you every morning. This is the harness that gives it a memory: notes on your disk that the assistant reads before answering you, deterministic guards that block bad edits before they land, and a session-end ritual that files what mattered. Whether you write, run a company, or just want context to stop disappearing between conversations, the same surface works.
+
+---
+
 Microsoft DELEGATE-52 ([arxiv.org/abs/2604.15597](https://arxiv.org/abs/2604.15597), April 2026) measured what most operators already feel: frontier LLMs corrupt 25% of professional content over 20 edit interactions. Document size amplifies the failure 5×. The paper concludes the only reliable mitigation is a domain-specific verification harness around the model.
 
 This is one.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -650,10 +650,8 @@ git_clone_safe() {
   local ec=$?
   if [[ "$ec" == "124" ]]; then
     err "$desc — clone exceeded ${GIT_CLONE_TIMEOUT_SECS}s timeout. Skipping; re-run later."
-    return 1
   elif [[ "$ec" -ne 0 ]]; then
     err "$desc — clone failed (exit $ec)"
-    return 1
   fi
   return 0
 }
@@ -687,13 +685,16 @@ claude_install_safe() {
 }
 
 # pipx_install_safe PKG — respects DRY_RUN.
+# Always returns 0 (failures land in FAILED via err); set -e in bootstrap
+# would otherwise kill the whole install on a single tool's network blip.
 pipx_install_safe() {
   local pkg="$1"
   if [[ $DRY_RUN -eq 1 ]]; then
     dry "would: pipx install $pkg"
     return 0
   fi
-  pipx install "$pkg" 2>&1 | tail -3 || return 1
+  pipx install "$pkg" 2>&1 | tail -3 || err "pipx install $pkg failed"
+  return 0
 }
 
 # ───────────────────────────────────────────────────────────────────────────────

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -193,6 +193,10 @@ for arg in "$@"; do
         echo "ERROR: install-hooks-user-level.py not found." >&2
         exit 2
       fi ;;
+    --uninstall)
+      UNINSTALL=1 ;;
+    --force)
+      FORCE=1 ;;
     --help|-h)
       cat <<'HELP'
 Usage: bash bootstrap.sh [OPTIONS]
@@ -201,6 +205,8 @@ Install or update the ai-brain-starter setup. Safe to re-run.
 
 Options:
   --dry-run, -n                 Show what would be installed without making changes
+  --uninstall                   Remove everything bootstrap installed (with confirmation)
+  --force                       Skip the uninstall confirmation prompt
   --restore                     Interactive restore from .bak files (closes #2)
   --smoke-test                  Run end-to-end verification of the installed setup
   --detect-partial              Scan for half-installed components (closes #4)
@@ -208,11 +214,20 @@ Options:
                                 universally including inside git worktrees)
   --help, -h                    This help
 
+Environment:
+  GIT_CLONE_TIMEOUT_SECS        Timeout (default 60s) for any git clone
+  EMAIL_GATE_BYPASS=1           Skip the email-gate (development)
+  PREFLIGHT_BYPASS=1            Skip the preflight check (development)
+  SKIP_VENDOR_SKILLS=1          Skip third-party plugin marketplaces (air-gapped)
+  REQUIRED_CLAUDE_VERSION       Override the minimum Claude Code version (default 2.1.133)
+
 Logs: every run is appended to ~/.claude/.bootstrap.log (closes #3).
 HELP
       exit 0 ;;
   esac
 done
+UNINSTALL="${UNINSTALL:-0}"
+FORCE="${FORCE:-0}"
 
 # Tee subsequent output to the log (header + everything that follows)
 exec > >(tee -a "$BOOTSTRAP_LOG") 2>&1
@@ -234,6 +249,43 @@ is_linux() { [[ "$(uname -s)" == "Linux" ]]; }
 
 have() { command -v "$1" >/dev/null 2>&1; }
 
+# run_with_timeout SECS CMD [ARGS...] — portable timeout wrapper.
+# Prefers GNU `timeout` (Linux + Mac with coreutils) or `gtimeout` (brew),
+# falls back to a pure-shell background+wait+kill so it works on a clean Mac.
+# Returns 124 on timeout, otherwise the command's exit code.
+run_with_timeout() {
+  local secs="$1"; shift
+  if have timeout; then
+    timeout "$secs" "$@"; return $?
+  fi
+  if have gtimeout; then
+    gtimeout "$secs" "$@"; return $?
+  fi
+  "$@" &
+  local pid=$!
+  local elapsed=0
+  while [[ $elapsed -lt $secs ]] && kill -0 "$pid" 2>/dev/null; do
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+  if kill -0 "$pid" 2>/dev/null; then
+    kill -TERM "$pid" 2>/dev/null
+    sleep 1
+    kill -KILL "$pid" 2>/dev/null
+    wait "$pid" 2>/dev/null || true
+    return 124
+  fi
+  wait "$pid"
+  return $?
+}
+
+# version_at_least REQUIRED ACTUAL — semver via sort -V.
+version_at_least() {
+  local required="$1" actual="$2"
+  [[ -z "$actual" ]] && return 1
+  [[ "$(printf '%s\n%s\n' "$required" "$actual" | sort -V | head -1)" == "$required" ]]
+}
+
 # ───────────────────────────────────────────────────────────────────────────────
 # Locale detection + bilingual translation helper
 # Override via BOOTSTRAP_LANG=es|en. Otherwise: $LC_ALL > $LANG > AppleLocale > en.
@@ -248,6 +300,120 @@ detect_lang() {
 }
 LANG_CODE="$(detect_lang)"
 t() { [[ "$LANG_CODE" == "es" ]] && echo "$2" || echo "$1"; }
+
+# ───────────────────────────────────────────────────────────────────────────────
+# Claude Code minimum-version check
+# Older Claude Code versions error cryptically on the /quick-try plugin path.
+# Surface a clear upgrade command instead. Override REQUIRED_CLAUDE_VERSION
+# to test against an older version. Bypass via PREFLIGHT_BYPASS=1.
+# ───────────────────────────────────────────────────────────────────────────────
+REQUIRED_CLAUDE_VERSION="${REQUIRED_CLAUDE_VERSION:-2.1.133}"
+if [[ "${PREFLIGHT_BYPASS:-0}" != "1" ]] && have claude; then
+  CLAUDE_VERSION_RAW="$(claude --version 2>/dev/null | head -1)"
+  CLAUDE_VERSION="$(printf '%s' "$CLAUDE_VERSION_RAW" | awk '{print $1}')"
+  if [[ -n "$CLAUDE_VERSION" ]] && ! version_at_least "$REQUIRED_CLAUDE_VERSION" "$CLAUDE_VERSION"; then
+    hdr "$(t "Claude Code is too old" "Claude Code está desactualizado")"
+    err "$(t "Detected Claude Code $CLAUDE_VERSION — bootstrap requires $REQUIRED_CLAUDE_VERSION or newer." \
+            "Detectado Claude Code $CLAUDE_VERSION — el bootstrap necesita $REQUIRED_CLAUDE_VERSION o más nuevo.")"
+    log "$(t "Upgrade with: npm i -g @anthropic-ai/claude-code@latest" \
+            "Actualizá con: npm i -g @anthropic-ai/claude-code@latest")"
+    log "$(t "Then re-run: bash bootstrap.sh" \
+            "Después volvé a correr: bash bootstrap.sh")"
+    log "$(t "Override (development only): REQUIRED_CLAUDE_VERSION=$CLAUDE_VERSION bash bootstrap.sh" \
+            "Bypass (sólo desarrollo): REQUIRED_CLAUDE_VERSION=$CLAUDE_VERSION bash bootstrap.sh")"
+    exit 2
+  fi
+fi
+
+# ───────────────────────────────────────────────────────────────────────────────
+# State file — last successful run timestamp surfaced at next run start.
+# ───────────────────────────────────────────────────────────────────────────────
+BOOTSTRAP_STATE="$HOME/.claude/.bootstrap-state"
+PREVIOUS_RUN_TIMESTAMP=""
+if [[ -f "$BOOTSTRAP_STATE" ]]; then
+  PREVIOUS_RUN_TIMESTAMP="$(head -1 "$BOOTSTRAP_STATE" 2>/dev/null || true)"
+fi
+
+# ───────────────────────────────────────────────────────────────────────────────
+# Uninstall — remove what bootstrap installed.
+# PRESERVES: vault data, custom skills, custom MCPs, custom marketplaces.
+# ───────────────────────────────────────────────────────────────────────────────
+if [[ "$UNINSTALL" == "1" ]]; then
+  hdr "$(t "Uninstall preview" "Vista previa de la desinstalación")"
+  printf "\n  %s\n\n" "$(t "Bootstrap will remove the following if confirmed:" \
+                          "El bootstrap va a remover lo siguiente si confirmás:")"
+  UNINSTALL_TARGETS=(
+    "$HOME/.claude/skills/ai-brain-starter"
+    "$HOME/.claude/skills/humanizer"
+    "$HOME/.claude/skills/superpowers"
+    "$HOME/.claude/skills/lean-ctx"
+    "$HOME/.claude/skills/rich-elicitation"
+    "$HOME/.claude/skills/vercel-agent-skills"
+    "$BOOTSTRAP_STATE"
+    "$HOME/.claude/.ai-brain-starter-email-on-file"
+    "$HOME/.claude/.ai-brain-starter-hmac-secret"
+  )
+  PRESENT=()
+  for t_path in "${UNINSTALL_TARGETS[@]}"; do
+    [[ -e "$t_path" ]] && PRESENT+=("$t_path")
+  done
+  for p in "${PRESENT[@]}"; do printf "    - %s\n" "$p"; done
+  printf "\n  %s\n" "$(t "Plus settings.json entries: obsidian-skills marketplace + 3 enabled plugins" \
+                          "Más entradas de settings.json: marketplace obsidian-skills + 3 plugins habilitados")"
+  printf "  %s\n\n" "$(t "Plus .mcp.json entries: granola, chatprd" \
+                          "Más entradas de .mcp.json: granola, chatprd")"
+  printf "  %s\n" "$(t "PRESERVED: vault, custom skills, custom MCPs, custom marketplaces, custom hooks." \
+                       "PRESERVADO: vault, skills propias, MCPs propios, marketplaces propios, hooks propios.")"
+  printf "  %s\n\n" "$(t "settings.json + .mcp.json get backed up before edit (recoverable via .bak files)." \
+                          "settings.json + .mcp.json se respaldan antes de editar (recuperable vía .bak).")"
+
+  if [[ "$FORCE" != "1" ]]; then
+    printf "  %s " "$(t "Type 'yes' to proceed (anything else cancels):" \
+                       "Escribí 'yes' para continuar (cualquier otra cosa cancela):")"
+    read -r CONFIRM
+    if [[ "$CONFIRM" != "yes" ]]; then
+      log "$(t "Cancelled. Nothing changed." "Cancelado. Nada cambió.")"
+      exit 0
+    fi
+  fi
+
+  hdr "$(t "Uninstalling" "Desinstalando")"
+  for p in "${PRESENT[@]}"; do
+    rm -rf "$p" && ok "removed: $p"
+  done
+
+  if [[ -f "$HOME/.claude/.mcp.json" ]]; then
+    backup_file "$HOME/.claude/.mcp.json"
+    python3 - <<'PY' || warn "MCP cleanup failed"
+import json, os
+p = os.path.expanduser("~/.claude/.mcp.json")
+m = json.load(open(p))
+for srv in ("granola", "chatprd"):
+    m.get("mcpServers", {}).pop(srv, None)
+with open(p, "w") as f: json.dump(m, f, indent=2)
+PY
+    ok "MCP entries cleaned"
+  fi
+
+  if [[ -f "$HOME/.claude/settings.json" ]]; then
+    backup_file "$HOME/.claude/settings.json"
+    python3 - <<'PY' || warn "settings cleanup failed"
+import json, os
+p = os.path.expanduser("~/.claude/settings.json")
+s = json.load(open(p))
+s.get("extraKnownMarketplaces", {}).pop("obsidian-skills", None)
+ep = s.get("enabledPlugins", {})
+for plug in ("obsidian@obsidian-skills", "context7", "playwright"):
+    ep.pop(plug, None)
+with open(p, "w") as f: json.dump(s, f, indent=2)
+PY
+    ok "settings.json entries cleaned"
+  fi
+
+  printf "\n  %s\n" "$(t "Uninstall complete. Plugin marketplaces remain — remove via 'claude plugin marketplace remove <name>' if desired." \
+                       "Desinstalación completa. Los marketplaces de plugins quedan — removelos con 'claude plugin marketplace remove <name>' si querés.")"
+  exit 0
+fi
 
 # ───────────────────────────────────────────────────────────────────────────────
 # Email gate (universal). Every install passes through the form once. The form
@@ -466,6 +632,70 @@ backup_file() {
   fi
 }
 
+# git_clone_safe URL DEST [DESCRIPTION] — respects DRY_RUN, enforces a 60s
+# timeout via run_with_timeout so a hanging clone doesn't stall indefinitely.
+GIT_CLONE_TIMEOUT_SECS="${GIT_CLONE_TIMEOUT_SECS:-60}"
+git_clone_safe() {
+  local url="$1"
+  local dest="$2"
+  local desc="${3:-clone $url}"
+  if [[ $DRY_RUN -eq 1 ]]; then
+    dry "would: $desc → $dest"
+    return 0
+  fi
+  if [[ -d "$dest/.git" ]]; then
+    return 0
+  fi
+  run_with_timeout "$GIT_CLONE_TIMEOUT_SECS" git clone --quiet "$url" "$dest" 2>/dev/null
+  local ec=$?
+  if [[ "$ec" == "124" ]]; then
+    err "$desc — clone exceeded ${GIT_CLONE_TIMEOUT_SECS}s timeout. Skipping; re-run later."
+    return 1
+  elif [[ "$ec" -ne 0 ]]; then
+    err "$desc — clone failed (exit $ec)"
+    return 1
+  fi
+  return 0
+}
+
+# claude_marketplace_safe REPO — respects DRY_RUN, idempotent.
+claude_marketplace_safe() {
+  local repo="$1"
+  if claude plugin marketplace list 2>/dev/null | grep -q "GitHub ($repo)"; then
+    return 0
+  fi
+  if [[ $DRY_RUN -eq 1 ]]; then
+    dry "would: claude plugin marketplace add $repo"
+    return 0
+  fi
+  hdr "Adding marketplace: $repo"
+  claude plugin marketplace add "$repo" 2>&1 | tail -2 || err "marketplace add failed: $repo"
+}
+
+# claude_install_safe TARGET — respects DRY_RUN, idempotent.
+claude_install_safe() {
+  local target="$1"
+  if claude plugin list 2>/dev/null | grep -q "❯ $target$"; then
+    return 0
+  fi
+  if [[ $DRY_RUN -eq 1 ]]; then
+    dry "would: claude plugin install $target"
+    return 0
+  fi
+  hdr "Installing plugin: $target"
+  claude plugin install "$target" 2>&1 | tail -2 || err "plugin install failed: $target"
+}
+
+# pipx_install_safe PKG — respects DRY_RUN.
+pipx_install_safe() {
+  local pkg="$1"
+  if [[ $DRY_RUN -eq 1 ]]; then
+    dry "would: pipx install $pkg"
+    return 0
+  fi
+  pipx install "$pkg" 2>&1 | tail -3 || return 1
+}
+
 # ───────────────────────────────────────────────────────────────────────────────
 # Header
 # ───────────────────────────────────────────────────────────────────────────────
@@ -492,6 +722,14 @@ echo "  $(t \
   "When it's done, Claude continues with the setup interview automatically." \
   "Cuando termine, Claude continúa con la entrevista de setup automáticamente.")"
 echo "  $(t "You don't need to type anything." "No necesitás tipear nada.")"
+
+if [[ -n "$PREVIOUS_RUN_TIMESTAMP" ]]; then
+  printf "\n  \033[36m·\033[0m %s %s. %s\n" \
+    "$(t "Last successful run:" "Última corrida exitosa:")" \
+    "$PREVIOUS_RUN_TIMESTAMP" \
+    "$(t "Re-runs are idempotent — already-installed components are skipped." \
+        "Las recorridas son idempotentes — los componentes ya instalados se saltean.")"
+fi
 echo
 [[ $DRY_RUN -eq 0 ]] && sleep 1
 
@@ -927,12 +1165,16 @@ if [[ ${#SKILLS_TO_SYNC[@]} -gt 0 ]]; then
       done
     fi
   else
-    warn "sync-skills.sh not found — using direct copy (no backups)"
-    for sub in "${SKILLS_TO_SYNC[@]}"; do
-      src="$SKILL_DIR/skills/$sub"
-      dst="$HOME/.claude/skills/$sub"
-      [[ -d "$src" ]] && do_cmd "cp -R $src → $dst" mkdir -p "$dst" && do_cmd "" cp -R "$src/." "$dst/"
-    done
+    if [[ $DRY_RUN -eq 1 ]]; then
+      dry "would copy bundled skills directly (sync-skills.sh path not yet on disk in dry-run): ${SKILLS_TO_SYNC[*]}"
+    else
+      warn "sync-skills.sh not found — using direct copy (no backups)"
+      for sub in "${SKILLS_TO_SYNC[@]}"; do
+        src="$SKILL_DIR/skills/$sub"
+        dst="$HOME/.claude/skills/$sub"
+        [[ -d "$src" ]] && do_cmd "cp -R $src → $dst" mkdir -p "$dst" && do_cmd "" cp -R "$src/." "$dst/"
+      done
+    fi
   fi
 fi
 
@@ -946,10 +1188,13 @@ fi
 
 if [[ ! -d "$HOME/.claude/skills/humanizer" ]]; then
   hdr "Installing humanizer (de-AI writing pass)"
-  git clone --quiet https://github.com/adelaidasofia/humanizer.git "$HOME/.claude/skills/humanizer" \
-    || err "humanizer clone failed"
+  git_clone_safe "https://github.com/adelaidasofia/humanizer.git" \
+                 "$HOME/.claude/skills/humanizer" \
+                 "humanizer clone"
 fi
-[[ -d "$HOME/.claude/skills/humanizer" ]] && ok "humanizer skill installed"
+if [[ $DRY_RUN -eq 0 && -d "$HOME/.claude/skills/humanizer" ]]; then
+  ok "humanizer skill installed"
+fi
 
 # ───────────────────────────────────────────────────────────────────────────────
 # obra/superpowers (engineering-discipline skills, MIT, Jesse Vincent)
@@ -962,10 +1207,13 @@ fi
 
 if [[ ! -d "$HOME/.claude/skills/superpowers" ]]; then
   hdr "Installing obra/superpowers (engineering-discipline skills)"
-  git clone --quiet https://github.com/obra/superpowers.git "$HOME/.claude/skills/superpowers" \
-    || err "superpowers clone failed (skipping; install manually with: git clone https://github.com/obra/superpowers.git ~/.claude/skills/superpowers)"
+  git_clone_safe "https://github.com/obra/superpowers.git" \
+                 "$HOME/.claude/skills/superpowers" \
+                 "superpowers clone"
 fi
-[[ -d "$HOME/.claude/skills/superpowers" ]] && ok "superpowers skills installed"
+if [[ $DRY_RUN -eq 0 && -d "$HOME/.claude/skills/superpowers" ]]; then
+  ok "superpowers skills installed"
+fi
 
 # ───────────────────────────────────────────────────────────────────────────────
 # Vendor-published agent-skill bundles (engineering + operations adjacents)
@@ -980,23 +1228,18 @@ fi
 
 if [[ "${SKIP_VENDOR_SKILLS:-0}" != "1" ]]; then
 
-  # Helper: register a marketplace + install a plugin (idempotent)
+  # Register a marketplace + install a plugin (idempotent + DRY_RUN-safe).
   # Args: $1=owner/repo (marketplace source) $2=plugin@marketplace-id (install target)
   install_plugin() {
     local repo="$1"
     local target="$2"
-    local marketplace_id="${target##*@}"
-
-    if ! claude plugin marketplace list 2>/dev/null | grep -q "GitHub ($repo)"; then
-      hdr "Adding marketplace: $repo"
-      claude plugin marketplace add "$repo" 2>&1 | tail -2 || err "marketplace add failed: $repo"
+    if claude plugin list 2>/dev/null | grep -q "❯ $target$"; then
+      ok "plugin ready: $target (already installed)"
+      return 0
     fi
-
-    if ! claude plugin list 2>/dev/null | grep -q "❯ $target$"; then
-      hdr "Installing plugin: $target"
-      claude plugin install "$target" 2>&1 | tail -2 || err "plugin install failed: $target"
-    fi
-    ok "plugin ready: $target"
+    claude_marketplace_safe "$repo"
+    claude_install_safe "$target"
+    [[ $DRY_RUN -eq 0 ]] && ok "plugin ready: $target"
   }
 
   # Sentry SDK + AI monitoring skills (Apache 2.0, vendor-published).
@@ -1009,17 +1252,11 @@ if [[ "${SKIP_VENDOR_SKILLS:-0}" != "1" ]]; then
   # Marketplace bundle. We install the relevant 8 plugins (Python toolchain +
   # security-defaults + property-based testing + diff review + clarification).
   # Skipped: blockchain/smart-contract specifics, Burp Suite, DWARF, etc.
-  if ! claude plugin marketplace list 2>/dev/null | grep -q "GitHub (trailofbits/skills)"; then
-    hdr "Adding marketplace: trailofbits/skills"
-    claude plugin marketplace add trailofbits/skills 2>&1 | tail -2 || err "trailofbits marketplace add failed"
-  fi
+  claude_marketplace_safe "trailofbits/skills"
   for plugin in modern-python insecure-defaults sharp-edges property-based-testing static-analysis testing-handbook-skills differential-review ask-questions-if-underspecified; do
-    if ! claude plugin list 2>/dev/null | grep -q "❯ $plugin@trailofbits$"; then
-      hdr "Installing trailofbits plugin: $plugin"
-      claude plugin install "$plugin@trailofbits" 2>&1 | tail -1 || err "trailofbits/$plugin install failed"
-    fi
+    claude_install_safe "$plugin@trailofbits"
   done
-  ok "trailofbits plugins ready"
+  [[ $DRY_RUN -eq 0 ]] && ok "trailofbits plugins ready"
 
   # Stripe agent-toolkit (MIT, vendor-published).
   # Single plugin in a marketplace bundle. Includes stripe-best-practices
@@ -1050,13 +1287,16 @@ if [[ "${SKIP_VENDOR_SKILLS:-0}" != "1" ]]; then
   # to the top-level path so Claude auto-loads it.
   if [[ ! -d "$HOME/.claude/skills/lean-ctx" ]]; then
     hdr "Installing yvgude/lean-ctx (Apache 2.0, manual cherry-pick)"
-    git clone --quiet https://github.com/yvgude/lean-ctx.git "$HOME/.claude/skills/lean-ctx" \
-      || err "lean-ctx clone failed"
+    git_clone_safe "https://github.com/yvgude/lean-ctx.git" \
+                   "$HOME/.claude/skills/lean-ctx" \
+                   "lean-ctx clone"
   fi
-  if [[ -d "$HOME/.claude/skills/lean-ctx" ]] && [[ ! -L "$HOME/.claude/skills/lean-ctx/SKILL.md" ]] && [[ -f "$HOME/.claude/skills/lean-ctx/skills/lean-ctx/SKILL.md" ]]; then
+  if [[ $DRY_RUN -eq 0 && -d "$HOME/.claude/skills/lean-ctx" ]] && [[ ! -L "$HOME/.claude/skills/lean-ctx/SKILL.md" ]] && [[ -f "$HOME/.claude/skills/lean-ctx/skills/lean-ctx/SKILL.md" ]]; then
     ln -sf "$HOME/.claude/skills/lean-ctx/skills/lean-ctx/SKILL.md" "$HOME/.claude/skills/lean-ctx/SKILL.md"
   fi
-  [[ -L "$HOME/.claude/skills/lean-ctx/SKILL.md" ]] && ok "lean-ctx installed (top-level SKILL.md symlinked for auto-discovery)"
+  if [[ $DRY_RUN -eq 0 && -L "$HOME/.claude/skills/lean-ctx/SKILL.md" ]]; then
+    ok "lean-ctx installed (top-level SKILL.md symlinked for auto-discovery)"
+  fi
 
   # coreyhaines31/marketingskills (MIT, 27.5k stars). Marketplace bundle with
   # 41 marketing skills covering CRO, copywriting, SEO, paid ads, growth.
@@ -1073,10 +1313,13 @@ if [[ "${SKIP_VENDOR_SKILLS:-0}" != "1" ]]; then
   # is auto-discoverable).
   if [[ ! -d "$HOME/.claude/skills/rich-elicitation" ]]; then
     hdr "Installing CyberZenithX/Rich-Elicitation-Skill (MIT)"
-    git clone --quiet https://github.com/CyberZenithX/Rich-Elicitation-Skill.git "$HOME/.claude/skills/rich-elicitation" \
-      || err "rich-elicitation clone failed"
+    git_clone_safe "https://github.com/CyberZenithX/Rich-Elicitation-Skill.git" \
+                   "$HOME/.claude/skills/rich-elicitation" \
+                   "rich-elicitation clone"
   fi
-  [[ -f "$HOME/.claude/skills/rich-elicitation/SKILL.md" ]] && ok "rich-elicitation installed (top-level SKILL.md auto-discoverable)"
+  if [[ $DRY_RUN -eq 0 && -f "$HOME/.claude/skills/rich-elicitation/SKILL.md" ]]; then
+    ok "rich-elicitation installed (top-level SKILL.md auto-discoverable)"
+  fi
 
   # vercel-labs/agent-skills (NO LICENSE — all-rights-reserved by default).
   # Per CLAUDE.md license-hygiene: "No LICENSE file: treat as all-rights-reserved.
@@ -1088,10 +1331,13 @@ if [[ "${SKIP_VENDOR_SKILLS:-0}" != "1" ]]; then
   # If Vercel adds a license later, switch to plugin install or symlink.
   if [[ ! -d "$HOME/.claude/skills/vercel-agent-skills" ]]; then
     hdr "Cloning vercel-labs/agent-skills (NO LICENSE — read-only reference)"
-    git clone --quiet https://github.com/vercel-labs/agent-skills.git "$HOME/.claude/skills/vercel-agent-skills" \
-      || err "vercel-labs/agent-skills clone failed"
+    git_clone_safe "https://github.com/vercel-labs/agent-skills.git" \
+                   "$HOME/.claude/skills/vercel-agent-skills" \
+                   "vercel-labs/agent-skills clone"
   fi
-  [[ -d "$HOME/.claude/skills/vercel-agent-skills" ]] && ok "vercel-agent-skills cloned (read-only reference; no auto-load)"
+  if [[ $DRY_RUN -eq 0 && -d "$HOME/.claude/skills/vercel-agent-skills" ]]; then
+    ok "vercel-agent-skills cloned (read-only reference; no auto-load)"
+  fi
 
   # Skill_Seekers (MIT, yusufkaraaslan). Converts documentation from 17 source
   # types into production-ready formats for 24+ AI platforms. NOT a SKILL.md-
@@ -1105,42 +1351,19 @@ if [[ "${SKIP_VENDOR_SKILLS:-0}" != "1" ]]; then
   if ! command -v skill-seekers > /dev/null 2>&1; then
     if command -v pipx > /dev/null 2>&1; then
       hdr "Installing skill-seekers via pipx (MIT)"
-      pipx install skill-seekers 2>&1 | tail -3 || err "skill-seekers pipx install failed (manual: pipx install skill-seekers)"
+      pipx_install_safe skill-seekers || err "skill-seekers pipx install failed (manual: pipx install skill-seekers)"
     else
       err "pipx not found, cannot install skill-seekers (manual: pipx install skill-seekers OR pip install --user skill-seekers)"
     fi
   fi
-  command -v skill-seekers > /dev/null 2>&1 && ok "skill-seekers CLI installed"
+  if [[ $DRY_RUN -eq 0 ]] && command -v skill-seekers > /dev/null 2>&1; then
+    ok "skill-seekers CLI installed"
+  fi
   # Remove the earlier wrong-install if present (idempotent cleanup)
   if [[ -d "$HOME/.claude/skills/skill-seekers" ]] && [[ -f "$HOME/.claude/skills/skill-seekers/CLAUDE.md" ]] && [[ ! -f "$HOME/.claude/skills/skill-seekers/SKILL.md" ]]; then
     log "Removing wrong-install of skill-seekers (was git-cloned to skills dir, but it's a CLI tool not a SKILL.md skill)"
     rm -rf "$HOME/.claude/skills/skill-seekers"
   fi
-
-  # lean-ctx (Apache 2.0, yvgude). MCP server + context runtime: session
-  # caching, AST-aware compression, 90+ shell patterns to reduce token usage.
-  # Direct fit for substrate's token-optimization line.
-  if [[ ! -d "$HOME/.claude/skills/lean-ctx" ]]; then
-    hdr "Installing yvgude/lean-ctx (Apache 2.0)"
-    git clone --quiet https://github.com/yvgude/lean-ctx.git "$HOME/.claude/skills/lean-ctx" \
-      || err "lean-ctx clone failed (skipping; install manually: git clone https://github.com/yvgude/lean-ctx.git ~/.claude/skills/lean-ctx)"
-  fi
-  [[ -d "$HOME/.claude/skills/lean-ctx" ]] && ok "lean-ctx installed"
-
-  # Vercel-labs agent-skills (NO LICENSE — all-rights-reserved by default).
-  # Includes next-best-practices, next-cache-components, next-upgrade,
-  # react-best-practices, composition-patterns, web-design-guidelines,
-  # react-native-skills. Bootstrap-clone is user-side fetch from Vercel's
-  # GitHub. Per CLAUDE.md license-hygiene: "No LICENSE file: treat as
-  # all-rights-reserved. Reading is fine; copying is infringement." We do NOT
-  # fork or redistribute; users fetch directly from Vercel's repo. If Vercel
-  # adds a license later, we revisit.
-  if [[ ! -d "$HOME/.claude/skills/vercel-agent-skills" ]]; then
-    hdr "Installing vercel-labs/agent-skills (NO LICENSE — read-only)"
-    git clone --quiet https://github.com/vercel-labs/agent-skills.git "$HOME/.claude/skills/vercel-agent-skills" \
-      || err "vercel-labs/agent-skills clone failed (skipping; install manually: git clone https://github.com/vercel-labs/agent-skills.git ~/.claude/skills/vercel-agent-skills)"
-  fi
-  [[ -d "$HOME/.claude/skills/vercel-agent-skills" ]] && ok "vercel-agent-skills installed"
 
 fi
 
@@ -1391,6 +1614,34 @@ if [[ -f "$EMAIL_MARKER" && $DRY_RUN -eq 0 ]]; then
       >/dev/null 2>&1 || true
     set -e
   fi
+fi
+
+# ───────────────────────────────────────────────────────────────────────────────
+# Post-install diagnose — final go/no-go beyond the basic CHECKS above.
+# Skipped in dry-run. Non-blocking.
+# ───────────────────────────────────────────────────────────────────────────────
+
+DIAGNOSE_SCRIPT="$SKILL_DIR/scripts/diagnose.sh"
+if [[ ! -f "$DIAGNOSE_SCRIPT" ]] && [[ -f "$HOME/Desktop/ai-brain-starter/scripts/diagnose.sh" ]]; then
+  DIAGNOSE_SCRIPT="$HOME/Desktop/ai-brain-starter/scripts/diagnose.sh"
+fi
+if [[ -f "$DIAGNOSE_SCRIPT" ]] && [[ "$DRY_RUN" -eq 0 ]]; then
+  hdr "$(t "Post-install diagnose" "Diagnóstico post-instalación")"
+  log "$(t "Running scripts/diagnose.sh for the final go/no-go." \
+          "Corriendo scripts/diagnose.sh para el go/no-go final.")"
+  set +e
+  bash "$DIAGNOSE_SCRIPT" 2>&1 | tail -40
+  DIAG_RC=$?
+  set -e
+  if [[ $DIAG_RC -ne 0 ]]; then
+    warn "$(t "Diagnose reported issues — see output above. Re-running bootstrap is safe." \
+            "Diagnose reportó problemas — mirá arriba. Volver a correr el bootstrap es seguro.")"
+  fi
+fi
+
+# State breadcrumb so the next run can surface "last successful run"
+if [[ "$DRY_RUN" -eq 0 ]]; then
+  echo "$(date +%Y-%m-%dT%H:%M:%S%z)" > "$BOOTSTRAP_STATE" 2>/dev/null || true
 fi
 
 # ───────────────────────────────────────────────────────────────────────────────

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1239,7 +1239,7 @@ if [[ "${SKIP_VENDOR_SKILLS:-0}" != "1" ]]; then
     fi
     claude_marketplace_safe "$repo"
     claude_install_safe "$target"
-    [[ $DRY_RUN -eq 0 ]] && ok "plugin ready: $target"
+    if [[ $DRY_RUN -eq 0 ]]; then ok "plugin ready: $target"; fi
   }
 
   # Sentry SDK + AI monitoring skills (Apache 2.0, vendor-published).
@@ -1256,7 +1256,7 @@ if [[ "${SKIP_VENDOR_SKILLS:-0}" != "1" ]]; then
   for plugin in modern-python insecure-defaults sharp-edges property-based-testing static-analysis testing-handbook-skills differential-review ask-questions-if-underspecified; do
     claude_install_safe "$plugin@trailofbits"
   done
-  [[ $DRY_RUN -eq 0 ]] && ok "trailofbits plugins ready"
+  if [[ $DRY_RUN -eq 0 ]]; then ok "trailofbits plugins ready"; fi
 
   # Stripe agent-toolkit (MIT, vendor-published).
   # Single plugin in a marketplace bundle. Includes stripe-best-practices

--- a/docs/HEALTH_ARTICLE_PROMPT.md
+++ b/docs/HEALTH_ARTICLE_PROMPT.md
@@ -1,0 +1,227 @@
+---
+name: health-article-prompt
+description: Self-contained prompt for drafting a Substack article about the health stack (Apple Health / Oura / Fitbit + cycle-aware coaching + journal pairing + auto-trigger chain). Paste into a fresh Claude Code session. Output: two Substack drafts (English + Spanish) saved to your two publications, NOT published.
+---
+
+# Substack article prompt — the health package, for healthy people who are not tech people
+
+Copy everything below the `---PROMPT---` marker into a fresh Claude Code session. The session must have:
+- The user's vault loaded (CLAUDE.md auto-loads)
+- The substack MCP connected (`mcp__substack__create_draft` etc. available)
+- The user's voice rules in their vault at `⚙️ Meta/rules/voice-style.md` + `voice-firewall.md` + `life-history-prose.md`
+- The advisory panel roster in `⚙️ Meta/rules/advisory-panel.md`
+
+The prompt assumes the writer has used the health stack at least once and wants to share the experience. If the writer has not yet imported their own health data and run `/coach today`, the article will read as a product spec instead of a lived story — the writer will need to fill in concrete moments from their own data and mark them with the `[FILL IN]` convention this prompt establishes.
+
+---PROMPT---
+
+I want to draft a Substack article about the health package my AI Brain Starter substrate now ships. The audience is healthy people who care about longevity and self-knowledge but are not tech people. No jargon. No "MCP server" or "DuckDB" — translate everything to human concepts.
+
+Two outputs: one English draft for my main publication, one Spanish (Colombian, tú form) draft for my secondary publication. Both saved as drafts, NEVER published — I review them first.
+
+## Before drafting (mandatory)
+
+Read these files in full, in this order:
+
+1. `⚙️ Meta/rules/voice-style.md` — what my voice IS (warm, direct, no fluff, no preaching, the specific register established in the voice rules file)
+2. `⚙️ Meta/rules/voice-firewall.md` — binary DON'Ts (no em dashes in external prose, no exclamation marks, no LinkedIn-influencer tone, banned framings)
+3. `⚙️ Meta/rules/life-history-prose.md` — every fact (age, year, location, sensory detail, dollar amount, named person, direct quote) MUST trace to a vault source OR be marked `[FILL IN]`. Never invent.
+4. `⚙️ Meta/rules/advisory-panel.md` — the panel rules, especially Rule 9 (Jackie Kennedy required on every public-facing review) and Rule 2 (named panelists only, no archetypes)
+5. The CHANGELOG entries for health-mcp v0.1 through v0.5.1 at `~/dev/ai-brain-starter/docs/CHANGELOG.md` — these tell you exactly what shipped, in order, with the panel reasoning for each decision. The article should be told FROM the lived experience side, not the engineering side, but you need this for accuracy.
+6. `~/dev/ai-brain-starter/docs/AUTOMATION.md` — the why-/journal-is-the-gate explanation. Useful for the philosophy section.
+
+Do NOT read individual SKILL.md files. They are dense and will leak engineering jargon into your draft. The CHANGELOG and AUTOMATION.md are the right altitude.
+
+## What the article should cover
+
+A reader who has never heard of any of this should finish the article understanding:
+
+1. **What problem this solves.** They have an Apple Watch / Oura Ring / Fitbit / phone health app. The data sits in separate apps. None of it pairs with their journal, their weekly review, their actual mood that week. The "smart coaching" promises elsewhere are templates dressed up as personalization.
+
+2. **What the system actually does, in lived terms.** Each morning, after they journal, their phone has tomorrow's workout in the calendar, sized to last night's sleep, this week's recovery, where they are in their cycle if they have one, what their journal said about how they felt yesterday. Their lab results from last month sit in the same place as their sleep data. When their `mood is low for a stretch, the system can show them whether it's because their Vitamin D came back low in last month's labs, or whether they were chronically under-fueling, or whether it's an anniversary pattern they've been carrying for three years without naming.
+
+3. **The seven kinds of insight it can surface.** Use these as concrete "and here's an example of what this looks like" sections. Each one should land with a specific scenario, not a feature list. The scenarios are illustrative; the writer can mark them `[FILL IN with my own example]` if they want to use their actual data later.
+
+   - **Cycle-phase correction.** "Your HRV was 18% below baseline mid-week. But you were in mid-luteal phase. That dip is physiology, not a recovery deficit." Most coaches and apps would tell you to rest more. The system tells you the truer thing.
+   - **Floor pairing.** "On the days you wrote 'Fear' in your journal frontmatter this month, your sleep latency averaged 23 minutes vs 11 on the others. Your body registers the worry before you name it. For the next two weeks, when sleep latency runs long, write before bed instead of in the morning."
+   - **Under-fuel detection.** "Five of the last fourteen days, you ate less than 70% of what you burned. The recovery score kept telling you to rest more. The actual prescription was eat enough." Most fitness apps cannot tell the difference.
+   - **Anniversary patterns.** "Your HRV this month is 14% below the same month last year. It's also 14% below the same month the year before. Three years of the same dip in the same month. That's not random. That's worth a conversation."
+   - **Lab status flagging.** "Your Vitamin D came back at 28 ng/mL last month, below range. The persistent low-mood pattern this month may have a metabolic floor under it. Worth a re-test in 90 days after supplementation."
+   - **Sleep regularity.** "Your bed-time variance was 87 minutes over the last 14 days. Your wake-time was 72 minutes. The body is in chronic low-grade jet lag. Pick a wake time within a 30-minute window for the next two weeks."
+   - **Longevity panel.** "VO2Max trended down 4% over 90 days. Zone 2 minutes ran 124 per week against a 180 target. Cardio capacity is the priority lever this quarter."
+
+4. **The philosophical line.** Auto-trigger the analysis, never auto-trigger the action. The system prepares the workout, appends body context to yesterday's journal, drops the workout in the calendar — but logging completion stays manual. The body stays in the loop on what actually happened. Frame this as the difference between coaching and surveillance.
+
+5. **What's automatic.** The reader should understand that they do not need to remember a single command. They journal (their existing habit) and the system runs the chain. If they skip journaling for a few days, the system quietly waits. It never works harder than they do.
+
+6. **What's still manual, and why.** Apple Health requires a one-time export from the iPhone (the system can pull it weekly after that). Labs require uploading the CSV from their patient portal once a quarter. These are the only friction points and the reader should know about them upfront.
+
+7. **The case for labs.** Apple Health captures roughly the visible 20% of health — heart rate, sleep, steps, exercise. The chemistry that drives chronic disease (ApoB, fasting insulin, hs-CRP, full thyroid panel, Vitamin D, ferritin) is invisible to it. Quarterly labs run roughly $200-400 direct-pay at LabCorp or Quest in the US. The labs change the prescription. Frame this as a self-knowledge investment, not a cost.
+
+8. **The privacy line.** Local-only. Their health data never leaves their machine. The system does not send anything to OpenAI or Anthropic or any third party beyond what their existing wearable apps already do. This is one paragraph, near the top, not buried.
+
+## Article structure
+
+```
+Title: [a line, not a headline — something like "The body has a journal too" or "What my Oura Ring told my journal" or "A longevity coach that actually reads my mood"]
+
+Subtitle: one line, the promise. No exclamation marks.
+
+Opening (2 paragraphs):
+  A scene. The writer was juggling data across [N] apps, never paired with their journal,
+  and noticed [a specific pattern] that none of the apps surfaced. Use [FILL IN] if the
+  writer needs to add their own scene later. This is the hook.
+
+## What I built (1-2 paragraphs)
+  Plain English description of the system. Not feature list. The before/after.
+
+## The seven kinds of insight
+  Seven sub-sections, one per insight type from the list above. Each: a one-line setup,
+  then a scenario in italics or quotes, then 1-2 sentences on what this changed for
+  the writer. Use [FILL IN] for personal moments the writer wants to add.
+
+## The line between coaching and surveillance
+  The auto-trigger-analysis / never-auto-trigger-action philosophy.
+  Bainbridge dissent (panel 2026-05-10) is the load-bearing principle here.
+  Two paragraphs. This is the part that distinguishes the article from a fitness-app review.
+
+## What's automatic, what stays manual
+  Practical. One short paragraph each. The reader should be able to imagine themselves
+  doing it.
+
+## Why labs matter
+  One or two paragraphs. The 20% / 80% framing. The labs that move the prescription.
+  Direct-pay range. Not a sales pitch, an invitation.
+
+## A privacy note
+  Local-only. Two sentences. Earlier in the article would also work — Jackie's vote.
+
+## Closing
+  Friction is not suffering. The point of the system isn't to optimize a body into a
+  spreadsheet, it's to inhabit a body better. Land on a sentence the reader can carry
+  with them.
+
+(Bottom of post, one line below the close, separated by a horizontal rule:)
+Built it as open-source for anyone running an AI Brain Starter. github.com/adelaidasofia/ai-brain-starter
+```
+
+Length target: 1,500 to 2,500 words. Not shorter (it would lose the lived register). Not longer (it would lose readers).
+
+## Voice rules (mandatory)
+
+- **No em dashes.** Use commas, colons, periods, parentheses. Substack is external prose; the no-em-dash rule applies.
+- **No exclamation marks.**
+- **No LinkedIn-influencer tone.** No "Here's what most people get wrong" or "I learned 5 things." No listicles. The voice is first-person, lived, slightly philosophical, warm.
+- **No preaching.** The writer noticed something true. They are not selling longevity.
+- **Friction is not suffering.** Surface this thesis (or whichever canonical thesis the writer's voice rules establish) if relevant.
+- **No "let me share" / "let me tell you" / "I want to talk about"** openers. Start in the scene.
+- **First occurrence of Floor names → wikilinks.** `[[Fear]]`, `[[Courage]]`, etc. on first occurrence. Spanish version uses Spanish aliases (`[[Miedo]]`, `[[Valentía]]`).
+- **No bullet lists in body prose** except in the "seven insights" section. Otherwise sentences and paragraphs.
+
+## Life-history claims
+
+Every concrete claim ("I noticed X on Y date", "my HRV ran Z%", "I journaled on a Thursday and saw...") must either:
+
+1. Trace to a vault source the writer can cite, OR
+2. Be marked `[FILL IN]` so the writer can replace with their actual experience before publishing
+
+Do NOT invent specific numbers, dates, or sensory details. The scenarios under "The seven kinds of insight" are illustrative — they are written as anonymous "your" examples, not "I" claims. If the writer wants to make any of them first-person, they will swap [FILL IN] for their actual data before publish.
+
+## After the English draft is composed: panel review
+
+Per advisory-panel.md Rule 9 (Jackie Kennedy required on every public-facing review), convene a 5-voice panel on the EN draft:
+
+1. **Jackie Kennedy Onassis** — public image, what does this look like to the reader who does not know me, is the privacy commitment visible enough, does the close land
+2. **Elizabeth Gilbert** — creative voice check, does the opening pull a reader in, is the language alive
+3. **Maya Angelou** — does the writing have weight, is the closing line worth carrying
+4. **Brené Brown** — does the article respect the reader, does it preach, does it land without making the reader feel diminished
+5. **One dissenter from the Wisdom & Meaning section** — Thich Nhat Hanh OR Marcus Aurelius. The dissent role is "is the writer making the body more legible without making it more lived" (the Bainbridge axis from the 2026-05-10 panel)
+
+Each voice speaks 1-2 sentences in their authentic register. At least one MUST dissent or push back. Apply the notes that score 80+ conviction (Rule 11). Reject low-conviction notes politely.
+
+After applying panel notes, run the humanizer pass:
+
+```
+/humanizer
+```
+
+This is non-negotiable. The Substack publisher rule requires it BEFORE the draft is saved.
+
+After /humanizer returns, run the verification script:
+
+```
+/usr/bin/python3 "<VAULT_ROOT>/⚙️ Meta/scripts/verify_humanizer_pass.py"
+```
+
+If that script flags anything, fix it and re-run /humanizer. Loop until clean.
+
+## After the EN draft is clean: Spanish translation
+
+Translate to Colombian Spanish, tú form (NOT usted, NOT vosotros). Match the same warm + direct register. Do NOT word-for-word translate — re-write the article in the same voice. Spanish has its own rhythm and the article should sound like it was written in Spanish, not translated.
+
+Floor wikilinks use Spanish aliases on first occurrence: `[[Miedo]]`, `[[Valentía]]`, `[[Aceptación]]`, etc.
+
+Run /humanizer on the Spanish draft too. Some AI-Spanish telltales are different from AI-English telltales; the humanizer skill knows both.
+
+Re-run `verify_humanizer_pass.py` on the Spanish draft. Loop until clean.
+
+## After both drafts are clean: save to Substack
+
+Use the substack MCP. The user has two configured publications (check via `mcp__substack__list_publications`):
+
+- **Primary (English):** publish to the writer's main Substack publication
+- **Secondary (Spanish):** publish to the writer's Spanish secondary publication
+
+For each: call `mcp__substack__create_draft(title, body, subtitle, audience="everyone")`. Do NOT publish. The writer will read both drafts and decide.
+
+Surface the two draft IDs and URLs to me at the end so I can open them and review.
+
+## Final acceptance criteria
+
+Before declaring done:
+
+- [ ] Both EN and ES drafts saved (NOT published) in their respective Substack publications
+- [ ] EN draft is 1,500-2,500 words
+- [ ] ES draft is 1,500-2,500 words (Spanish runs ~15% longer than English, so the ES draft may be slightly larger)
+- [ ] Zero em dashes in either body (commas, colons, periods, parentheses only)
+- [ ] Zero exclamation marks in either body
+- [ ] Floor wikilinks present on first occurrence in each language
+- [ ] Bottom-of-post one-line link to github.com/adelaidasofia/ai-brain-starter present in both
+- [ ] Privacy commitment visible in the first third of the article (Jackie's vote)
+- [ ] At least one dissent voice in the panel pass actually changed something in the draft
+- [ ] /humanizer pass clean on both
+- [ ] `verify_humanizer_pass.py` returns 0 errors on both
+- [ ] At least 3 of the seven insight scenarios are marked `[FILL IN]` so the writer can replace with their lived experience before publishing
+- [ ] No invented dates, dollar amounts, or named-person quotes (life-history-prose rule)
+
+## What to surface to me at the end
+
+- Both Substack draft URLs (so I can open and review)
+- Word counts
+- Panel synthesis: which voice changed what
+- Any [FILL IN] markers I need to address before publishing
+- /humanizer summary: how many AI-signal corrections were applied
+
+Confirm understanding, then start with the voice-rule reads.
+
+---END PROMPT---
+
+## Notes for the writer using this prompt
+
+This prompt is intentionally heavy on guardrails. The article is about a system the writer built. The temptation to over-claim, to slip into "I built this revolutionary tool" register, is real. The voice-style + voice-firewall + humanizer chain catches that. Jackie's panel seat catches public-image risks. The `[FILL IN]` convention prevents fabricated life-history.
+
+The single most important sentence to internalize before writing: **the article is about inhabiting a body better, not optimizing one**. If a paragraph slips toward "biohacker" or "optimize", cut it.
+
+The single most important panel note is Bainbridge's dissent from the 2026-05-10 health-mcp build panel: *"Auto-trigger the analysis. Never auto-trigger the action."* That principle is the article's spine. Without it, the article reads as another fitness app pitch.
+
+## When to use this prompt
+
+- After the writer has imported their own health data via `/health-setup` and `/ingest-health` and run `/coach today` at least once
+- After at least one `/journal` session has fired the auto-chain
+- Optionally, after a few weeks of accumulated body-track sections so the writer has lived examples to fill in
+
+The prompt works without those prerequisites (the seven scenarios are illustrative), but the article will feel more grounded if the writer has used the system themselves first.
+
+## Bilingual reminder
+
+Substack drafts in this stack ALWAYS ship as EN + ES pairs. The Spanish version is not optional, not a "later" — both drafts get created in the same session. The Spanish audience for this kind of substrate is hungry and underserved.


### PR DESCRIPTION
## Summary

Discovered during a real-install test in a sandbox HOME (the post-PR-#41 verification): lean-ctx clone failed mid-bootstrap, `git_clone_safe` returned 1, `set -e` killed the whole bootstrap script before sentry / stripe / cloudflare / claude-seo / superpowers / marketing-skills plugins could install. End result: half-installed state, no `.bootstrap-state` written, no diagnose run.

Same latent risk in `pipx_install_safe` (skill-seekers).

## Fix

Both helpers always `return 0`. The `FAILED` array continues to track individual failures so they still surface in the final summary, but a single tool's network blip no longer aborts the whole install. Mirrors the existing pattern used elsewhere in bootstrap (e.g. `pipx install graphifyy >/dev/null 2>&1 || err "..."` which doesn't propagate failure).

## Test plan

- [x] `bash -n bootstrap.sh` syntax OK
- [ ] Sandbox real-install (`HOME=$SANDBOX bash bootstrap.sh`) reaches the post-install diagnose + writes `.bootstrap-state` even if one tool fails
- [ ] CI green
- [ ] FAILED array still surfaces individual tool failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)