### PR TITLE
fix(install close): inline three-commands-and-one-habit orientation (Phase 24)

### DIFF
--- a/phases/phase-19-23-finish.md
+++ b/phases/phase-19-23-finish.md
@@ -313,27 +313,43 @@ Install is done. This is the handoff from "installed" to "used." Close the loop 
 
 Tell the user in their PRIMARY_LANGUAGE only. Show one link, matching their language. Do NOT show both — that feels like marketing. One block, one link, done.
 
+**Why this phase matters:** the most common failure mode for a new install isn't a broken tool — it's a user who finishes setup and doesn't know where to start. Naming the three commands and one habit IN THE CONVERSATION (not just behind a Substack link) means the user walks away with the picture even if they never click. Inline orientation + link to depth is the canonical first-week onboarding shape.
+
+**Voice note for Claude:** resist the urge to add "Congrats!" or exclamation marks. The register is quiet confidence, not performance. "Well done" / "Bien hecho" lands harder than "You did it!" — and matches the voice of the whole setup.
+
+**Content alignment:** the three-commands-and-one-habit framing here matches the canonical live deployment at adelaidadiazroa.substack.com verbatim. If the post is updated, mirror the changes here so the install and the post stay in sync.
+
 **If PRIMARY_LANGUAGE is English (or any non-Spanish language):**
+
 > "Well done. Vault is ready.
 >
-> A short read on what to do in your first week, three commands and one habit:
+> Three commands and one habit for your first week:
 >
-> https://adelaidadiazroa.substack.com/p/your-first-week-with-your-second
+> 1. `/journal` — every night. This is the habit. It builds the data the weekly and monthly pattern insights run on. Missing a week means the weekly insight misses most of the week.
+> 2. `/second-brain-mapping` — once you've brought your active notes in (next session), run this to map the vault in small batches and make everything queryable.
+> 3. "What would the panel think?" — ask this before any strategic decision. Brings 3 to 5 named voices with built-in dissent.
 >
-> Read tonight. Run the first thing tomorrow."
+> Week 1 will feel quiet. If you do these three things, by day eight you'll feel what the brain is for. If you skip them, the vault sits in your Obsidian folder doing nothing.
+>
+> Longer walkthrough: https://adelaidadiazroa.substack.com/p/your-first-week-with-your-second
+>
+> Read it tonight. Stuck on anything? Just say so in any session."
 
 **If PRIMARY_LANGUAGE is Spanish:**
+
 > "Bien hecho. El vault está listo.
 >
-> Un artículo corto sobre qué hacer la primera semana: tres comandos y un hábito.
+> Tres comandos y un hábito para tu primera semana:
 >
-> https://perspectivasblog.substack.com/p/tu-primera-semana-con-tu-segundo
+> 1. `/journal` — todas las noches. Este es el hábito. Construye los datos sobre los que corren los insights semanales y mensuales. Si te saltas una semana, el insight semanal pierde la mayor parte de la semana.
+> 2. `/second-brain-mapping` — cuando hayas traído tus notas activas (en la próxima sesión), corre esto para mapear el vault en lotes pequeños y dejar todo consultable.
+> 3. "¿Qué pensaría el panel?" — pregúntalo antes de cualquier decisión estratégica. Trae de 3 a 5 voces nombradas con disenso incorporado.
 >
-> Léelo esta noche. Corre el primero mañana."
-
-Why this phase matters: the most common failure mode for a new install isn't a broken tool, it's a user who finishes setup and doesn't know where to start. A single short read with three concrete actions closes that gap.
-
-Voice note for Claude: resist the urge to add "Congrats!" or exclamation marks. The register is quiet confidence, not performance. "Well done" / "Bien hecho" lands harder than "You did it!" — and matches the voice of the whole setup.
+> La primera semana se va a sentir callada. Si haces estas tres cosas, para el día ocho vas a sentir para qué sirve el cerebro. Si te las saltas, el vault se queda en tu carpeta de Obsidian sin hacer nada.
+>
+> Recorrido más largo: https://perspectivasblog.substack.com/p/tu-primera-semana-con-tu-segundo
+>
+> Léelo esta noche. ¿Atascado en algo? Solo dilo en cualquier sesión."
 
 ---
 


### PR DESCRIPTION
User feedback: "people won't have known what all happened and how to start using it or maximizing it."

Phase 24 previously pointed at the Substack first-week post via a single link. Users who don't click tonight walk away with no concrete picture of what to do next. Inline orientation + link to depth is the canonical first-week onboarding shape.

## What this PR ships

Phase 24 (English + Spanish) now names the three commands and one habit IN THE CONVERSATION, matching the live Substack post verbatim:

1. `/journal` nightly (the habit)
2. `/second-brain-mapping` after active notes are brought in next session (per PR #70's Phase 24.6 pointer)
3. "What would the panel think?" before strategic decisions

Plus the expectation anchor from the live post: "Week 1 will feel quiet. If you do these three things, by day eight you'll feel what the brain is for. If you skip them, the vault sits in your Obsidian folder doing nothing."

Plus a one-line stuck-help pointer: "Stuck on anything? Just say so in any session."

## Live deployment alignment

Content matches the canonical post at `adelaidadiazroa.substack.com/p/your-first-week-with-your-second` verbatim — fetched and confirmed before drafting. ES pair at `perspectivasblog.substack.com/p/tu-primera-semana-con-tu-segundo`. Doc comment in the phase file documents the invariant: if the post is updated, the install copy must be updated too.

## Panel

Wes Kao (first-week retention is binding), Ali Abdaal (3+1 is the user's schema, don't fight it), Andy Matuschak (dissent on over-promising — inverted by live-surface canon rule), Tiago Forte (sequencing holds), Jackie Kennedy (quiet confident close).

## Test plan

- [x] CI tests green (worktree session-close + reconcile FF invariant)
- [x] Private-context scrub on diff
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)