### PR TITLE
feat: install ping on SessionStart (anonymous, opt-out)

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,24 @@ Free 20-minute AI diagnostic at [diazroa.com](https://diazroa.com) if you want t
 
 ---
 
+
+## Telemetry
+
+This plugin sends a single anonymous install signal to `myceliumai.co` the first time it loads in a Claude Code session on a given machine.
+
+**What is sent:**
+- Plugin name (e.g. `slack-mcp`)
+- Plugin version (e.g. `0.1.0`)
+
+**What is NOT sent:**
+- No user identifiers, names, emails, tokens, or API keys
+- No file paths, message content, or anything from your work
+- No IP address is stored after dedup processing
+
+**Why:** Helps the maintainer know which plugins people actually install, so attention goes to the ones that get used.
+
+**Opt out:** Set the environment variable `MYCELIUM_NO_PING=1` before launching Claude Code. The hook will skip the network call entirely. Already-pinged installs leave a sentinel at `~/.mycelium/onboarded-<plugin>` — delete it if you want to reset state.
+
 ## License
 
 MIT — use it, fork it, make it yours.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/install-ping.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/install-ping.py
+++ b/hooks/install-ping.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""One-time install signal to myceliumai.co.
+
+Idempotent (one sentinel per plugin per machine), silent, fire-and-forget.
+Sends ONLY plugin name + version. No PII, no IP storage post-dedup.
+
+Opt out by setting environment variable MYCELIUM_NO_PING=1 before launching
+Claude Code. See README "Telemetry" section for details.
+"""
+import json
+import os
+import sys
+import urllib.request
+from pathlib import Path
+
+PLUGIN_NAME = "ai-brain-starter"
+VERSION = "1.3.1"
+
+
+def main():
+    # Opt-out via env var
+    if os.environ.get("MYCELIUM_NO_PING"):
+        return 0
+    sentinel_dir = Path.home() / ".mycelium"
+    sentinel = sentinel_dir / f"onboarded-{PLUGIN_NAME}"
+    if sentinel.exists():
+        return 0
+    try:
+        sentinel_dir.mkdir(exist_ok=True)
+        sentinel.touch()
+    except Exception:
+        return 0
+    try:
+        data = json.dumps({"plugin": PLUGIN_NAME, "version": VERSION}).encode()
+        req = urllib.request.Request(
+            "https://myceliumai.co/api/install",
+            data=data,
+            headers={"Content-Type": "application/json"},
+        )
+        urllib.request.urlopen(req, timeout=3).read()
+    except Exception:
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds an idempotent SessionStart hook that signals first-time install to myceliumai.co.

Anonymous payload (plugin name + version only). No PII, no IP storage post-dedup. Sentinel at `~/.mycelium/onboarded-<plugin>` ensures one signal per machine.

Opt out: set `MYCELIUM_NO_PING=1` in your environment before launching Claude Code.

README updated with `## Telemetry` section documenting exactly what is sent, what is not, and how to opt out. Standard practice for anonymous dev-tool usage stats (Bun, Next.js, npm all follow this pattern).