### PR TITLE
fix(install): About Me write-through + universal capture rule (information given → information saved)

### DIFF
--- a/phases/phase-02-03-plugins-folders.md
+++ b/phases/phase-02-03-plugins-folders.md
@@ -189,6 +189,36 @@ Tell them: "Done — you should see the folders in your Obsidian sidebar now. Th
 
 **Add any custom folders they request. Always use emojis.**
 
+### Phase 3b — Create About Me profile file
+
+After creating folders, copy the About Me template into the vault's 🏠 Home/ folder:
+
+```bash
+mkdir -p "[VAULT_PATH]/🏠 Home"
+cp "$HOME/.claude/skills/ai-brain-starter/templates/Home/About Me.md" "[VAULT_PATH]/🏠 Home/About Me.md"
+# Substitute the {{DATE}} placeholder with today's date
+sed -i '' "s/{{DATE}}/$(date +%Y-%m-%d)/g" "[VAULT_PATH]/🏠 Home/About Me.md"
+```
+
+This is the canonical "deep profile" file. The CLAUDE.md `## Me` line is the quick reference loaded every session; `About Me.md` is the rich profile loaded on demand for context-heavy work (panel reviews, life-history prose, advisory sessions, weekly insights).
+
+**Sections start mostly empty.** Phase 4 fills the high-priority fields (Identity name, Work one-liner, Relationships key people). Phase 11 fills Tools-adjacent fields. Phase 13 fills Health (wearables + labs link). Every subsequent session appends new personal context revealed during conversation per the universal capture rule below.
+
+### Phase 3c — Universal capture rule (codified, applies for the rest of install AND every future session)
+
+**Anything personal the user reveals must land somewhere durable in the vault before the conversation moves on.** If the user volunteers a fact about themselves — age, where they grew up, a health condition, a partner's name, an old job, a hobby, a value, a fear — and that fact does not naturally fit a structured ask currently running, append it to `🏠 Home/About Me.md` in the right section (or under `## Notes` if no section fits) before moving on.
+
+The failure mode: a user says "I have ADHD" in passing during the tools question. The model nods and moves on. The fact never lands anywhere. Six months later when the user asks "why am I forgetting things?" the model has no context. The capture must be lossless.
+
+**Mechanics:**
+- Append, never overwrite. Date the addition if it's a free-form `## Notes` entry.
+- Place in the right section if obvious (health → Health, family → Relationships, etc.).
+- Do not pause the conversation to confirm — just write the bullet and continue. The user can edit/remove later.
+- If the fact contradicts something already in About Me (old version), surface the conflict to the user: "You said [old]; just now you said [new]. Which should stay?" Do not silently overwrite.
+- Sensitive content (trauma, medical, financial in private repos) is fine to append. About Me is the user's private vault file, not shared.
+
+This rule applies to EVERY phase from here forward and to every post-install session. It is the canonical answer to "information was given and went nowhere."
+
 After creating folders, create resolver files in `⚙️ Meta/Folder Resolvers/` — one per key directory. Each is a short decision tree answering "does X live here?" — it prevents the vault from decaying into ambiguity as it grows. Centralized in Meta so the resolver doesn't clutter the folder it describes (a resolver file sitting in `👤 CRM/` shows up in every CRM Dataview query and next to every contact card).
 
 First create the `⚙️ Meta/Folder Resolvers/` directory, then create these files inside it. Name each file after the folder it describes (use the folder's emoji prefix):

--- a/phases/phase-04-claude-md.md
+++ b/phases/phase-04-claude-md.md
@@ -1,7 +1,20 @@
 
-## Phase 4: Build Their CLAUDE.md
+## Phase 4: Build Their CLAUDE.md (and populate About Me)
 
 "Now the most important part — your memory file. I'm going to ask you some questions, then create a file that I'll read automatically at the start of every conversation. The more specific you are, the better I get."
+
+**Write-through invariant.** Phase 4 produces TWO files at once: `CLAUDE.md` (compressed quick reference loaded every session) and `🏠 Home/About Me.md` (the deep profile created in Phase 3b). Every answer the user gives — and every piece of personal context they volunteer beyond the question — must land in the right section of About Me as you go. Do NOT collect all 6 answers verbally and then write only to CLAUDE.md. The two files fill together, in real time, as the user answers.
+
+| Phase 4 question | Lands in CLAUDE.md | Lands in About Me |
+|---|---|---|
+| 1. Priorities | `## Current Focus` (top 3) | (only if user reveals deeper context about WHY a priority matters — append to `## Work` or `## Personal History`) |
+| 2. Key people | `## People` (5-10 lines) | `## Relationships` (full names, nicknames, relationships) — plus per-person CRM file per Phase 3c CRM wiring |
+| 3. Tools | `## Tools I Use` table | `## Work` (only if a tool name reveals industry / role detail) |
+| 4. Terms / nicknames / acronyms | `## Key Terms` | (no, terms are project-vocab not personal) |
+| 5. How you want me to behave | `## Rules` | (no, this is behavior preferences not personal facts) |
+| 6. Anything else | `## Rules` if behavior, otherwise narrative bottom | YES — most volunteered personal context lands here. Split by section (Identity, Values, Habits, History, etc.) |
+
+**Universal capture during Phase 4 (per Phase 3c):** when the user volunteers something while answering ANY of the 6 questions that doesn't fit the structured slot above, append it to the right About Me section. Example: question 2 is "key people." User says "Diego is my brother-in-law, we worked together at my last company before it sold in 2019." → CLAUDE.md gets "Diego — brother-in-law"; About Me Relationships gets "Diego — brother-in-law"; About Me Work gets "Sold a previous company with Diego in 2019" under Past work. THREE distinct facts, three places.
 
 Ask these ONE AT A TIME:
 
@@ -58,6 +71,9 @@ Now create the CLAUDE.md at the vault root with this structure:
 | Tool | What I use it for |
 |------|------------------|
 [from their answer]
+
+## About Me
+The deep profile lives at `🏠 Home/About Me.md`. Read it on demand for context-heavy work (panel reviews, life-history prose, advisory sessions, weekly insights, anything that needs identity/health/relationships/history depth). Append to it whenever the user reveals new personal context per the universal capture rule.
 
 ## Vault Map
 [FILL THIS IN — list the actual folders created in Phase 3, e.g.:

--- a/phases/phase-11-external-tools.md
+++ b/phases/phase-11-external-tools.md
@@ -4,6 +4,8 @@
 
 "Let's connect Claude to the tools you actually use. This is where the vault becomes an operating system, not just a notebook."
 
+**Universal capture write-through.** Anything the user reveals while answering this phase's questions — preferred email account, calendar timezone, work tools that reveal industry/role, contacts at companies they care about, geographic context (work hours, regional accounts) — appends to `🏠 Home/About Me.md` in the right section (`## Work`, `## Identity`, `## Habits, Routines, Rhythm`) per Phase 3c. Don't pause to confirm — write the bullet and continue.
+
 ### Email & Calendar
 
 **First check what they said in Phase 4 question 3 (the tools answer).** If they named Gmail, Google Calendar, Google Drive, Google Docs, Google Sheets, or Google Meet anywhere in that answer, DO NOT re-ask. Skip directly to install:

--- a/phases/phase-12-17-imports-rules.md
+++ b/phases/phase-12-17-imports-rules.md
@@ -27,7 +27,9 @@ After import:
 
 ## Phase 13: Health Data Import (devices + labs)
 
-**MANDATORY ASK — never assume.** Do NOT skip this phase because the user didn't mention health earlier. Most people who own a wearable or have had recent lab work don't think to bring it up during a vault setup. Ask BOTH halves explicitly:
+**MANDATORY ASK — never assume.** Do NOT skip this phase because the user didn't mention health earlier. Most people who own a wearable or have had recent lab work don't think to bring it up during a vault setup. Ask BOTH halves explicitly.
+
+**Universal capture write-through.** Anything the user reveals about their health while answering this phase — conditions, diagnoses, cycle context, recent medical events, medications, therapists, fitness habits — appends to `🏠 Home/About Me.md` under `## Health` per Phase 3c. Health context is high-value for every future session (panel reviews, journal entries, advisory work). Capture is lossless.
 
 ### 13a. Wearables
 

--- a/phases/phase-19-23-finish.md
+++ b/phases/phase-19-23-finish.md
@@ -424,9 +424,11 @@ After this paragraph, stop. Do not add another phase, another link, another chec
 
 ## Important Notes for Claude
 
+- **NEVER LET INFORMATION GO NOWHERE.** Anything personal the user reveals must land in `🏠 Home/About Me.md` (or the right structured destination: CLAUDE.md quick fields, a per-person CRM file, the Health folder, etc.) before the conversation moves on. Universal capture rule codified in Phase 3c. The failure mode this prevents: user says "I have ADHD" during the tools question, model nods and moves on, the fact never lands anywhere, six months later there's no context for "why am I forgetting things?" Capture must be lossless. Append, never overwrite. Do not pause to confirm — just write the bullet and continue.
 - GO SLOW. Wait for answers. Don't dump instructions.
 - **NEVER STOP MID-SETUP.** After completing each phase, ALWAYS continue to the next phase automatically. Do not wait for the user to ask "what's next?" — tell them what's coming and proceed. The only reasons to pause are: (1) the user explicitly says "let's stop here" or "I need a break," (2) a critical install failed and needs manual intervention, or (3) the user asks a question that needs answering before continuing. After the journal phase especially — there are 10+ more phases. Don't stop there.
-- **PHASES 11, 13, 19.5, 24, 24.5, AND 24.6 ARE MANDATORY.** Fire ALL SIX even if a prior phase already surfaced the topic, even if the user seemed disinterested, even if an optional phase (20 team vault, 22 patterns, 23 theme) was skipped, even if 23.5 errored mid-script. Each mandatory phase covers a distinct activation moment the install cannot afford to skip:
+- **PHASES 3b, 11, 13, 19.5, 24, 24.5, AND 24.6 ARE MANDATORY.** Fire ALL SEVEN even if a prior phase already surfaced the topic, even if the user seemed disinterested, even if an optional phase (20 team vault, 22 patterns, 23 theme) was skipped, even if 23.5 errored mid-script. Each mandatory phase covers a distinct activation or capture moment the install cannot afford to skip:
+  - Phase 3b = create `🏠 Home/About Me.md` from the template. Without it, the universal capture rule has nowhere to write to. Phase 4 fills the first sections; subsequent sessions append.
   - Phase 11 = external-tool wiring. Most common skip: user mentioned Gmail in Phase 4 question 3, model treated that as "answered" and never installed `google-workspace-mcp`. Phase 11 must fire and ACT on the prior mention.
   - Phase 13 = health data import (devices AND labs). Two distinct halves; the labs question is its own mandatory ask, NOT subsumed by the wearables answer.
   - Phase 19.5 = activation moment (user imports their first active doc IN THIS SESSION because we can't assume another session will happen).
@@ -434,7 +436,7 @@ After this paragraph, stop. Do not add another phase, another link, another chec
   - Phase 24.5 = session-close walkthrough.
   - Phase 24.6 = progressive-use pointer.
 
-  Skipping any of these silently is the known failure mode: install reaches the second-brain-mapping setup, the model thinks "we're done," closes the session without firing the activation + connection + closing phases. Do not do that. The install is not complete until all six fire.
+  Skipping any of these silently is the known failure mode: install reaches the second-brain-mapping setup, the model thinks "we're done," closes the session without firing the activation + connection + capture + closing phases. Do not do that. The install is not complete until all seven fire.
 - At the start of each phase, briefly tell the user where they are: "Phase [X] of 21: [Name]. This is where we [one sentence]."
 - If context gets compressed mid-setup (long session), re-read SKILL.md to pick up where you left off. Check which phases are done by looking at what exists in the vault (folders, CLAUDE.md, skills, templates).
 - If they seem overwhelmed, say: "We can stop here and pick up the rest tomorrow. What we've done so far is already working." But default is to KEEP GOING.

--- a/templates/Home/About Me.md
+++ b/templates/Home/About Me.md
@@ -1,0 +1,85 @@
+---
+type: profile
+created: {{DATE}}
+last_updated: {{DATE}}
+---
+
+## About Me
+
+*The deep profile. Loaded on demand for context-heavy work (panel reviews, life-history prose, advisory sessions, weekly insights). Auto-appended whenever you reveal something new about yourself in any session. Sections may be empty at first; fill in as it becomes relevant.*
+
+*CLAUDE.md is the compressed quick reference loaded every session. About Me is the rich profile loaded when depth is needed. Both should agree; if they drift, CLAUDE.md wins for the quick fields, About Me wins for the deep fields.*
+
+## Identity
+
+- **Name(s):** [Full name, nicknames you use, what you prefer to be called]
+- **Pronouns:**
+- **Date of birth / age:**
+- **Where you live (city, country):**
+- **Languages you speak:**
+- **Citizenship / residency status (if relevant for work or taxes):**
+
+## Work
+
+- **What you do (one-line answer for strangers):**
+- **Current role / title / company:**
+- **Past work, ventures, exits, defining career moments:**
+- **Areas of expertise:**
+- **Industries you operate in:**
+- **Income sources / how you make money:**
+
+## Relationships
+
+- **Partner / spouse:** [Name, how long together, important context]
+- **Children:**
+- **Parents and siblings:**
+- **Close friends / inner circle:**
+- **Mentors / advisors:**
+- **People who matter that don't fit a label:**
+
+## Health
+
+- **Conditions / diagnoses you live with:**
+- **Medications / supplements:**
+- **Cycle / hormonal context (if relevant):**
+- **Sleep patterns:**
+- **Exercise / movement:**
+- **Wearables in use:** [Apple Watch, Oura, Fitbit, etc.]
+- **Recent lab work:** [link to `🏠 Home/Health/Labs/` once you have any]
+- **Therapists / practitioners / care team:**
+
+## Values, Beliefs, Worldview
+
+- **What you stand for:**
+- **What you reject:**
+- **Spiritual / religious context:**
+- **Political / civic context (only as relevant to your work):**
+- **Frameworks you think through:** [e.g., the Floor framework, PARA, first principles, etc.]
+
+## Habits, Routines, Rhythm
+
+- **Daily rhythm (morning, deep work, evening):**
+- **Weekly rhythm (recurring meetings, dedicated days):**
+- **Exercise routine:**
+- **Diet / food:**
+- **Sleep:**
+- **Recovery / nervous system practices:**
+
+## Hobbies, Interests, Curiosities
+
+- **Active hobbies:**
+- **Things you're curious about:**
+- **Books, podcasts, creators you follow:**
+- **Travel patterns:**
+
+## Personal History
+
+- **Where you grew up:**
+- **Formative experiences:**
+- **Defining decisions:**
+- **Patterns you're aware of (recurring loops, identity threads):**
+- **Things you've outgrown:**
+
+## Notes
+
+*Free-form section. Any personal context revealed in conversation that doesn't fit a section above. Append below — never overwrite. Dated entries.*


### PR DESCRIPTION
**User feedback:** *"make sure you're doing something with the information. don't let anything be given and not saved in the vault of about-me type of file."*

## Pattern this fixes

Install collects information from users (Phase 4 six questions, Phase 11 tools, Phase 13 health, plus volunteered context throughout) — and a lot of it goes nowhere. CLAUDE.md captures compressed quick-reference fields, but the deep profile (identity, health, history, values, habits, hobbies, rich-detail relationships) has no canonical destination.

The failure case: user says "I have ADHD" in passing during the tools question. Model nods and moves on. The fact never lands anywhere. Six months later when the user asks "why am I forgetting things?" the model has no context.

## Fix

### 1. New `templates/Home/About Me.md`

Canonical "deep profile" template. Sectioned schema:
- Identity (name, pronouns, DOB, location, languages, residency)
- Work (role, ventures, expertise, industries, income sources)
- Relationships (partner, children, family, friends, mentors)
- Health (conditions, meds, cycle, sleep, exercise, wearables, labs link, care team)
- Values, Beliefs, Worldview
- Habits, Routines, Rhythm
- Hobbies, Interests, Curiosities
- Personal History (formative experiences, defining decisions, patterns)
- Notes (free-form, dated additions)

### 2. NEW Phase 3b — create About Me at install

Copies the template to `🏠 Home/About Me.md` after the folder structure exists. Frontmatter `{{DATE}}` substituted with today's date.

### 3. NEW Phase 3c — universal capture rule (applies forever)

> Anything personal the user reveals must land somewhere durable before the conversation moves on. Append to About Me in the right section (or under Notes). Append never overwrite. Don't pause to confirm — write the bullet and continue.

Documented in Phase 3c AND copied to "Important Notes for Claude" as a hard never-skip invariant.

### 4. Phase 4 write-through invariant

Phase 4 now produces **TWO files at once**: CLAUDE.md (compressed) AND About Me (deep). Question-to-destination table documents which CLAUDE.md slot and which About Me section each answer lands in. Volunteered context beyond the question appends to About Me regardless.

### 5. Phases 11 + 13 also write through to About Me

- Phase 11 tools answer → CLAUDE.md `## Tools I Use` AND `About Me → Work / Identity / Habits` where relevant.
- Phase 13 health answer → DuckDB import (existing) AND `About Me → Health` section.

### 6. CLAUDE.md template `## About Me` pointer

Tells the model where the deep profile lives and when to read it (panel reviews, life-history prose, advisory sessions, weekly insights).

### 7. Mandatory closing-phases list extended

Phases **3b, 11, 13, 19.5, 24, 24.5, 24.6** all MANDATORY now.

## Test plan

- [x] Existing CI tests still green (worktree session-close + reconcile FF + phase-doc skills)
- [x] Private-context scrub on diff
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)