### PR TITLE
fix(vertical-packs): healthcare + finance install protocols at parity with legal

### DIFF
--- a/skills/vertical-finance/SKILL.md
+++ b/skills/vertical-finance/SKILL.md
@@ -78,7 +78,12 @@ See `retention/defaults.md` for the full table.
 /vertical-finance init
 ```
 
-Stages drafts, prints a review checklist, stops.
+The init command:
+
+1. Verifies the substrate is installed and at a compatible version.
+2. Stages all schema, connector, retention, and decision-audit files under `drafts/finance/`. Nothing is auto-applied; the CFO, controller, and internal-audit lead must review and merge.
+3. Prints a review checklist that names every file staged and the SOX / SEC 17a-4 / state-law citation each enforces.
+4. Stops. The finance organization reviews and merges manually.
 
 ## Status
 

--- a/skills/vertical-healthcare/SKILL.md
+++ b/skills/vertical-healthcare/SKILL.md
@@ -76,7 +76,12 @@ See `retention/defaults.md`.
 /vertical-healthcare init
 ```
 
-Stages drafts, prints a review checklist, stops.
+The init command:
+
+1. Verifies the substrate is installed and at a compatible version.
+2. Stages all schema, connector, retention, and decision-audit files under `drafts/healthcare/`. Nothing is auto-applied; the privacy officer, security officer, and clinical informatics lead must review and merge.
+3. Prints a review checklist that names every file staged and the HIPAA / state-law citation each enforces.
+4. Stops. The covered entity reviews and merges manually.
 
 ## Status
 


### PR DESCRIPTION
## Summary

Smoke test on `/vertical-healthcare init` (panel Move #1 from 2026-05-09) surfaced that vertical-healthcare AND vertical-finance both shipped one-line "Stages drafts, prints a review checklist, stops" install sections. vertical-legal shipped a precise 4-step protocol that names the stage directory, the reviewers, and the explicit stop. This PR brings the other two packs to parity.

## What changed

- `skills/vertical-healthcare/SKILL.md` Install section: now 4 steps, stage dir `drafts/healthcare/`, reviewers = privacy officer + security officer + clinical informatics lead.
- `skills/vertical-finance/SKILL.md` Install section: now 4 steps, stage dir `drafts/finance/`, reviewers = CFO + controller + internal-audit lead.

## Smoke test performed

Cloned ai-brain-starter cold to a temp dir, verified all 9 healthcare files land on disk, frontmatter is structurally valid, all referenced files exist. The install-protocol gap was the only finding. Same gap in finance, identical fix.

## Why this matters

A user invoking `/vertical-healthcare init` or `/vertical-finance init` gets Claude reading SKILL.md and inventing the install steps if the steps aren't documented. Cantrill's "specifics or it didn't happen" — file presence is not a working skill.

## Follow-up worth opening

CI gate that asserts every `skills/vertical-*/SKILL.md` carries an Install section with at least four numbered steps. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)