### PR TITLE
docs(bootstrap): correct stale section-header comments after de-gating

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -72,11 +72,11 @@ function T([string]$en, [string]$es) {
     if ($script:LangCode -eq "es") { return $es } else { return $en }
 }
 
-# ─── Email gate (universal, one-time) ──────────────────────────────────────
-# Every install passes through the form once. The form at
-# https://myceliumai.co/install captures email + context, mints a 32-char
-# token, emails the install command. This script validates the token and
-# writes a marker file. Future re-runs find the marker and skip the gate.
+# ─── Optional signup ───────────────────────────────────────────────────────
+# The install does NOT gate on email. The block below runs only when an
+# email or token was already provided (web-form path, or EMAIL/NAME env
+# vars); with nothing provided it is skipped and the install proceeds.
+# The setup interview makes one optional email ask at the end.
 $emailMarker = "$env:USERPROFILE\.claude\.ai-brain-starter-email-on-file"
 $installApiBase = if ($env:MYCELIUM_INSTALL_API) { $env:MYCELIUM_INSTALL_API } else { "https://myceliumai.co" }
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -426,13 +426,12 @@ PY
 fi
 
 # ───────────────────────────────────────────────────────────────────────────────
-# Email gate (universal). Every install passes through the form once. The form
-# at https://myceliumai.co/install captures email + context, mints a 32-char
-# token, and emails the install command. Bootstrap validates the token and
-# writes a marker file. Future bootstrap re-runs find the marker and skip the
-# gate. Existing users (no marker yet) get the same prompt on their next run.
+# Optional signup. The install does NOT gate on email. The block below runs
+# only when an email or token was already provided (the web-form path, or
+# EMAIL=/NAME= env vars); with nothing provided it is skipped and the install
+# proceeds. The setup interview makes one optional email ask at the end.
 #
-# Bypass for development: EMAIL_GATE_BYPASS=1 bash bootstrap.sh
+# Bypass entirely for development: EMAIL_GATE_BYPASS=1 bash bootstrap.sh
 # ───────────────────────────────────────────────────────────────────────────────
 EMAIL_MARKER="$HOME/.claude/.ai-brain-starter-email-on-file"
 INSTALL_API_BASE="${MYCELIUM_INSTALL_API:-https://myceliumai.co}"


### PR DESCRIPTION
## Summary

PR #91 de-gated the install but left the `bootstrap.sh` / `bootstrap.ps1` section-header comments describing the old "every install passes through the form, re-runs skip the gate" behavior. Those comments now contradict the code right below them. Both updated to describe the optional, non-blocking signup. Comment-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)