### PR TITLE
Fix five install-time improvisations from friend-test feedback

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -11,6 +11,23 @@ Your tone: warm, clear, encouraging. They might not be technical. Explain things
 
 **CRITICAL: Never stop to present a menu of options between phases.** Don't ask "What do you want to do next?" or list choices. That kills momentum. Instead, **flow directly into the next phase.** Each phase transitions naturally: finish one, brief intro to the next, keep going. The only time you pause is when a phase requires their specific input. Between phases, the default is: keep moving. If a phase doesn't apply based on what they said in Phase 1, skip it silently.
 
+### BANNED PATTERNS — if you catch yourself about to write any of these, stop and continue the install
+
+These are improvisations that look helpful but break the install. Do NOT write any of them:
+
+| If you find yourself writing... | Do this instead |
+|---|---|
+| "Three options for what to do now: A. Pause / B. Push through Phase X / C. All the way through" | Continue to the next phase. Pick yourself, never the user. |
+| "What's still ahead (optional, can do later)" tables | The phases are NOT optional. Run all of them. |
+| "Want to keep going or pause here?" / "Should we stop here for tonight?" | Continue. Only the user can ask to stop. |
+| "Two ways to start it: (1) say start (2) Fresh session (recommended)" | NEVER offer fresh-session. Start the interview in THIS session. |
+| "Quit and reopen Claude Code, then paste..." / "hooks load properly in a clean session" | NEVER. Continue in this session. Hooks already loaded. |
+| "I'll skip Phase X — you didn't mention [topic]" | Don't assume. ASK explicitly per phase. (Books, wearables, frameworks, backup — every phase has a mandatory ask.) |
+| "Here are some default voices for your journal panel — want to swap any?" | The full 90+ roster goes into the daily-journal skill verbatim. The skill picks 3-5 per-entry. No setup-time panel customization. |
+| "Want me to..." mid-phase, except when a phase REQUIRES a specific user input | Just do it. Direction is already clear: complete the install. |
+
+**The install runs until Phase 24 ends.** No pause options, no progress-check menus, no fresh-session handoffs. If the user genuinely needs to stop, they will say so — wait for that explicit signal, never offer it.
+
 **Update check:** Before starting, check if this skill is up to date by running `cd ~/.claude/skills/ai-brain-starter && git log --oneline -1` and comparing to the latest on GitHub. If behind, offer to update. If yes, run `git pull`, read `docs/CHANGELOG.md`, and summarize what's new in plain English.
 
 ## Already Set Up? Use This Instead

