### PR TITLE
fix(install): time-tracking path pre-resolve + Phase 24.7 self-verify + E2E bootstrap CI test

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -230,6 +230,21 @@ jobs:
       - name: run integration test
         run: bash tests/integration/test_worktree_session_close.sh
 
+  bootstrap-dry-run:
+    name: bootstrap.sh end-to-end dry-run (no parse errors, all skills + commands fire)
+    runs-on: ubuntu-latest
+    # End-to-end coverage of the install path. Asserts bootstrap.sh
+    # --dry-run exits 0 (no syntax errors, no unbound variables, no
+    # logic breaks in any of the install sections) AND mentions every
+    # required skill AND fires the commands install section.
+    # Catches the bug class where a new section in bootstrap.sh has an
+    # error that only surfaces when a real install runs.
+    # No untrusted user input referenced.
+    steps:
+      - uses: actions/checkout@v6
+      - name: run E2E test
+        run: bash tests/integration/test_bootstrap_dry_run.sh
+
   phase-doc-skills-installed:
     name: phase-doc slash commands have matching install entries
     runs-on: ubuntu-latest

--- a/hooks/detect-closing-signal.py
+++ b/hooks/detect-closing-signal.py
@@ -530,6 +530,19 @@ def _full_cascade_block(
 ) -> str:
     """The reusable cascade-instruction block."""
     pending = ", ".join(pending_outcomes) if pending_outcomes else "(none)"
