### PR TITLE
feat(influencer-pack): idea engine as the content-generation spine

### DIFF
--- a/skills/influencer-pack/README.md
+++ b/skills/influencer-pack/README.md
@@ -1,6 +1,6 @@
 # Influencer Pack
 
-A creator-economy vertical pack for the ai-brain-starter substrate. The pack ships typed-memory categories, platform connectors, retention defaults, and decision-audit patterns so a creator can install a working second-brain on day one instead of inventing the vocabulary from scratch.
+A creator-economy vertical pack for the ai-brain-starter substrate. The pack ships typed-memory categories, platform connectors, the idea engine, retention defaults, and decision-audit patterns so a creator can install a working second-brain on day one instead of inventing the vocabulary from scratch.
 
 ## What the pack covers
 
@@ -23,8 +23,9 @@ The pack init step verifies these are present and prompts the operator to instal
 
 | Layer | Where it lands |
 |---|---|
-| 9 typed-memory categories | `schema/typed-memory-categories.md` |
+| 12 typed-memory categories | `schema/typed-memory-categories.md` |
 | 16 platform connector specs | `connectors/<platform>.md` |
+| Idea engine (the content-generation spine) | `idea-engine/<file>.md` |
 | Retention defaults | `retention/defaults.md` |
 | Decision-audit patterns | `decision-audit/<pattern>.md` |
 
@@ -43,4 +44,4 @@ A future build will add `operator-pack/` (SMB brick-and-mortar) and `founder-pac
 
 ## License
 
-MIT, same as the rest of ai-brain-starter. Schema is open-core. Workflow content + paid-product mechanics live in the runtime layer, not in this repo.
+MIT, same as the rest of ai-brain-starter. The schema and the idea-engine mechanism are open-core. Calibrated workflow content — tuned generation prompts, per-language filter corpora — and paid-product mechanics live in the runtime layer, not in this repo.

--- a/skills/influencer-pack/README.md
+++ b/skills/influencer-pack/README.md
@@ -44,4 +44,4 @@ A future build will add `operator-pack/` (SMB brick-and-mortar) and `founder-pac
 
 ## License
 
-MIT, same as the rest of ai-brain-starter. The schema and the idea-engine mechanism are open-core. Calibrated workflow content — tuned generation prompts, per-language filter corpora — and paid-product mechanics live in the runtime layer, not in this repo.
+MIT, same as the rest of ai-brain-starter. The schema and the idea-engine mechanism are open-core. Calibrated workflow content (tuned generation prompts, per-language filter corpora) and paid-product mechanics live in the runtime layer, not in this repo.

--- a/skills/influencer-pack/SKILL.md
+++ b/skills/influencer-pack/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: influencer-pack
-description: Pre-configured creator-economy vertical pack for the ai-brain-starter substrate. Ships typed-memory categories for audience, DMs, content, collabs, and creator revenue; connector configs for Instagram, TikTok, YouTube, Substack, X, LinkedIn, Stan Store, Stripe, Patreon; retention defaults aligned with Meta + TikTok + YouTube data-handling expectations; decision-audit patterns for sponsored-disclosure and brand-deal terms. Use when onboarding a creator, personal-brand operator, or content-engine team that needs the substrate to come pre-shaped to the work rather than starting from a blank vault.
+description: Pre-configured creator-economy vertical pack for the ai-brain-starter substrate. Ships typed-memory categories for audience, DMs, content, collabs, and creator revenue; connector configs for Instagram, TikTok, YouTube, Substack, X, LinkedIn, Stan Store, Stripe, Patreon; retention defaults aligned with Meta + TikTok + YouTube data-handling expectations; the idea engine, an evidence-grounded content-idea generator that learns the creator's taste from every discard; decision-audit patterns for sponsored-disclosure and evidence-grounding. Use when onboarding a creator, personal-brand operator, or content-engine team that needs the substrate to come pre-shaped to the work rather than starting from a blank vault.
 trigger: /influencer-pack
 argument-hint: "init | status | rebuild [--platform <name>]"
 ---
@@ -21,12 +21,26 @@ Run `/influencer-pack init` and the pack writes:
 
 | Layer | What ships | Where it lands |
 |---|---|---|
-| Schema | 9 typed-memory categories with frontmatter contracts | `schema/typed-memory-categories.md` |
+| Schema | 12 typed-memory categories with frontmatter contracts | `schema/typed-memory-categories.md` |
 | Connectors | 16 platform connector specs (Instagram, TikTok, YouTube, Substack, X, LinkedIn, Stan Store, Stripe, Patreon, more) | `connectors/*.md` |
+| Idea engine | The content-generation spine: bucket structure, discard loop, compounding taste profile, pre-filter interface | `idea-engine/*.md` |
 | Retention | Per-category retention defaults aligned with platform terms of service and creator-economy norms | `retention/defaults.md` |
-| Decision audit | Sponsored-content disclosure pattern and brand-deal acceptance pattern | `decision-audit/*.md` |
+| Decision audit | Sponsored-content disclosure and evidence-grounding patterns | `decision-audit/*.md` |
 
 Nothing is auto-applied to a live install. The pack stages drafts under `drafts/` and prints the path; the operator reviews and accepts before merging into the production memory layer.
+
+## The idea engine
+
+The idea engine is the pack's spine. It is what turns the typed-memory layer from an archive into a working content engine, and it is the piece the rest of the pack orbits.
+
+It does two things a generic AI idea generator does not:
+
+- **Every idea is grounded in real audience evidence.** No idea is proposed without a verbatim quote from a real comment, DM, or piece of the creator's own content behind it. An idea that cannot cite real evidence is dropped, not softened. The enforcing pattern is `decision-audit/evidence-grounding.md`.
+- **It learns the creator's taste.** Every idea the creator discards is logged with a reason and compounded into a `taste-profile` — a weighted, confidence-scored model, not a rolling reject list. Later runs read the profile and stop proposing what the creator keeps rejecting. The engine improves with use, and the profile is the creator's switching cost.
+
+The engine reads `content-piece`, `dm-conversation`, and `audience-question`; it writes `content-idea`, `idea-discard`, and `taste-profile`. The full mechanism — bucket structure, generation flow, the discard loop, the compounding-profile math, the prompt-cache layout — is in `idea-engine/mechanism.md`. The noise filter that keeps adoration and bot text out of the generation context is in `idea-engine/pre-filter.md`.
+
+`/content-engine` is the creator-facing skill that runs the engine.
 
 ## Required companion skills
 
