### PR TITLE
fix(slash-commands): ship commands/ + bootstrap installs to ~/.claude/commands/

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1185,6 +1185,48 @@ fi
 [[ ${#SKILL_SYMLINKS[@]} -gt 0 ]] && log "Symlinks preserved untouched: ${#SKILL_SYMLINKS[@]} skill(s)"
 
 # ───────────────────────────────────────────────────────────────────────────────
+# Slash commands — install commands/*.md into ~/.claude/commands/
+# Skill folders alone do NOT register slash commands in Claude Code's palette.
+# Plugin-style `commands/<name>.md` files do. Without this step, users get the
+# skills installed but typing `/` doesn't surface them in the command list.
+# This was the surface bug behind the 2026-05-14 install report where
+# /second-brain-mapping didn't appear in the palette after install completed.
+# ───────────────────────────────────────────────────────────────────────────────
+hdr "Installing slash commands"
+COMMANDS_SRC="$SKILL_DIR/commands"
+COMMANDS_DST="$HOME/.claude/commands"
+if [[ -d "$COMMANDS_SRC" ]]; then
+  mkdir -p "$COMMANDS_DST"
+  COMMAND_COUNT=0
+  COMMAND_BACKED_UP=0
+  STAMP="$(date +%Y-%m-%d-%H%M)"
+  for cmd_src in "$COMMANDS_SRC"/*.md; do
+    [[ -f "$cmd_src" ]] || continue
+    cmd_name="$(basename "$cmd_src")"
+    cmd_dst="$COMMANDS_DST/$cmd_name"
+    if [[ -f "$cmd_dst" ]]; then
+      if ! cmp -s "$cmd_src" "$cmd_dst"; then
+        cp "$cmd_dst" "$cmd_dst.bak-$STAMP"
+        BACKUPS+=("$cmd_dst.bak-$STAMP")
+        cp "$cmd_src" "$cmd_dst"
+        COMMAND_BACKED_UP=$((COMMAND_BACKED_UP + 1))
+      fi
+    else
+      cp "$cmd_src" "$cmd_dst"
+      COMMAND_COUNT=$((COMMAND_COUNT + 1))
+    fi
+  done
+  if [[ $COMMAND_COUNT -gt 0 || $COMMAND_BACKED_UP -gt 0 ]]; then
+    ok "commands: $COMMAND_COUNT new, $COMMAND_BACKED_UP updated (backups preserved)"
+    UPDATED+=("slash commands ($COMMAND_COUNT new, $COMMAND_BACKED_UP updated)")
+  else
+    ok "commands: already current"
+  fi
+else
+  warn "commands/ directory not found at $COMMANDS_SRC — slash commands will not appear in palette"
+fi
+
+# ───────────────────────────────────────────────────────────────────────────────
 # Humanizer
 # ───────────────────────────────────────────────────────────────────────────────
 

--- a/commands/daily-journal.md
+++ b/commands/daily-journal.md
@@ -1,0 +1,5 @@
+---
+description: "Daily journal interview and entry creator with emotional floor tagging"
+---
+
+The user typed `/daily-journal`. Invoke the `daily-journal` skill via the Skill tool, forwarding any arguments the user provided after the slash command. If `daily-journal` is not in the available-skills list, tell the user the skill isn't installed and suggest running `bash ~/.claude/skills/ai-brain-starter/bootstrap.sh` to install it.

--- a/commands/deconstruct.md
+++ b/commands/deconstruct.md
@@ -1,0 +1,5 @@
+---
+description: "First-principles analyst: surface hidden assumptions, find foundational truths, rebuild from scratch"
+---
+
+The user typed `/deconstruct`. Invoke the `deconstruct` skill via the Skill tool, forwarding any arguments the user provided after the slash command. If `deconstruct` is not in the available-skills list, tell the user the skill isn't installed and suggest running `bash ~/.claude/skills/ai-brain-starter/bootstrap.sh` to install it.

--- a/commands/diagnose.md
+++ b/commands/diagnose.md
@@ -1,0 +1,5 @@
+---
+description: "Run a self-check on your AI Brain Starter install (CLAUDE.md, Meta folder, skills, hooks, MCPs)"
+---
+
+The user typed `/diagnose`. Invoke the `diagnose` skill via the Skill tool, forwarding any arguments the user provided after the slash command. If `diagnose` is not in the available-skills list, tell the user the skill isn't installed and suggest running `bash ~/.claude/skills/ai-brain-starter/bootstrap.sh` to install it.

--- a/commands/graphify.md
+++ b/commands/graphify.md
@@ -1,0 +1,5 @@
+---
+description: "Turn your vault into a clustered knowledge graph with HTML and JSON outputs"
+---
+
+The user typed `/graphify`. Invoke the `graphify` skill via the Skill tool, forwarding any arguments the user provided after the slash command. If `graphify` is not in the available-skills list, tell the user the skill isn't installed and suggest running `bash ~/.claude/skills/ai-brain-starter/bootstrap.sh` to install it.

--- a/commands/humanizer.md
+++ b/commands/humanizer.md
@@ -1,0 +1,5 @@
+---
+description: "Strip AI-isms from external prose and rewrite in your actual voice"
+---
+
+The user typed `/humanizer`. Invoke the `humanizer` skill via the Skill tool, forwarding any arguments the user provided after the slash command. If `humanizer` is not in the available-skills list, tell the user the skill isn't installed and suggest running `bash ~/.claude/skills/ai-brain-starter/bootstrap.sh` to install it.

--- a/commands/insights.md
+++ b/commands/insights.md
@@ -1,0 +1,5 @@
+---
+description: "Weekly or monthly journal insights with pattern recognition and panel feedback"
+---
+
+The user typed `/insights`. Invoke the `insights` skill via the Skill tool, forwarding any arguments the user provided after the slash command. If `insights` is not in the available-skills list, tell the user the skill isn't installed and suggest running `bash ~/.claude/skills/ai-brain-starter/bootstrap.sh` to install it.

--- a/commands/meeting-todos.md
+++ b/commands/meeting-todos.md
@@ -1,0 +1,5 @@
+---
+description: "Extract action items from a meeting note and route them to the right to-do file"
+---
+
+The user typed `/meeting-todos`. Invoke the `meeting-todos` skill via the Skill tool, forwarding any arguments the user provided after the slash command. If `meeting-todos` is not in the available-skills list, tell the user the skill isn't installed and suggest running `bash ~/.claude/skills/ai-brain-starter/bootstrap.sh` to install it.

--- a/commands/nano-banana.md
+++ b/commands/nano-banana.md
@@ -1,0 +1,5 @@
+---
+description: "Generate or edit images using Google's Gemini Image model"
+---
+
+The user typed `/nano-banana`. Invoke the `nano-banana` skill via the Skill tool, forwarding any arguments the user provided after the slash command. If `nano-banana` is not in the available-skills list, tell the user the skill isn't installed and suggest running `bash ~/.claude/skills/ai-brain-starter/bootstrap.sh` to install it.

--- a/commands/patterns.md
+++ b/commands/patterns.md
@@ -1,0 +1,5 @@
+---
+description: "Scan recent sessions for recurring patterns and turn them into captures (rules, concept notes, writing seeds)"
+---
+
+The user typed `/patterns`. Invoke the `patterns` skill via the Skill tool, forwarding any arguments the user provided after the slash command. If `patterns` is not in the available-skills list, tell the user the skill isn't installed and suggest running `bash ~/.claude/skills/ai-brain-starter/bootstrap.sh` to install it.

--- a/commands/repurpose-talk.md
+++ b/commands/repurpose-talk.md
@@ -1,0 +1,5 @@
+---
+description: "Turn a speaking engagement into 10-30 pieces of content"
+---
+
+The user typed `/repurpose-talk`. Invoke the `repurpose-talk` skill via the Skill tool, forwarding any arguments the user provided after the slash command. If `repurpose-talk` is not in the available-skills list, tell the user the skill isn't installed and suggest running `bash ~/.claude/skills/ai-brain-starter/bootstrap.sh` to install it.

--- a/commands/second-brain-mapping.md
+++ b/commands/second-brain-mapping.md
@@ -1,0 +1,5 @@
+---
+description: "Map your vault: extract structured metadata from every typed file, surface cross-doc insights, optionally build a knowledge graph"
+---
+
+The user typed `/second-brain-mapping`. Invoke the `second-brain-mapping` skill via the Skill tool, forwarding any arguments the user provided after the slash command. If `second-brain-mapping` is not in the available-skills list, tell the user the skill isn't installed and suggest running `bash ~/.claude/skills/ai-brain-starter/bootstrap.sh` to install it.

--- a/commands/setup-vault-types.md
+++ b/commands/setup-vault-types.md
@@ -1,0 +1,5 @@
+---
+description: "Configure which document types your vault uses (journals, books, meetings, clients, etc.) and scaffold extractors"
+---
+
+The user typed `/setup-vault-types`. Invoke the `setup-vault-types` skill via the Skill tool, forwarding any arguments the user provided after the slash command. If `setup-vault-types` is not in the available-skills list, tell the user the skill isn't installed and suggest running `bash ~/.claude/skills/ai-brain-starter/bootstrap.sh` to install it.

--- a/tests/integration/test_phase_doc_slash_commands_installed.sh
+++ b/tests/integration/test_phase_doc_slash_commands_installed.sh
@@ -26,6 +26,7 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 BOOTSTRAP="$REPO_ROOT/bootstrap.sh"
 SKILLS_DIR="$REPO_ROOT/skills"
+COMMANDS_DIR="$REPO_ROOT/commands"
 
 # Slash commands documented as user-runnable in phase docs.
 # Maintained explicitly so we don't accidentally promote a closing-signal
@@ -72,6 +73,18 @@ for skill in "${REQUIRED_SKILLS[@]}"; do
     echo "FAIL: $skill is referenced as a slash command in phase docs but is NOT in any bootstrap.sh install loop" >&2
     echo "  Phase docs reference /$skill but new installs won't have it." >&2
     echo "  Add '$skill' to the 'for sub in ...' loops in bootstrap.sh." >&2
+    FAILED=$((FAILED + 1))
+    continue
+  fi
+  # (c) commands/<skill>.md exists in repo. Without this file, the skill
+  # folder is installed but the slash command doesn't appear in the
+  # Claude Code palette. This was the surface bug behind the 2026-05-14
+  # install report where /second-brain-mapping wasn't surfaced even
+  # though the skill folder existed.
+  if [ ! -f "$COMMANDS_DIR/$skill.md" ]; then
+    echo "FAIL: commands/$skill.md missing in repo" >&2
+    echo "  Without this file, /$skill won't appear in the Claude Code slash command palette." >&2
+    echo "  Skill folders alone don't register palette entries — commands/<name>.md does." >&2
     FAILED=$((FAILED + 1))
     continue
   fi


### PR DESCRIPTION
## Surface bug

After PR #73 fixed the skill-folder install drift, the user typed `/` in a fresh session and STILL didn't see `/second-brain-mapping`. Cause: `~/.claude/skills/second-brain-mapping/` exists, but Claude Code reads palette entries from plugin-style `commands/<name>.md` markdown files — not from skill folders.

Skill folders alone don't register slash commands in the palette.

## Fix

### 1. `commands/` directory at repo root

12 markdown files, one per required slash command:

```
commands/
├── daily-journal.md
├── deconstruct.md
├── diagnose.md
├── graphify.md
├── humanizer.md
├── insights.md
├── meeting-todos.md
├── nano-banana.md
├── patterns.md
├── repurpose-talk.md
├── second-brain-mapping.md
└── setup-vault-types.md
```

Each file has frontmatter description (shown in palette) + a one-paragraph instruction telling the model to invoke the matching skill via the Skill tool, forwarding any user arguments. If the skill isn't installed, the command file tells the user to re-run bootstrap.

### 2. Bootstrap installs `commands/*.md` to `~/.claude/commands/`

New section in `bootstrap.sh` runs after skill install. Creates `~/.claude/commands/` if missing, copies each command file, backup-before-overwrite for any pre-existing user files. Without this step, fresh installs land skills but not the palette entries.

### 3. CI test extended

`tests/integration/test_phase_doc_slash_commands_installed.sh` now asserts three drift directions for every required skill:
- **(a)** matching skill folder in `skills/`
- **(b)** in bootstrap install loop
- **(c)** matching `commands/<name>.md` in repo

Any of the three out of sync = gate fails.

## Test plan

- [x] `bash tests/integration/test_phase_doc_slash_commands_installed.sh` → "All 12 required skills present in repo AND in bootstrap install loop."
- [x] All other CI tests still green
- [x] `bash -n bootstrap.sh` → OK
- [x] Private-context scrub on diff
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)