### PR TITLE
Kill workshop mode entirely + polyglot Phase 1 language ask

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -26,16 +26,17 @@ These improvisations look helpful in the moment but break the install. Catch you
 | "I'll skip Phase X — you didn't mention [topic]" | Don't assume. ASK explicitly per phase. (Books, wearables, frameworks, backup — every phase has a mandatory ask.) |
 | "Here are some default voices for your journal panel — want to swap any?" | The full 90+ roster goes into the daily-journal skill verbatim. The skill picks 3-5 per-entry. No setup-time panel customization. |
 | "Want me to..." mid-phase, except when a phase REQUIRES a specific user input | Just do it. Direction is already clear: complete the install. |
-| "For the workshop we'll just do CORE / defer connectors / skip OAuth / trim to phase X" | Every install runs every phase. Workshop mode adds a transcript and tagged telemetry; it does NOT cut content. Time / room-pace / "they'll get tired" framings are out of frame per the project's best-of-best lockout. |
+| "For the workshop we'll just do CORE / defer connectors / skip OAuth / trim to phase X" | No workshop mode exists. There is one install. Every phase runs. Time / room-pace / "they'll get tired" framings are out of frame per the project's best-of-best lockout. |
 | "Light version / lite install / quick path / minimum viable setup" | No such tier exists. There is one install: the full install. If the user asks for a stripped version, decline once and explain that the install is general-enough that everyone benefits from all phases. |
 | "We can phase this in — Phase 11 next session, Phase 18 the week after" | The install is one flow, not a roadmap. Continue. The only legitimate pause is the user explicitly saying "I need to stop now." |
+| "I see your recap file says `lang: en` so I'll continue in English" / silently inheriting any language default | The recap is a HINT, never authoritative. Phase 1 Step 1.0 ALWAYS runs and asks the language question. The user picks. No silent defaults from server-side form choices, browser locale, OS locale, or anything else. |
 
 **The install runs until the final phase ends.** No pause options, no progress-check menus, no fresh-session handoffs. If the user genuinely needs to stop, they will say so — wait for that explicit signal, never offer it.
 
-**Telemetry capture (Goldsmith pattern).** After each phase completes, append one JSON line to `~/.claude/.ai-brain-starter-install.jsonl` describing what happened. Schema:
+**Telemetry capture.** After each phase completes, append one JSON line to `~/.claude/.ai-brain-starter-install.jsonl` describing what happened. Schema:
 
 ```json
-{"ts": "2026-05-12T17:42:00Z", "phase": "10a", "outcome": "completed", "user_redirected": false, "new_improvisation_seen": null, "workshop_mode": false}
+{"ts": "2026-05-12T17:42:00Z", "phase": "10a", "outcome": "completed", "user_redirected": false, "new_improvisation_seen": null}
 ```
 
 `outcome` ∈ {`completed`, `skipped_on_user_no`, `errored`}. Set `new_improvisation_seen` to a short string ONLY when the user catches you doing something this skill didn't tell you to do (the file is the diff between what the skill prescribed and what you actually did). That string is the maintainer's signal for the next BANNED PATTERNS row. Use the `append-install-event` helper at `scripts/install-telemetry.py` when present; fall back to `jq -c .` from bash if not.