@@ -44,7 +58,7 @@ The influencer-pack assumes these substrate skills are also installed in `~/.cla
 | Skill | What it does | Trigger |
 |---|---|---|
 | `/dm-closer` | Drafts DM responses in the creator's tone, qualifies fan vs prospect vs brand-collab, escalates high-value contacts to manual review. | Always-on |
-| `/content-engine` | Generates short-form posts (Reels, Shorts, TikToks) from anchor recordings plus AI b-roll plus trend formats. | Weekly batch |
+| `/content-engine` | Runs the idea engine: proposes evidence-grounded content ideas across three audience buckets and learns from every discard via the taste profile. Also turns approved ideas and anchor recordings into platform-native drafts. See `idea-engine/mechanism.md`. | Weekly batch |
 | `/weekly-creator-report` | Monday-morning rollup: revenue by source, top content by reach plus revenue, audience growth, collab pipeline status. | Cron at 7am Monday |
 | `/collab-pipeline` | Tracks inbound brand asks plus outbound creator-to-creator collabs with stage, terms, next-step. | Always-on |
 | `/voice-fingerprint-update` | Re-trains the written-voice fingerprint on the last 30 days of approved content. Reads from `External Inputs/YouTube/` (via `ingest-youtube`), the Substack archive, and the IG caption history. | Monthly cron |

--- a/skills/influencer-pack/SKILL.md
+++ b/skills/influencer-pack/SKILL.md
@@ -36,9 +36,9 @@ The idea engine is the pack's spine. It is what turns the typed-memory layer fro
 It does two things a generic AI idea generator does not:
 
 - **Every idea is grounded in real audience evidence.** No idea is proposed without a verbatim quote from a real comment, DM, or piece of the creator's own content behind it. An idea that cannot cite real evidence is dropped, not softened. The enforcing pattern is `decision-audit/evidence-grounding.md`.
-- **It learns the creator's taste.** Every idea the creator discards is logged with a reason and compounded into a `taste-profile` — a weighted, confidence-scored model, not a rolling reject list. Later runs read the profile and stop proposing what the creator keeps rejecting. The engine improves with use, and the profile is the creator's switching cost.
+- **It learns the creator's taste.** Every idea the creator discards is logged with a reason and compounded into a `taste-profile`, a weighted, confidence-scored model, not a rolling reject list. Later runs read the profile and stop proposing what the creator keeps rejecting. The engine improves with use, and the profile is the creator's switching cost.
 
-The engine reads `content-piece`, `dm-conversation`, and `audience-question`; it writes `content-idea`, `idea-discard`, and `taste-profile`. The full mechanism — bucket structure, generation flow, the discard loop, the compounding-profile math, the prompt-cache layout — is in `idea-engine/mechanism.md`. The noise filter that keeps adoration and bot text out of the generation context is in `idea-engine/pre-filter.md`.
+The engine reads `content-piece`, `dm-conversation`, and `audience-question`; it writes `content-idea`, `idea-discard`, and `taste-profile`. The full mechanism (bucket structure, generation flow, the discard loop, the compounding-profile math, the prompt-cache layout) is in `idea-engine/mechanism.md`. The noise filter that keeps adoration and bot text out of the generation context is in `idea-engine/pre-filter.md`.
 
 `/content-engine` is the creator-facing skill that runs the engine.
 

--- a/skills/influencer-pack/decision-audit/evidence-grounding.md
+++ b/skills/influencer-pack/decision-audit/evidence-grounding.md
@@ -1,0 +1,66 @@
+# Decision-audit pattern: evidence grounding
+
+The idea engine proposes content based on what a creator's audience actually said. This pattern enforces that every proposed idea traces to real audience evidence, so the engine cannot invent demand that does not exist.
+
+## Why this exists
+
+A content-idea generator that hallucinates is worse than useless — it is actively harmful. If the engine proposes "your audience keeps asking about X" and the audience never asked about X, the creator makes content for demand that is not there, and they stop trusting every other idea the engine proposes.
+
+The failure is quiet. A fabricated idea reads exactly like a grounded one. The only defense is to make grounding a hard, checked invariant rather than a hope.
+
+This pattern reduces fabricated ideas to near-zero by gating `content-idea` writes on real evidence.
+
+## The rule
+
+Every `content-idea` record must satisfy both conditions:
+
+1. `evidence_quotes` is a non-empty list of verbatim quotes.
+2. At least one of `basis_content_ids`, `basis_conversation_ids`, `basis_question_ids` is non-empty, and every FK in those lists resolves to a real record in the typed-memory layer.
+
+An idea that cannot cite real evidence is not softened, not flagged, not proposed with a caveat. It is dropped.
+
+## How the pattern enforces
+
+Two gates, at two stages:
+
+**Write-time (schema).** The substrate rejects a `content-idea` document that has an empty `evidence_quotes` list or no resolvable `basis_*` FK. This is the same write-time schema rejection every typed-memory category gets; for `content-idea` the evidence fields are part of the contract.
+
+**Generation-time (pre-write gate).** Before the engine writes a batch, it runs each candidate through the gate:
+
+```
+def assert_idea_grounded(idea, typed_memory):
+    if not idea.evidence_quotes:
+        raise EvidenceGapError(f"{idea.idea_id}: no evidence_quotes")
+    basis = idea.basis_content_ids + idea.basis_conversation_ids + idea.basis_question_ids
+    if not basis:
+        raise EvidenceGapError(f"{idea.idea_id}: no basis FK")
+    for fk in basis:
+        if not typed_memory.exists(fk):
+            raise EvidenceGapError(f"{idea.idea_id}: basis FK {fk} does not resolve")
+    for quote in idea.evidence_quotes:
+        if not typed_memory.quote_traces_to_basis(quote, basis):
+            raise EvidenceGapError(f"{idea.idea_id}: evidence quote not found in any basis record")
+```
+
+A candidate that raises `EvidenceGapError` is dropped from the batch; the batch proceeds with the ideas that pass. A run that drops every candidate returns an empty batch — a correct result, not a failure.
+
+## ID-strip backstop
+
+The generation model is instructed to keep raw record IDs and hashes out of human-facing text fields (`angle`, `why_good`, `suggested_angle`). Models leak IDs anyway. A defensive ID-strip pass runs over every emitted `content-idea` and removes any raw ID or hash that reached a text field; IDs belong only in the `basis_*` FK lists, where the substrate resolves them into links at render time.
+
+The backstop is belt-and-suspenders: the prompt instruction is the belt, the strip pass is the suspenders. Neither is trusted alone.
+
+## Audit trail
+
+Every grounding check writes a hash-chained entry to the audit log: timestamp, `idea_id`, batch ID, pass or fail, and on fail the specific gap. The audit log is append-only.
+
+If a drop is later found to be a false positive — the evidence was real but the FK resolution missed it — the operator marks the audit entry `revoked: true` with a reason. The entry stays; the log is never edited.
+
+## What this pattern does not do
+
+This pattern checks that an idea is *grounded*. It does not check that an idea is *good* — that is the creator's judgment, expressed through the discard loop (`idea-engine/mechanism.md`). A well-grounded idea the creator does not like is a valid output of the engine and a valid `idea-discard`. Grounding is the floor, not the ceiling.
+
+## Related patterns
+
+- `idea-engine/mechanism.md` — the engine this pattern gates.
+- `decision-audit/sponsored-disclosure.md` — the other pre-publish gate in the pack.

--- a/skills/influencer-pack/decision-audit/evidence-grounding.md
+++ b/skills/influencer-pack/decision-audit/evidence-grounding.md
@@ -4,7 +4,7 @@ The idea engine proposes content based on what a creator's audience actually sai
 
 ## Why this exists
 
-A content-idea generator that hallucinates is worse than useless — it is actively harmful. If the engine proposes "your audience keeps asking about X" and the audience never asked about X, the creator makes content for demand that is not there, and they stop trusting every other idea the engine proposes.
+A content-idea generator that hallucinates is worse than useless; it is actively harmful. If the engine proposes "your audience keeps asking about X" and the audience never asked about X, the creator makes content for demand that is not there, and they stop trusting every other idea the engine proposes.
 
 The failure is quiet. A fabricated idea reads exactly like a grounded one. The only defense is to make grounding a hard, checked invariant rather than a hope.
 
@@ -42,7 +42,7 @@ def assert_idea_grounded(idea, typed_memory):
             raise EvidenceGapError(f"{idea.idea_id}: evidence quote not found in any basis record")
 ```
 
