### PR TITLE
feat(hooks): inject CRM love-language context on UserPromptSubmit

### DIFF
--- a/docs/LOVE_LANGUAGE_HOOK.md
+++ b/docs/LOVE_LANGUAGE_HOOK.md
@@ -1,0 +1,114 @@
+# Love language context hook
+
+When you name someone in your prompt and they have a `## [[5 Love Languages]]` section in their CRM card, the assistant gets that section as additional context before it responds. The point: the assistant matches how you express care to how the person actually receives it — not the channel you'd default to.
+
+## What it does
+
+`hooks/inject-love-language-context.py` runs on every `UserPromptSubmit`. If the prompt contains the name (or alias, or globally-unique first name) of any CRM person who has codified love language data, the hook injects that data as `additionalContext`.
+
+Example: you say *"I'm calling Sam later, what should I say"*. The hook reads `👤 CRM/Sam.md`, finds the love language section, and injects it. The assistant then drafts a reply using Sam's primary channel — words of affirmation, quality time, acts of service, physical touch, or receiving gifts — instead of guessing.
+
+The hook is silent when:
+- The prompt names nobody who has a love-language section
+- The vault root isn't detectable
+- The CRM folder doesn't exist
+- The environment variable `LOVE_LANGUAGE_HOOK_DISABLE=1` is set
+
+## How to add love language data
+
+Two options. The hook reads both formats.
+
+### Option 1: H2 section (clean)
+
+In any CRM card under `👤 CRM/` (or `CRM/`):
+
+```markdown
+## [[5 Love Languages]]
+- Quality time — 35%
+- Words of affirmation — 25%
+- Physical touch — 20%
+- Acts of service — 15%
+- Receiving gifts — 5%
+*Source: their quiz result on 2025-04-12*
+```
+
+### Option 2: Roam-template indented bullet (legacy)
+
+If you imported your CRM from Roam, you might already have this structure:
+
+```markdown
+  * [[5 Love Languages]]
+    * Quality time — 35%
+    * Words of affirmation — 25%
+    * Physical touch — 20%
+    * Acts of service — 15%
+    * Receiving gifts — 5%
+```
+
+Both work. Hook stops at the next heading or the next sibling top-level bullet.
+
+## Name matching
+
+The hook matches three forms (case- and accent-insensitive):
+
+1. **Filename** without `.md`: `Sam Rivera.md` → matches "Sam Rivera"
+2. **Frontmatter aliases**: any string in the `aliases:` list. Phone numbers (starting with `+`) and single characters are skipped.
+3. **First name** ONLY if globally unique across the CRM. If two cards have the first name "Daniel", neither matches on "Daniel" alone — you'd need the full name or an alias. This prevents wrong-person false matches.
+
+Example: a card at `👤 CRM/María José Hernández.md` with `aliases: [Majo]` matches "María José Hernández", "Maria Jose Hernandez", "Majo", and "María" — but only "María" if no other card has that first name.
+
+## Index cache
+
+Performance: scanning every CRM file on every prompt would slow things down. The hook caches the index at `~/.claude/.love-language-index.json`. Cache invalidates when:
+
+- The newest `.md` mtime in the CRM folder is newer than the cache's build time
+- The cache is more than 1 day old
+- The CRM folder path changes (e.g., you renamed your CRM folder)
+
+Force a rebuild by deleting the cache file: `rm ~/.claude/.love-language-index.json`.
+
+## Vault root detection
+
+In order:
+
+1. `VAULT_ROOT` environment variable
+2. Walk up from `cwd` looking for any `CRM/` or `👤 CRM/` folder
+3. Walk up from `cwd` looking for `⚙️ Meta/Current Priorities.md`
+
+Override the CRM folder name with `CRM_DIR_NAME=YourCrmFolderName`.
+
+## Installation
+
+If you ran `bootstrap.sh` or `install-hooks-user-level.py` after this hook landed, you're already set up. Verify with:
+
+```bash
+python3 ~/.claude/skills/ai-brain-starter/scripts/install-hooks-user-level.py --verify
+```
+
+To add to an existing install without re-running the full installer:
+
+```bash
+python3 ~/.claude/skills/ai-brain-starter/scripts/install-hooks-user-level.py
+```
+
+The installer is idempotent — it skips entries it already added.
+
+## Cap
+
+The hook injects at most 5 people per prompt. If you name 8 friends in one message, the first 5 (by encounter order) get their love languages surfaced. Cap is hardcoded as `MAX_INJECTED_PEOPLE` in the source file — change it if your prompts routinely name large groups.
+
+## What the assistant should do with the data
+
+The companion behavior — i.e., *using* the injected data in drafts instead of just acknowledging it — isn't enforced by this hook. It depends on the assistant being told to apply love language data when it's present. Add a CLAUDE.md rule or memory entry like:
+
+> When the `[love-language-context]` block appears in the prompt, treat that data as a binding spec for HOW to express care toward the named person — gifts, replies, apologies, planning. Match the channel of care they actually receive love through, not the one you'd default to. Don't restate the data back; apply it.
+
+Adapt the rule to your voice.
+
+## Why this exists
+
+The 5 Love Languages framework (Gary Chapman, 1992) maps how people express and receive love through five channels: words of affirmation, acts of service, receiving gifts, quality time, physical touch. Mismatch between giving and receiving channels is the most common silent root cause of feeling unloved in relationships. Most CRMs treat people as static identities; this hook treats people as channels of care and shapes the assistant's relational output accordingly.
+
+## Bypass
+
+Set `LOVE_LANGUAGE_HOOK_DISABLE=1` in the environment to suppress the hook for one session. The hook silently no-ops; no error, no message.

