### PR TITLE
docs: add first-party skills catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ Every tool is installed and wired during setup. They work together, not in isola
 | `/optimize-brain` | Deep vault optimization: CRM, graphs, dashboards, compression, wikilinks |
 | `/mem-search` | Search Claude's cross-session memory database |
 
+The table above is the daily-driver subset. The full first-party catalog — forty-plus skills grouped by what they do — is in [`docs/SKILLS.md`](docs/SKILLS.md).
+
 ### Power tools under the hood
 
 - **Graphify** — knowledge graph extraction with community detection, audit trails, and 80-92% token savings via wrapper scripts
@@ -361,6 +363,7 @@ If what you need is agent federation, swarm topologies, or a 300-tool MCP server
 
 - **[`RELIABILITY_MANIFESTO.md`](RELIABILITY_MANIFESTO.md)** — the five architectural pillars (vault as ground truth, hooks as deterministic guards, rule extraction, decision-outcome trail, session-close cascade) and the five failure modes they prevent (hallucination, silent failure, cold start, drift, knowledge loss). Read this if you want to understand why the system is shaped the way it is.
 - **[`docs/MCP_STACK.md`](docs/MCP_STACK.md)** — the 13 companion MCP servers (Slack, iMessage, WhatsApp, Google Workspace, Apollo, Substack, lu.ma, parse, graph-query, and more). All public, MIT, draft+confirm on writes, JSONL audit, prompt-injection scrubber. Install whichever subset you need.