-A candidate that raises `EvidenceGapError` is dropped from the batch; the batch proceeds with the ideas that pass. A run that drops every candidate returns an empty batch — a correct result, not a failure.
+A candidate that raises `EvidenceGapError` is dropped from the batch; the batch proceeds with the ideas that pass. A run that drops every candidate returns an empty batch, which is a correct result, not a failure.
 
 ## ID-strip backstop
 
@@ -54,13 +54,13 @@ The backstop is belt-and-suspenders: the prompt instruction is the belt, the str
 
 Every grounding check writes a hash-chained entry to the audit log: timestamp, `idea_id`, batch ID, pass or fail, and on fail the specific gap. The audit log is append-only.
 
-If a drop is later found to be a false positive — the evidence was real but the FK resolution missed it — the operator marks the audit entry `revoked: true` with a reason. The entry stays; the log is never edited.
+If a drop is later found to be a false positive (the evidence was real but the FK resolution missed it), the operator marks the audit entry `revoked: true` with a reason. The entry stays; the log is never edited.
 
 ## What this pattern does not do
 
-This pattern checks that an idea is *grounded*. It does not check that an idea is *good* — that is the creator's judgment, expressed through the discard loop (`idea-engine/mechanism.md`). A well-grounded idea the creator does not like is a valid output of the engine and a valid `idea-discard`. Grounding is the floor, not the ceiling.
+This pattern checks that an idea is *grounded*. It does not check that an idea is *good*; that is the creator's judgment, expressed through the discard loop (`idea-engine/mechanism.md`). A well-grounded idea the creator does not like is a valid output of the engine and a valid `idea-discard`. Grounding is the floor, not the ceiling.
 
 ## Related patterns
 
-- `idea-engine/mechanism.md` — the engine this pattern gates.
-- `decision-audit/sponsored-disclosure.md` — the other pre-publish gate in the pack.
+- `idea-engine/mechanism.md` (the engine this pattern gates).
+- `decision-audit/sponsored-disclosure.md` (the other pre-publish gate in the pack).

--- a/skills/influencer-pack/idea-engine/mechanism.md
+++ b/skills/influencer-pack/idea-engine/mechanism.md
@@ -13,9 +13,9 @@ Every generation run produces ideas in three buckets, because the three source s
 
 | Bucket | Source | What it surfaces |
 |---|---|---|
-| `audience-comments` | `dm-conversation` records with `subtype: comment`, plus `audience-question` | Recurring public questions and reactions — what the audience asks out loud |
-| `audience-dms` | `dm-conversation` records (direct messages) | Private, higher-intent questions — what the audience will not ask in public |
-| `top-content` | `content-piece` records ranked by engagement | What already worked — ideas are evolutions, not repeats |
+| `audience-comments` | `dm-conversation` records with `subtype: comment`, plus `audience-question` | Recurring public questions and reactions, what the audience asks out loud |
+| `audience-dms` | `dm-conversation` records (direct messages) | Private, higher-intent questions the audience will not ask in public |
+| `top-content` | `content-piece` records ranked by engagement | What already worked; ideas are evolutions, not repeats |
 
 A bucket can come back with fewer ideas than its target, or empty. Quality is the gate, not the count. An empty bucket is a valid result; a padded bucket is a defect.
 
