### PR TITLE
fix(install): Phase 11 mandatory + Phase 4 carryover + Phase 13 lab tests

### DIFF
--- a/phases/phase-11-external-tools.md
+++ b/phases/phase-11-external-tools.md
@@ -1,9 +1,16 @@
 ## Phase 11: Connect External Tools
 
+**MANDATORY ASK — never skip, regardless of what the user mentioned earlier.** If the user listed Gmail / Google Calendar / Outlook / Slack / any other tool back in Phase 4 question 3, that's INFORMATION; this phase is where Claude actually wires the MCP. The known failure mode: model captures "Gmail" in CLAUDE.md `## Tools I Use` and then SKIPS this phase thinking the question is already answered. Phase 11 must fire even when prior phases already surfaced the tool name. The question changes from "do you use it?" to "you mentioned Gmail earlier — installing google-workspace-mcp now."
+
 "Let's connect Claude to the tools you actually use. This is where the vault becomes an operating system, not just a notebook."
 
 ### Email & Calendar
-Ask: "Do you use Gmail / Google Calendar / Google Drive / Google Docs? Or Outlook / Microsoft 365?"
+
+**First check what they said in Phase 4 question 3 (the tools answer).** If they named Gmail, Google Calendar, Google Drive, Google Docs, Google Sheets, or Google Meet anywhere in that answer, DO NOT re-ask. Skip directly to install:
+
+> "You mentioned [Gmail / Google Calendar / etc.] back in the tools section, so I'm installing `google-workspace-mcp` now. One MCP that covers Gmail, Calendar, Drive, Docs, Sheets, and Meet. Supports multiple accounts (work + personal) and is token-efficient. I'll walk you through the Google Cloud OAuth setup."
+
+**Otherwise ask:** "Do you use Gmail / Google Calendar / Google Drive / Google Docs? Or Outlook / Microsoft 365?"
 
 **If they use ANY Google Workspace surface (Gmail, Calendar, Drive, Docs, Sheets, Meet) — install `google-workspace-mcp` as the default.** Do NOT recommend Settings → Connectors first. The MCP covers all 5 surfaces in one install, supports multiple accounts, and is token-efficient.
 

--- a/phases/phase-12-17-imports-rules.md
+++ b/phases/phase-12-17-imports-rules.md
@@ -25,13 +25,15 @@ After import:
 - Add wikilinks to concepts that match existing vault notes
 - "Your reading and your thinking are now connected. When you write about a topic, your book highlights surface as context."
 
-## Phase 13: Health Data Import
+## Phase 13: Health Data Import (devices + labs)
 
-**MANDATORY ASK — never assume.** Do NOT skip this phase because the user didn't mention a wearable earlier. Most people who own an Apple Watch, Oura, Fitbit, Garmin, or Whoop don't think to bring it up during setup. Ask explicitly now:
+**MANDATORY ASK — never assume.** Do NOT skip this phase because the user didn't mention health earlier. Most people who own a wearable or have had recent lab work don't think to bring it up during a vault setup. Ask BOTH halves explicitly:
+
+### 13a. Wearables
 
 "Do you wear or use any of these? Apple Watch / Apple Health, Oura Ring, Fitbit, Garmin, Whoop, or any other health-tracking device or app?"
 
-Wait for their answer. If they say yes (even to one), continue. If they explicitly say "no, none of these," then skip to Phase 14.
+Wait for their answer. If they say yes (even to one), continue. If they say "no, none of these," move to 13b.
 
 If yes: "We can import your health data and cross-reference it with your journal entries. Imagine asking 'what do my best weeks have in common?' and getting back: gym 4x, sleep before midnight, HRV above 40, no social media after 9pm. The habit tracking from your journal gives you the subjective data — this gives you the objective data."
 
@@ -44,7 +46,19 @@ Then walk through their specific source. If they have the `health-setup` skill i
 
 After import, the `health-context` skill (auto-fires on journal entries) pairs body data with Floor tags — so a "Floor: Joy" entry with "HRV 22, RHR 78, sleep 5h 12m" gets the parasympathetic-state caveat automatically.
 
-If they explicitly said no to all wearables, skip this phase silently — Phase 10's habit tracking already covers the subjective side.
+### 13b. Lab tests + health reports
+
+ASK regardless of the wearables answer — devices and labs are different surfaces, and someone with no wearable may still have rich annual bloodwork. Phrasing matters: don't say "medical records" (intimidating); say "lab tests or any health reports."
+
+"Have you had any recent lab tests, bloodwork, hormone panels, or other health reports in the last year or two? PDFs, images of paper results, anything? Even one set of bloodwork is enough to start."
+
+If they say yes: "Save the PDFs or photos in your vault under `🏠 Home/Health/Labs/` (create the folder if it doesn't exist). When you mention symptoms, energy, mood, or anything body-related in journals, I'll cross-reference. For PDF lab panels, the `parse-mcp interpret` tool extracts the structured values and writes a markdown summary next to the original. You can also just drop them in and ask me 'what's in here?' when we're back in a session."
+
+Walk through one if they have it handy right now: "Want to drop one in now? I'll show you the flow once so you know how it works."
+
+If they say no: "Cool. If you do bloodwork later — annual physical, perimenopause panel, fertility screen, whatever — drop the PDFs in `🏠 Home/Health/Labs/` and I'll know what to do."
+
+If they explicitly said no to BOTH wearables and labs, skip the rest of Phase 13 silently — Phase 10's habit tracking covers the subjective side. Otherwise, the body track in journals is now wired.
 
 ## Phase 14: Build Your Concept Taxonomy
 