+- **[`docs/SKILLS.md`](docs/SKILLS.md)** — the full first-party skill catalog, forty-plus skills grouped by what they do
 - **[`docs/POWER_TOOLS.md`](docs/POWER_TOOLS.md)** — every third-party skill, MCP server, and Obsidian plugin, with attribution and source links
 - **[`docs/MEMORY_SYSTEM.md`](docs/MEMORY_SYSTEM.md)** — how Claude accumulates knowledge across sessions using typed memories
 - **[`docs/TOKEN_OPTIMIZATION.md`](docs/TOKEN_OPTIMIZATION.md)** — how to stop burning tokens on overhead: compress Claude-facing files, cap memory, route cheap work to cheap models

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -1,0 +1,88 @@
+# Skills Catalog
+
+The first-party skills that ship with AI Brain Starter. Every one is a markdown file you can read in a few minutes; install puts each where Claude Code can find and trigger it. Most are invoked with a slash command (`/journal`, `/graphify`, `/coach`); a few auto-fire on the right cue.
+
+This is the first-party catalog — the skills built for the substrate itself. For the third-party skills, MCP servers, and Obsidian plugins also bundled at install, see [`POWER_TOOLS.md`](POWER_TOOLS.md). To see what a skill's output actually looks like, [`EXAMPLES.md`](../EXAMPLES.md) shows a real journal entry and weekly insight report.
+
+---
+
+## Daily practice
+
+The everyday rituals — the surface you touch most.
+
+- **rise** — morning consciousness routine. Identifies your emotional Floor from a natural check-in, surfaces the day's top one to three priorities, sets an intention.
+- **daily-journal** — daily journal interview with a live advisory panel that meets your draft and pushes back where the thinking is soft.
+- **coaching** — multi-pass coaching session for a hard conversation, a decision you are second-guessing, or accumulated tension that will not fit in a daily entry.
+- **insights** — weekly and monthly journal insight reports: Floor trends, avoidance flags, wins, life-coach and therapist observations.
+- **sunday-review** — weekly meta-review that orchestrates the weekly insight, pattern scan, vault hygiene, and decision retrospective in one flow.
+- **patterns** — the Instinct Engine. Scans recent sessions, journals, and decisions for recurring patterns and turns them into concrete captures.
+- **deconstruct** — first-principles analyst. Surfaces hidden assumptions, finds the foundational truths, rebuilds from scratch, names the high-leverage move.
+
+## Health and longevity
+
+- **coach** — longevity and fitness coach. Issues a daily workout prescription that reads recovery, sleep, and cycle phase from your wearable, paired with today's Floor.
+- **health-setup** — interactive setup wizard for the health connector. Picks the right wearable (Apple Watch, Oura, Fitbit, Garmin, Whoop) and walks token setup end to end.
+- **health-context** — auto-fires when the journaling, coaching, panel, or insight skills run, pulling the day's health context into them.
+- **health-doctor** — observability surface for the health auto-trigger chain. Shows data-source freshness, the last prescription, missed days.
+- **ingest-health** — imports Apple Health data into the local database the health skills read from.
+- **longitudinal** — multi-year health pattern surface. Scans years of data and returns only the strongest correlations.
+- **backfill-journal-body-context** — walks past journal entries and appends a body-data section, pairing each day with its health metrics.
+
+## Knowledge graph and vault structure
+
+- **graphify** — turns any input (code, docs, papers, images) into a knowledge graph with clustered communities, an HTML view, and an audit report.
+- **second-brain-mapping** — unified vault-mapping pipeline. Extracts structured metadata from every typed file and surfaces cross-document insights.
+- **setup-vault-types** — interactive wizard to configure which document types your vault uses and scaffold extractors for custom ones.
+- **resolver-query** — reads your rule resolver and answers a natural-language question by surfacing the matching rule.
+- **diagnose** — self-check against an installed vault. Verifies CLAUDE.md, the Meta folder, skills, hooks, and the journal index; prints a green/yellow/red report.
+
+## Capture and to-dos
+
+- **meeting-todos** — extracts action items from a meeting note and files them, separating your tasks from everyone else's.
+- **note-todos** — the same extraction for any non-meeting note: class notes, book notes, podcast notes, transcripts, panel writeups.
+
+## Ingestion — pull external sources into the vault
+
+- **ingest-github** — recent merged PRs, issues, and commits from a repository.
+- **ingest-gmail** — recent Gmail messages matching a label or query.
+- **ingest-linear** — recent Linear issues, comments, and status changes.
+- **ingest-notion** — recent pages or database entries from Notion.
+- **ingest-slack** — recent messages from a Slack channel.
+- **ingest-whatsapp** — recent messages from a WhatsApp chat.
+- **ingest-youtube** — a YouTube video transcript, or a channel's recent uploads.
+
+Each writes queryable markdown into the vault and is idempotent: re-running on the same day overwrites cleanly.
+
+## Writing and content
+
+- **repurpose-talk** — turns one speaking engagement into 10 to 30 content pieces: LinkedIn posts, Substack notes, a video-clip plan.
+- **nano-banana** — image generation, editing, and composition via Google's Gemini 3 Pro Image model.
+- **remotion-best-practices** — best practices for building videos in React with Remotion.
+- **seo-substrate** — SEO and GEO substrate for solo founders and indie creators: technical SEO, schema, AI-search optimization, bilingual routing.
+
+## Turn finished work into durable memory
+
+- **synth-pr-to-sop** — reads a merged PR and synthesizes a reusable workflow SOP.
+- **synth-thread-to-sop** — reads a resolved Slack thread and files a typed memory entry: a decision, an exception, or a procedure.
+- **extract-rules-from-vault** — walks a company's existing artifacts (a Slack export, a Notion export, a folder of documents) and emits draft rules, skills, and a starter CLAUDE.md so a new install does not begin empty.
+
+## Engineering substrates
+
+- **tdd-substrate** — test-driven development substrate for solo and small-team builds: iron-law red-green-refactor with dual-runtime examples.
+- **modern-python-substrate** — modern Python toolchain: uv, ruff, ty, pytest, a src layout, pyproject.toml as the single source of truth.
+
+## Teams and vertical packs
+
+- **for-my-team** — walks you through what changes when a personal vault becomes a team vault.
+- **vertical-finance** — pre-configured finance vertical pack: typed-memory categories for deals, retention defaults, connector configs.
+- **vertical-healthcare** — pre-configured healthcare vertical pack: typed-memory categories for patient-adjacent work, compliant retention defaults.
+- **vertical-legal** — pre-configured legal vertical pack: matter management, privilege handling, retention aligned to bar rules.
+- **influencer-pack** — pre-configured creator-economy vertical pack: audience, DMs, content, collabs, and creator-revenue categories.
+
+## Consulting lead generation
+
+- **security-snapshot** — generates a client-ready security hygiene snapshot for a prospect domain. A free lead magnet for a consulting practice.
+
+---
+
+Forty-plus skills, and the set grows. Install registers each so Claude Code triggers it on the right cue; you do not memorize a command list. New to the system? Start with **rise** in the morning and **daily-journal** at night — the rest reveals itself as the work calls for it.


### PR DESCRIPTION
## Summary
- New `docs/SKILLS.md`: curated catalog of all 43 first-party skills, grouped by purpose (daily practice, health, knowledge graph, capture, ingestion, writing, synthesis, engineering substrates, teams/verticals, lead-gen).
- The README Toolkit table surfaced only ~11 commands; `POWER_TOOLS.md` covers third-party content only. There was no single index of what the substrate itself ships.
- Linked from the README Toolkit section and the Deeper Documentation list.

## Test plan
- [ ] `docs/SKILLS.md` renders on GitHub
- [ ] README links to `docs/SKILLS.md` resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)