@@ -83,24 +84,11 @@ This setup has 25 phases (0-24). Each phase is stored in its own file under `pha
 | **23.5** | `phases/phase-19-23-finish.md` (appended) | **MUST BE LAST INSTALL PHASE — token-aware.** second-brain-mapping install: `/setup-vault-types` wizard, first free metadata + insight run, defer graphify decision (expensive), wire CRM auto-log from journal. Phases 1 + 4 are zero-LLM; Phase 2 (graphify) is opt-in. |
 | 24 | `phases/phase-19-23-finish.md` (appended) | Handoff from installed to used. Point the user to a short companion read on recommended first-week uses (three commands and one habit). Language-conditional: show only the link matching their PRIMARY_LANGUAGE. Closes the "now what?" gap. |
 
-Everyone gets the full second-brain experience (advisory panel, knowledge graph, automatic context routing, monthly insights, Instinct Engine, connectors, imports, polish, handoff). No exceptions.
+Everyone gets the full second-brain experience (advisory panel, knowledge graph, automatic context routing, monthly insights, Instinct Engine, connectors, imports, polish, handoff). No exceptions. No modes, no flags, no "workshop install" branch — there is one install and one user experience.
 
-### Workshop mode — reliability layer ONLY
+### Mid-flow checkpoints
 
-**Trigger:** the env var `WORKSHOP_MODE=1`, OR a recap file `~/.claude/.ai-brain-starter-recap.json` with `"branch": "workshop"`, OR the user's first message contains the phrase "workshop install" / "instalación de taller".
-
-Workshop mode does NOT change what gets installed. It adds a transparency layer for the facilitator. ALL 25 phases still run. OAuth still happens. Connectors, imports, polish — everything ships, same as a solo install.
-
-What workshop mode ADDS (never cuts):
-
-1. **Verbose per-attendee transcript** at `~/.claude/.ai-brain-starter-workshop-transcript.md` — every Bash / Write / Edit / Skill tool call appended with a one-line summary so the facilitator can read where each attendee got stuck after the room ends.
-2. **Telemetry lines tagged `workshop_mode: true`** in `~/.claude/.ai-brain-starter-install.jsonl` so the maintainer can filter `python3 scripts/install-telemetry.py summarize --workshop-only` and see what surfaced across the cohort.
-
-That's it. No deferrals, no "CORE only" shortcut, no OAuth skipping. The install runs full-length whether the user is in a workshop room, on their couch, or in an airport.
-
-### Always-on mid-flow checkpoints
-
-For every install (workshop or solo), at the end of Phase 5, Phase 10, Phase 17, and Phase 23, give a one-line orientation: `Checkpoint — [Phase X] done. Up next: [Phase Y]. [What just landed in one short clause].` Estimate elapsed time honestly only if asked; don't volunteer time numbers (treats minutes as a feature, which they aren't).
+At the end of Phase 5, Phase 10, Phase 17, and Phase 23, give a one-line orientation: `Checkpoint — [Phase X] done. Up next: [Phase Y]. [What just landed in one short clause].` Estimate elapsed time only if explicitly asked; don't volunteer time numbers (treats minutes as a feature, which they aren't).
 
 ### Progress tracking (always on)
 
@@ -115,13 +103,12 @@ On the next install run (or session resume), read this file FIRST and skip to th
 ### How to Execute
 
 1. **Check progress file.** Read `~/.claude/.ai-brain-starter-progress.json`. If present, jump to the first un-completed phase. If absent, start at Phase 0.
-2. **Note workshop mode.** If active, set up the per-attendee transcript path and tag telemetry. Do NOT change which phases run — every phase still runs.
-3. Read the phase file for the current phase.
-4. Execute it (interview the user, create files, install tools).
-5. When the phase completes, append a telemetry line to `~/.claude/.ai-brain-starter-install.jsonl` AND update the progress file (`last_completed_phase`). Helper script: `scripts/install-telemetry.py append <phase> <outcome>` (falls back to `jq`-based bash if Python isn't ready).
-6. Move to the next phase in the table.
-7. If a phase doesn't apply (the user explicitly answered no to that phase's mandatory ask, or no relevant context exists), skip silently — but still write the telemetry line with `outcome: "skipped_on_user_no"` so the maintainer can see drop rates per phase. "Doesn't apply" never means "we're behind schedule" — it means the user explicitly opted out of that specific feature.
-8. At the start of each phase, briefly tell the user where they are: "Phase [X]: [Name]. This is where we [one sentence]."
+2. Read the phase file for the current phase.
+3. Execute it (interview the user, create files, install tools).
+4. When the phase completes, append a telemetry line to `~/.claude/.ai-brain-starter-install.jsonl` AND update the progress file (`last_completed_phase`). Helper script: `scripts/install-telemetry.py append <phase> <outcome>` (falls back to `jq`-based bash if Python isn't ready).
+5. Move to the next phase in the table.
+6. If a phase doesn't apply (the user explicitly answered no to that phase's mandatory ask, or no relevant context exists), skip silently — but still write the telemetry line with `outcome: "skipped_on_user_no"` so the maintainer can see drop rates per phase. "Doesn't apply" never means "we're behind schedule" — it means the user explicitly opted out of that specific feature.
+7. At the start of each phase, briefly tell the user where they are: "Phase [X]: [Name]. This is where we [one sentence]."
 
 ### Variables to Track Across Phases
 

--- a/phases/phase-01-welcome.md
+++ b/phases/phase-01-welcome.md
@@ -17,24 +17,21 @@ If the bootstrap completed via the email-gated install path, it cached the user'
 }
 ```
 
-If the file exists and parses cleanly, set these in your working memory and **DO NOT re-ask the corresponding questions**:
+If the file exists and parses cleanly, capture these into your working memory:
 
 - `RECAP_NAME` from `name`
 - `RECAP_EMAIL` from `email`
-- `PRIMARY_LANGUAGE` from `lang` (skip Step 1.0 entirely if present)
+- `RECAP_LANG` from `lang` — **a HINT, never authoritative**. Do NOT pre-set `PRIMARY_LANGUAGE` from this. Step 1.0 still runs and the user still picks.
 - `RECAP_BRANCH` (informational, used to tune Phase 11 wiring)
 - `RECAP_OS` (informational, used to skip the OS-detection step in Phase 5)
 
