### PR TITLE
fix(close-cascade): resolve session artifacts to main vault from a worktree

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -314,3 +314,38 @@ jobs:
             done
           done < <(grep -rn -E '`scripts/[A-Za-z0-9_./-]+\.(sh|ps1|py|plist)`' phases/ 2>/dev/null || true)
           [ -f /tmp/lint-ref-fail ] && exit 1 || exit 0
+
+  detect-closing-signal-worktree:
+    name: detect-closing-signal resolves to main vault from a worktree
+    runs-on: ubuntu-latest
+    # Catches the session-artifact stranding bug class: the UserPromptSubmit
+    # close-cascade hook (hooks/detect-closing-signal.py) set vault_root from
+    # its cwd, so when the cascade fired inside a worktree the session file,
+    # Decisions, Captures and Time Tracking all resolved worktree-side and
+    # were discarded when the worktree was archived. Same class as the
+    # worktree-session-close job (#65) but for Layer 1 of the cascade, not the
+    # Stop hook. Test asserts the resolved session file lands in the MAIN
+    # vault, never under .claude/worktrees/, and the worktree slug is kept.
+    # No untrusted user input is referenced in any run: command.
+    steps:
+      - uses: actions/checkout@v6
+      - name: run integration test
+        run: bash tests/integration/test_detect_closing_signal_worktree.sh
+
+  stranded-session-artifacts-watchdog:
+    name: stranded-session-artifacts watchdog detects uncommitted worktree writes
+    runs-on: ubuntu-latest
+    # Layer 3 of the stranding defense: hooks/surface-stranded-session-artifacts.py
+    # is a SessionStart watchdog that flags session artifacts left uncommitted
+    # inside a worktree (which the archive step would discard). Test asserts it
+    # detects an uncommitted session file, names the offending worktree, stays
+    # silent when worktrees are clean, and does not flag committed artifacts.
+    # No untrusted user input is referenced in any run: command.
+    steps:
+      - uses: actions/checkout@v6
+      - name: configure git identity
+        run: |
+          git config --global user.email "ci@example.com"
+          git config --global user.name "ci"
+      - name: run integration test
+        run: bash tests/integration/test_stranded_session_artifacts_watchdog.sh

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,23 @@ description: What's new in AI Brain Starter — plain English, no jargon
 
 ---
 
+## 2026-05-17: the session-close cascade no longer strands artifacts in a worktree
+
+**Who this affects:** anyone who uses git worktrees and runs the session-close cascade.
+
+When you said "bye" or "wrapping up" from inside a worktree, the close cascade pre-resolved the session file, Decisions, Captures and Time Tracking to the *worktree's* own `Meta/` folder, not the main vault. A worktree sits on a throwaway `claude/<slug>` branch, so when the worktree was archived those writes showed up as "uncommitted changes that will be permanently discarded." Session history was silently lost.
+
+PR #66 fixed this same bug class for the Stop hook (`session-end-hook.sh`). It was never fixed for the UserPromptSubmit hook (`detect-closing-signal.py`), the Layer 1 hook that pre-resolves the paths the model writes to. This release closes that gap.
+
+**What changed:**
+- `detect-closing-signal.py` gains `resolve_main_vault()`. When the cascade fires inside a worktree, the vault root is collapsed back to the main vault before any artifact path is resolved. Session files keep the worktree slug in their filename; only the directory changes to the main vault. Mirrors the `resolve_main_vault()` already in `session-end-hook.sh`.
+- New SessionStart watchdog `surface-stranded-session-artifacts.py`. It scans every worktree for session artifacts left uncommitted and surfaces them loudly at the next session start, before they can be archived away. This is the uncommitted-changes companion to `surface-orphan-claude-branches.py`, which already covers committed-but-unmerged commits on `claude/*` branches.
+- Two new CI tests (`test_detect_closing_signal_worktree.sh`, `test_stranded_session_artifacts_watchdog.sh`) enforce both invariants and fail on revert.
+
+**What you should do:** nothing required, the auto-update picks it up. To wire the new watchdog into your SessionStart hooks immediately, re-run `bash ~/.claude/skills/ai-brain-starter/bootstrap.sh` (idempotent).
+
+---
+
 ## 2026-05-14: install hardening — slash commands actually appear in the palette + activation in this session + capture everything
 
 **Who this affects:** anyone who installed before today. Twelve PRs landed today that fix gaps in the install flow. The most user-visible:

