### PR TITLE
fix(phase-00): ban Monitor tool on bootstrap (kills 'Human: Human:' install spam)

### DIFF
--- a/phases/phase-00-install.md
+++ b/phases/phase-00-install.md
@@ -14,6 +14,8 @@ Non-technical users will think nothing is happening if Claude goes silent during
 
 As bootstrap prints its own check-mark lines per tool, you don't need to narrate each one. The output is already reassuring. Chime in once at the end: *"All tools ready. Now let's get you set up."* Or, on failure: *"A couple of tools didn't install (listed above). I'll work around them for now and we can retry at the end. None of them are blocking what we're about to do."*
 
+**DO NOT use the Monitor tool on bootstrap output.** Monitor renders every stdout line as a separate "Human:" turn in the conversation transcript — empty lines from brew/npm chatter included. Users see a wall of bare `Human:` labels interspersed with progress messages and leaked `<task-notification>` XML blocks. Bootstrap's own stdout is already user-visible — just `Bash(bash bootstrap.sh)` and let it print directly. If you want async progress, set `run_in_background: true` on the Bash call and read the result when it finishes. Monitor is for log-streaming long-running daemons, not installers.
+
 ---
 
 ### Step 0.1a. Email — ask once, in chat (skip if marker already on disk)


### PR DESCRIPTION
## Summary

Install report from a user: the install session printed a wall of bare `Human:` labels interspersed with progress text and leaked `<task-notification>` XML blocks. Screenshot showed the Monitor event title `bootstrap install progress + errors` and an event tagged `libnghttp3` (a Node.js homebrew dependency).

Root cause: the model running Phase 0 improvised by wrapping `bootstrap.sh` in the Monitor tool. Every stdout line — including empty brew/npm chatter — became a separate "Human:" turn in the conversation transcript. Events whose body rendered empty collapsed to bare `Human:` labels. The underlying notification XML leaked when the UI couldn't render it as a chip.

The existing guidance in Step 0.0 (*"bootstrap's check-mark lines are reassuring, don't narrate each one"*) wasn't strong enough — the model added Monitor anyway to "be helpful." This is the same family as PRs #57/#59/#60/#62 (banned install-time improvisations).

## Fix

One added paragraph in Step 0.0:

```
**DO NOT use the Monitor tool on bootstrap output.** Monitor renders every
stdout line as a separate "Human:" turn in the conversation transcript —
empty lines from brew/npm chatter included. Users see a wall of bare
`Human:` labels interspersed with progress messages and leaked
`<task-notification>` XML blocks. Bootstrap's own stdout is already
user-visible — just `Bash(bash bootstrap.sh)` and let it print directly.
If you want async progress, set `run_in_background: true` on the Bash
call and read the result when it finishes. Monitor is for log-streaming
long-running daemons, not installers.
```

## Test plan

- [x] No tests needed (doc-only change)
- [ ] CI green on existing gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)