@@ -25,7 +25,7 @@ One generation run, per platform:
 
 1. **Pull** the bucket sources from the typed-memory layer for the lookback window.
 2. **Pre-filter** the comment and DM text through the noise filter (`idea-engine/pre-filter.md`) so adoration, bot, and trivial messages never reach the model. This is a cost control and a signal control.
-3. **Group into patterns.** The model reads the full filtered set and groups it by recurring theme. Three differently-worded versions of the same question are one pattern, one idea — not three.
+3. **Group into patterns.** The model reads the full filtered set and groups it by recurring theme. Three differently-worded versions of the same question are one pattern, one idea, not three.
 4. **Ground each idea in evidence.** Each candidate idea must carry at least one verbatim quote and at least one basis FK to the real record it came from. A candidate that cannot cite real evidence is dropped, not softened.
 5. **Emit `content-idea` records** in the three-block shape below.
 6. **Apply the taste profile.** The creator's current `taste-profile` is passed into the run; the model suppresses angles, formats, and topics the profile marks as rejected.
@@ -34,9 +34,9 @@ One generation run, per platform:
 
 Every `content-idea` carries three blocks the creator can scan in seconds:
 
-- **Evidence** — the verbatim quotes from real comments, DMs, or captions that motivated the idea.
-- **Why it is good** — one or two sentences: the pain, curiosity, or audience segment it serves.
-- **Suggested angle** — hook, body focus, and close. The angle, not a finished script. The creator writes the script in their own voice.
+- **Evidence:** the verbatim quotes from real comments, DMs, or captions that motivated the idea.
+- **Why it is good:** one or two sentences naming the pain, curiosity, or audience segment it serves.
+- **Suggested angle:** hook, body focus, and close. The angle, not a finished script. The creator writes the script in their own voice.
 
 ## Evidence grounding
 
@@ -58,7 +58,7 @@ The discard is not a thumbs-down that disappears. It is a durable, reasoned sign
 
 A naive engine feeds the last N discards into the prompt as a "do not repeat" list. That is anti-repetition, not learning: it works at 50 discards and degrades into noise at 500.
 
-The idea engine compounds discards into a structured `taste-profile` instead — a weighted, confidence-scored model of the creator's preferences, recomputed on a cadence rather than regrown every run.
+The idea engine compounds discards into a structured `taste-profile` instead, a weighted, confidence-scored model of the creator's preferences, recomputed on a cadence rather than regrown every run.
 
 **Recompute.** On a schedule (default weekly) and on demand, the engine reads the creator's accumulated `idea-discard` records and accepted or published `content-idea` records, and recomputes the `taste-profile`:
 
@@ -66,7 +66,7 @@ The idea engine compounds discards into a structured `taste-profile` instead —
 - `weight` (0 to 1) is how strongly the theme recurs across the observed set.
 - `confidence` scales with the number of observations supporting the theme, so a profile built on 6 discards is correctly weaker than one built on 200, and the engine does not over-fit to a tiny sample.
 
-**Use.** Each generation run takes the current `taste-profile` as input. High-weight, high-confidence `rejected_*` entries suppress matching candidates before they are emitted; `preferred_*` entries bias ranking. The profile is one record per creator, recomputed in place — not an ever-growing prompt.
+**Use.** Each generation run takes the current `taste-profile` as input. High-weight, high-confidence `rejected_*` entries suppress matching candidates before they are emitted; `preferred_*` entries bias ranking. The profile is one record per creator, recomputed in place, not an ever-growing prompt.
 
 This is what makes the engine improve with use, and it is the creator's switching cost: the profile is theirs, and a competitor's tool starts from zero taste data.
 
@@ -74,19 +74,19 @@ This is what makes the engine improve with use, and it is the creator's switchin
 
 A generation run sends two context blocks to the model:
 
-1. **Cacheable block** — the large, stable context: the bucket sources (top content, transcripts, filtered comments and DMs), audience demographics, the creator's voice fingerprint. This block is marked cacheable so repeat runs in a session reuse it at no input cost.
-2. **Non-cached block** — the run instruction, the current `taste-profile`, and the recent `idea-discard` set.
+1. **Cacheable block** holds the large, stable context: the bucket sources (top content, transcripts, filtered comments and DMs), audience demographics, the creator's voice fingerprint. This block is marked cacheable so repeat runs in a session reuse it at no input cost.
+2. **Non-cached block** holds the run instruction, the current `taste-profile`, and the recent `idea-discard` set.
 
 The taste profile and the discards go in the **non-cached** block on purpose. They change every time the creator discards an idea. If they were in the cacheable block, every discard would invalidate the cache and the next run would pay full input cost. Keeping the volatile learning signal out of the cached block is what keeps the engine cheap to run at scale.
 
 ## Open-core boundary
 
-This file specifies the *mechanism* — the buckets, the flow, the discard loop, the compounding-profile math, the cache layout. The mechanism is open; anyone can build the engine from this spec.
+This file specifies the *mechanism*: the buckets, the flow, the discard loop, the compounding-profile math, the cache layout. The mechanism is open; anyone can build the engine from this spec.
 
 Three things are deliberately not in this repo:
 