--- a/phases/phase-19-23-finish.md
+++ b/phases/phase-19-23-finish.md
@@ -426,7 +426,15 @@ After this paragraph, stop. Do not add another phase, another link, another chec
 
 - GO SLOW. Wait for answers. Don't dump instructions.
 - **NEVER STOP MID-SETUP.** After completing each phase, ALWAYS continue to the next phase automatically. Do not wait for the user to ask "what's next?" — tell them what's coming and proceed. The only reasons to pause are: (1) the user explicitly says "let's stop here" or "I need a break," (2) a critical install failed and needs manual intervention, or (3) the user asks a question that needs answering before continuing. After the journal phase especially — there are 10+ more phases. Don't stop there.
-- **PHASES 19.5, 24, 24.5, AND 24.6 ARE MANDATORY.** Fire ALL FOUR even if a prior optional phase (20 team vault, 22 patterns, 23 theme) was skipped or 23.5 errored mid-script. Phase 19.5 = activation moment (the user imports their first active doc IN THIS SESSION because we can't assume another session will happen). Phase 24 = Substack first-week handoff with inline three-commands-and-one-habit orientation. Phase 24.5 = session-close walkthrough. Phase 24.6 = progressive-use pointer. Skipping any of these silently is a known failure mode: install reaches the second-brain-mapping setup, the model thinks "we're done," closes the session without firing the activation + closing phases. Do not do that. The install is not complete until all four fire.
+- **PHASES 11, 13, 19.5, 24, 24.5, AND 24.6 ARE MANDATORY.** Fire ALL SIX even if a prior phase already surfaced the topic, even if the user seemed disinterested, even if an optional phase (20 team vault, 22 patterns, 23 theme) was skipped, even if 23.5 errored mid-script. Each mandatory phase covers a distinct activation moment the install cannot afford to skip:
+  - Phase 11 = external-tool wiring. Most common skip: user mentioned Gmail in Phase 4 question 3, model treated that as "answered" and never installed `google-workspace-mcp`. Phase 11 must fire and ACT on the prior mention.
+  - Phase 13 = health data import (devices AND labs). Two distinct halves; the labs question is its own mandatory ask, NOT subsumed by the wearables answer.
+  - Phase 19.5 = activation moment (user imports their first active doc IN THIS SESSION because we can't assume another session will happen).
+  - Phase 24 = Substack first-week handoff with inline three-commands-and-one-habit orientation.
+  - Phase 24.5 = session-close walkthrough.
+  - Phase 24.6 = progressive-use pointer.
+
+  Skipping any of these silently is the known failure mode: install reaches the second-brain-mapping setup, the model thinks "we're done," closes the session without firing the activation + connection + closing phases. Do not do that. The install is not complete until all six fire.
 - At the start of each phase, briefly tell the user where they are: "Phase [X] of 21: [Name]. This is where we [one sentence]."
 - If context gets compressed mid-setup (long session), re-read SKILL.md to pick up where you left off. Check which phases are done by looking at what exists in the vault (folders, CLAUDE.md, skills, templates).
 - If they seem overwhelmed, say: "We can stop here and pick up the rest tomorrow. What we've done so far is already working." But default is to KEEP GOING.


### PR DESCRIPTION
User feedback from a friend's install: two known-class failures.

## 1. Gmail mentioned but Google Workspace MCP never installed

User named Gmail back in Phase 4 question 3 (tools). The model captured it in CLAUDE.md `## Tools I Use` and treated Phase 11 (external tools) as "already answered" — never installing `google-workspace-mcp`. Result: install completed but Gmail / Calendar / Drive / Docs were not wired.

**Fix:** MANDATORY ASK guard at the top of Phase 11. Fires regardless of Phase 4 capture. Explicit carryover logic: if user named any Google surface in Phase 4 question 3, SKIP the re-ask and proceed directly to install (saves a round-trip) while still firing the install step.

## 2. No ask about lab tests

Phase 13 asks about wearables but NOT lab tests. Devices and labs are different surfaces. Someone with no wearable may still have rich annual bloodwork.

**Fix:** Phase 13 split into 13a (wearables, existing logic preserved) and 13b (lab tests + health reports, new). Phrasing avoids "medical records" (intimidating); asks for "lab tests, bloodwork, hormone panels, or other health reports." Tells user to drop PDFs in `🏠 Home/Health/Labs/` and points at parse-mcp `interpret` for structured extraction. Walks through one example if user has a PDF handy.

## 3. Mandatory closing-phases list extended

`phase-19-23-finish.md` "Important Notes for Claude" — Phases **11, 13, 19.5, 24, 24.5, 24.6** are MANDATORY. Each phase's distinct activation moment is documented inline so the model can't conflate "topic mentioned earlier" with "phase already fired."

## Test plan

- [x] CI tests still green (worktree session-close + reconcile FF + phase-doc skills)
- [x] Private-context scrub
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)