### PR TITLE
docs(readme): install prompt — explicit fetch instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Bootstrap touches your `~/.claude/` directory and registers third-party content.
 Open the [Claude Code desktop app](https://claude.ai/download), sign in with a paid Claude account (Pro, Max, or Team), and paste this into the chat:
 
 ```
-Install ai-brain-starter for me: https://github.com/adelaidasofia/ai-brain-starter
+Install ai-brain-starter for me. Read https://github.com/adelaidasofia/ai-brain-starter and follow the install steps in the README.
 ```
 
 That's the whole prompt. After you paste, what happens:
@@ -142,7 +142,7 @@ No browser tab, no terminal copy-paste, no token to fish out of your inbox.
 Abrí la [app de escritorio de Claude Code](https://claude.ai/download), logueate con una cuenta paga de Claude (Pro, Max o Team), y pegá esto en el chat:
 
 ```
-Instalá ai-brain-starter para mí: https://github.com/adelaidasofia/ai-brain-starter
+Instalá ai-brain-starter para mí. Leé https://github.com/adelaidasofia/ai-brain-starter y seguí los pasos de instalación del README.
 ```
 
 Ese es el prompt entero. Después de pegarlo, lo que pasa:


### PR DESCRIPTION
## Summary

Real-world test in a sandbox: pasting the simplified install prompt failed. Claude saw the URL but did NOT fetch it — instead it inspected leftover sandbox state and got distracted (cat settings.json, ls directories) before doing any install work.

Root cause: \`Install ai-brain-starter for me: <URL>\` is too implicit. Claude needs an explicit verb (\"Read X\") that says fetch + follow before it'll WebFetch the README.

## Fix

Two short sentences, no technical noise about email gates or browsers:

```
Install ai-brain-starter for me. Read https://github.com/adelaidasofia/ai-brain-starter and follow the install steps in the README.
```

Same shape in Spanish.

## Test plan

- [x] Personal-data scrub passed
- [x] EN + ES kept in lockstep
- [ ] Re-test in clean sandbox: this time Claude fetches the URL first, asks email + name, runs bootstrap, continues into setup interview

🤖 Generated with [Claude Code](https://claude.com/claude-code)