### PR TITLE
fix(install close): silent backup detection + future-session pointer + mandatory closing phases

### DIFF
--- a/phases/phase-12-17-imports-rules.md
+++ b/phases/phase-12-17-imports-rules.md
@@ -80,18 +80,37 @@ This is what turns a vault from a filing system into a thinking system. The conc
 
 ## Phase 15: Backup & Sync Setup
 
-**MANDATORY ASK — never skip.** If their vault folder dies and there's no backup, the entire install is lost work. Always ask:
+**Silent detection. Do NOT ask the user to pick from a list.** Open-ended "Google Drive / iCloud / Dropbox / Git / local — pick one?" mid-install is the classic attrition point. The user lacks context to choose, momentum dies. Detect their current state and surface it; only prompt for action when there is no sync detected.
 
-"How do you want to back up your vault? Pick one: Google Drive, iCloud, Dropbox, Git (private GitHub repo), or just local (manual external-drive copies)?"
+Run this detection silently and capture the result:
 
-**Important:** "Your vault is just a folder of files. If that folder disappears, everything is gone. Let's make sure it's backed up."
+```bash
+VAULT="[VAULT_PATH]"
+case "$VAULT" in
+  *"/Mobile Documents/iCloud~md~obsidian/"*|*"/iCloud Drive/"*)
+    echo "BACKUP_DETECTED=iCloud" ;;
+  *"/Google Drive/"*|*"/GoogleDrive/"*|*"/Google Drive - "*)
+    echo "BACKUP_DETECTED=Google Drive" ;;
+  *"/Dropbox/"*|*"/Dropbox - "*)
+    echo "BACKUP_DETECTED=Dropbox" ;;
+  *"/OneDrive/"*|*"/OneDrive - "*)
+    echo "BACKUP_DETECTED=OneDrive" ;;
+  *)
+    echo "BACKUP_DETECTED=none" ;;
+esac
+```
 
-Options:
-- **Google Drive / Dropbox / iCloud:** "Move your vault folder into your cloud sync folder. It'll back up automatically. This also lets you access it from multiple devices."
-- **Git:** "If you're comfortable with git, we can initialize a repo and push to GitHub (private). This gives you version history — you can undo any change."
-- **Just local:** "At minimum, set a reminder to copy the vault folder to an external drive once a week."
+**If a sync is detected** (`iCloud`, `Google Drive`, `Dropbox`, `OneDrive`): say ONE sentence confirming, then move on. No ask.
 
-If they want to share the vault with a team: "Google Drive is the best option for team vaults. Everyone installs Google Drive for Desktop, opens the vault in Obsidian, and the files sync. I can help you set up a separate team vault later."
+> "Your vault is in [DETECTED], so it's syncing automatically. Anything you write lands in your cloud backup within seconds. Moving on."
+
+**If no sync is detected** (vault lives on Desktop, Documents, raw home, etc.): surface the risk in one sentence + offer the one-line fix. Still no five-option menu.
+
+> "Heads up: your vault is at `[VAULT_PATH]`, which doesn't sync to a cloud backup. If your laptop dies, the vault is gone. The fastest fix is to move the folder into iCloud Drive (or Google Drive / Dropbox / OneDrive — whichever you already use). Want me to wait while you do that, or carry on and come back to it?"
+
+Wait for a yes/no. On yes, give them the drag-and-drop instructions for their detected OS. On no, log a `[backup-deferred]` line to the session file so the next session's `/diagnose` surfaces it. Do NOT block the install. Backup is important but the install closing flow is more important than getting a perfect answer here.
+
+Team-vault sharing is handled separately in Phase 20 — do NOT mention it here.
 
 ## Phase 16: Add Obsidian Power Rules to CLAUDE.md
 

--- a/phases/phase-19-23-finish.md
+++ b/phases/phase-19-23-finish.md
@@ -351,10 +351,33 @@ Do NOT explain the layered architecture, the hooks, the language packs, the Haik
 
 ---
 