-- The **calibrated noise-filter corpora** — the per-market, per-language pattern libraries that make the pre-filter sharp. The substrate ships the filter *interface* and a generic seed (`idea-engine/pre-filter.md`); the calibrated corpora live in the runtime layer.
-- The **calibrated generation prompt** — the tuned model instruction. The substrate specifies what it must do; the tuned text lives in the runtime layer.
-- The **per-creator `taste-profile` data** — the creator's own accumulated preference data. It belongs to the creator and is hosted in their runtime, never published.
+- The **calibrated noise-filter corpora:** the per-market, per-language pattern libraries that make the pre-filter sharp. The substrate ships the filter *interface* and a generic seed (`idea-engine/pre-filter.md`); the calibrated corpora live in the runtime layer.
+- The **calibrated generation prompt:** the tuned model instruction. The substrate specifies what it must do; the tuned text lives in the runtime layer.
+- The **per-creator `taste-profile` data:** the creator's own accumulated preference data. It belongs to the creator and is hosted in their runtime, never published.
 
 A generic build from this spec works. A build with calibrated corpora and a populated taste profile works better. The gap between the two is the runtime layer's job, not a gap in this spec.

--- a/skills/influencer-pack/idea-engine/mechanism.md
+++ b/skills/influencer-pack/idea-engine/mechanism.md
@@ -1,0 +1,92 @@
+# Idea engine: mechanism
+
+The idea engine is the influencer pack's content-generation spine. It proposes new content ideas to the creator, and it does two things a generic AI idea generator does not:
+
+1. **Every idea is grounded in real audience evidence.** No proposed idea exists without a verbatim quote from a real comment, DM, or piece of the creator's own content behind it. The enforcing pattern is `decision-audit/evidence-grounding.md`.
+2. **The engine learns the creator's taste.** Every idea the creator discards is logged with a reason and folded into a compounding `taste-profile`. Later generations read that profile and stop proposing what the creator keeps rejecting.
+
+The engine reads from the typed-memory layer (`content-piece`, `dm-conversation`, `audience-question`) and writes `content-idea`, `idea-discard`, and `taste-profile` records back to it.
+
+## The three buckets
+
+Every generation run produces ideas in three buckets, because the three source surfaces carry different signal:
+
+| Bucket | Source | What it surfaces |
+|---|---|---|
+| `audience-comments` | `dm-conversation` records with `subtype: comment`, plus `audience-question` | Recurring public questions and reactions — what the audience asks out loud |
+| `audience-dms` | `dm-conversation` records (direct messages) | Private, higher-intent questions — what the audience will not ask in public |
+| `top-content` | `content-piece` records ranked by engagement | What already worked — ideas are evolutions, not repeats |
+
+A bucket can come back with fewer ideas than its target, or empty. Quality is the gate, not the count. An empty bucket is a valid result; a padded bucket is a defect.
+
+## Generation flow
+
+One generation run, per platform:
+
+1. **Pull** the bucket sources from the typed-memory layer for the lookback window.
+2. **Pre-filter** the comment and DM text through the noise filter (`idea-engine/pre-filter.md`) so adoration, bot, and trivial messages never reach the model. This is a cost control and a signal control.
+3. **Group into patterns.** The model reads the full filtered set and groups it by recurring theme. Three differently-worded versions of the same question are one pattern, one idea — not three.
+4. **Ground each idea in evidence.** Each candidate idea must carry at least one verbatim quote and at least one basis FK to the real record it came from. A candidate that cannot cite real evidence is dropped, not softened.
+5. **Emit `content-idea` records** in the three-block shape below.
+6. **Apply the taste profile.** The creator's current `taste-profile` is passed into the run; the model suppresses angles, formats, and topics the profile marks as rejected.
+
+### The three-block idea shape
+
+Every `content-idea` carries three blocks the creator can scan in seconds:
+
+- **Evidence** — the verbatim quotes from real comments, DMs, or captions that motivated the idea.
+- **Why it is good** — one or two sentences: the pain, curiosity, or audience segment it serves.
+- **Suggested angle** — hook, body focus, and close. The angle, not a finished script. The creator writes the script in their own voice.
+
+## Evidence grounding
+
+The engine is forbidden from inventing audience demand. Every `content-idea` is rejected at write time unless it carries a non-empty `evidence_quotes` list and at least one `basis_*` FK to a real record. Raw IDs and hashes are never written into human-facing text fields; an ID-strip backstop removes any that leak. The full rule, the write-time gate, and the audit trail are in `decision-audit/evidence-grounding.md`.
+
+This is the difference between a tool the creator trusts and one that quietly hallucinates what the audience wants.
+
+## The discard loop
+
+When the creator rejects a proposed idea:
+
+1. The engine writes an `idea-discard` record with the rejection `reason_code`, an optional note, and a frozen snapshot of the idea's angle, bucket, and platform.
+2. The source `content-idea` record's `status` is set to `discarded`.
+3. The next generation run reads recent discards and the `taste-profile` (below). It does not re-propose a discarded idea or a near-variant of one.
+
+The discard is not a thumbs-down that disappears. It is a durable, reasoned signal. `idea-discard` records are retained indefinitely (`retention/defaults.md`) precisely because they are the engine's training data.
+
+## The compounding taste profile
+
+A naive engine feeds the last N discards into the prompt as a "do not repeat" list. That is anti-repetition, not learning: it works at 50 discards and degrades into noise at 500.
+
+The idea engine compounds discards into a structured `taste-profile` instead — a weighted, confidence-scored model of the creator's preferences, recomputed on a cadence rather than regrown every run.
+
+**Recompute.** On a schedule (default weekly) and on demand, the engine reads the creator's accumulated `idea-discard` records and accepted or published `content-idea` records, and recomputes the `taste-profile`:
+
+- Each recurring rejection theme becomes a `rejected_angles` / `rejected_formats` / `rejected_topics` entry. Each recurring acceptance theme becomes a `preferred_*` entry.
+- `weight` (0 to 1) is how strongly the theme recurs across the observed set.
+- `confidence` scales with the number of observations supporting the theme, so a profile built on 6 discards is correctly weaker than one built on 200, and the engine does not over-fit to a tiny sample.
+
+**Use.** Each generation run takes the current `taste-profile` as input. High-weight, high-confidence `rejected_*` entries suppress matching candidates before they are emitted; `preferred_*` entries bias ranking. The profile is one record per creator, recomputed in place — not an ever-growing prompt.
+
+This is what makes the engine improve with use, and it is the creator's switching cost: the profile is theirs, and a competitor's tool starts from zero taste data.
+
+## Prompt-cache architecture
+
+A generation run sends two context blocks to the model:
+
+1. **Cacheable block** — the large, stable context: the bucket sources (top content, transcripts, filtered comments and DMs), audience demographics, the creator's voice fingerprint. This block is marked cacheable so repeat runs in a session reuse it at no input cost.
+2. **Non-cached block** — the run instruction, the current `taste-profile`, and the recent `idea-discard` set.
+
+The taste profile and the discards go in the **non-cached** block on purpose. They change every time the creator discards an idea. If they were in the cacheable block, every discard would invalidate the cache and the next run would pay full input cost. Keeping the volatile learning signal out of the cached block is what keeps the engine cheap to run at scale.
+
+## Open-core boundary
+
+This file specifies the *mechanism* — the buckets, the flow, the discard loop, the compounding-profile math, the cache layout. The mechanism is open; anyone can build the engine from this spec.
+
+Three things are deliberately not in this repo:
+
+- The **calibrated noise-filter corpora** — the per-market, per-language pattern libraries that make the pre-filter sharp. The substrate ships the filter *interface* and a generic seed (`idea-engine/pre-filter.md`); the calibrated corpora live in the runtime layer.
+- The **calibrated generation prompt** — the tuned model instruction. The substrate specifies what it must do; the tuned text lives in the runtime layer.
+- The **per-creator `taste-profile` data** — the creator's own accumulated preference data. It belongs to the creator and is hosted in their runtime, never published.
+
+A generic build from this spec works. A build with calibrated corpora and a populated taste profile works better. The gap between the two is the runtime layer's job, not a gap in this spec.