+`name` + `email` are facts the user typed themselves on the install page. Reuse them. `lang` is a server-side default from a one-field form (the install page defaults to `"en"` if no language is selected — Sneider's signup hit this default and the recap.lang was `"en"` even though no one ever asked him). Treat it as background context only.
+
 If the file is missing or malformed, fall back to the standard interview flow below (ask everything from scratch).
 
-When `RECAP_NAME` is set, your opening line in the user's primary language should be a **personalized welcome**, not a generic "Hey":
+**No personalized welcome before Step 1.0 runs.** The recap'd name lands in the Step 1.1 welcome AFTER the user has picked a language. Pre-emptive welcomes in English or Spanish would lock the conversation into a language the user never confirmed. Wait.
 
-- English: *"Welcome back, [name]. Let's get your second brain set up."*
-- Spanish: *"Hola [name], qué bueno verte. Vamos a poner en marcha tu segundo cerebro."*
-
-This eliminates the duplication between the install form and the setup interview. The user feels the system already knows them on sentence one.
-
-After reading the recap, continue with Step 1.−1 (mode detection) below. Skip Step 1.0 if `PRIMARY_LANGUAGE` is set from the recap.
+After reading the recap, continue with Step 1.−1 (mode detection) below. **Step 1.0 always runs. No exceptions.**
 
 ### Step 1.−1 — Detect mode: NEW PERSONAL VAULT vs JOINING EXISTING TEAM VAULT (run BEFORE the language question)
 
@@ -133,13 +130,38 @@ If we routed to mode B (joining an existing team vault), do NOT run Phases 2, 3,
 
 Don't ask the language question (1.0) or any of the personal-setup questions (1.1) — those are for new personal vaults only. The team vault already has its own CLAUDE.md with its own conventions.
 
-### Step 1.0 — Languages (ASK FIRST, BEFORE ANYTHING ELSE)
+### Step 1.0 — Languages (ASK FIRST, BEFORE ANYTHING ELSE — NO EXCEPTIONS)
 
-Before any other question, ask **in English**:
+**This step always runs.** Not "unless the recap has a lang field." Not "unless the user's first message was in English." Not "unless Phase -2 already set something." Always. The user has to pick.
 
-> "Quick first question: **what languages do you usually take notes and journal in?** It can be one, two, three, whatever. Some people slip into a second language for emotional content, or use one language for work and another for personal stuff — that's normal, tell me all of them.
+**Open polyglot.** The very first message you send must show the user their language is one of the options — not buried, not after a paragraph of English. Open with this exact greeting (verbatim, including the line breaks and the emoji-free wave), translated into the most common languages the substrate expects, with the call-to-action at the end:
+
+> 👋
 >
-> Then: **which one is your primary?** (The one you think and write in most.) I'll run the rest of this setup in that primary language and build everything — your CLAUDE.md, your journal prompts, your concept notes, your folder names — in it. The other languages will get added as aliases on every concept note, so wikilinks resolve no matter which language you wrote the entry in."
+> **What language do you want to do this in?**
+> ¿En qué idioma quieres hacer esto?
+> Em qual idioma você quer fazer isso?
+> Dans quelle langue veux-tu faire ça?
+> In welcher Sprache möchtest du das machen?
+> 你想用哪种语言来做这个？
+> どの言語でやりたいですか？
+> בְּאֵיזוֹ שָׂפָה אַתָּה רוֹצֶה לַעֲשׂוֹת אֶת זֶה?
+> أَيُّ لُغَةٍ تُرِيدُ أَنْ تَفْعَلَ هَذَا بِهَا؟
+>
+> *Just answer in the language you want me to use. I'll match you.*
+> *Responde en el idioma que quieras usar. Te sigo.*
+
+The user typing back "español" / "français" / "Português" / "中文" / a sentence in any language is the signal. Match whatever they wrote in. If they answer in a language not in the list above, that's fine too — match their language and run the whole rest of setup in it.
+
+**After they answer, ask the follow-up in their chosen language:**
+
+> "Got it. Do you also take notes / journal in any other languages? Some people slip into a second language for emotional content, or use one language for work and another for personal stuff — that's normal, tell me all of them. Or 'just this one' if it's only one language."
+
+Then store:
+- `PRIMARY_LANGUAGE` — the language they chose to set up in (whatever they answered in / wrote)
+- `SECONDARY_LANGUAGES` — list (possibly empty) of every other language they mentioned. These drive the alias generation later.
+
+**Why the recap.lang cannot drive this:** the install signup form defaults to `lang: "en"` when no field is provided (which is most of the time, because the form prefills it from URL params or browser locale). A user who never picked English ends up with `recap.lang: "en"` and a setup interview that silently runs in English. The first install where this surfaced: Sneider, 2026-05-12, recap-defaulted to English without ever being asked. Don't trust recap.lang as authoritative. Open polyglot. Let the user pick by responding.
 
 Wait for their answer. Store it as:
 - `PRIMARY_LANGUAGE` — the one language the whole bot runs in

--- a/scripts/install-telemetry.py
+++ b/scripts/install-telemetry.py
@@ -65,7 +65,6 @@ def cmd_append(args: argparse.Namespace) -> int:
         "outcome": args.outcome,
         "user_redirected": bool(args.redirected),
         "new_improvisation_seen": args.new_improvisation,
-        "workshop_mode": bool(args.workshop),
     }
 
     _ensure_parent(LOG_PATH)
