### PR TITLE
fix(bootstrap): install second-brain-mapping + setup-vault-types + diagnose; CI test prevents drift

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -230,6 +230,22 @@ jobs:
       - name: run integration test
         run: bash tests/integration/test_worktree_session_close.sh
 
+  phase-doc-skills-installed:
+    name: phase-doc slash commands have matching install entries
+    runs-on: ubuntu-latest
+    # Catches the bug class where a phase doc tells the user to "run /foo"
+    # but the bootstrap install loop never copies the skill folder to
+    # ~/.claude/skills/, so /foo doesn't appear in their slash command list.
+    # Source incident: fresh install completed but /second-brain-mapping
+    # was missing because bootstrap.sh's install loop didn't include it.
+    # Test asserts: every user-runnable slash command referenced in phase
+    # docs has (a) a matching skill folder in skills/ AND (b) is in the
+    # bootstrap install loop.
+    steps:
+      - uses: actions/checkout@v6
+      - name: run integration test
+        run: bash tests/integration/test_phase_doc_slash_commands_installed.sh
+
   reconcile-ff-invariant:
     name: reconcile-worktree-shared FF invariant (PR #68)
     runs-on: ubuntu-latest

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -19,7 +19,8 @@
 #     - Claude Code (via npm) and Obsidian (desktop app)
 #     - graphify CLI + Claude skill (with optimization scripts)
 #     - All bundled sub-skills: graphify, meeting-todos, patterns, insights,
-#       deconstruct, daily-journal, repurpose-talk, nano-banana (skill docs only)
+#       deconstruct, daily-journal, repurpose-talk, nano-banana (skill docs only),
+#       second-brain-mapping, setup-vault-types, diagnose
 #     - humanizer (de-AI writing) — cloned from its own fork repo
 #     - Granola + ChatPRD MCPs
 #     - Marketplace: obsidian-skills (kepano); plugins: obsidian, context7, playwright
@@ -1089,7 +1090,7 @@ SKILL_FORKS=()
 SKILL_SYMLINKS=()
 SKILLS_TO_SYNC=()
 
-for sub in graphify meeting-todos patterns insights deconstruct daily-journal repurpose-talk nano-banana; do
+for sub in graphify meeting-todos patterns insights deconstruct daily-journal repurpose-talk nano-banana second-brain-mapping setup-vault-types diagnose; do
   dst="$HOME/.claude/skills/$sub"
 
   if [[ -L "$dst" ]]; then
@@ -1490,7 +1491,7 @@ for check in "${CHECKS[@]}"; do
   fi
 done
 # Skill folders (full bundled set + humanizer + ai-brain-starter itself)
-for sub in graphify meeting-todos patterns insights deconstruct daily-journal repurpose-talk nano-banana humanizer ai-brain-starter diagnose; do
+for sub in graphify meeting-todos patterns insights deconstruct daily-journal repurpose-talk nano-banana humanizer ai-brain-starter diagnose second-brain-mapping setup-vault-types; do
   if [[ -d "$HOME/.claude/skills/$sub" ]]; then
     ok "skill: $sub"
   else

--- a/tests/integration/test_phase_doc_slash_commands_installed.sh
+++ b/tests/integration/test_phase_doc_slash_commands_installed.sh
@@ -48,9 +48,19 @@ REQUIRED_SKILLS=(
 
 FAILED=0
 
+# Skills installed via a SEPARATE clone path (not from skills/ folder).
+# These skip the (a) folder check but still get the (b) install-loop check.
+# humanizer = cloned from its own public fork repo per bootstrap.sh header.
+SEPARATE_CLONE_SKILLS="humanizer"
+
 for skill in "${REQUIRED_SKILLS[@]}"; do
-  # (a) skill folder exists in repo
-  if [ ! -d "$SKILLS_DIR/$skill" ]; then
+  is_separate_clone=0
+  for sc in $SEPARATE_CLONE_SKILLS; do
+    [ "$skill" = "$sc" ] && is_separate_clone=1
+  done
+
+  # (a) skill folder exists in repo (skipped for separate-clone skills)
+  if [ "$is_separate_clone" = "0" ] && [ ! -d "$SKILLS_DIR/$skill" ]; then
     echo "FAIL: skills/$skill/ folder missing in repo" >&2
     FAILED=$((FAILED + 1))
     continue
@@ -59,8 +69,8 @@ for skill in "${REQUIRED_SKILLS[@]}"; do
   # copies files to ~/.claude/skills/). We scan for the literal skill
   # name as a token in the loop's "for sub in" line.
   if ! grep -E "^for sub in .*\b${skill}\b.*; do" "$BOOTSTRAP" >/dev/null 2>&1; then
-    echo "FAIL: skills/$skill/ exists in repo but is NOT in any bootstrap.sh install loop" >&2
-    echo "  Phase docs reference /$skill but new installs won't have the skill folder." >&2
+    echo "FAIL: $skill is referenced as a slash command in phase docs but is NOT in any bootstrap.sh install loop" >&2
+    echo "  Phase docs reference /$skill but new installs won't have it." >&2
     echo "  Add '$skill' to the 'for sub in ...' loops in bootstrap.sh." >&2
     FAILED=$((FAILED + 1))
     continue

--- a/tests/integration/test_phase_doc_slash_commands_installed.sh
+++ b/tests/integration/test_phase_doc_slash_commands_installed.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Test that every slash command referenced in phase docs as a user-runnable
+# skill has (a) a matching skill folder in skills/ AND (b) is in the
+# bootstrap.sh install loop. Prevents the bug class where a phase doc
+# tells the user to "run /foo" but the skill was never installed by the
+# bootstrap, so /foo doesn't appear in their slash command list.
+#
+# Source incident: a fresh install completed successfully, Phase 23.5
+# instructed the user to run /second-brain-mapping, but the skill was
+# never copied to ~/.claude/skills/ because bootstrap.sh's install loop
+# didn't include it. Typing "/" in a new session didn't surface the
+# command at all. Skill folder existed in the repo but the install loop
+# was hardcoded to a smaller list.
+#
+# Skills audited: those referenced in `templates/rules/` and `phases/`
+# documents as user-invocable slash commands. Excludes:
+#   - Built-in slash commands (/wrap-up, /close, /journal as alias)
+#   - Internal scripts (vault-metadata-extract.py is a script, not a skill)
+#   - Closing-signal keywords (/cerrar, /fechar, /encerrar — detector keywords,
+#     not skills)
+#
+# Self-contained. Exit 0 = pass. Exit 1 = fail with details.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BOOTSTRAP="$REPO_ROOT/bootstrap.sh"
+SKILLS_DIR="$REPO_ROOT/skills"
+
+# Slash commands documented as user-runnable in phase docs.
+# Maintained explicitly so we don't accidentally promote a closing-signal
+# keyword (/cerrar) or a script reference (/auto-crm-from-mentions) into
+# the audit.
+REQUIRED_SKILLS=(
+  "graphify"
+  "meeting-todos"
+  "patterns"
+  "insights"
+  "deconstruct"
+  "daily-journal"
+  "repurpose-talk"
+  "nano-banana"
+  "humanizer"
+  "diagnose"
+  "second-brain-mapping"
+  "setup-vault-types"
+)
+
+FAILED=0
+
+for skill in "${REQUIRED_SKILLS[@]}"; do
+  # (a) skill folder exists in repo
+  if [ ! -d "$SKILLS_DIR/$skill" ]; then
+    echo "FAIL: skills/$skill/ folder missing in repo" >&2
+    FAILED=$((FAILED + 1))
+    continue
+  fi
+  # (b) skill is in the bootstrap install loop (the one that actually
+  # copies files to ~/.claude/skills/). We scan for the literal skill
+  # name as a token in the loop's "for sub in" line.
+  if ! grep -E "^for sub in .*\b${skill}\b.*; do" "$BOOTSTRAP" >/dev/null 2>&1; then
+    echo "FAIL: skills/$skill/ exists in repo but is NOT in any bootstrap.sh install loop" >&2
+    echo "  Phase docs reference /$skill but new installs won't have the skill folder." >&2
+    echo "  Add '$skill' to the 'for sub in ...' loops in bootstrap.sh." >&2
+    FAILED=$((FAILED + 1))
+    continue
+  fi
+done
+
+# Cross-check: every skill in the install loop has a matching folder in
+# skills/. Catches typos in the install list.
+INSTALL_LIST=$(grep -E "^for sub in .* second-brain-mapping " "$BOOTSTRAP" | head -1 | sed -E 's/^for sub in (.*); do/\1/')
+if [ -n "$INSTALL_LIST" ]; then
+  for skill in $INSTALL_LIST; do
+    # Skip skills installed by separate clone paths (humanizer, ai-brain-starter)
+    case "$skill" in
+      humanizer|ai-brain-starter) continue ;;
+    esac
+    if [ ! -d "$SKILLS_DIR/$skill" ]; then
+      echo "FAIL: bootstrap install loop lists '$skill' but skills/$skill/ does not exist" >&2
+      FAILED=$((FAILED + 1))
+    fi
+  done
+fi
+
+if [ "$FAILED" -gt 0 ]; then
+  echo "" >&2
+  echo "$FAILED skill(s) failed the phase-doc / install-loop integrity check." >&2
+  exit 1
+fi
+
+echo "All ${#REQUIRED_SKILLS[@]} required skills present in repo AND in bootstrap install loop."


### PR DESCRIPTION
## Source incident

Fresh install completed successfully. Phase 23.5 instructed the user to run `/second-brain-mapping`. Typing `/` in a new session didn't surface the command — the skill folder was never copied to `~/.claude/skills/` because `bootstrap.sh`'s install loop (line 1092) was hardcoded to a list of 8 skills that didn't include it.

## Affected skills

Referenced in phase docs as user-invocable slash commands, but missing from the install loop:

| Skill | Where referenced | Was installed? |
|---|---|---|
| `second-brain-mapping` | Phase 23.5 step 1 + step 5 | ❌ |
| `setup-vault-types` | Phase 23.5 step 2 | ❌ |
| `diagnose` | scripts/diagnose.sh (post-install check) | ❌ install / ✅ verify |

The verify loop at line 1493 listed `diagnose`, but since the install loop never copied it, the verify always failed silently. `second-brain-mapping` and `setup-vault-types` weren't in either loop.

## Fix

1. **Install loop (line 1092):** add `second-brain-mapping`, `setup-vault-types`, `diagnose`.
2. **Verify loop (line 1493):** add `second-brain-mapping`, `setup-vault-types` (diagnose was already there).
3. **Header comment (line 22):** updated to reflect the full bundled list.

## Drift prevention

New CI test `tests/integration/test_phase_doc_slash_commands_installed.sh` asserts:
- **(a)** every user-runnable slash command referenced in phase docs has a matching skill folder in `skills/`
- **(b)** every required skill is in the bootstrap install loop
- **(c)** every skill in the install loop has a matching folder (catches typos)

Wired into `lint.yml` as new job `phase-doc-skills-installed`. Runs on every PR. Same pattern family as the `worktree-session-close` (#65) and `reconcile-ff-invariant` (#68) tests: each fix to a bug class ships with a CI test that would fail on revert.

## Test plan

- [x] `bash tests/integration/test_phase_doc_slash_commands_installed.sh` → "All 12 required skills present in repo AND in bootstrap install loop."
- [x] `bash tests/integration/test_worktree_session_close.sh` → green
- [x] `bash tests/integration/test_reconcile_ff_invariant.sh` → green
- [x] `bash -n bootstrap.sh` → OK
- [x] Private-context scrub on diff
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)