### PR TITLE
fix(influencer-pack): freeze format on idea-discard for the taste profile

### DIFF
--- a/skills/influencer-pack/idea-engine/mechanism.md
+++ b/skills/influencer-pack/idea-engine/mechanism.md
@@ -48,7 +48,7 @@ This is the difference between a tool the creator trusts and one that quietly ha
 
 When the creator rejects a proposed idea:
 
-1. The engine writes an `idea-discard` record with the rejection `reason_code`, an optional note, and a frozen snapshot of the idea's angle, bucket, and platform.
+1. The engine writes an `idea-discard` record with the rejection `reason_code`, an optional note, and a frozen snapshot of the idea's angle, bucket, platform, and format.
 2. The source `content-idea` record's `status` is set to `discarded`.
 3. The next generation run reads recent discards and the `taste-profile` (below). It does not re-propose a discarded idea or a near-variant of one.
 

--- a/skills/influencer-pack/schema/typed-memory-categories.md
+++ b/skills/influencer-pack/schema/typed-memory-categories.md
@@ -212,9 +212,10 @@ reason_note: optional, free text the creator adds
 angle_snapshot: required (the discarded idea's angle, frozen so the signal survives if the content-idea record is later archived)
 source_bucket: required (frozen from the discarded idea)
 platform: required (frozen from the discarded idea)
+format: required (frozen from the discarded idea)
 ```
 
-`angle_snapshot`, `source_bucket`, and `platform` are copied (frozen) onto the discard record rather than read through the FK, so the learning signal survives independently of the `content-idea` it came from.
+`angle_snapshot`, `source_bucket`, `platform`, and `format` are copied (frozen) onto the discard record rather than read through the FK, so the learning signal survives independently of the `content-idea` it came from. `format` is frozen so the taste profile can compute `rejected_formats` from the discard alone.
 
 ## taste-profile
 


### PR DESCRIPTION
## Summary

A correctness follow-up to PR #84. The `taste-profile` schema declares `rejected_formats`, but the `idea-discard` snapshot froze only angle, bucket, and platform — so the taste profile could not compute `rejected_formats` once a source `content-idea` was archived.

- `schema/typed-memory-categories.md`: `idea-discard` now freezes `format`.
- `idea-engine/mechanism.md`: the discard-loop step lists `format` in the frozen snapshot.

The runtime already implements this (`memory-runtime-pro` PR #54: `IdeaDiscard` carries `format`); this aligns the substrate spec.

## Test plan

- [ ] `lint` CI green (privacy scan, syntax checks, integration tests)
- [ ] `idea-discard` schema and `mechanism.md` agree on the frozen snapshot fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)