### PR TITLE
fix(detect-closing-signal): strong-tier matches override FP guards

### DIFF
--- a/hooks/detect-closing-signal.py
+++ b/hooks/detect-closing-signal.py
@@ -186,12 +186,15 @@ def classify_signal(prompt: str, packs: dict, custom: list[str]) -> tuple[str | 
 
     text = prompt.strip()
 
-    # False-positive guards run FIRST
-    if is_false_positive(text, packs.get("false_positive_guards", [])):
-        log_debug("false-positive guard matched, skipping")
-        return (None, None)
+    # Strong-tier matches (custom, explicit, high_confidence) OVERRIDE
+    # false-positive guards. The guard is meant to catch "okay let's continue"
+    # mid-conversation transitions — NOT to suppress "okay let's close this
+    # session" which contains a clear close verb. Fix shipped 2026-05-12 after
+    # an "Okay, let's close this session" prompt was silently suppressed by the
+    # `^ok(ay)?[,.\s]+(let'?s|now)...` guard despite high_confidence pattern
+    # `\b(let'?s\s+)?close\s+(this|the)\s+session\b` also matching.
 
-    # User custom patterns are highest authority
+    # User custom patterns are highest authority — always win, FP guard skipped
     for pattern in custom:
         try:
             if re.search(pattern, text, re.IGNORECASE | re.MULTILINE):
@@ -199,7 +202,23 @@ def classify_signal(prompt: str, packs: dict, custom: list[str]) -> tuple[str | 
         except re.error:
             continue
 
-    for level in ("explicit", "high_confidence", "emoji_only", "ambiguous"):
+    # Strong tiers (explicit, high_confidence) override FP guards
+    for level in ("explicit", "high_confidence"):
+        for pattern in packs.get(level, []):
+            try:
+                if re.search(pattern, text, re.IGNORECASE | re.MULTILINE):
+                    log_debug(f"matched [{level}] (FP guard bypassed): {pattern}")
+                    return (level, pattern)
+            except re.error as e:
+                log_debug(f"bad pattern '{pattern}': {e}")
+                continue
+
+    # For weaker tiers (emoji_only, ambiguous), apply FP guards
+    if is_false_positive(text, packs.get("false_positive_guards", [])):
+        log_debug("false-positive guard matched (no strong-tier match), skipping")
+        return (None, None)
+
+    for level in ("emoji_only", "ambiguous"):
         for pattern in packs.get(level, []):
             try:
                 if re.search(pattern, text, re.IGNORECASE | re.MULTILINE):


### PR DESCRIPTION
## Bug

The false-positive guard ran FIRST and could suppress explicit/high_confidence close signals.

**Example failure** (caught in production tonight):

User prompt: `"Okay, let's close this session."`

This matched BOTH:
- High-confidence pattern: `\b(let'?s\s+)?close\s+(this|the)\s+session\b`
- FP guard pattern: `^ok(ay)?[,.\s]+(let'?s|now)\b...`

Guard won. Close signal silently suppressed. The session-close cascade never fired. Model wrote a summary claiming "closing the session" but Phase 0c–0e + aggregators + git snapshot never ran.

## Fix

Check custom + explicit + high_confidence patterns BEFORE the FP guards. FP guards now only apply to weak-tier (`emoji_only`, `ambiguous`) matches where ambiguity is the actual concern.

Rationale: FP guards exist to catch mid-conversation transitions like `"okay let's continue"` / `"ok now do X"`. They should NOT suppress unambiguous close intent like `"okay let's close this session"` where the close verb is explicit.

## Verification

6/6 test cases pass:

| Prompt | Expected | Result |
|---|---|---|
| `Okay, let's close this session.` | match | `high_confidence` |
| `okay let's continue with the next thing` | skip | `None` (FP guard) |
| `good night` | match | `high_confidence` |
| `ok now do X` | skip | `None` (FP guard) |
| `wrapping up` | match | `high_confidence` |
| `thanks that's all` | match | `high_confidence` |

Original failure case now correctly fires the cascade injection. True mid-conversation transitions still correctly skipped.