### PR TITLE
fix(cycle): stop silently defaulting to luteal when cycle data is stale

### DIFF
--- a/services/health-mcp/cycle.py
+++ b/services/health-mcp/cycle.py
@@ -70,14 +70,28 @@ def _cycle_lengths(starts: list[date]) -> list[int]:
 
 def _band_phase(cycle_day: int, cycle_length: int) -> str:
     """Map a cycle day to a phase. Bands scale to cycle_length; the 28-day
-    bands are stretched/compressed proportionally."""
+    bands are stretched/compressed proportionally.
+
+    Returns "unknown" when the data is stale: if cycle_day exceeds the
+    scaled luteal upper-bound by more than ~50%, the last logged menstrual
+    flow is too far in the past to trust as the current-cycle anchor. This
+    matters for users with sparse cycle data - without this guard, any day
+    months after the last logged flow silently bucketed as 'luteal' and
+    corrupted every downstream Floor body fingerprint.
+    """
     if cycle_length <= 0:
         return "unknown"
     scale = cycle_length / 28.0
     for phase, (lo, hi) in PHASE_BAND_28D.items():
         if lo * scale <= cycle_day <= hi * scale:
             return phase
-    return "luteal"
+    # Out-of-band cycle day. Tolerance up to +50% past luteal upper-bound
+    # (~42 days for a 28-day cycle) accommodates mild irregularity. Beyond
+    # that, the anchor is stale and we should NOT silently default to luteal.
+    luteal_hi = PHASE_BAND_28D.get("luteal", (15, 28))[1]
+    if cycle_day <= int(luteal_hi * scale * 1.5):
+        return "luteal"
+    return "unknown"
 
 
 def _ovulation_refinement(con: "duckdb.DuckDBPyConnection", target: date, window_days: int = 5) -> str | None:


### PR DESCRIPTION
## Summary

`_band_phase` had a bare `return "luteal"` fallthrough when `cycle_day` fell outside the scaled phase bands. For users with sparse menstrual flow records (logged once or twice a year), this silently classified months of stale data as luteal — corrupting every downstream Floor body fingerprint that grouped by cycle phase.

## How it surfaced

Running 10-year /longitudinal analytics: every Floor across 1,622 journal entries read 88-100% luteal cycle distribution. Statistically impossible across multiple Floors with distinct emotional content. Briden + Sims both flagged it as a data-quality red flag in panel review.

## The fix

When `cycle_day` exceeds the scaled luteal upper-bound by more than 50% (~42 days for a 28-day cycle), return "unknown" instead of "luteal". 50% tolerance accommodates mild irregularity (Briden's point); beyond that, the anchor is stale.

## Downstream impact

- `floor_body_fingerprint.cycle_phase_distribution`: reflects real cycle context when present, reports fewer days when stale
- `correlate(group_by="cycle_phase")`: stale-anchor days no longer pollute luteal grouping, sharpens any real cycle signal

## Test plan

- [x] 28d / day 5 → menstrual (unchanged)
- [x] 28d / day 22 → luteal (unchanged)
- [x] 28d / day 40 → luteal (within +50% tolerance)
- [x] 28d / day 100 → unknown (was: luteal — bug)
- [x] 28d / day 200 → unknown (was: luteal — bug)
- [x] 113 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)