+    # Pre-resolve the Time Tracking surface (codified 2026-05-14). The Phase 1
+    # bullet used to say "if vault uses it" and require the model to infer
+    # presence; that produced a false-negative when the model checked the
+    # wrong directory. Resolving here mirrors the pattern for session_file +
+    # captures_file: the model trusts the injected path, no inference.
+    time_tracking_file = meta_dir / "Time Tracking.md"
+    if time_tracking_file.is_file():
+        tt_line = (
+            f"  Time tracking:    {time_tracking_file}  "
+            f"(append today's entry under a ## YYYY-MM-DD heading; create the heading if missing)"
+        )
+    else:
+        tt_line = "  Time tracking:    (not in this vault, skip the time-tracking step)"
     return f"""SESSION CLOSE — pre-resolved context (use these exact values):
 
   Timestamp:        {timestamp_human}
@@ -538,6 +551,7 @@ def _full_cascade_block(
   Session file:     {session_file}  (already pre-built with frontmatter + headers; fill in the body)
   Decisions dir:    {decisions_dir}  (write per-decision files here, slug-named)
   Captures file:    {captures_file}
+{tt_line}
   Decisions with empty Outcome (review for backfill): {pending}
 
 PHASE 0b — Incomplete-work gate (DO THIS FIRST, before any writes):
@@ -566,8 +580,12 @@ PHASE 1 — Single-pass conversation scan (compose all in memory before writing)
     Outcomes where this session resolved them.
   • Delegations: items for others get @Name + drafted Slack/WhatsApp/email
     message ready to send.
-  • Time tracking entry (if vault uses it): one line, format
-    "HH:MMam - HH:MMam | Category | Brief", inferred from conversation.
+  • Time tracking entry: append to the Time tracking file resolved above
+    (path is authoritative, do NOT search for it or claim it doesn't exist).
+    One line, format "HH:MMam - HH:MMam | Category | Brief", inferred from
+    conversation. If the resolved path says "(not in this vault, skip)",
+    skip this step. Otherwise: append under today's date heading; create
+    the heading if missing.
 
 PHASE 2 — Batch writes (one tool-call block, append never overwrite):
   • Fill in the pre-built session file (paths above).

--- a/phases/phase-19-23-finish.md
+++ b/phases/phase-19-23-finish.md
@@ -434,7 +434,31 @@ Trigger the cascade now by treating "install completed Phase 24.6" as equivalent
 6. Phase 2b git snapshot — commits everything to the vault's local git so the install state is recoverable
 7. Phase 3 aggregators — rebuilds Last Session.md so the user's NEXT session opens with full context about yesterday's install
 
-After the cascade completes, ONE LINE goodbye in the user's PRIMARY_LANGUAGE: "Vault is saved. See you in your next session." or "Vault guardado. Nos vemos en tu próxima sesión." Then truly stop.
+After the cascade completes, run a self-verification check before saying goodbye. Invoke the `diagnose` skill (it landed during Phase 0 bootstrap) via the Skill tool with `skill: diagnose`. The skill scans the installed state and returns a green/yellow/red report covering:
+- CLAUDE.md exists at vault root with required sections
+- About Me file exists in 🏠 Home/ with template structure
+- ⚙️ Meta/ folder and subfolders created
+- Required skills landed in ~/.claude/skills/
+- Required slash commands landed in ~/.claude/commands/
+- MCPs registered (granola, chatprd, google-workspace if applicable)
+- Hooks installed (session-start-context, post-tool-use-learnings, etc.)
+- session-end-hook.sh present and executable
+- No .ps1 BOM issues (Windows only)
+
+Read the diagnose output. If everything is green, proceed to the goodbye. If anything is yellow (warning) or red (failure), surface a one-paragraph summary in the user's PRIMARY_LANGUAGE BEFORE the goodbye:
+
+**EN:** "Before we close — one quick verification. [Skill folder X / MCP Y / Hook Z] didn't land cleanly. Most things are fine. To fix this specific item, [exact one-line command from diagnose output]. Otherwise everything else is set up."
+
+**ES:** "Antes de cerrar — una verificación rápida. [Skill X / MCP Y / Hook Z] no quedó bien instalado. La mayoría está bien. Para arreglar específicamente eso: [comando exacto del diagnose]. Lo demás quedó listo."
+
+Then say the goodbye line:
+
+**EN:** "Vault is saved. See you in your next session."
+**ES:** "Vault guardado. Nos vemos en tu próxima sesión."
+
+Then truly stop.
+
+**Why self-verification at install close:** every previous install bug class (skill folder missing, command not registered, MCP not wired, About Me not created) was silent until the user hit it days or weeks later. Running `diagnose` automatically catches these AT INSTALL TIME so the user can re-run bootstrap or fix the specific item before they leave with a half-broken vault. The skill exists in the install bundle — use it.
 
 **Why this phase matters:** without it, install conversations were getting lost. Personal context revealed during install lands in About Me (per Phase 3c universal capture) but the SESSION RECORD — what got done, what got chosen, what's pending — only exists if close fires. Users who install and walk away without saying "bye" would lose the install context entirely. The user already gave you the equivalent of a "bye" by completing the install. Don't wait for the explicit word — fire the close now.
 

--- a/tests/integration/test_bootstrap_dry_run.sh
+++ b/tests/integration/test_bootstrap_dry_run.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Test the bootstrap.sh end-to-end via --dry-run. Asserts:
+#   1. bootstrap.sh --dry-run exits 0 (no parse errors, no early aborts)
+#   2. The expected log lines appear in stdout (sub-skill loop fires for
+#      each required skill, commands loop fires, verification loop fires)
+#
+# Catches the bug class where a new section in bootstrap.sh has a syntax
+# error, an unbound variable, or a logic break that only surfaces when
+# someone runs a real install. End-to-end coverage we previously didn't
+# have. Same drift-prevention family as the worktree-session-close (#65),
+# reconcile-ff (#68), and phase-doc-skills (#73) tests.
+#
+# Self-contained. Sets EMAIL/NAME/LANG_HINT env so the bootstrap doesn't
+# block on the email-gate. Doesn't write outside its tmpdir.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BOOTSTRAP="$REPO_ROOT/bootstrap.sh"
+
+if [ ! -f "$BOOTSTRAP" ]; then
+  echo "ERROR: $BOOTSTRAP not found" >&2
+  exit 1
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Pre-stage the email marker so the bootstrap doesn't try to mint a token.
+export HOME="$TMP"
+mkdir -p "$HOME/.claude"
+touch "$HOME/.claude/.ai-brain-starter-email-on-file"
+
+# Pre-create a fake SKILL_DIR so the bootstrap finds itself.
+mkdir -p "$HOME/.claude/skills/ai-brain-starter"
+# Symlink the test runner's repo into the SKILL_DIR position so bootstrap
+# can find templates, skills/, scripts/, etc.
+rmdir "$HOME/.claude/skills/ai-brain-starter"
+ln -s "$REPO_ROOT" "$HOME/.claude/skills/ai-brain-starter"
+
+# Run bootstrap --dry-run. Capture stdout + stderr + exit code.
+OUT_FILE="$TMP/bootstrap.out"
+ERR_FILE="$TMP/bootstrap.err"
+EMAIL="ci@example.com" NAME="CI Test" LANG_HINT="en" \
+  bash "$BOOTSTRAP" --dry-run > "$OUT_FILE" 2> "$ERR_FILE"
+EXIT_CODE=$?
+
+# ─── Assertion 1: bootstrap exited 0 ───────────────────────────────
+if [ "$EXIT_CODE" -ne 0 ]; then
+  echo "FAIL: bootstrap.sh --dry-run exited $EXIT_CODE" >&2
+  echo "--- stderr ---" >&2
+  cat "$ERR_FILE" >&2
+  echo "--- stdout (last 30 lines) ---" >&2
+  tail -30 "$OUT_FILE" >&2
+  exit 1
+fi
+echo "PASS: bootstrap.sh --dry-run exited 0"
+
+# ─── Assertion 2: required skills referenced in the install loop ───
+# We don't expect them to be INSTALLED (it's a dry run) but we expect
+# the loop to mention each one as "would install" / "would sync".
+REQUIRED_SKILLS=(
+  "graphify"
+  "meeting-todos"
+  "patterns"
+  "insights"
+  "deconstruct"
+  "daily-journal"
+  "repurpose-talk"
+  "nano-banana"
+  "second-brain-mapping"
+  "setup-vault-types"
+  "diagnose"
+)
+
+MISSING=0
+for skill in "${REQUIRED_SKILLS[@]}"; do
+  if ! grep -q "$skill" "$OUT_FILE"; then
+    echo "FAIL: skill '$skill' not mentioned in bootstrap dry-run output" >&2
+    MISSING=$((MISSING + 1))
+  fi
+done
+
+if [ "$MISSING" -gt 0 ]; then
+  echo "$MISSING skill(s) missing from bootstrap dry-run output" >&2
+  echo "--- stdout (last 60 lines) ---" >&2
+  tail -60 "$OUT_FILE" >&2
+  exit 1
+fi
+echo "PASS: all ${#REQUIRED_SKILLS[@]} required skills appear in bootstrap dry-run output"
+
+# ─── Assertion 3: commands section fires ──────────────────────────
+if ! grep -qi "commands" "$OUT_FILE"; then
+  echo "FAIL: bootstrap dry-run did not mention the commands install section" >&2
+  echo "  (Phase 24's slash command palette registration depends on this.)" >&2
+  exit 1
+fi
+echo "PASS: commands install section fired in dry-run"
+
+echo
+echo "All assertions passed. Bootstrap end-to-end dry-run is clean."


### PR DESCRIPTION
Two commits, both install-close-related, shipping together.

## Commit 1: hooks: detect-closing-signal pre-resolves Time Tracking path

The Phase 1 bullet used to hedge "Time tracking entry (if vault uses it)" and force the model to infer whether the surface existed. That produced a false-negative when the model checked the wrong directory (a daily-logs folder rather than `⚙️ Meta/Time Tracking.md`) and concluded the vault did not have a time-tracking surface.

Fix: `_full_cascade_block` now resolves `meta_dir / "Time Tracking.md"` and injects either the resolved path with append-instructions (when the file exists) or a "skip the time-tracking step, the vault doesn't use it" line (when it doesn't). No more model inference, no more wrong-directory false-negatives.

## Commit 2: fix(install): self-verify via /diagnose at Phase 24.7 + E2E bootstrap CI test

Best-of-best verification layer that was missing across today's 13 install-hardening PRs. Two coordinated additions:

### 2a. Phase 24.7 self-verification

After the close cascade completes and BEFORE the goodbye, invoke the `diagnose` skill via the Skill tool. It returns a green/yellow/red report covering CLAUDE.md, About Me, ⚙️ Meta/, required skills, required commands, MCPs, hooks, session-end-hook executable, .ps1 BOM. If anything is yellow/red, surface a one-paragraph summary in PRIMARY_LANGUAGE with the exact remedy line before the goodbye.

Self-verification at install close means users don't leave with a half-broken vault that surfaces a week later.

### 2b. End-to-end bootstrap CI test

`tests/integration/test_bootstrap_dry_run.sh` runs `bootstrap.sh --dry-run` with a tmpdir HOME + email-gate pre-staged. Asserts:

- bootstrap.sh --dry-run exits 0 (no syntax errors, no unbound vars, no logic breaks in any install section)
- All 11 required skills mentioned in dry-run output
- Commands install section fires

Wired into `lint.yml` as new job `bootstrap-dry-run`. Catches the bug class where a new section in bootstrap.sh has an error that only surfaces when a real install runs.

Same drift-prevention pattern as the worktree-session-close (#65), reconcile-ff (#68), phase-doc-skills (#73) tests.

## Test plan

- [x] All existing CI tests green (worktree session-close + reconcile FF + phase-doc skills + new bootstrap-dry-run)
- [x] Private-context scrub
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)