--- a/hooks.json
+++ b/hooks.json
@@ -148,6 +148,11 @@
             "type": "command",
             "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/surface-orphan-claude-branches.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'",
             "statusMessage": "Checking for orphan claude/* branches..."
+          },
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/surface-stranded-session-artifacts.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'",
+            "statusMessage": "Checking worktrees for stranded session artifacts..."
           }
         ]
       }

--- a/hooks/detect-closing-signal.py
+++ b/hooks/detect-closing-signal.py
@@ -40,7 +40,9 @@ Or via absolute path during install:
   python3 ~/.claude/skills/ai-brain-starter/hooks/detect-closing-signal.py
 
 Environment variables (all optional):
-  VAULT_ROOT — vault path. Defaults to cwd.
+  VAULT_ROOT — vault path. Defaults to cwd. Worktree paths are collapsed to
+               the main vault root so session artifacts never strand on a
+               worktree (see resolve_main_vault).
   CLOSING_SIGNAL_LANGS — comma-separated language packs to load (default: en,es,pt)
   CLOSING_SIGNAL_DETECTION — "regex" (default) or "hybrid" (regex + Haiku fallback)
   CLOSING_SIGNAL_DEBUG — set to 1 for stderr trace
@@ -283,6 +285,30 @@ def derive_worktree(cwd: Path) -> str:
         except OSError:
             pass
     return "main"
+
+
+def resolve_main_vault(path: Path) -> Path:
+    """Collapse a worktree path to the MAIN vault root.
+
+    If `path` is inside `<vault>/.claude/worktrees/<slug>/...`, return
+    `<vault>` — the main vault root. Otherwise return `path` unchanged.
+
+    Session artifacts (the session file, Decisions/, Captures, Time
+    Tracking) MUST land in the main vault. A worktree's own checkout sits
+    on a throwaway `claude/<slug>` branch; anything written there is
+    discarded when the worktree is archived. The close cascade can fire
+    from inside a worktree, so the cwd-derived vault root must be
+    collapsed back to main before any artifact path is resolved.
+
+    Mirrors resolve_main_vault() in scripts/session-end-hook.sh — the same
+    fix applied to the Stop hook for issue #65 / PR #66. This hook (the
+    UserPromptSubmit Layer 1 of the cascade) was never brought to parity.
+    """
+    marker = "/.claude/worktrees/"
+    text = str(path)
+    if marker in text:
+        return Path(text.split(marker, 1)[0])
+    return path
 
 
 def find_meta_dir(vault_root: Path) -> Path:
@@ -666,7 +692,13 @@ def main() -> int:
             emit_passthrough()
             return 0
 