--- a/hooks.json
+++ b/hooks.json
@@ -35,6 +35,11 @@
           },
           {
             "type": "command",
+            "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/inject-love-language-context.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'",
+            "statusMessage": "Checking CRM for love language context..."
+          },
+          {
+            "type": "command",
             "command": "python3 ~/.claude/skills/ai-brain-starter/scripts/email-gate-hook.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'",
             "statusMessage": "Checking email-on-file marker..."
           },

--- a/hooks/inject-love-language-context.py
+++ b/hooks/inject-love-language-context.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""
+UserPromptSubmit hook: when the prompt names a CRM person whose card has
+a [[5 Love Languages]] section, inject that section as additionalContext
+so the assistant uses it when drafting messages, planning gifts, choosing
+how to apologize, or designing any relational interaction.
+
+Pattern: vault-context.py. UserPromptSubmit → check prompt → optionally
+inject additionalContext → exit 0 always (never block).
+
+Vault root auto-detection (in order):
+  1. VAULT_ROOT env var
+  2. Walk up from cwd looking for any `CRM/` or `👤 CRM/` folder
+  3. Walk up from cwd looking for `⚙️ Meta/Current Priorities.md`
+  4. Silent exit if not found
+
+CRM folder name auto-detection:
+  - `👤 CRM/` (emoji prefix, vault default)
+  - `CRM/` (plain)
+  - Override via CRM_DIR_NAME env var
+
+Index cache: ~/.claude/.love-language-index.json. Rebuilt when the newest
+CRM .md file is newer than the cache, or when the cache is >1 day old.
+
+Name matching:
+  - Filename without .md (canonical name)
+  - Any alias declared in frontmatter `aliases:` list (skips phone numbers)
+  - First-name match ONLY if globally unique across the CRM
+  - Accent-insensitive, case-insensitive
+
+Wire into settings.json under hooks.UserPromptSubmit:
+    {
+      "type": "command",
+      "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/inject-love-language-context.py"
+    }
+
+Bypass: set env var LOVE_LANGUAGE_HOOK_DISABLE=1 to suppress.
+"""
+import json
+import os
+import re
+import sys
+import time
+import unicodedata
+from typing import Optional, List, Dict
+
+INDEX_PATH = os.path.expanduser("~/.claude/.love-language-index.json")
+INDEX_MAX_AGE_SEC = 60 * 60 * 24  # 1 day
+MAX_INJECTED_PEOPLE = 5  # cap to avoid context bloat
+CRM_DIR_CANDIDATES = ["👤 CRM", "CRM"]
+
+
+def strip_accents(s: str) -> str:
+    return "".join(
+        c for c in unicodedata.normalize("NFD", s)
+        if unicodedata.category(c) != "Mn"
+    )
+
+
+def normalize(s: str) -> str:
+    return strip_accents(s).lower().strip()
+
+
+def find_vault_root() -> Optional[str]:
+    """Return the vault root path, or None if not found."""
+    env_root = os.environ.get("VAULT_ROOT")
+    if env_root and os.path.isdir(env_root):
+        return env_root
+
+    # Walk up from cwd looking for any CRM folder or the canonical meta file
+    cur = os.getcwd()
+    for _ in range(8):
+        for name in CRM_DIR_CANDIDATES:
+            if os.path.isdir(os.path.join(cur, name)):
+                return cur
+        if os.path.isfile(os.path.join(cur, "⚙️ Meta", "Current Priorities.md")):
+            return cur
+        parent = os.path.dirname(cur)
+        if parent == cur:
+            break
+        cur = parent
+    return None
+
+
+def find_crm_dir(vault_root: str) -> Optional[str]:
+    """Locate the CRM folder inside the vault."""
+    override = os.environ.get("CRM_DIR_NAME")
+    candidates = [override] if override else []
+    candidates.extend(CRM_DIR_CANDIDATES)
+    for name in candidates:
+        if not name:
+            continue
+        path = os.path.join(vault_root, name)
+        if os.path.isdir(path):
+            return path
+    return None
+
+
+def extract_love_language_section(content: str) -> Optional[str]:
+    """Return the markdown section starting at a [[5 Love Languages]] heading.
+
+    Handles both H2-style (## [[5 Love Languages]]) and Roam-template-style
+    (  * [[5 Love Languages]] indented bullet). Stops at the next heading
+    or sibling top-level bullet.
+    """
+    lines = content.splitlines()
+    section_lines = []
+    in_section = False
+    indent_anchor: Optional[str] = None
+
+    for line in lines:
+        if not in_section:
+            if re.match(r"^#{2,3}\s+\[\[5 Love Languages\]\]", line):
+                in_section = True
+                section_lines.append(line)
+                indent_anchor = None
+                continue
+            m = re.match(r"^(\s*)\*\s+\[\[5 Love Languages\]\]\s*$", line)
+            if m:
+                in_section = True
+                section_lines.append(line)
+                indent_anchor = m.group(1)
+                continue
+        else:
+            if re.match(r"^#{1,3}\s", line) and "[[5 Love Languages]]" not in line:
+                break
+            if indent_anchor is not None:
+                m = re.match(r"^(\s*)\*\s", line)
+                if m and len(m.group(1)) == len(indent_anchor):
+                    break
+            section_lines.append(line)
+
+    if not section_lines:
+        return None
+    while section_lines and not section_lines[-1].strip():
+        section_lines.pop()
+    return "\n".join(section_lines)
+
+
+def parse_frontmatter_aliases(content: str) -> List[str]:
+    """Return aliases declared in YAML frontmatter (inline-list or block-list)."""
+    if not content.startswith("---"):
+        return []
+    end = content.find("\n---", 4)
+    if end < 0:
+        return []
+    fm = content[4:end]
+    aliases: List[str] = []
+    in_aliases = False
+    for line in fm.splitlines():
+        if re.match(r"^aliases\s*:\s*\[", line):
+            inside = re.search(r"\[(.*?)\]", line)
+            if inside:
+                for item in inside.group(1).split(","):
+                    val = item.strip().strip('"').strip("'")
+                    if val:
+                        aliases.append(val)
+            in_aliases = False
+            continue
+        if re.match(r"^aliases\s*:\s*$", line):
+            in_aliases = True
+            continue
+        if in_aliases:
+            m = re.match(r"^\s+-\s+(.+)$", line)
+            if m:
+                val = m.group(1).strip().strip('"').strip("'")
+                if val:
+                    aliases.append(val)
+            else:
+                in_aliases = False
+    return aliases
+
+
+def build_index(crm_dir: str) -> dict:
+    """Scan CRM folder and build {canonical_name: {section, aliases, first_name}}."""
+    index: Dict[str, dict] = {}
+    if not os.path.isdir(crm_dir):
+        return {"_built_at": time.time(), "people": {}}
+    for entry in os.scandir(crm_dir):
+        if not entry.is_file() or not entry.name.endswith(".md"):
+            continue
+        canonical = entry.name[:-3]
+        try:
+            with open(entry.path, "r", encoding="utf-8") as f:
+                content = f.read()
+        except Exception:
+            continue
+        section = extract_love_language_section(content)
+        if not section:
+            continue
+        aliases = parse_frontmatter_aliases(content)
+        clean_aliases = [a for a in aliases if not a.startswith("+") and len(a) > 1]
+        first_name = canonical.split()[0]
+        index[canonical] = {
+            "section": section,
+            "aliases": clean_aliases,
+            "first_name": first_name,
+        }
+    return {"_built_at": time.time(), "people": index, "_crm_dir": crm_dir}
+
+
+def load_or_rebuild_index(crm_dir: str) -> dict:
+    """Return the people index, rebuilding the cache when stale."""
+    need_rebuild = True
+    cache: Optional[dict] = None
+    if os.path.exists(INDEX_PATH):
+        try:
+            with open(INDEX_PATH, "r", encoding="utf-8") as f:
+                cache = json.load(f)
+            built_at = cache.get("_built_at", 0)
+            cached_crm_dir = cache.get("_crm_dir")
+            age = time.time() - built_at
+            if age < INDEX_MAX_AGE_SEC and cached_crm_dir == crm_dir:
+                crm_mtime = max(
+                    (e.stat().st_mtime for e in os.scandir(crm_dir) if e.name.endswith(".md")),
+                    default=0,
+                )
+                if crm_mtime <= built_at:
+                    need_rebuild = False
+        except Exception:
+            need_rebuild = True
+
+    if need_rebuild:
+        cache = build_index(crm_dir)
+        try:
+            os.makedirs(os.path.dirname(INDEX_PATH), exist_ok=True)
+            with open(INDEX_PATH, "w", encoding="utf-8") as f:
+                json.dump(cache, f, ensure_ascii=False, indent=2)
+        except Exception:
+            pass
+    return cache or {"_built_at": 0, "people": {}}
+
+
+def find_matches(prompt: str, index: dict) -> List[str]:
+    """Return canonical names whose person-tokens appear in the prompt."""
+    people: Dict[str, dict] = index.get("people", {})
+    if not people:
+        return []
+
+    first_name_counts: Dict[str, int] = {}
+    for info in people.values():
+        key = normalize(info["first_name"])
+        first_name_counts[key] = first_name_counts.get(key, 0) + 1
+
+    p_norm = " " + normalize(prompt) + " "
+    matches: List[str] = []
+
+    for canonical, info in people.items():
+        candidates = [canonical] + info.get("aliases", [])
+        fn = info["first_name"]
+        if first_name_counts.get(normalize(fn), 0) == 1:
+            candidates.append(fn)
+        for cand in candidates:
+            cand_norm = normalize(cand)
+            if not cand_norm or len(cand_norm) < 3:
+                continue
+            pattern = r"\b" + re.escape(cand_norm) + r"\b"
+            if re.search(pattern, p_norm):
+                matches.append(canonical)
+                break
+
+    seen = set()
+    uniq: List[str] = []
+    for c in matches:
+        if c not in seen:
+            seen.add(c)
+            uniq.append(c)
+        if len(uniq) >= MAX_INJECTED_PEOPLE:
+            break
+    return uniq
+
+
+def main() -> None:
+    if os.environ.get("LOVE_LANGUAGE_HOOK_DISABLE") == "1":
+        sys.exit(0)
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
+
+    prompt = payload.get("prompt", "") or ""
+    if not prompt.strip():
+        sys.exit(0)
+
+    vault_root = find_vault_root()
+    if not vault_root:
+        sys.exit(0)
+    crm_dir = find_crm_dir(vault_root)
+    if not crm_dir:
+        sys.exit(0)
+
+    index = load_or_rebuild_index(crm_dir)
+    matches = find_matches(prompt, index)
+    if not matches:
+        sys.exit(0)
+
+    parts = [
+        "[love-language-context] CRM love language data for the people named in this prompt.",
+        "USE this when drafting messages, planning gifts, choosing how to apologize, or",
+        "designing any relational interaction with them — match the channel of care they",
+        "actually receive love through, not the one you would default to.",
+        "",
+    ]
+    for canonical in matches:
+        info = index["people"][canonical]
+        parts.append(f"=== {canonical} ===")
+        parts.append(info["section"])
+        parts.append("")
+
+    out = {
+        "hookSpecificOutput": {
+            "hookEventName": "UserPromptSubmit",
+            "additionalContext": "\n".join(parts),
+        }
+    }
+    print(json.dumps(out))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/install-hooks-user-level.py
+++ b/scripts/install-hooks-user-level.py
@@ -62,6 +62,7 @@ ABS_FINGERPRINTS = [
     "ai-brain-starter/hooks/log-skill-usage.py",
     "ai-brain-starter/hooks/first-week-checkin.py",
     "ai-brain-starter/hooks/migrate-to-user-level.py",
+    "ai-brain-starter/hooks/inject-love-language-context.py",
     "ai-brain-starter/scripts/session-end-hook.sh",
     "ai-brain-starter/scripts/email-gate-hook.py",
     "ai-brain-starter/⚙️ Meta/scripts/graph-context-hook.sh",

--- a/templates/CRM-examples/example-author-maintainer.md
+++ b/templates/CRM-examples/example-author-maintainer.md
@@ -46,6 +46,19 @@ Building AI systems that compound over time. Translating between technical and n
 - Available for paid Brain Setup, Implementation Sprint, or Fractional engagements (see for-teams/working-with-me.md)
 - Free 20-minute AI diagnostic at https://diazroa.com
 
+## 5 Love Languages
+
+If you have asked someone in your life to take the [5 Love Languages quiz](https://5lovelanguages.com/quizzes), drop their result into this section using the format below. The `inject-love-language-context.py` hook reads this section automatically whenever the person's name appears in your prompt, and uses it to shape how the assistant drafts messages, plans gifts, or designs apologies for them.
+
+- Quality time — 35%
+- Words of affirmation — 25%
+- Physical touch — 20%
+- Acts of service — 15%
+- Receiving gifts — 5%
+*Source: replace with where this came from — quiz date, a transcribed screenshot, a conversation, etc.*
+
+The hook matches the person's filename, any frontmatter alias, and (if globally unique) their first name. Case- and accent-insensitive. Caches in `~/.claude/.love-language-index.json` and refreshes when any CRM file changes or the cache turns one day old. Delete this section if you do not want to use the hook — it silently no-ops for cards that omit it.
+
 ## How this card auto-populates
 
 You fill this out once. The system keeps it alive after that:


### PR DESCRIPTION
## Summary
- New `hooks/inject-love-language-context.py` injects a CRM person's love-language data (Words / Quality time / Acts of service / Physical touch / Receiving gifts) as `additionalContext` when that person is named in the user's prompt.
- Same pattern as `vault-context.py`: UserPromptSubmit → scan → inject → exit 0. Silent when no match, when vault root can't be detected, or when `LOVE_LANGUAGE_HOOK_DISABLE=1`.
- Reads two markdown formats (H2 `## [[5 Love Languages]]` + Roam-template indented bullet `  * [[5 Love Languages]]`) so existing Roam imports work unchanged.
- Index cached at `~/.claude/.love-language-index.json`, rebuilt on any CRM file change or after 1 day. Cap of 5 people per prompt to prevent context bloat.
- Name matching: filename, frontmatter aliases, and globally-unique first name (so "Daniel" doesn't false-match when two cards share that first name). Case- and accent-insensitive.

## What's in
- `hooks/inject-love-language-context.py` — new hook (267 lines, std-lib only)
- `hooks.json` — registered under UserPromptSubmit
- `scripts/install-hooks-user-level.py` — added fingerprint for installer ownership / clean uninstall
- `templates/CRM-examples/example-author-maintainer.md` — added a "5 Love Languages" section to show the format
- `docs/LOVE_LANGUAGE_HOOK.md` — full docs: formats, matching, cache, bypass, intended assistant behavior

## Why
Most CRMs treat people as static identities. Love-language data turns each card into a channel-of-care spec the assistant can act on. Mismatch between giving and receiving channels is the most common silent root cause of feeling unloved in relationships; the hook closes that gap at draft time without the user having to remember everyone's channel.

## Test plan
- [x] Smoke-tested on a synthetic vault at `/tmp/love-test/` with `VAULT_ROOT` env var — hook correctly extracted and injected the section
- [x] Ambiguous first-name guard works: "Daniel" with two Daniel cards doesn't match either; full name still matches
- [x] Aliases work: "Lex" matches a card with `aliases: [Lex]`
- [x] Accent-folding works: "Mariajose" matches "Mariajosé" filename
- [x] Personal-data scrub clean against the standing word-boundary regex (Adelaida, Diaz-Roa, Onde, etc.) — pre-commit hook independently verified
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)