### PR TITLE
fix: close commit-time race for reconcile-worktree-shared

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,28 @@ description: What's new in AI Brain Starter — plain English, no jargon
 
 ---
 
+## 2026-05-19: close the commit-time race for reconcile-worktree-shared
+
+**Who this affects:** anyone using git worktrees inside an Obsidian vault with the `reconcile-worktree-shared.py` SessionEnd hook, who has ALSO seen the worktree-archive prompt fire "N uncommitted changes will be discarded" warnings on byte-identical-to-main files.
+
+Reconcile fires at SessionEnd. Between then and the worktree-archive prompt, OTHER committers (hookify-auto-commit, auto-snapshot, your own commit wrappers) can land commits on master. The active worktree branch falls behind. Archive sees those byte-identical files as "uncommitted" and warns. False positive, but it trains the eye to ignore the warning - which would mask a real loss the day a worktree edit ISN'T also at main.
+
+**What's new:**
+
+**`scripts/post-commit-ff-worktrees.sh`** - a generic helper any committer can call after landing a commit on main. It enumerates active claude/* worktrees via `git worktree list --porcelain` and `git merge --ff-only` each one to the main branch tip. Silent on success, silent on FF-impossible (diverged branches are the reconcile-on-SessionEnd fallback's job, not ours). Parses worktree-list output line-by-line via bash `case` - never `awk $2`, because AWK's default field split silently truncates worktree paths containing spaces.
+
+**`tests/integration/test_post_commit_ff_worktrees.sh`** - CI test for the helper. Three assertions: FF advances a strict-ancestor worktree branch, space-containing paths parse correctly, diverged branches are left alone.
+
+**What you should do:** if you maintain your own commit wrapper(s), call the helper as the last step after a successful commit:
+
+```bash
+bash /path/to/post-commit-ff-worktrees.sh "$MAIN_VAULT"
+```
+
+And ALSO wire `reconcile-worktree-shared.py` into your `~/.claude/settings.json` Stop hooks (not just SessionEnd) so the FF fires between assistant turns. SessionEnd alone leaves a race window between the hook firing and the archive prompt.
+
+---
+
 ## 2026-05-18: NVIDIA Tier-2 helpers + two new SessionStart hooks
 
 **Who this affects:** anyone running LLM-calling scripts in their vault, or anyone whose Claude desktop sessions sometimes wedge after a few days.

--- a/hooks/reconcile-worktree-shared.py
+++ b/hooks/reconcile-worktree-shared.py
@@ -27,13 +27,29 @@ CONFIG (per user, once):
 1. Set VAULT_ROOT below to your vault root, OR rely on auto-detect (walks up
    from cwd looking for the .claude/worktrees/ pattern).
 2. Edit SHARED_PATTERNS to match your worktree-discipline rules.
-3. Wire into ~/.claude/settings.json:
+3. Wire into ~/.claude/settings.json BOTH SessionEnd AND Stop hooks. SessionEnd
+   alone leaves a race window between when the hook fires and when the
+   worktree-archive prompt runs (other committers, like hookify-auto-commit
+   or auto-snapshot, can land commits on master in between). Stop fires after
+   every assistant turn and closes that window:
      "SessionEnd": [
        {"matcher": "", "hooks": [{
          "type": "command",
          "command": "python3 ~/.claude/hooks/reconcile-worktree-shared.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'"
        }]}
+     ],
+     "Stop": [
+       {"hooks": [{
+         "type": "command",
+         "command": "python3 ~/.claude/hooks/reconcile-worktree-shared.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'"
+       }]}
      ]
+
+4. (Optional, recommended) For zero-window race closure, have your commit
+   wrappers call scripts/post-commit-ff-worktrees.sh after each successful
+   commit on main. The helper enumerates active claude/* worktree branches
+   and FFs them to master, so an upcoming archive prompt never sees the
+   stale state in the first place.
 
 BYPASS: WORKTREE_RECONCILE_BYPASS=1
 """

--- a/scripts/post-commit-ff-worktrees.sh
+++ b/scripts/post-commit-ff-worktrees.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# post-commit-ff-worktrees.sh - fast-forward active claude/* worktree branches
+# to the main branch tip after a commit lands on main.
+#
+# Purpose:
+# Closes the commit-time race between (a) any committer that lands a commit on
+# master/main and (b) the reconcile-worktree-shared.py SessionEnd hook. Without
+# this, every commit on main leaves active worktree branches stale, surfacing
+# as false-positive "N uncommitted changes will be discarded" warnings at the
+# worktree-archive prompt - even when the worktree's filesystem is byte-
+# identical to main.
+#
+# Usage (call AFTER a successful commit on main):
+#   bash /path/to/post-commit-ff-worktrees.sh /path/to/main/vault
+#
+# Argument: the absolute path to the main vault (= the repo root). The script
+# enumerates worktrees from this repo and FFs each claude/* branch to the main
+# branch tip. The main vault itself is never touched.
+#
+# Behavior:
+# - Detects master vs main automatically (master first, falls back to main).
+# - Iterates `git worktree list --porcelain` line-by-line via bash `case`,
+#   never `awk $2`. AWK's default field split breaks at the first space in a
+#   worktree path with spaces (e.g. paths containing words like "My Notes")
+#   and silently truncates every path. Bash `case` matches the literal
+#   "worktree " prefix and strips it without splitting.
+# - For each worktree on a claude/* branch (NOT the main vault itself):
+#   try `git merge --ff-only --no-edit <main_branch>`.
+# - Silent on success (FF advances branch pointer with no new commit).
+# - Silent on FF failure (worktree branch genuinely diverged - that's the
+#   reconcile-on-SessionEnd fallback's job, not ours).
+#
+# Bypass: POST_COMMIT_FF_BYPASS=1
+
+set -euo pipefail
+
+if [ "${POST_COMMIT_FF_BYPASS:-0}" = "1" ]; then
+    exit 0
+fi
+
+MAIN_VAULT="${1:-}"
+if [ -z "$MAIN_VAULT" ]; then
+    echo "usage: post-commit-ff-worktrees.sh <main-vault-path>" >&2
+    exit 2
+fi
+
+if [ ! -d "$MAIN_VAULT/.git" ] && [ ! -f "$MAIN_VAULT/.git" ]; then
+    echo "post-commit-ff-worktrees: $MAIN_VAULT is not a git repo root" >&2
+    exit 0
+fi
+
+# Detect the main branch name (master vs main). Match the same logic used
+# in reconcile-worktree-shared.py.
+MAIN_BRANCH="master"
+if ! git -C "$MAIN_VAULT" show-ref --verify --quiet refs/heads/master; then
+    MAIN_BRANCH="main"
+fi
+
+current_wt=""
+git -C "$MAIN_VAULT" worktree list --porcelain 2>/dev/null \
+    | while IFS= read -r line; do
+        case "$line" in
+            "worktree "*)
+                current_wt="${line#worktree }"
+                ;;
+            "branch refs/heads/claude/"*)
+                if [ -n "$current_wt" ] && [ "$current_wt" != "$MAIN_VAULT" ]; then
+                    git -C "$current_wt" merge --ff-only --no-edit "$MAIN_BRANCH" \
+                        >/dev/null 2>&1 || true
+                fi
+                current_wt=""
+                ;;
+            "")
+                current_wt=""
+                ;;
+        esac
+    done

--- a/tests/integration/test_post_commit_ff_worktrees.sh
+++ b/tests/integration/test_post_commit_ff_worktrees.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Test post-commit-ff-worktrees.sh - the helper that closes the commit-time
+# race for reconcile-worktree-shared.py.
+#
+# Bug class this guards against:
+# Reconcile fires at SessionEnd. Between SessionEnd and worktree-archive
+# prompt, OTHER committers (hookify-auto-commit, auto-snapshot, the user's
+# vault-safe-commit equivalent) can land commits on master, leaving the
+# active worktree branch behind master. The archive prompt then surfaces
+# byte-identical files as false-positive uncommitted changes. The helper
+# script lets any committer FF active claude/* worktrees post-commit.
+#
+# Three assertions:
+#   1. Helper FFs a claude/* worktree branch when master moves ahead of it
+#      and the worktree branch is a strict ancestor.
+#   2. Helper handles worktree paths containing spaces (the real-world
+#      bug - AWK $2 truncates "/path/with spaces/..." silently).
+#   3. Helper leaves diverged worktree branches alone (FF-only fails
+#      cleanly; the reconcile fallback handles those).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HELPER="$REPO_ROOT/scripts/post-commit-ff-worktrees.sh"
+
+if [ ! -f "$HELPER" ]; then
+  echo "ERROR: $HELPER not found" >&2
+  exit 1
+fi
+
+# Use a tmpdir name with a space to exercise the space-safe parse
+TMP="$(mktemp -d -t 'starter-ff-XXXXXX')/ff test dir"
+mkdir -p "$TMP"
+trap 'rm -rf "$(dirname "$TMP")"' EXIT
+
+VAULT="$TMP/vault with spaces"
+mkdir -p "$VAULT"
+cd "$VAULT"
+git init --quiet --initial-branch=master
+git config user.email "test@example.com"
+git config user.name "Test"
+
+# Seed: one shared-canonical file at main vault
+mkdir -p .claude
+echo "v1" > .claude/hookify.test.local.md
+git add -A
+git commit --quiet -m "init"
+MASTER_SHA_INIT=$(git rev-parse HEAD)
+
+# Create claude/* worktree off master HEAD
+mkdir -p .claude/worktrees
+git worktree add --quiet -b claude/test-ff ".claude/worktrees/test-ff"
+WT_SHA_INIT=$(git -C ".claude/worktrees/test-ff" rev-parse HEAD)
+
+if [ "$MASTER_SHA_INIT" != "$WT_SHA_INIT" ]; then
+  echo "FAIL: worktree branch did not start at master tip" >&2
+  exit 1
+fi
+
+# Advance master with a new commit (simulating hookify-auto-commit / auto-snapshot)
+echo "v2" > .claude/hookify.test.local.md
+git add .claude/hookify.test.local.md
+git commit --quiet -m "auto-commit: hookify drift"
+MASTER_SHA_POST=$(git rev-parse HEAD)
+
+if [ "$MASTER_SHA_INIT" = "$MASTER_SHA_POST" ]; then
+  echo "FAIL: master did not advance" >&2
+  exit 1
+fi
+
+# Run the helper
+bash "$HELPER" "$VAULT" >/dev/null 2>&1
+
+# Assertion 1: worktree branch FF'd to master
+WT_SHA_AFTER_FF=$(git rev-parse refs/heads/claude/test-ff)
+if [ "$WT_SHA_AFTER_FF" != "$MASTER_SHA_POST" ]; then
+  echo "FAIL: worktree branch did not FF to master after helper ran" >&2
+  echo "  master:        $MASTER_SHA_POST" >&2
+  echo "  worktree:      $WT_SHA_AFTER_FF" >&2
+  exit 1
+fi
+echo "PASS: helper FF'd worktree branch to master"
+
+# Assertion 2: space-safe parse worked end-to-end. The vault path is
+# "$TMP/vault with spaces" (4 spaces). If the helper truncated on space,
+# Assertion 1 would have silently no-op'd. The fact that it passed proves
+# the parse handled spaces correctly.
+echo "PASS: space-safe parse of worktree paths"
+
+# Assertion 3: diverged worktree branch left alone
+git worktree add --quiet -b claude/test-diverged ".claude/worktrees/test-diverged"
+
+cd ".claude/worktrees/test-diverged"
+echo "divergent" > divergent.md
+git add divergent.md
+git commit --quiet -m "diverged: worktree-local commit"
+DIVERGED_SHA_PRE=$(git rev-parse HEAD)
+cd "$VAULT"
+
+# Advance master once more
+echo "v3" > .claude/hookify.test.local.md
+git add .claude/hookify.test.local.md
+git commit --quiet -m "auto-commit: another drift"
+MASTER_SHA_POST_2=$(git rev-parse HEAD)
+
+# Helper should attempt FF, fail silently on diverged, advance the other
+bash "$HELPER" "$VAULT" >/dev/null 2>&1
+
+DIVERGED_SHA_POST=$(git rev-parse refs/heads/claude/test-diverged)
+if [ "$DIVERGED_SHA_POST" != "$DIVERGED_SHA_PRE" ]; then
+  echo "FAIL: helper modified diverged worktree branch (should have left alone)" >&2
+  echo "  pre:  $DIVERGED_SHA_PRE" >&2
+  echo "  post: $DIVERGED_SHA_POST" >&2
+  exit 1
+fi
+echo "PASS: diverged worktree branch left alone (FF-only failed cleanly)"
+
+# Sanity: the non-diverged worktree advanced again
+WT_SHA_FINAL=$(git rev-parse refs/heads/claude/test-ff)
+if [ "$WT_SHA_FINAL" != "$MASTER_SHA_POST_2" ]; then
+  echo "FAIL: non-diverged worktree did not FF on second helper run" >&2
+  exit 1
+fi
+echo "PASS: non-diverged worktree FF'd on second helper run"
+
+echo
+echo "All assertions passed. Post-commit FF helper closes the race correctly."


### PR DESCRIPTION
## Summary

Reconcile-worktree-shared.py fires at SessionEnd. Between then and the worktree-archive UI prompt, other committers (your commit wrappers, auto-snapshot, hookify-auto-commit equivalents) can land commits on main, leaving the active claude/* worktree branch behind. Archive then surfaces byte-identical files as 'uncommitted', warning they will be discarded. False positive, but trains the eye to ignore the warning, masking a real loss the day a worktree edit isn't also at main.

Same bug family as #65 (worktree session-close routing) and #68 (reconcile FF instead of commit). Different timing layer.

## What's in this PR

- **`scripts/post-commit-ff-worktrees.sh`** — generic helper any committer can call after a commit lands on main. Enumerates active claude/* worktrees and FFs each to main. Parses `git worktree list --porcelain` line-by-line via bash `case`, never `awk \$2` (worktree paths with spaces silently truncate under default awk field-split).
- **`tests/integration/test_post_commit_ff_worktrees.sh`** — 3 assertions:
  1. FF advances a strict-ancestor worktree branch
  2. Space-containing worktree paths parse correctly end-to-end
  3. Diverged worktree branches left alone (FF-only fails cleanly, reconcile fallback handles those)
- **`docs/CHANGELOG.md`** — 2026-05-19 entry explaining the race and the helper
- **`hooks/reconcile-worktree-shared.py`** — docstring updated to recommend Stop-hook wiring in addition to SessionEnd, plus the post-commit helper for defense in depth

## Test plan

- [x] `bash tests/integration/test_post_commit_ff_worktrees.sh` — 4 assertions pass locally
- [x] Helper syntax `bash -n` clean
- [x] Test syntax `bash -n` clean
- [x] Personal-data scrub on diff: clean (0 matches)
- [ ] CI lint workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)