--- a/skills/influencer-pack/idea-engine/pre-filter.md
+++ b/skills/influencer-pack/idea-engine/pre-filter.md
@@ -2,10 +2,10 @@
 
 Before any comment or DM text reaches the generation model, the idea engine runs it through a noise filter. The filter does two jobs:
 
-- **Cost control.** A creator with an engaged audience receives a large volume of low-substance messages — pure adoration, one-word reactions, automated funnel messages. Sending those to the model is paid input tokens for zero signal.
+- **Cost control.** A creator with an engaged audience receives a large volume of low-substance messages: pure adoration, one-word reactions, automated funnel messages. Sending those to the model is paid input tokens for zero signal.
 - **Signal control.** The model proposes better ideas when it reads substance, not noise. Adoration and bot text dilute the pattern-grouping step.
 
-This file specifies the filter *interface* and the generic rule set. The calibrated, per-language pattern corpora that make the filter sharp are not in this repo — see "Open-core boundary" below.
+This file specifies the filter *interface* and the generic rule set. The calibrated, per-language pattern corpora that make the filter sharp are not in this repo. See "Open-core boundary" below.
 
 ## Interface
 
@@ -25,16 +25,16 @@ is_likely_automated(text) -> bool
     auto-replies, link-only or contact-only messages.
 ```
 
-Text that fails its predicate is excluded from the generation context. It is not deleted from the typed-memory layer — the `dm-conversation` record stays; it is simply not passed to the model for this run.
+Text that fails its predicate is excluded from the generation context. It is not deleted from the typed-memory layer. The `dm-conversation` record stays; it is simply not passed to the model for this run.
 
 ## Generic rule set
 
-The substrate ships this generic, language-agnostic seed. It is deliberately conservative — it drops only clear noise:
+The substrate ships this generic, language-agnostic seed. It is deliberately conservative; it drops only clear noise:
 
 - **Drop** text that is only emoji or punctuation.
 - **Drop** text that is only a URL, only an email address, or only a contact handle.
 - **Drop** text that, after trimming generic praise tokens, has fewer than ~15 characters of remaining substance.
-- **Keep** any text containing a question mark — a question is strong signal even when short.
+- **Keep** any text containing a question mark, since a question is strong signal even when short.
 - **Drop** text matching the automated-message rules (funnel-onboarding phrasing, keyword auto-reply triggers, "link in bio" style calls to action).
 
 A run never drops a `content-piece` caption or transcript through this filter. The filter applies to *audience* text (comments, DMs), not the creator's own content.
@@ -48,6 +48,6 @@ Two calibration inputs sharpen the filter beyond the generic seed, and both are 
 
 ## Open-core boundary
 
-The interface and the generic rule set above are open — they are the pattern, and they are enough to build a working filter.
+The interface and the generic rule set above are open: they are the pattern, and they are enough to build a working filter.
 
-The **calibrated corpora** — the per-language adoration and bot pattern libraries, and the per-creator automation vocabulary — are not in this repo. They are calibrated against real audience data, they are the difference between a filter that catches obvious noise and one that catches most of it, and they live in the runtime layer. See `idea-engine/mechanism.md` "Open-core boundary".
+The **calibrated corpora** (the per-language adoration and bot pattern libraries, and the per-creator automation vocabulary) are not in this repo. They are calibrated against real audience data, they are the difference between a filter that catches obvious noise and one that catches most of it, and they live in the runtime layer. See `idea-engine/mechanism.md` "Open-core boundary".

--- a/skills/influencer-pack/idea-engine/pre-filter.md
+++ b/skills/influencer-pack/idea-engine/pre-filter.md
@@ -1,0 +1,53 @@
+# Idea engine: pre-filter
+
+Before any comment or DM text reaches the generation model, the idea engine runs it through a noise filter. The filter does two jobs:
+
+- **Cost control.** A creator with an engaged audience receives a large volume of low-substance messages — pure adoration, one-word reactions, automated funnel messages. Sending those to the model is paid input tokens for zero signal.
+- **Signal control.** The model proposes better ideas when it reads substance, not noise. Adoration and bot text dilute the pattern-grouping step.
+
+This file specifies the filter *interface* and the generic rule set. The calibrated, per-language pattern corpora that make the filter sharp are not in this repo — see "Open-core boundary" below.
+
+## Interface
+
+The filter exposes three predicates. A generation run calls them over every candidate comment and DM before the pattern-grouping step.
+
+```
+is_substantive_comment(text) -> bool
+    True if the comment carries enough substance to inform an idea.
+
+is_substantive_dm(text) -> bool
+    True if the direct message carries enough substance to inform an idea.
+    More permissive than the comment predicate (DMs are higher-intent by
+    default) but adds an automated-message check.
+
+is_likely_automated(text) -> bool
+    True if the text looks machine-generated: funnel onboarding, keyword
+    auto-replies, link-only or contact-only messages.
+```
+
+Text that fails its predicate is excluded from the generation context. It is not deleted from the typed-memory layer — the `dm-conversation` record stays; it is simply not passed to the model for this run.
+
+## Generic rule set
+
+The substrate ships this generic, language-agnostic seed. It is deliberately conservative — it drops only clear noise:
+
+- **Drop** text that is only emoji or punctuation.
+- **Drop** text that is only a URL, only an email address, or only a contact handle.
+- **Drop** text that, after trimming generic praise tokens, has fewer than ~15 characters of remaining substance.
+- **Keep** any text containing a question mark — a question is strong signal even when short.
+- **Drop** text matching the automated-message rules (funnel-onboarding phrasing, keyword auto-reply triggers, "link in bio" style calls to action).
+
+A run never drops a `content-piece` caption or transcript through this filter. The filter applies to *audience* text (comments, DMs), not the creator's own content.
+
+## Calibration is per-creator
+
+Two calibration inputs sharpen the filter beyond the generic seed, and both are gathered at install, not shipped in this repo:
+
+- **Language and market corpora.** Adoration phrasing, praise tokens, and bot patterns are language- and market-specific. The generic seed catches obvious noise in any language; a corpus tuned to the creator's actual audience language catches far more.
+- **The creator's own automation vocabulary.** If the creator runs a chatbot or a funnel, its stock phrases appear inside their own DM threads. The install step asks the creator for the names and stock phrases of their bots, courses, and funnels, and adds them to the automated-message rules so the engine does not mistake the creator's own funnel output for audience signal.
+
+## Open-core boundary
+
+The interface and the generic rule set above are open — they are the pattern, and they are enough to build a working filter.
+
+The **calibrated corpora** — the per-language adoration and bot pattern libraries, and the per-creator automation vocabulary — are not in this repo. They are calibrated against real audience data, they are the difference between a filter that catches obvious noise and one that catches most of it, and they live in the runtime layer. See `idea-engine/mechanism.md` "Open-core boundary".

--- a/skills/influencer-pack/retention/defaults.md
+++ b/skills/influencer-pack/retention/defaults.md
@@ -22,7 +22,7 @@ The defaults below balance creator workflow needs against platform terms-of-serv
 | `voice-fingerprint-audio` | creator-controlled | encrypted, retention is whatever the creator decides |
 | `audience-question` | indefinite | question patterns persist across years |
 | `content-idea` | indefinite | the creator's content-roadmap history; cheap to keep |
-| `idea-discard` | indefinite | the idea engine's training signal — must never auto-archive, or the taste profile loses its basis |
+| `idea-discard` | indefinite | the idea engine's training signal; must never auto-archive, or the taste profile loses its basis |
 | `taste-profile` | indefinite | one living record per creator, recomputed in place |
 
 ## Jurisdictional overrides

--- a/skills/influencer-pack/retention/defaults.md
+++ b/skills/influencer-pack/retention/defaults.md
@@ -21,6 +21,9 @@ The defaults below balance creator workflow needs against platform terms-of-serv
 | `voice-fingerprint` (written) | indefinite | recompute is expensive; keep until the creator changes voice deliberately |
 | `voice-fingerprint-audio` | creator-controlled | encrypted, retention is whatever the creator decides |
 | `audience-question` | indefinite | question patterns persist across years |
+| `content-idea` | indefinite | the creator's content-roadmap history; cheap to keep |
+| `idea-discard` | indefinite | the idea engine's training signal — must never auto-archive, or the taste profile loses its basis |
+| `taste-profile` | indefinite | one living record per creator, recomputed in place |
 
 ## Jurisdictional overrides
 

--- a/skills/influencer-pack/schema/typed-memory-categories.md
+++ b/skills/influencer-pack/schema/typed-memory-categories.md
@@ -1,8 +1,10 @@
 # Influencer pack: typed-memory categories
 
-Nine categories ship with the influencer pack. Each category lists the required frontmatter that the substrate enforces at write time, plus optional frontmatter that downstream queries depend on.
+Twelve categories ship with the influencer pack. Each category lists the required frontmatter that the substrate enforces at write time, plus optional frontmatter that downstream queries depend on.
 
 A document that does not match its declared category schema is rejected at write time and surfaced as a recoverable error to the operator.
+
+The final three categories — `content-idea`, `idea-discard`, `taste-profile` — back the idea engine, the pack's content-generation spine. See `idea-engine/mechanism.md`.
 
 ## audience-segment
 
@@ -170,3 +172,67 @@ transcript_word_count: required, integer
 why_kept: required, one of [reference, inspiration, competitive-analysis, repurposing-input, fact-check]
 linked_content: optional, list of content_id FKs (when this source informed a published piece)
 ```