--- a/phases/phase-10a-journaling.md
+++ b/phases/phase-10a-journaling.md
@@ -466,7 +466,11 @@ Based on what came up in Steps 1–3 AND which triggers fired mid-interview (see
 
 **The Advisory Panel roster:**
 
-During setup, offer the user the full roster below and let them **customize the panel** — add voices, remove voices, replace voices with people relevant to their life (their grandmother, their favorite professor, a specific author). Save the final roster into the generated skill so the daily journal uses the user's actual panel, not a generic one. If the user doesn't want to customize, use the default roster below as-is.
+**DO NOT ask the user to customize the panel at setup time.** No "default 5" proposed for approval. No "want to swap any in?" prompt. The full roster below gets installed into the daily-journal skill verbatim, and the skill's Step 5 selects 3-5 panelists PER ENTRY based on which mid-interview triggers fired and what surfaced in Steps 1-3. This guarantees variation across entries — a finance-stress journal pulls Hormozi + Buffett + Gabor Maté; a creative-block journal pulls Rubin + Gilbert + Brené Brown; a relationship journal pulls Perel + Tatkin + Solomon. Same default 5 every day would defeat the point.
+
+The user CAN edit the roster later by asking ("add my grandmother as a panelist," "remove Hormozi"). That edit lands in the daily-journal SKILL.md directly. But never volunteer the customization prompt at setup — it adds a decision they don't need to make and locks them into a static panel.
+
+Install the full roster below into the daily-journal skill exactly as written:
 
 *Wealth & Strategy:*
 Naval Ravikant (leverage, asymmetric bets, freedom-through-clarity) · Warren Buffett (capital allocation, simplicity, patience, circle of competence) · Ray Dalio (macro cycles, principles-based decisions, risk parity) · Alex Hormozi (execution, offers, scaling) · Tom Wheelwright (tax strategy, entity design, intergenerational planning) · Marc Andreessen (tech thesis, software-eats-world, founder empathy) · Stephen Schwarzman (PE discipline, scale-up playbooks) · Howard Marks (credit cycles, risk management, second-level thinking) · Sam Zell (contrarian, distressed value, downside-first thinking) · Robert Kiyosaki (cash-flow mindset, financial education) · Ken Griffin (risk-adjusted returns, market microstructure) · Laurene Powell Jobs (impact investing, values-led legacy) · Richard Branson (joyful entrepreneurship, brand magic)
@@ -510,6 +514,6 @@ Jane Goodall (planetary compassion, stewardship, humility with action) · Charle
 *Creativity:*
 Rick Rubin (creativity via presence, subtractive genius, trust the muse) · Elizabeth Gilbert (creative courage, fear alchemy, permission to play) · Twyla Tharp (creative discipline, daily craft)
 
-**Customize by user.** During setup, ask: *"This is the default advisory panel. Want to add, swap, or remove anyone? You can replace any of these with a specific person in your life — a mentor, a grandparent, a coach — and I'll build them into the skill."* Whatever they say, bake into Step 5 of the generated skill.
+**No setup-time customization prompt.** Install the full roster above verbatim into the daily-journal SKILL.md. The skill picks 3-5 per entry from this full roster based on what surfaces — variation is the feature, not a bug. If the user later asks to add a specific person (grandmother, mentor, professor) or remove one of the listed voices, edit the daily-journal SKILL.md directly at that point. Never volunteer the customization question.
 
-**Advisory Panel Roster:** The full panel roster, voice routing trigger table, and panel customization instructions are in `phases/phase-10b-panel-roster.md`. Read that file when you reach Step 5 of the journal skill generation.
+**Advisory Panel Roster:** The full panel roster and voice routing trigger table are in `phases/phase-10b-panel-roster.md`. Read that file when you reach Step 5 of the journal skill generation.

--- a/phases/phase-11-external-tools.md
+++ b/phases/phase-11-external-tools.md
@@ -3,20 +3,17 @@
 "Let's connect Claude to the tools you actually use. This is where the vault becomes an operating system, not just a notebook."
 
 ### Email & Calendar
-Ask: "Do you use Gmail? Google Calendar? Outlook?"
-- "In Claude Code, go to Settings → Connectors. Connect Gmail and Google Calendar. Once connected, I can search your email, draft replies with full context, check your schedule, and create events."
-- If they use Outlook/Microsoft 365: "Same thing — connect Microsoft 365 from the connectors page."
+Ask: "Do you use Gmail / Google Calendar / Google Drive / Google Docs? Or Outlook / Microsoft 365?"
 
-**If they use Gmail, offer the upgrade path:**
+**If they use ANY Google Workspace surface (Gmail, Calendar, Drive, Docs, Sheets, Meet) — install `google-workspace-mcp` as the default.** Do NOT recommend Settings → Connectors first. The MCP covers all 5 surfaces in one install, supports multiple accounts, and is token-efficient.
 
-Say:
+Tell them: "I'm going to install `google-workspace-mcp` — one MCP that covers Gmail, Calendar, Drive, Docs, and Sheets. It supports multiple Google accounts (work + personal) and uses fewer tokens than the official connectors. I'll walk you through the Google Cloud OAuth setup."
 
-> "If you want multi-account and token efficiency while connecting to Google, there's an open-source MCP, [google-workspace-mcp](https://github.com/adelaidasofia/google-workspace-mcp). 61 tools across Gmail, Calendar, Drive, Docs, and Sheets. Setup is ~45 min the first time (mostly Google Cloud OAuth consent screen config), then ~90 sec per additional account. Want to install it?"
+Then install it directly (don't ask "want to install it?" — they already said they use Google):
 
-If yes:
 1. Clone: `git clone https://github.com/adelaidasofia/google-workspace-mcp ~/.claude/google-workspace-mcp`
 2. Install deps: `cd ~/.claude/google-workspace-mcp && pip install -r requirements.txt`
-3. Walk them through `SETUP.md` for the OAuth consent screen (this is the slow part — GCP console UI, creating an OAuth client, downloading `client_secret.json`, dropping it in the repo folder).
+3. Walk them through `SETUP.md` for the OAuth consent screen. This is the one slow part — GCP console UI, creating an OAuth client, downloading `client_secret.json`, dropping it in the repo folder. Stay with them through every screen; this is where non-tech users give up. Use the Visual Reassurance Protocol throughout.
 4. Register in `~/.claude.json` mcpServers block:
    ```json
    "google-workspace": {
@@ -24,12 +21,14 @@ If yes:
      "args": ["/Users/<user>/.claude/google-workspace-mcp/server.py"]
    }
    ```
-5. Authorize each account: `python3 -c "from accounts import add_account; add_account()"` — browser opens, they grant consent, refresh token lands in macOS Keychain.
-6. Verify: restart Claude Code, check Settings → MCP, confirm `google-workspace` is listed with 61 tools.
+5. Authorize each account: `python3 -c "from accounts import add_account; add_account()"` — browser opens, they grant consent, refresh token lands in macOS Keychain. Ask them upfront which accounts (work + personal + any others) and run this once per account.
+6. Verify: restart Claude Code, check Settings → MCP, confirm `google-workspace` is listed with 61 tools across Gmail/Calendar/Drive/Docs/Sheets.
 
-**Tell them:** "Once this is installed, you can keep the official Gmail connector on OR turn it off. The MCP version replaces it with more power. If you only have one Gmail account and don't care about tokens, the official connector is fine — skip this."
+**Non-mac users:** the MCP stores tokens in macOS Keychain on Mac. On Windows/Linux, tokens fall back to an encrypted file (the `keyring` library picks the right backend). Flag this if they're not on macOS so they know tokens aren't in Keychain-level security.
 
-**Non-mac users:** the MCP stores tokens in macOS Keychain today. On Windows/Linux, tokens fall back to an encrypted file (the `keyring` library picks the right backend). Flag this if they're not on macOS so they know tokens aren't in Keychain-level security.
+**If they use Outlook / Microsoft 365 instead:** "Go to Settings → Connectors and connect Microsoft 365. Once connected, I can search your email, draft replies with full context, check your schedule, and create events."
+
+**If they use both:** install `google-workspace-mcp` for Google and add the Microsoft 365 connector for Outlook.
 
 ### Communication
 Ask: "Do you use Slack?"

--- a/phases/phase-12-17-imports-rules.md
+++ b/phases/phase-12-17-imports-rules.md
@@ -1,10 +1,14 @@
 # Phases 12-17: Imports, Taxonomy, Backup, and Obsidian Rules
 
+**Run every phase in this file. Ask each phase's question explicitly.** Do NOT skip a phase because the user didn't mention the topic earlier — most users have no idea these features exist until you ask. Banned framings: "Skip — you didn't mention books / wearables / a framework / a backup tool." Always ask. Then skip only if their explicit answer is no.
+
 ---
 
 ## Phase 12: Import Book Notes & Highlights
 
-Ask: "Do you read books and highlight? (Kindle, Apple Books, Readwise, physical books with notes?)"
+**MANDATORY ASK — do NOT skip because they didn't bring up books earlier.** Ask now:
+
+"Do you read books and highlight? (Kindle, Apple Books, Readwise, physical books with margin notes?)"
 
 If yes, explain: "Your book highlights are some of the most valuable notes you have — they're the ideas that resonated enough to mark. Let's get them in."
 
@@ -21,23 +25,32 @@ After import:
 - Add wikilinks to concepts that match existing vault notes
 - "Your reading and your thinking are now connected. When you write about a topic, your book highlights surface as context."
 
-## Phase 13: Health Data Import (Optional)
+## Phase 13: Health Data Import
 
-**Note:** Basic habit tracking (gym, sleep, mood, scrolling) is already built into the journal skill from Phase 10. This phase is ONLY for importing external health data sources.
+**MANDATORY ASK — never assume.** Do NOT skip this phase because the user didn't mention a wearable earlier. Most people who own an Apple Watch, Oura, Fitbit, Garmin, or Whoop don't think to bring it up during setup. Ask explicitly now:
 
-Ask: "Do you use any health tracking devices or apps? (Apple Health, Fitbit, Garmin, Oura, Whoop?)"
+"Do you wear or use any of these? Apple Watch / Apple Health, Oura Ring, Fitbit, Garmin, Whoop, or any other health-tracking device or app?"
 
-If yes: "We can import your health data and cross-reference it with your journal entries. Imagine asking 'what do my best weeks have in common?' and getting back: gym 4x, sleep before midnight, no social media after 9pm. The habit tracking from your journal gives you the subjective data — this gives you the objective data."
+Wait for their answer. If they say yes (even to one), continue. If they explicitly say "no, none of these," then skip to Phase 14.
 
-Walk through their specific source:
-- **Apple Health:** Export via Apple Health app → Share → Export All Health Data. Creates a zip with XML. We can parse steps, sleep, heart rate, workouts into YAML frontmatter on journal entries.
-- **Fitbit / Garmin / Oura / Whoop:** Check if they have API access or export options. Some have Obsidian community plugins.
+If yes: "We can import your health data and cross-reference it with your journal entries. Imagine asking 'what do my best weeks have in common?' and getting back: gym 4x, sleep before midnight, HRV above 40, no social media after 9pm. The habit tracking from your journal gives you the subjective data — this gives you the objective data."
 
-If they don't have any health devices, skip this phase entirely — Phase 10 already handles the habit tracking.
+Then walk through their specific source. If they have the `health-setup` skill installed (from the ai-brain-starter bundle), invoke it via the Skill tool to handle wearable wiring end-to-end. Otherwise:
+
+- **Apple Watch / Apple Health:** Export via Apple Health app → Share → Export All Health Data. Creates a zip with XML. The `ingest-health` skill (also bundled) imports it into a local DuckDB. Three modes: XML export.zip, Simple Health Export CSV folder, Health Auto Export TCP-live.
+- **Oura Ring:** Personal Access Token from cloud.ouraring.com → set `OURA_TOKEN` env var. The `health-setup` skill wires this end-to-end.
+- **Fitbit / Garmin / Whoop:** each has its own auth dance. `health-setup` skill handles each one.
+- **Apple Watch without export hassle:** Health Auto Export iOS app pushes live data via TCP. Walk them through it.
+
+After import, the `health-context` skill (auto-fires on journal entries) pairs body data with Floor tags — so a "Floor: Joy" entry with "HRV 22, RHR 78, sleep 5h 12m" gets the parasympathetic-state caveat automatically.
+
+If they explicitly said no to all wearables, skip this phase silently — Phase 10's habit tracking already covers the subjective side.
 
 ## Phase 14: Build Your Concept Taxonomy
 
-Ask: "Do you have a framework you think about life through? (Values, principles, categories, a personal philosophy?) Or do you want to build one?"
+**MANDATORY ASK** — concept notes are how the vault stops being a filing cabinet. Always run this phase.
+
+Ask: "Do you have a framework you think about life through? (Values, principles, categories, a personal philosophy?) Or do you want to build one from the themes already in your writing?"
 
 Not everyone has a framework like the High-Rise. But everyone has recurring themes. Help them identify theirs:
 
@@ -67,7 +80,9 @@ This is what turns a vault from a filing system into a thinking system. The conc
 
 ## Phase 15: Backup & Sync Setup
 
-Ask: "How do you want to back up your vault? (Google Drive, iCloud, Dropbox, Git, or just local?)"
+**MANDATORY ASK — never skip.** If their vault folder dies and there's no backup, the entire install is lost work. Always ask:
+
+"How do you want to back up your vault? Pick one: Google Drive, iCloud, Dropbox, Git (private GitHub repo), or just local (manual external-drive copies)?"
 
 **Important:** "Your vault is just a folder of files. If that folder disappears, everything is gone. Let's make sure it's backed up."
 


### PR DESCRIPTION
## What
Five Claude-improvised behaviors caught during a non-tech friend's end-to-end install, all fixed at the skill level so they can't recur:

1. **SKILL.md BANNED PATTERNS table** — explicit phrasings Claude must never write mid-install ("Three options for what to do now: A. Pause / B. Push through / C. All the way", "What's still ahead (optional)", "Want to keep going or pause?", "Two ways to start: ... Fresh session recommended", "Quit and reopen", "I'll skip — you didn't mention X", "Default panel — want to swap?"). The existing "never stop" prose wasn't catching the reflex.

2. **Phase 11 (external tools)** — flip `google-workspace-mcp` to the default install for ANY Google Workspace surface (Gmail, Calendar, Drive, Docs, Sheets, Meet). It was previously an "upgrade path" offered after Settings → Connectors, which led Claude to recommend the Connectors flow first. Outlook / Microsoft 365 still routes to Connectors.

3. **Phase 13 (health data)** — MANDATORY explicit ask for wearables. Names the devices (Apple Watch, Oura, Fitbit, Garmin, Whoop) so the question is concrete. No more "Skip — no wearable mentioned" — most users don't think to bring it up. Wires to `health-setup` + `ingest-health` skills.

4. **Phase 12 / 14 / 15** — same mandatory-ask treatment for books, taxonomy, backup. No "you didn't mention X earlier" skips.

5. **Phase 10a** — kill the setup-time "default 5 panel — want to swap?" prompt. Full roster goes into the daily-journal skill verbatim; Step 5 picks 3-5 panelists per-entry from the full roster based on what surfaces. Variation across entries IS the feature. User edits the roster later by asking.

## Why
Friend-test surfaced five distinct "I improvised something the skill didn't tell me to" failure modes. Adding more general "never stop" prose at the top of SKILL.md wasn't enough — the fix is layered: top-level banned-patterns table catches the reflex, and each phase has its own mandatory-ask language so improvisation has no remaining slack.

## Test plan
- [ ] Re-run install end-to-end on a fresh machine
- [ ] Verify the install runs through all phases without offering a pause-option menu
- [ ] Verify Phase 11 installs google-workspace-mcp by default for Gmail users
- [ ] Verify Phase 13 asks the wearable question explicitly, by name
- [ ] Verify the daily-journal skill gets the full panel roster, not a default-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)