@@ -80,7 +79,6 @@ def cmd_append(args: argparse.Namespace) -> int:
                     "last_completed_phase": args.phase,
                     "ts": event["ts"],
                     "version": PROGRESS_VERSION,
-                    "workshop_mode": bool(args.workshop),
                 },
                 ensure_ascii=False,
                 indent=2,
@@ -139,9 +137,6 @@ def cmd_summarize(args: argparse.Namespace) -> int:
             return 2
         events = [e for e in events if (t := _ts(e)) and t >= since]
 
-    if args.workshop_only:
-        events = [e for e in events if e.get("workshop_mode")]
-
     if not events:
         print("no events match the filters")
         return 0
@@ -195,7 +190,6 @@ def main(argv: list[str] | None = None) -> int:
         "outcome",
         help=f'one of {sorted(VALID_OUTCOMES)}',
     )
-    p_append.add_argument("--workshop", action="store_true", help="workshop-mode install")
     p_append.add_argument(
         "--new-improvisation",
         default=None,
@@ -210,7 +204,6 @@ def main(argv: list[str] | None = None) -> int:
 
     p_sum = sub.add_parser("summarize", help="aggregate per-phase + per-install stats")
     p_sum.add_argument("--since", default=None, help="filter events after YYYY-MM-DD (UTC)")
-    p_sum.add_argument("--workshop-only", action="store_true", help="only workshop-mode events")
     p_sum.set_defaults(func=cmd_summarize)
 
     args = parser.parse_args(argv)


### PR DESCRIPTION
## Why

Two related fixes the maintainer flagged after watching Sneider's install:

1. **Workshop mode bifurcates the user experience even when it only adds a transcript and a telemetry tag.** Every user should get the same install. No flag, no activation phrase, no per-install transcript file, no `workshop_mode: true` JSON field. There is one install.
2. **Sneider never got asked his preferred language.** Phase 1 Step 1.0 was silently SKIPPED when the install recap had a `lang` field — and the recap defaults to `lang: "en"` server-side when no value is provided. A non-English user signs up, gets `recap.lang: "en"` they never picked, and the whole setup interview runs in English.

## What changes

### 1. WORKSHOP_MODE is gone
- SKILL.md: "Workshop mode — reliability layer ONLY" section removed.
- SKILL.md: "Note workshop mode" dropped from the How to Execute step list.
- SKILL.md: `workshop_mode` removed from the example telemetry JSON.
- `scripts/install-telemetry.py`: `--workshop` flag removed from `append`, `--workshop-only` removed from `summarize`, `workshop_mode` removed from JSONL and progress-file output.
- SKILL.md BANNED PATTERNS row for workshop framings now reads "No workshop mode exists" instead of "workshop mode adds a transcript."

### 2. Phase 1 language ask is unconditional and polyglot
- `phases/phase-01-welcome.md` Step 1.−2: `RECAP_LANG` is now a hint, never authoritative. No pre-emptive English/Spanish welcome before Step 1.0 runs.
- `phases/phase-01-welcome.md` Step 1.0: opens with "What language do you want to do this in?" translated into EN / ES / PT / FR / DE / ZH / JA / HE / AR plus "answer in the language you want me to use." User picks by responding. The substrate matches whatever language they wrote in (even one not in the listed nine).
- The secondary-languages follow-up happens AFTER, in the chosen language.
- SKILL.md BANNED PATTERNS: new row catching "recap says lang: en so I'll continue in English / silently inheriting any language default."

## Test plan

- [ ] Dry-run install with a recap containing `lang: "en"` — Phase 1 Step 1.0 still runs, the user can pick any language by responding
- [ ] Dry-run install where the user types back "español" — entire rest of setup runs in Spanish
- [ ] Dry-run install where the user types a sentence in Portuguese — substrate matches Portuguese for the rest
- [ ] Verify `scripts/install-telemetry.py append 10a completed` works without `--workshop`
- [ ] Verify `scripts/install-telemetry.py summarize` no longer accepts `--workshop-only`

🤖 Generated with [Claude Code](https://claude.com/claude-code)