+
+## content-idea
+
+A single generated content idea: one proposed Reel, carousel, video, or newsletter, grounded in real audience evidence. The output unit of the idea engine. Every `content-idea` must trace to at least one real audience record; an idea with no evidence is rejected at write time (see `decision-audit/evidence-grounding.md`).
+
+```yaml
+type: content-idea
+idea_id: required, unique within tenant
+generated_date: required, ISO 8601
+batch_id: required (groups every idea emitted by one generation run)
+source_bucket: required, one of [audience-comments, audience-dms, top-content]
+platforms: required, list, subset of [instagram, tiktok, youtube, substack, x, linkedin]
+angle: required, one-line thesis of the idea (no raw IDs or hashes in this field)
+format: required, one of [reel, carousel, image-post, story, short, long-video, newsletter, thread, post]
+evidence_quotes: required, non-empty list of verbatim quotes from real audience records
+why_good: required, 1-2 sentences (the pain, curiosity, or segment the idea serves)
+suggested_angle: required, hook + body focus + close (the angle, not a full script)
+basis_content_ids: optional, list of content-piece FKs
+basis_conversation_ids: optional, list of dm-conversation FKs
+basis_question_ids: optional, list of audience-question FKs
+status: required, one of [proposed, accepted, discarded, published]
+linked_content: optional, FK to content-piece once the idea is published
+```
+
+At least one of `basis_content_ids`, `basis_conversation_ids`, `basis_question_ids` must be non-empty, and `evidence_quotes` must be non-empty. The substrate rejects a `content-idea` that fails either condition. This is the evidence-grounding invariant; the enforcing pattern is `decision-audit/evidence-grounding.md`.
+
+## idea-discard
+
+The record of a creator rejecting a generated idea, with the reason. The idea engine's learning signal: every discard feeds the `taste-profile` recompute so future generations stop proposing what the creator keeps rejecting.
+
+```yaml
+type: idea-discard
+discard_id: required, unique within tenant
+idea_id: required, FK to content-idea
+discarded_date: required, ISO 8601
+reason_code: required, one of [topic-covered, not-interested, too-basic, off-voice, wrong-format, other]
+reason_note: optional, free text the creator adds
+angle_snapshot: required (the discarded idea's angle, frozen so the signal survives if the content-idea record is later archived)
+source_bucket: required (frozen from the discarded idea)
+platform: required (frozen from the discarded idea)
+```
+
+`angle_snapshot`, `source_bucket`, and `platform` are copied (frozen) onto the discard record rather than read through the FK, so the learning signal survives independently of the `content-idea` it came from.
+
+## taste-profile
+
+The compounding model of one creator's idea preferences, recomputed from their accumulated `idea-discard` and accepted `content-idea` records. This is what makes the idea engine learn: a weighted, confidence-scored model, not a rolling list of recent rejections. Distinct from `voice-fingerprint` — that models how the creator *writes*; this models what the creator wants to *make*.
+
+```yaml
+type: taste-profile
+profile_id: required, unique within tenant (one active profile per creator)
+updated_date: required, ISO 8601
+discards_observed: required, integer (count of idea-discard records folded into this profile)
+accepts_observed: required, integer (count of accepted or published content-idea records folded in)
+rejected_angles: required, list of {pattern, weight, confidence} entries
+rejected_formats: required, list of {format, weight, confidence} entries
+rejected_topics: required, list of {topic, weight, confidence} entries
+preferred_angles: required, list of {pattern, weight, confidence} entries
+preferred_formats: required, list of {format, weight, confidence} entries
+preferred_topics: required, list of {topic, weight, confidence} entries
+recompute_basis: required, list of idea-discard and content-idea FKs folded in the most recent recompute
+```
+
+`weight` is how strongly a signal recurs (0 to 1); `confidence` scales with how many observations support it, so a profile built on 6 discards is correctly treated as weaker than one built on 200. The recompute cadence and the weighting math are in `idea-engine/mechanism.md`.