-        vault_root = Path(os.environ.get("VAULT_ROOT", str(cwd)))
+        # Resolve the vault root. When the close cascade fires from inside a
+        # worktree, cwd IS the worktree; resolve_main_vault collapses it back
+        # so every session artifact lands in the main vault, never a throwaway
+        # claude/<slug> branch that gets discarded when the worktree archives.
+        vault_root = resolve_main_vault(
+            Path(os.environ.get("VAULT_ROOT") or cwd)
+        )
 
         langs = [
             x.strip() for x in

--- a/hooks/surface-stranded-session-artifacts.py
+++ b/hooks/surface-stranded-session-artifacts.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""SessionStart hook: surface session artifacts left UNCOMMITTED in a worktree.
+
+A worktree's own checkout sits on a throwaway `claude/<slug>` branch. Anything
+written there and not committed is discarded when the worktree is archived
+("N uncommitted changes that will be permanently discarded"). Session files,
+Decisions, Captures and Time Tracking belong in the MAIN vault.
+
+detect-closing-signal.py resolves close-cascade writes to the main vault
+(resolve_main_vault). This hook is the Layer 3 canary: at the NEXT session
+start it scans every worktree for uncommitted session artifacts and surfaces
+them loudly, so a slip-through is caught the next day instead of silently
+discarded weeks later.
+
+Complements surface-orphan-claude-branches.py:
+  - that hook : committed-but-unmerged commits on claude/* branches.
+  - this hook : uncommitted changes in a worktree working dir.
+
+Output: silent when clean. One systemMessage block if any worktree holds
+uncommitted session artifacts.
+
+Performance: git status is pathspec-scoped to the Meta session dirs, so it
+never walks the full vault tree.
+
+Bypass: STRANDED_ARTIFACT_SURFACE_BYPASS=1 in env.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# Session-artifact paths under the vault's Meta dir. A worktree holding an
+# uncommitted change to any of these is at risk of losing it on archive.
+ARTIFACT_SUBPATHS = (
+    "Sessions",
+    "Decisions",
+    "Handoffs",
+    "Pending Team Broadcasts",
+    "Session Captures.md",
+    "Time Tracking.md",
+)
+
+
+def find_vault_root(cwd: Path) -> Path | None:
+    """Walk up to the vault root (a dir with .git/ and a Meta-ish folder).
+
+    If cwd is inside a worktree, reset to the main vault first. Mirrors
+    find_vault_root() in surface-orphan-claude-branches.py.
+    """
+    parts = cwd.parts
+    if ".claude" in parts:
+        idx = parts.index(".claude")
+        if idx + 1 < len(parts) and parts[idx + 1] == "worktrees":
+            if idx > 0:
+                cwd = Path(*parts[:idx])
+
+    p = cwd.resolve()
+    for _ in range(8):
+        if not p.is_dir():
+            break
+        if (p / ".git").exists():
+            try:
+                children = list(p.iterdir())
+            except OSError:
+                children = []
+            for child in children:
+                if child.is_dir() and child.name.endswith("Meta"):
+                    return p
+        parent = p.parent
+        if parent == p:
+            break
+        p = parent
+    return None
+
+
+def find_meta_name(worktree: Path) -> str | None:
+    """Return the Meta dir name inside a worktree (emoji prefix or plain)."""
+    for name in ("⚙️ Meta", "Meta"):
+        if (worktree / name).is_dir():
+            return name
+    return None
+
+
+def stranded_in_worktree(worktree: Path) -> list[str]:
+    """Return uncommitted session-artifact paths inside a worktree.
+
+    git status is scoped via pathspec to the Meta session dirs only, so it
+    does not walk the whole vault. Non-existent paths are filtered out up
+    front so git is never handed a pathspec that matches nothing.
+    """
+    meta = find_meta_name(worktree)
+    if meta is None:
+        return []
+
+    pathspecs = []
+    for sub in ARTIFACT_SUBPATHS:
+        if (worktree / meta / sub).exists():
+            pathspecs.append(f"{meta}/{sub}")
+    if not pathspecs:
+        return []
+
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(worktree), "-c", "core.quotePath=false",
+             "status", "--porcelain", "--"] + pathspecs,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return []
+    if result.returncode != 0:
+        return []
+
+    stranded = []
+    for line in result.stdout.splitlines():
+        if len(line) < 4:
+            continue
+        path = line[3:]
+        # Rename entries are "orig -> new"; the new path is what is at risk.
+        if " -> " in path:
+            path = path.split(" -> ", 1)[1]
+        stranded.append(path)
+    return stranded
+
+
+def main() -> int:
+    if os.environ.get("STRANDED_ARTIFACT_SURFACE_BYPASS"):
+        return 0
+
+    # SessionStart payload arrives on stdin (JSON). Drain so we never block.
+    try:
+        sys.stdin.read()
+    except Exception:
+        pass
+
+    vault = find_vault_root(Path.cwd())
+    if vault is None:
+        return 0
+
+    worktrees_dir = vault / ".claude" / "worktrees"
+    if not worktrees_dir.is_dir():
+        return 0
+
+    try:
+        worktrees = sorted(d for d in worktrees_dir.iterdir() if d.is_dir())
+    except OSError:
+        return 0
+
+    findings = []
+    for wt in worktrees:
+        stranded = stranded_in_worktree(wt)
+        if stranded:
+            findings.append((wt.name, stranded))
+
+    if not findings:
+        return 0
+
+    total = sum(len(files) for _, files in findings)
+    lines = []
+    for slug, files in findings:
+        shown = ", ".join(files[:6])
+        if len(files) > 6:
+            shown += f", +{len(files) - 6} more"
+        lines.append(f"  - {slug}: {shown}")
+
+    msg = (
+        f"[stranded-artifacts] {total} session artifact(s) sit UNCOMMITTED "
+        f"inside {len(findings)} worktree(s) - they will be discarded when the "
+        f"worktree is archived:\n"
+        + "\n".join(lines)
+        + "\n\nMove each to the main vault now: rewrite it at the main-vault "
+        "path, or `git -C <worktree> add` + commit then merge the branch home. "
+        "detect-closing-signal.py resolves close-cascade writes to the main "
+        "vault; this catches anything that slipped through. Sibling: "
+        "surface-orphan-claude-branches.py (committed-but-unmerged half)."
+    )
+    print(json.dumps({"systemMessage": msg}))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integration/test_detect_closing_signal_worktree.sh
+++ b/tests/integration/test_detect_closing_signal_worktree.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Test: detect-closing-signal.py resolves session-artifact paths to the MAIN
+# vault, even when the close cascade fires from inside a worktree.
+#
+# Bug class: the UserPromptSubmit hook set vault_root from its own cwd. Fired
+# inside <vault>/.claude/worktrees/<slug>/, cwd IS the worktree, so the
+# session file, decisions dir, captures and time-tracking all resolved
+# worktree-side. When the worktree was archived those writes were discarded
+# as "uncommitted changes" — session history silently lost.
+#
+# Same bug class as issue #65 (tests/integration/test_worktree_session_close.sh)
+# but for the UserPromptSubmit hook, not the Stop hook. PR #66 fixed the Stop
+# hook; this hook (Layer 1 of the cascade) was never brought to parity.
+#
+# Assertions:
+#   1. Fired from a worktree cwd, the resolved meta_dir is the MAIN vault's.
+#   2. The session file resolves under the MAIN vault, never .claude/worktrees/.
+#   3. The pre-built session shell is physically written to the MAIN vault.
+#   4. The worktree slug is still preserved in the session filename.
+#   5. Fired from a normal (non-worktree) cwd, paths resolve unchanged.
+#
+# Self-contained: tmpdir fake vault, HOME redirected so the marker file never
+# touches the real ~/.claude. Exit 0 = pass, 1 = fail with detail on stderr.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOK="$REPO_ROOT/hooks/detect-closing-signal.py"
+if [ ! -f "$HOOK" ]; then
+  echo "ERROR: $HOOK not found" >&2
+  exit 1
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+VAULT="$TMP/vault"
+WT="$VAULT/.claude/worktrees/test-slug"
+# A real worktree carries the vault's Meta/ tree (it is a git checkout of it),
+# so the fixture creates Meta/ on both the main vault and the worktree side.
+mkdir -p "$VAULT/Meta/Sessions" "$VAULT/Meta/Decisions"
+mkdir -p "$WT/Meta/Sessions" "$WT/Meta/Decisions"
+
+# run_hook <cwd> <session_id> -> echoes the marker file path the hook wrote.
+# VAULT_ROOT is explicitly unset so the hook exercises its cwd-based default
+# resolution (the path the real session-close cascade takes).
+run_hook() {
+  local cwd="$1" sid="$2" stdin_json
+  stdin_json=$(python3 -c "import json,sys; print(json.dumps({'prompt':sys.argv[1],'session_id':sys.argv[2],'cwd':sys.argv[3]}))" \
+    "let's close this session" "$sid" "$cwd")
+  printf '%s' "$stdin_json" | env -u VAULT_ROOT HOME="$TMP" python3 "$HOOK" >/dev/null 2>&1 || true
+  echo "$TMP/.claude/.closing-signal-${sid}.json"
+}
+
+marker_field() {
+  python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get(sys.argv[2],''))" "$1" "$2"
+}
+
+# --- Worktree case --------------------------------------------------------
+MARKER_WT="$(run_hook "$WT" "test-wt")"
+if [ ! -f "$MARKER_WT" ]; then
+  echo "FAIL: hook wrote no marker for the worktree run (close signal not detected?)" >&2
+  exit 1
+fi
+
+META_WT="$(marker_field "$MARKER_WT" meta_dir)"
+SESSION_WT="$(marker_field "$MARKER_WT" session_file)"
+
+if [ "$META_WT" != "$VAULT/Meta" ]; then
+  echo "FAIL: meta_dir resolved worktree-side, not to the main vault" >&2
+  echo "  expected: $VAULT/Meta" >&2
+  echo "  got:      $META_WT" >&2
+  exit 1
+fi
+echo "PASS: meta_dir resolves to the main vault from a worktree"
+
+case "$SESSION_WT" in
+  *"/.claude/worktrees/"*)
+    echo "FAIL: session file resolved inside the worktree (discarded on archive)" >&2
+    echo "  got: $SESSION_WT" >&2
+    exit 1
+    ;;
+esac
+case "$SESSION_WT" in
+  "$VAULT/Meta/Sessions/"*) ;;
+  *)
+    echo "FAIL: session file is not under the main vault Meta/Sessions/" >&2
+    echo "  got: $SESSION_WT" >&2
+    exit 1
+    ;;
+esac
+echo "PASS: session file resolves under the main vault, not the worktree"
+
+if [ ! -f "$SESSION_WT" ]; then
+  echo "FAIL: pre-built session shell was not written at $SESSION_WT" >&2
+  exit 1
+fi
+echo "PASS: session shell physically written to the main vault"
+
+case "$(basename "$SESSION_WT")" in
+  *-test-slug.md) ;;
+  *)
+    echo "FAIL: worktree slug lost from the session filename" >&2
+    echo "  got: $(basename "$SESSION_WT")" >&2
+    exit 1
+    ;;
+esac
+echo "PASS: worktree slug preserved in the session filename"
+
+# --- Non-worktree case (no regression) ------------------------------------
+MARKER_MAIN="$(run_hook "$VAULT" "test-main")"
+if [ ! -f "$MARKER_MAIN" ]; then
+  echo "FAIL: hook wrote no marker for the non-worktree run" >&2
+  exit 1
+fi
+
+META_MAIN="$(marker_field "$MARKER_MAIN" meta_dir)"
+SESSION_MAIN="$(marker_field "$MARKER_MAIN" session_file)"
+
+if [ "$META_MAIN" != "$VAULT/Meta" ]; then
+  echo "FAIL: non-worktree meta_dir resolution regressed" >&2
+  echo "  expected: $VAULT/Meta" >&2
+  echo "  got:      $META_MAIN" >&2
+  exit 1
+fi
+case "$SESSION_MAIN" in
+  "$VAULT/Meta/Sessions/"*) ;;
+  *)
+    echo "FAIL: non-worktree session file resolution regressed" >&2
+    echo "  got: $SESSION_MAIN" >&2
+    exit 1
+    ;;
+esac
+echo "PASS: non-worktree paths resolve unchanged (no regression)"
+
+echo
+echo "All assertions passed. detect-closing-signal.py worktree invariant holds."

--- a/tests/integration/test_stranded_session_artifacts_watchdog.sh
+++ b/tests/integration/test_stranded_session_artifacts_watchdog.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Test: surface-stranded-session-artifacts.py — SessionStart watchdog that
+# detects session artifacts left UNCOMMITTED inside a worktree.
+#
+# Bug class: when the close cascade wrote a session file / Decisions / Time
+# Tracking into a worktree's own checkout, those writes sat uncommitted and
+# were discarded when the worktree was archived ("N uncommitted changes that
+# will be permanently discarded"). detect-closing-signal.py now resolves
+# close-cascade writes to the main vault; this watchdog is the Layer 3 canary
+# that surfaces anything that still slips through, at the NEXT session start.
+#
+# Complements surface-orphan-claude-branches.py: that hook catches the
+# committed-but-unmerged half (commits on claude/* branches); this hook
+# catches the uncommitted half (changes in a worktree working dir).
+#
+# Assertions:
+#   1. Silent when every worktree is clean.
+#   2. Detects an uncommitted session file in a worktree, names that worktree.
+#   3. Does not flag a clean worktree.
+#   4. Does not flag a session artifact once it is committed (that is the
+#      sibling hook's job — this one is uncommitted-only).
+#
+# Self-contained: tmpdir fake vault + real git worktrees. Exit 0 = pass.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOK="$REPO_ROOT/hooks/surface-stranded-session-artifacts.py"
+if [ ! -f "$HOOK" ]; then
+  echo "FAIL: watchdog hook not found at $HOOK" >&2
+  exit 1
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+VAULT="$TMP/vault"
+mkdir -p "$VAULT"
+cd "$VAULT"
+git init --quiet --initial-branch=master
+git config user.email "test@example.com"
+git config user.name "Test"
+
+mkdir -p "Meta/Sessions" "Meta/Decisions"
+echo "committed session" > "Meta/Sessions/2026-01-01T00-00-main.md"
+echo "# vault" > README.md
+git add -A
+git commit --quiet -m "init"
+
+# Two worktrees: one will get a stranded artifact, one stays clean.
+git worktree add --quiet -b claude/wt-stranded ".claude/worktrees/wt-stranded"
+git worktree add --quiet -b claude/wt-clean ".claude/worktrees/wt-clean"
+
+# run_watchdog -> echoes the systemMessage text ("" when the hook is silent)
+run_watchdog() {
+  printf '{}' | python3 "$HOOK" 2>/dev/null \
+    | python3 -c "import json,sys; raw=sys.stdin.read().strip(); print(json.loads(raw).get('systemMessage','') if raw else '')"
+}
+
+# --- Assertion 1: clean state -> silent ----------------------------------
+cd "$VAULT"
+OUT="$(run_watchdog)"
+if [ -n "$OUT" ]; then
+  echo "FAIL: watchdog flagged something when all worktrees are clean" >&2
+  echo "  got: $OUT" >&2
+  exit 1
+fi
+echo "PASS: watchdog silent when no artifacts are stranded"
+
+# --- Assertion 2: strand a session file -> detected ----------------------
+echo "stranded session body" \
+  > "$VAULT/.claude/worktrees/wt-stranded/Meta/Sessions/2026-05-17T12-00-wt-stranded.md"
+cd "$VAULT"
+OUT="$(run_watchdog)"
+if [ -z "$OUT" ]; then
+  echo "FAIL: watchdog did not detect the uncommitted session file in wt-stranded" >&2
+  exit 1
+fi
+case "$OUT" in
+  *wt-stranded*) ;;
+  *)
+    echo "FAIL: watchdog message did not name the wt-stranded worktree" >&2
+    echo "  got: $OUT" >&2
+    exit 1
+    ;;
+esac
+echo "PASS: watchdog detects an uncommitted session file in a worktree"
+
+# --- Assertion 3: the clean worktree must NOT be named -------------------
+case "$OUT" in
+  *wt-clean*)
+    echo "FAIL: watchdog falsely flagged the clean worktree" >&2
+    echo "  got: $OUT" >&2
+    exit 1
+    ;;
+esac
+echo "PASS: watchdog does not flag the clean worktree"
+
+# --- Assertion 4: a COMMITTED artifact is not flagged --------------------
+# Once committed it is no longer "uncommitted" — the committed-but-unmerged
+# case belongs to the sibling hook surface-orphan-claude-branches.py.
+cd "$VAULT/.claude/worktrees/wt-stranded"
+git add -A >/dev/null 2>&1
+git commit --quiet -m "commit the session file"
+cd "$VAULT"
+OUT="$(run_watchdog)"
+case "$OUT" in
+  *wt-stranded*)
+    echo "FAIL: watchdog flagged a COMMITTED session artifact (uncommitted-only scope)" >&2
+    echo "  got: $OUT" >&2
+    exit 1
+    ;;
+esac
+echo "PASS: watchdog does not flag committed session artifacts"
+
+echo
+echo "All assertions passed. stranded-session-artifact watchdog invariant holds."


### PR DESCRIPTION
## Summary
- The Layer 1 close-cascade hook (`detect-closing-signal.py`) set `vault_root` from its own cwd. Fired from inside a worktree, every session artifact (session file, Decisions, Captures, Time Tracking) resolved to the worktree's own `Meta/` on a throwaway `claude/<slug>` branch, and was discarded when the worktree was archived. PR #66 fixed this bug class for the Stop hook (`session-end-hook.sh`); the UserPromptSubmit hook was never brought to parity. This closes that gap.
- `detect-closing-signal.py` gains `resolve_main_vault()` (mirrors the one in `session-end-hook.sh`), applied to `vault_root`. Worktree paths collapse back to the main vault before any artifact path resolves; the worktree slug is still kept in the session filename.
- New SessionStart watchdog `surface-stranded-session-artifacts.py` scans every worktree for uncommitted session artifacts and surfaces them at the next session start. It is the uncommitted-changes companion to `surface-orphan-claude-branches.py` (committed-but-unmerged half).
- Two new CI tests enforce both invariants and fail on revert. `hooks.json` registers the watchdog; `docs/CHANGELOG.md` documents the fix.

## Test plan
- [x] `bash tests/integration/test_detect_closing_signal_worktree.sh` (5 assertions pass)
- [x] `bash tests/integration/test_stranded_session_artifacts_watchdog.sh` (4 assertions pass)
- [x] Existing integration suite still green: worktree-session-close, reconcile-ff-invariant, phase-doc-skills, bootstrap-dry-run
- [x] `python3 -m py_compile` clean on both hooks (Python 3.9 gate)
- [x] personal-data scrub clean on the staged diff (532 added lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)