+## Phase 24.6 — Future-session pointer (one paragraph, then end)
+
+After the close walkthrough, plant ONE seed for the next session — what to do AFTER they've read the Substack post and slept on it. This is not another decision to make tonight; it's the path forward they'll come back to. Speak in their PRIMARY_LANGUAGE, one paragraph, conversational register.
+
+**EN:**
+> "One more thing for your future self. Right now the vault is mostly empty. The more of your actual thinking that lives in here, the more I can do for you. Next time we work together: bring in the notes you're already using — the active project docs, the journal you've been writing in a different app, the meeting notes from last quarter. Not everything you've ever written. Just the stuff you're actually working from right now. Then ask me to have the panel review the organization — we can decide together what belongs where. Once that's settled, run `/second-brain-mapping` in a fresh session and the whole vault becomes queryable. That's the path. Tonight, just read the Substack post."
+
+**ES:**
+> "Una última cosa para tu yo del futuro. Ahora mismo el vault está casi vacío. Mientras más de tu pensamiento real viva acá adentro, más puedo hacer por ti. La próxima vez que trabajemos juntos: trae las notas que ya estás usando — los documentos de proyectos activos, el diario que has estado escribiendo en otra app, las notas de reuniones del último trimestre. No todo lo que has escrito en tu vida. Solo lo que estás usando ahora mismo. Después me pides que el panel revise la organización — decidimos juntos qué va dónde. Cuando eso esté claro, corre `/second-brain-mapping` en una sesión nueva y todo el vault se vuelve consultable. Ese es el camino. Esta noche, solo lee el Substack."
+
+Why this phase matters: install completion is the moment of highest motivation AND highest decision fatigue. The user can't act on more right now. But they will remember what's NEXT if you plant it cleanly. The right shape is "future-tense, single concrete next action, framed as the thing that turns the vault from empty room into actual brain."
+
+**Banned framings:**
+- "Now let's organize all your files." — too much, wrong moment.
+- "Bring in everything you've ever written." — exactly the bulk-import that pollutes the vault and degrades `/second-brain-mapping` output.
+- "Run `/second-brain-mapping` next" with no precondition — the skill produces empty output on a near-empty vault.
+- "Optionally..." — anything optional in a close phrase gets skipped; the future-session pointer is the actual closer.
+
+After this paragraph, stop. Do not add another phase, another link, another check. The install is done. The user closes this session and reads the Substack post.
+
+---
+
 ## Important Notes for Claude
 
 - GO SLOW. Wait for answers. Don't dump instructions.
 - **NEVER STOP MID-SETUP.** After completing each phase, ALWAYS continue to the next phase automatically. Do not wait for the user to ask "what's next?" — tell them what's coming and proceed. The only reasons to pause are: (1) the user explicitly says "let's stop here" or "I need a break," (2) a critical install failed and needs manual intervention, or (3) the user asks a question that needs answering before continuing. After the journal phase especially — there are 10+ more phases. Don't stop there.
+- **PHASES 24, 24.5, AND 24.6 ARE MANDATORY CLOSING PHASES.** Fire ALL THREE even if a prior optional phase (20 team vault, 22 patterns, 23 theme) was skipped or 23.5 errored mid-script. Phase 24 = Substack first-week handoff (the user does not get pointed at the post if you skip it). Phase 24.5 = session-close walkthrough (the close cascade is invisible if you skip it). Phase 24.6 = future-session pointer (the user doesn't know what to do next session if you skip it). Skipping any of these silently is a known failure mode: install reaches the second-brain-mapping setup, the model thinks "we're done," closes the session without firing 24/24.5/24.6. Do not do that. The install is not complete until all three fire.
 - At the start of each phase, briefly tell the user where they are: "Phase [X] of 21: [Name]. This is where we [one sentence]."
 - If context gets compressed mid-setup (long session), re-read SKILL.md to pick up where you left off. Check which phases are done by looking at what exists in the vault (folders, CLAUDE.md, skills, templates).
 - If they seem overwhelmed, say: "We can stop here and pick up the rest tomorrow. What we've done so far is already working." But default is to KEEP GOING.


### PR DESCRIPTION
User watched a friend's install. Two failure modes surfaced:
1. Phase 15 backup question (`Pick one: Google Drive, iCloud, Dropbox, Git, local`) confused the user and stalled momentum.
2. Install completed without the user ever reaching Phase 24 (Substack first-week handoff). They finished with no pointer to the companion read OR a concrete next-session action.

## Panel

Tiago Forte, Andy Matuschak (dissent), Ali Abdaal, Wes Kao, Jackie Kennedy.

Convergence: kill the five-option backup ask, silent-detect instead. Defer file-organization to a follow-up session. ONE next action at install close.

Andy Matuschak's binding dissent: don't recommend bulk-importing scattered notes. Bulk import pollutes the vault and degrades second-brain-mapping output. Reframe to "active, high-signal content only — what you're actually working from right now."

## Three coordinated fixes

### 1. `phases/phase-12-17-imports-rules.md` Phase 15 — silent backup detection

Replaced the MANDATORY-ASK five-option menu with a `case` statement on the vault path that detects iCloud / Google Drive / Dropbox / OneDrive. If sync detected → ONE confirmation sentence, move on. If not → surface the risk and ask one yes/no ("move it now or come back to it?"). No five-option menu.

### 2. `phases/phase-19-23-finish.md` new Phase 24.6 — future-session pointer

One paragraph in EN + ES, telling the user what to do NEXT session: bring active notes in, ask the panel to review the organization, then run `/second-brain-mapping` in a fresh session. Banned framings codified inline:
- No "organize all your files now" (wrong moment)
- No "bring everything you've ever written" (Matuschak dissent)
- No "Optionally..." (optional close phrases get skipped)

### 3. `phases/phase-19-23-finish.md` "Important Notes for Claude" — mandatory closing phases

Phases 24, 24.5, and 24.6 are now explicitly MANDATORY. Documented the known failure mode: install reaches the second-brain-mapping setup, model thinks "done", closes the session without firing the user-facing closers.

## Test plan

- [x] `bash tests/integration/test_worktree_session_close.sh` — still green
- [x] `bash tests/integration/test_reconcile_ff_invariant.sh` — still green
- [x] Private-context scrub on diff (no personal tokens added)
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)