--- a/skills/influencer-pack/schema/typed-memory-categories.md
+++ b/skills/influencer-pack/schema/typed-memory-categories.md
@@ -4,7 +4,7 @@ Twelve categories ship with the influencer pack. Each category lists the require
 
 A document that does not match its declared category schema is rejected at write time and surfaced as a recoverable error to the operator.
 
-The final three categories — `content-idea`, `idea-discard`, `taste-profile` — back the idea engine, the pack's content-generation spine. See `idea-engine/mechanism.md`.
+The final three categories (`content-idea`, `idea-discard`, `taste-profile`) back the idea engine, the pack's content-generation spine. See `idea-engine/mechanism.md`.
 
 ## audience-segment
 
@@ -218,7 +218,7 @@ platform: required (frozen from the discarded idea)
 
 ## taste-profile
 
-The compounding model of one creator's idea preferences, recomputed from their accumulated `idea-discard` and accepted `content-idea` records. This is what makes the idea engine learn: a weighted, confidence-scored model, not a rolling list of recent rejections. Distinct from `voice-fingerprint` — that models how the creator *writes*; this models what the creator wants to *make*.
+The compounding model of one creator's idea preferences, recomputed from their accumulated `idea-discard` and accepted `content-idea` records. This is what makes the idea engine learn: a weighted, confidence-scored model, not a rolling list of recent rejections. Distinct from `voice-fingerprint`, which models how the creator *writes*; this models what the creator wants to *make*.
 
 ```yaml
 type: taste-profile


### PR DESCRIPTION
## Summary

Re-centers the influencer-pack on the **idea engine**, its content-generation spine: an evidence-grounded, taste-learning content-idea generator.

- New `idea-engine/mechanism.md` (three buckets, generation flow, discard loop, compounding taste profile, prompt-cache layout) and `idea-engine/pre-filter.md` (generic noise-filter interface).
- New `decision-audit/evidence-grounding.md`: no real quote means no idea, gated at write time and generation time, with an ID-strip backstop.
- Schema: adds `content-idea`, `idea-discard`, `taste-profile` categories (9 to 12).
- Retention: `idea-discard` kept indefinitely (it is the engine's training signal).
- `SKILL.md` / `README.md` re-centered on the engine.

Open-core boundary: the mechanism and schema are public; calibrated generation prompts, per-language filter corpora, and per-creator taste data stay in the runtime layer.

## Test plan

- [ ] `lint` CI green (privacy scan, syntax checks, integration tests)
- [ ] Schema has 12 categories; cross-references to `idea-engine/*` and `decision-audit/evidence-grounding.md` resolve
- [ ] No personal-data tokens (verified locally; CI privacy job re-checks added lines)
- [ ] Pack files em-dash-free, consistent with the existing 17 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)