### PR TITLE
fix(close-cascade): inject ALL mandatory phases (0c/0d/0e + Phase 3 audit) — root cause of incomplete close

### DIFF
--- a/hooks/detect-closing-signal.py
+++ b/hooks/detect-closing-signal.py
@@ -559,6 +559,26 @@ Surface any background tasks still running, pipeline phases killed mid-run,
 errors not retried. Ask the user "finish now, or defer?" Wait for their call.
 If nothing incomplete: say "No incomplete work" and proceed.
 
+PHASE 0c — Consumable-artifact cleanup (model, BEFORE writes):
+Quick scan for handoff files + consumes_when artifacts. Run these (silent on
+empty), classify each match (consumed/in-flight/stale-untouched), and propose
+`git mv` to Handoffs/Archive/ for consumed items. Never delete without user
+confirm. If no matches found: silent skip, do NOT mention.
+  find "{meta_dir}/Handoffs" -maxdepth 1 -type f -name "*.md" 2>/dev/null
+  grep -lE "^consumes_when:" "{meta_dir}"/*.md 2>/dev/null
+
+PHASE 0d — Orphan task-list guard (model, BEFORE writes):
+Run the orphan-task-list scanner if it exists on this install (skip silently
+on missing — not all installs have it):
+  python3 "{meta_dir}/scripts/check-orphan-task-lists.py" 2>/dev/null || true
+If it fires and reports violators, surface the count + first sample to the
+user before proceeding to Phase 1.
+
+PHASE 0e — Launchd health check (model, BEFORE writes; macOS only):
+On macOS, re-bootstrap any unloaded launchd agents (skip silently if script
+missing or on non-Mac):
+  bash "{meta_dir}/scripts/check-launchd-health.sh" 2>/dev/null || true
+
 PHASE 1 — Single-pass conversation scan (compose all in memory before writing):
   • Belief shifts: did the user end the session believing something different?
   • Journal seeds: VERBATIM quotes where they revealed a belief, observation,
@@ -593,11 +613,39 @@ PHASE 2 — Batch writes (one tool-call block, append never overwrite):
   • Append journal seeds to Captures.
   • Personal vs team firewall: never let personal content leak to a team vault.
 
-The post-Stop hook handles aggregators, retention cleanup, git snapshot,
-worktree cleanup, audits. Don't run those yourself — they fire automatically
-after your turn ends.
+The post-Stop hook handles ONLY the mechanical pieces: aggregators
+(aggregate-sessions.py / aggregate-decisions.py), retention cleanup
+(stubs >7d), git snapshot (vault-safe-commit.sh), worktree-archive-prep.
+Don't run those yourself — they fire automatically after your turn ends.
 
-PHASE 3 — Final summary (one line):
+Phases 0c/0d/0e and the Phase 3 audit are MODEL-SIDE. The post-Stop hook
+does NOT run them.
+
+PHASE 3 — Functional audit (conditional, MODEL-SIDE):
+If this session shipped code or docs to a PUBLIC REPO that users download
+(ai-brain-starter, humanizer, mycelium-site, any *-mcp, etc.), run the
+6-step audit before close:
+  1. Syntax: `python3 -m py_compile` every new/modified .py;
+     `bash -n` every new/modified .sh;
+     `python3 -c "import json; json.load(open(...))"` every new/modified .json.
+  2. Path resolution: grep every `~/.claude/skills/...` path in docs/templates
+     against the actual filesystem. Every path must resolve.
+  3. Orphan scan: grep every new file under hooks/, scripts/, templates/
+     against the docs that should reference it. Unreferenced = invisible.
+  4. Smoke test: invoke each new script with `--help` or minimal args.
+  5. Misleading copy: search shipped docs for "this hook blocks X" /
+     "three gates enforce Y" that imply auto-installation. If the artifact
+     isn't auto-installed, rewrite to "opt-in, install via:".
+  6. Relative link check: resolve every `](...)` relative link in modified
+     README/docs against the filesystem.
+Report: "Audit: N python OK, M bash OK, K JSON OK, P paths resolved,
+Q orphans found + fixed, R smoke tests passed."
+If session shipped to a public repo and you SKIP this audit, you've left
+the close cascade incomplete. CI covers the bulk-mechanical checks
+(syntax, em-dash, cross-reference) but does NOT cover smoke tests,
+misleading copy, or unreferenced files. The audit catches what CI can't.
+
+PHASE 4 — Final summary (one line, after audit if Phase 3 fired):
 "Filed X seeds, Y to-dos (yours: A, delegations: B), Z decisions, checked
 off M items. Anything I missed?"
 


### PR DESCRIPTION
## Root cause

User ran `session-close`, model executed phases 0b → 1 → 2 → one-line summary, skipped 0c, 0d, 0e, AND the Phase 3 functional audit. Asked: why didn't the whole cascade fire? Let's fix it so it doesn't happen again.

The bug was in `hooks/detect-closing-signal.py`'s `_full_cascade_block`: the injected text told the model "the post-Stop hook handles aggregators, retention cleanup, git snapshot, worktree cleanup, audits — don't run those yourself." The vague "audits" made the model interpret Phase 3 functional audit as something the Stop hook handles (it doesn't). Plus phases 0c/0d/0e weren't injected at all.

## Fix

1. **Phases 0c/0d/0e now explicitly injected** with shell commands. Each is silent-skip if the script doesn't exist (not all installs have `check-orphan-task-lists.py` or `check-launchd-health.sh`).

2. **The "post-Stop hook" line now specific** about what it covers (aggregators, retention, git snapshot, worktree-archive-prep) AND what it does NOT cover ("Phases 0c/0d/0e and the Phase 3 audit are MODEL-SIDE. The post-Stop hook does NOT run them.").

3. **Phase 3 spelled out** with the 6-step functional audit (syntax, path resolution, orphan scan, smoke test, misleading copy, relative links) and the conditional "if this session shipped code or docs to a PUBLIC REPO." Notes that CI covers bulk-mechanical checks but doesn't substitute for smoke tests, misleading copy, or unreferenced files.

## Why now

Caught after today's 14 PRs shipped to ai-brain-starter — none had Phase 3 audit run explicitly during close. CI covered most (bash -n, py_compile, json validity, em-dash, phase-doc cross-ref, end-to-end bootstrap). But the discipline gap — model thinking "Stop hook handles audits, I'm done" — is the actual codification.

## Test plan

- [x] `python3 -m py_compile hooks/detect-closing-signal.py` ✅
- [x] All 4 existing CI tests still green
- [x] Private-context scrub
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)