### PR TITLE
fix: prevent orphan commits (reconcile FF) + kill install time-gate + wire key-people to CRM

### DIFF
--- a/hooks/reconcile-worktree-shared.py
+++ b/hooks/reconcile-worktree-shared.py
@@ -126,23 +126,71 @@ def main() -> None:
     if not reconciled:
         return
 
-    msg = (
-        f"auto: reconcile-worktree-shared synced {len(reconciled)} "
-        f"shared-canonical file(s) to match main vault\n\n"
-        + "\n".join(f"- {f}" for f in reconciled)
-    )
-    res = subprocess.run(
-        ["git", "-C", str(wt), "commit", "-m", msg, "--quiet"],
+    # PRIMARY PATH: fast-forward the worktree branch to the main branch tip.
+    # If the worktree branch is a strict ancestor of master/main (the normal
+    # case — worktrees are created from master HEAD and don't accumulate
+    # their own commits when hooks route writes to main), FF-merge advances
+    # the worktree branch pointer without creating any new commit. The
+    # "modified" files become "clean" naturally because HEAD now matches
+    # the working tree byte-for-byte. No orphan commit ever appears on
+    # `claude/<slug>`.
+    #
+    # FALLBACK: if FF fails (worktree branch diverged from main — a real
+    # session-end-hook commit landed there, or the user committed manually),
+    # fall back to the prior auto-commit behavior so the archive prompt
+    # still sees a clean state. This is the rare case and is exactly what
+    # generates orphans, but we prefer one orphan now to repeatedly warning
+    # about uncommitted bytes that already live on main.
+    main_branch = "master"
+    has_master = subprocess.run(
+        ["git", "-C", str(wt), "show-ref", "--verify", "--quiet", "refs/heads/master"],
+    ).returncode == 0
+    if not has_master:
+        # Repo uses "main" as default branch
+        main_branch = "main"
+
+    ff_result = subprocess.run(
+        ["git", "-C", str(wt), "merge", "--ff-only", "--no-edit", main_branch],
         capture_output=True,
+        text=True,
     )
-    if res.returncode == 0:
+
+    if ff_result.returncode == 0:
+        # FF succeeded: worktree branch now points at main's tip. Files that
+        # were "modified vs HEAD" are now "clean" because HEAD has the new
+        # content. No commit was created. Issue #65-family orphan-commit
+        # accumulation prevented.
         print(json.dumps({
             "systemMessage": (
-                f"[reconcile-worktree-shared] auto-staged + committed "
-                f"{len(reconciled)} shared-canonical file(s) on worktree "
-                f"that already matched main vault."
+                f"[reconcile-worktree-shared] fast-forwarded worktree branch "
+                f"to {main_branch} ({len(reconciled)} file(s) reconciled with "
+                f"no orphan commit)."
             )
         }))
+    else:
+        # FF failed: worktree branch has diverged from main (real session
+        # commits or manual work landed there). Fall back to auto-commit
+        # on the worktree branch so the archive prompt still sees clean
+        # state. This is the rare path.
+        msg = (
+            f"auto: reconcile-worktree-shared synced {len(reconciled)} "
+            f"shared-canonical file(s) to match main vault (FF to "
+            f"{main_branch} not possible — branch diverged)\n\n"
+            + "\n".join(f"- {f}" for f in reconciled)
+        )
+        commit_result = subprocess.run(
+            ["git", "-C", str(wt), "commit", "-m", msg, "--quiet"],
+            capture_output=True,
+        )
+        if commit_result.returncode == 0:
+            print(json.dumps({
+                "systemMessage": (
+                    f"[reconcile-worktree-shared] FF to {main_branch} not "
+                    f"possible; committed {len(reconciled)} file(s) on "
+                    f"worktree branch instead. Branch will need recovery "
+                    f"via scripts/recover-orphan-claude-branches.py."
+                )
+            }))
 
     if divergent:
         print(json.dumps({

--- a/phases/phase-01-welcome.md
+++ b/phases/phase-01-welcome.md
@@ -190,9 +190,9 @@ Now translate the welcome into their primary language and continue:
 
 If you want the full story behind this system — why it was built, what it does, and what surprised the creator most — check out: https://adelaidadiazroa.substack.com/p/how-i-built-a-second-brain-that-actually
 
-This takes about 2-3 hours if we do everything, or 30 minutes for the basics. We can go as deep as you want.
-
 First — a few questions so I know what we're working with:"
+
+**Do NOT mention how long the setup will take.** No "2-3 hours," no "30 minutes for the basics," no "we can go as deep as you want." The full version is the only version (workshop/basic-vs-full bifurcation was killed in PR #62 — `feedback_install_skill_banned_patterns.md`). Time estimates are time-gates in disguise per the best-of-best lockout and create dropout points where users self-select out of the full install. Just open the interview.
 
 Then ask these ONE AT A TIME. Wait for each answer before moving on:
 

--- a/phases/phase-04-claude-md.md
+++ b/phases/phase-04-claude-md.md
@@ -6,11 +6,33 @@
 Ask these ONE AT A TIME:
 
 1. "What are you working on right now? Top 3 priorities across work and life."
-2. "Who are the key people in your life right now? (Give me 5-10 names and who they are — coworker, partner, sister, boss, friend, whatever.)"
+2. "Who are the key people in your life right now? Give me 5-10. For each one I need: **full name, nickname or what you actually call them, and who they are** (coworker, partner, sibling, boss, friend, whatever). Example: *'Jane Doe, I call her Jane, my sister.'*"
 3. "What tools do you use daily? (Project management, email, calendar, note apps, design tools, etc.)"
 4. "Are there terms, abbreviations, or nicknames you use that I wouldn't know? (Project names, inside jokes, acronyms)"
 5. "How do you want me to behave? For example: be concise? explain things simply? push back on bad ideas? confirm before making changes?"
 6. "Anything else I should know about you that would help me be useful? (Your personality, what frustrates you, what motivates you, your values)"
+
+**For question 2, also write a per-person CRM file** at `[VAULT_PATH]/👤 CRM/<First Last>.md` for every person the user names. The CLAUDE.md `## People` section is the quick-reference index; the CRM file is the durable record that every future skill (meeting-todos, daily-journal, /patterns, panel attribution guard, advisory-panel exclusion) can read. Schema:
+
+```markdown
+---
+type: person
+nickname: <what they actually call them>
+relationship: <sibling | cofounder | client | friend | partner | etc.>
+created: <YYYY-MM-DD>
+---
+
+## <Full Name>
+
+**Also called:** <nickname>
+**Relationship:** <one line>
+
+### Notes
+
+[blank — accrues over time as the person comes up in journals, meetings, decisions]
+```
+
+If a name comes back ambiguous ("my sister" with no name, "my boss" with no name), ask one targeted follow-up. Never invent a full name or guess at spelling. If the user provides only one name, save that — incomplete is better than fabricated.
 
 Now create the CLAUDE.md at the vault root with this structure:
 


### PR DESCRIPTION
Three bundled fixes from a single install/post-mortem.

## 1. `hooks/reconcile-worktree-shared.py` — real orphan-commit prevention

Different bug class from #65, same family.

A user's vault had 51 orphan commits across 36 `claude/*` branches after the #65 surface was diagnosed and fixed. Inspection showed **33 of 51 (65%)** were `auto: reconcile-worktree-shared synced N shared-canonical file(s) to match main vault` commits. Every session-end created one because `.claude/hookify.*.local.md` showed as modified in the worktree (the auto-commit hook had written them to main vault; the worktree's index hadn't caught up).

The hook's commit step was a self-contained "clean up worktree status" — but it created branch history that diverged from master permanently. `worktree-prune.sh` (with PR #66's new refuse guard) then refused to delete because of the unmerged commits. Orphans accumulated forever.

**Fix:** try `git merge --ff-only <main>` FIRST. When the worktree branch is a strict ancestor of master (the normal case — worktrees are created from master HEAD and don't accumulate their own commits when other hooks route writes to main), FF advances the branch pointer with NO new commit. Modified files become clean naturally because HEAD now matches working tree byte-for-byte. Fall back to the prior auto-commit only when FF fails (worktree branch genuinely diverged).

The CI test from PR #66 still passes — it asserts the worktree-prune refuse behavior, which is unchanged.

## 2. `phases/phase-01-welcome.md` — kill the time-gate residue

Removed:
> "This takes about 2-3 hours if we do everything, or 30 minutes for the basics. We can go as deep as you want."

Per user feedback: don't surface install duration, no basic-vs-full bifurcation. Workshop mode and tier decomposition were already killed in PR #62 — this line was a residue that re-introduced the same time-gate-in-disguise pattern.

## 3. `phases/phase-04-claude-md.md` — wire key-people interview to CRM

The "key people in your life" interview step previously only populated the CLAUDE.md `## People` section as bullets. Now it ALSO:
- Asks for **full name AND nickname** (was only "names and who they are")
- Writes a per-person CRM file at `[VAULT_PATH]/👤 CRM/<First Last>.md` with frontmatter (`type: person`, `nickname`, `relationship`, `created`) plus a `## Notes` section for accrual over time

The CLAUDE.md People section stays as the quick-reference index; the CRM file is the durable record every other skill (meeting-todos, daily-journal, /patterns, panel attribution guard, advisory-panel exclusion) reads.

## Test plan

- [x] `bash tests/integration/test_worktree_session_close.sh` — 4 assertions pass
- [x] `python3 -m py_compile hooks/reconcile-worktree-shared.py`
- [x] Private-context scrub on diff (no personal tokens added)
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)