### PR TITLE
fix(install): pre-frame Claude Code's trust prompt

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -378,3 +378,22 @@ jobs:
             fi
           done < <(find README.md bootstrap.sh bootstrap.ps1 phases -type f \( -name '*.md' -o -name '*.sh' -o -name '*.ps1' \))
           exit $fail
+
+  trust-prompt-preframing:
+    name: install pre-frames Claude Code's trust prompt
+    runs-on: ubuntu-latest
+    # Catches the bug class from the May 2026 installer-panic incident: a
+    # non-technical user hit Claude Code's built-in trust prompt for the
+    # third-party plugins, marketplaces, and MCP servers the bootstrap
+    # registers, with no warning, and nearly abandoned the install thinking
+    # malware was being slipped onto the machine. The trust prompt is correct
+    # and is NOT suppressed; the fix is to pre-frame it everywhere the
+    # installer looks. Fails if any pre-framing surface is removed (README
+    # EN+ES sections, the maintainer-guide instruction, phase-00 Step 0.0b,
+    # the bootstrap.sh and bootstrap.ps1 heads-up lines), or if the false
+    # "no questions, it just runs" promise returns to the README.
+    # No untrusted user input is referenced in any run: command.
+    steps:
+      - uses: actions/checkout@v6
+      - name: run integration test
+        run: bash tests/integration/test_trust_prompt_preframing.sh

--- a/README.md
+++ b/README.md
@@ -115,13 +115,30 @@ Install ai-brain-starter for me. Read https://github.com/adelaidasofia/ai-brain-
 
 That's the whole prompt. After you paste, what happens:
 
-- Claude runs the installer for you (downloads and configures Homebrew, Python, Node, Obsidian, all skills, all MCPs). No questions first — it just runs.
+- Claude runs the installer for you. It sets up Homebrew, Python, Node, Obsidian, and the skills and tools the system uses. This takes a few minutes.
+- **One thing to expect:** during the install, Claude Code itself pauses and asks you to approve the tools being added. That pause is normal. It is Claude Code's own safety check, the same one that protects you from genuinely bad software. The next section, "What Claude will ask you," explains it in plain language. Approving it is the right move, and you can read exactly what is being added first.
 - The setup interview begins automatically. It opens by asking which language you want to use, then walks you through setup.
-- Near the end, Claude asks once — optionally — whether you'd like occasional install updates and a free founder workflow audit by email. Say yes or skip; the install is complete and yours either way.
+- Near the end, Claude asks once, optionally, whether you'd like occasional install updates and a free founder workflow audit by email. Say yes or skip. The install is complete and yours either way.
 
-No browser tab. No Terminal. No email required to install. Just paste.
+No browser tab. No Terminal. No email required to install. Just paste, and approve the one safety check when it appears.
 
 *Local install. Your vault data never leaves your machine. The email — if you choose to give one — is the only thing that touches our servers, and only what's listed in [`SECURITY.md`](SECURITY.md) and the [privacy policy](https://myceliumai.co/privacy).*
+
+### What Claude will ask you, and why it's safe
+
+Partway through the install, Claude Code stops and shows you a security prompt. It asks you to approve the plugins and tools being added, and it warns, in fairly strong language, that they come from third parties and are not verified by Anthropic.
+
+**This is expected, and reading it carefully was the right instinct.** Claude Code shows that prompt for *any* tool that did not come from Anthropic itself. It is not a sign that something is wrong. It is the same checkpoint that protects you from genuinely harmful software, doing its job on an ordinary install.
+
+Here is what you are approving:
+
+- **The ai-brain-starter plugin.** This project. MIT licensed, public, every file readable on GitHub.
+- **A small set of skill packs from established names.** Trail of Bits (a security firm), Stripe, Cloudflare, Sentry, and a few independent skill authors. Each one, with its license and what it does, is listed in [Before you paste](#before-you-paste--what-gets-installed) above.
+- **Two MCP servers.** Granola (meeting notes) and ChatPRD (drafting). Optional helpers you can remove later.
+
+None of this sends your files anywhere. The install is local, and your vault stays on your machine. If you would rather skip the third-party packs altogether, you can: set `SKIP_VENDOR_SKILLS=1`, described in [Before you paste](#before-you-paste--what-gets-installed).
+
+When the prompt appears, approving it is the normal choice. And if you ever want to undo everything, `bash bootstrap.sh --uninstall` removes all of it.
 
 <!-- ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ -->
 <!-- INSTALL GUIDE FOR THE ASSISTANT RUNNING THIS INSTALL -->
@@ -144,7 +161,7 @@ No browser tab. No Terminal. No email required to install. Just paste.
 > 3. When the installer prints `━━━ Install complete ━━━`, read `~/.claude/skills/ai-brain-starter/SKILL.md` and continue with Phase 1 of the setup interview. The interview opens by asking the user which language to use, then gathers their name and everything else as it goes — you do not need to collect anything before the install.
 > 4. If the installer's summary lists any failures, tell the user plainly which ones, and offer to re-run (it is idempotent).
 >
-> A note on tone: the user may be non-technical and simply trying a tool a friend recommended. Walk them through it like a calm guide, not a security review. Explain what each step does as you go; do not surface the install as a series of warnings.
+> A note on tone: the user may be non-technical and simply trying a tool a friend recommended. Walk them through it like a calm guide, not a security review. Do not improvise your own warnings or narrate each step as a risk. One exception, and it is required: Claude Code shows a built-in trust prompt for the third-party plugins and MCP servers this installs, and it will appear during or shortly after the install. Tell the user it is coming **before** they see it, calmly, as a normal and expected safety check that is safe to approve, and point them to the "What Claude will ask you" section of the README. An unframed trust prompt is the most common reason a non-technical installer panics and abandons the install. Pre-framing it is part of the install, not optional.
 
 <!-- ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ -->
 
@@ -184,13 +201,30 @@ Instalá ai-brain-starter para mí. Leé https://github.com/adelaidasofia/ai-bra
 
 Ese es el prompt entero. Después de pegarlo, lo que pasa:
 
-- Claude corre el instalador por vos (descarga y configura Homebrew, Python, Node, Obsidian, todas las skills, todos los MCPs). Sin preguntas primero — simplemente corre.
+- Claude corre el instalador por vos. Configura Homebrew, Python, Node, Obsidian, y las skills y herramientas que el sistema usa. Tarda unos minutos.
+- **Algo que vas a ver:** durante la instalación, Claude Code va a pausar y pedirte que apruebes las herramientas que se están agregando. Esa pausa es normal. Es el chequeo de seguridad propio de Claude Code, el mismo que te protege de software realmente malo. La sección de abajo, "Qué te va a preguntar Claude", lo explica en lenguaje simple. Aprobarlo es lo correcto, y podés leer exactamente qué se está agregando primero.
 - La entrevista de setup arranca automáticamente. Abre preguntándote en qué idioma querés hacerlo, y de ahí te guía por el setup.
-- Cerca del final, Claude te pregunta una vez — opcional — si querés novedades ocasionales de la instalación y una auditoría gratis de tu flujo de trabajo por email. Decí que sí o saltala; la instalación está completa y es tuya igual.
+- Cerca del final, Claude te pregunta una vez, opcional, si querés novedades ocasionales de la instalación y una auditoría gratis de tu flujo de trabajo por email. Decí que sí o saltala. La instalación está completa y es tuya igual.
 
-Sin pestaña del navegador. Sin Terminal. Sin email para instalar. Sólo pegás.
+Sin pestaña del navegador. Sin Terminal. Sin email para instalar. Sólo pegás, y aprobás el chequeo de seguridad cuando aparezca.
 
 *Instalación local. Los datos de tu vault no salen de tu máquina. El email — si elegís darlo — es lo único que toca nuestros servidores, y sólo lo que está listado en [`SECURITY.md`](SECURITY.md) y la [política de privacidad](https://myceliumai.co/privacy).*
+
+### Qué te va a preguntar Claude, y por qué es seguro
+
+En algún momento de la instalación, Claude Code frena y te muestra un aviso de seguridad. Te pide que apruebes los plugins y herramientas que se están agregando, y te advierte, en un tono bastante fuerte, que vienen de terceros y que Anthropic no los verificó.
+
+**Esto es esperado, y leerlo con cuidado fue el instinto correcto.** Claude Code muestra ese aviso para *cualquier* herramienta que no venga de Anthropic. No es señal de que algo esté mal. Es el mismo chequeo que te protege de software realmente dañino, haciendo su trabajo en una instalación normal.
+
+Esto es lo que estás aprobando:
+
+- **El plugin ai-brain-starter.** Este proyecto. Licencia MIT, público, cada archivo se puede leer en GitHub.
+- **Un grupo chico de packs de skills de nombres establecidos.** Trail of Bits (una firma de seguridad), Stripe, Cloudflare, Sentry, y algunos autores de skills independientes. Cada uno, con su licencia y lo que hace, está listado en [Before you paste](#before-you-paste--what-gets-installed) más arriba.
+- **Dos servidores MCP.** Granola (notas de reuniones) y ChatPRD (borradores). Ayudantes opcionales que podés remover después.
+
+Nada de esto manda tus archivos a ningún lado. La instalación es local y tu vault se queda en tu máquina. Si preferís saltarte los packs de terceros del todo, podés: poné `SKIP_VENDOR_SKILLS=1`, descrito en [Before you paste](#before-you-paste--what-gets-installed).
+
+Cuando aparezca el aviso, aprobarlo es la opción normal. Y si alguna vez querés deshacer todo, `bash bootstrap.sh --uninstall` lo remueve completo.
 
 <details>
 <summary>Usuarios existentes (re-corriendo después de un `git pull`)</summary>

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -621,6 +621,15 @@ if (-not (Test-Path $humDir)) {
 }
 if (Test-Path $humDir) { Ok "humanizer skill installed" } else { Err "humanizer clone failed" }
 
+# Trust-prompt heads-up: registering MCP servers + a plugin marketplace triggers
+# Claude Code's built-in trust prompt. Pre-frame it so non-technical installers
+# don't panic. Pairs with phase-00-install.md Step 0.0b.
+Write-Host ""
+Write-Host ("  " + (T "HEADS UP: Claude Code may pause to ask you to approve these tools." "AVISO: Claude Code puede pausar para pedirte que apruebes estas herramientas."))
+Write-Host ("  " + (T "That prompt is its normal safety check for anything not from Anthropic." "Ese aviso es su chequeo normal de seguridad para algo que no viene de Anthropic."))
+Write-Host ("  " + (T "It is expected and safe to approve. The README explains what gets added." "Es esperado y seguro aprobarlo. El README explica todo lo que se instala."))
+Write-Host ""
+
 # ─── Granola MCP ─────────────────────────────────────────────────────────────
 # SAFETY: backup .mcp.json before editing. Existing MCP servers (custom
 # integrations, other URL or stdio MCPs the user wired themselves) are

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -32,7 +32,10 @@
 #       influencer-pack) live in the repo as opt-in installs; not auto-installed.
 #     - humanizer (de-AI writing) — cloned from its own fork repo
 #     - Granola + ChatPRD MCPs
-#     - Marketplace: obsidian-skills (kepano); plugins: obsidian, context7, playwright
+#     - Marketplaces: obsidian-skills (kepano), enabling obsidian/context7/playwright;
+#       plus 7 vendor skill-pack marketplaces (sentry, trailofbits, stripe, cloudflare,
+#       claude-seo, superpowers, marketingskills). Skip all vendor packs with
+#       SKIP_VENDOR_SKILLS=1.
 #     - Mac: Obsidian CLI symlink to /usr/local/bin/obsidian (if the app ships it)
 #     - The ai-brain-starter skill itself
 #
@@ -1234,6 +1237,18 @@ fi
 # ───────────────────────────────────────────────────────────────────────────────
 
 if [[ "${SKIP_VENDOR_SKILLS:-0}" != "1" ]]; then
+
+  # Trust-prompt heads-up: adding third-party marketplaces triggers Claude
+  # Code's built-in trust prompt. Pre-frame it so non-technical installers
+  # don't panic. Pairs with phase-00-install.md Step 0.0b.
+  log ""
+  log "  ℹ️  $(t "HEADS UP: Claude Code may pause to ask you to approve these tools." \
+                  "AVISO: Claude Code puede pausar para pedirte que apruebes estas herramientas.")"
+  log "  ℹ️  $(t "That prompt is its normal safety check for anything not from Anthropic." \
+                  "Ese aviso es su chequeo normal de seguridad para algo que no viene de Anthropic.")"
+  log "  ℹ️  $(t "It is expected and safe to approve. The README explains what gets added." \
+                  "Es esperado y seguro aprobarlo. El README explica qué se agrega.")"
+  log ""
 
   # Register a marketplace + install a plugin (idempotent + DRY_RUN-safe).
   # Args: $1=owner/repo (marketplace source) $2=plugin@marketplace-id (install target)

--- a/phases/phase-00-install.md
+++ b/phases/phase-00-install.md
@@ -20,13 +20,13 @@ As bootstrap prints its own check-mark lines per tool, you don't need to narrate
 
 ### Step 0.0b. Tell the user about the trust prompt before it appears
 
-The bootstrap registers third-party plugin marketplaces and MCP servers (see the install table in Step 0.1). Once that happens, Claude Code shows its **built-in trust prompt** for the third-party content. You cannot suppress that prompt, and you should not want to — it is a real safety feature. But a non-technical user who hits it cold, with no warning, reads it as "malicious software is sneaking onto my machine," panics, and abandons the install. This has happened to a real installer.
+The bootstrap registers third-party plugin marketplaces and MCP servers (see the install table in Step 0.1). Once that happens, Claude Code shows its **built-in trust prompt** for the third-party content. You cannot suppress that prompt, and you should not want to. It is a real safety feature. But a non-technical user who hits it cold, with no warning, reads it as "malicious software is sneaking onto my machine," panics, and abandons the install. This has happened to a real installer.
 
-So get ahead of it. **Before** you invoke the bootstrap — or the instant you see the prompt appear, whichever comes first — tell the user, in their language, something close to this:
+So get ahead of it. **Before** you invoke the bootstrap (or the instant you see the prompt appear, whichever comes first), tell the user, in their language, something close to this:
 
 > "Heads up on one thing: in a moment Claude Code will pause and ask you to approve the tools we're installing. It may warn that they come from third parties or are not verified by Anthropic. That is Claude Code's normal safety check for anything that did not come from Anthropic itself, not a sign that anything is wrong. It is safe to approve. Everything being added is listed, with licenses, in the project's README. Go ahead and approve it when you see it, and I'll keep going."
 
-Adapt the wording to the user and the moment; do not read it robotically. The non-negotiable part: before they read the prompt themselves, the user must KNOW it is coming, that it is expected, and that approving is the normal choice. Never let the trust prompt be the first time they hear of it — an unframed trust prompt is the single most common reason a non-technical install gets abandoned.
+Adapt the wording to the user and the moment; do not read it robotically. The non-negotiable part: before they read the prompt themselves, the user must KNOW it is coming, that it is expected, and that approving is the normal choice. Never let the trust prompt be the first time they hear of it. An unframed trust prompt is the single most common reason a non-technical install gets abandoned.
 
 ---
 
@@ -62,7 +62,7 @@ If the user reached /setup-brain WITHOUT running bootstrap first (rare), the rep
 | Sub-skills | graphify, meeting-todos, patterns, insights, deconstruct, daily-journal, repurpose-talk, nano-banana (skill folder only; plugin install is deferred) |
 | Humanizer | cloned from its own public fork (idempotent, never touched on re-run) |
 | MCPs | granola + chatprd (registered in ~/.claude/.mcp.json with backup) |
-| Marketplaces / plugins | obsidian-skills (kepano), enabling obsidian/context7/playwright; PLUS seven vendor skill-pack marketplaces (getsentry, trailofbits, stripe, cloudflare, AgriciDaniel/claude-seo, obra/superpowers, coreyhaines31/marketingskills), skippable with SKIP_VENDOR_SKILLS=1. These third-party marketplaces are what trigger Claude Code's trust prompt — pre-frame it per Step 0.0b. |
+| Marketplaces / plugins | obsidian-skills (kepano), enabling obsidian/context7/playwright; PLUS seven vendor skill-pack marketplaces (getsentry, trailofbits, stripe, cloudflare, AgriciDaniel/claude-seo, obra/superpowers, coreyhaines31/marketingskills), skippable with SKIP_VENDOR_SKILLS=1. These third-party marketplaces are what trigger Claude Code's trust prompt; pre-frame it per Step 0.0b. |
 
 **Bootstrap does NOT touch:**
 - The user's vault CLAUDE.md (vault path isn't known until Phase 5)

--- a/phases/phase-00-install.md
+++ b/phases/phase-00-install.md
@@ -2,7 +2,7 @@
 
 **Do this silently before the conversation starts.** All mechanical installs live in `bootstrap.sh` (Mac/Linux) and `bootstrap.ps1` (Windows) at the repo root. Phase 0 is a thin orchestrator: detect platform, invoke bootstrap, handle the conversational follow-ups, then hand off to Phase 1.
 
-**Why one source of truth?** The install list (brew/python/node/pipx/gh/fastmcp, graphify, humanizer, all bundled sub-skills, Granola + ChatPRD MCPs, obsidian-skills marketplace, context7/playwright plugins, Obsidian app, Obsidian CLI symlink) used to live in two places: bootstrap scripts AND this phase file. They drifted. Now bootstrap is canonical. Every line of install logic lives there, on every platform. Phase 0 never copies bash.
+**Why one source of truth?** The install list (brew/python/node/pipx/gh/fastmcp, graphify, humanizer, all bundled sub-skills, Granola + ChatPRD MCPs, the obsidian-skills and vendor skill-pack marketplaces, context7/playwright plugins, Obsidian app, Obsidian CLI symlink) used to live in two places: bootstrap scripts AND this phase file. They drifted. Now bootstrap is canonical. Every line of install logic lives there, on every platform. Phase 0 never copies bash.
 
 ---
 
@@ -15,6 +15,18 @@ Non-technical users will think nothing is happening if Claude goes silent during
 As bootstrap prints its own check-mark lines per tool, you don't need to narrate each one. The output is already reassuring. Chime in once at the end: *"All tools ready. Now let's get you set up."* Or, on failure: *"A couple of tools didn't install (listed above). I'll work around them for now and we can retry at the end. None of them are blocking what we're about to do."*
 
 **DO NOT use the Monitor tool on bootstrap output.** Monitor renders every stdout line as a separate "Human:" turn in the conversation transcript — empty lines from brew/npm chatter included. Users see a wall of bare `Human:` labels interspersed with progress messages and leaked `<task-notification>` XML blocks. Bootstrap's own stdout is already user-visible — just `Bash(bash bootstrap.sh)` and let it print directly. If you want async progress, set `run_in_background: true` on the Bash call and read the result when it finishes. Monitor is for log-streaming long-running daemons, not installers.
+
+---
+
+### Step 0.0b. Tell the user about the trust prompt before it appears
+
+The bootstrap registers third-party plugin marketplaces and MCP servers (see the install table in Step 0.1). Once that happens, Claude Code shows its **built-in trust prompt** for the third-party content. You cannot suppress that prompt, and you should not want to — it is a real safety feature. But a non-technical user who hits it cold, with no warning, reads it as "malicious software is sneaking onto my machine," panics, and abandons the install. This has happened to a real installer.
+
+So get ahead of it. **Before** you invoke the bootstrap — or the instant you see the prompt appear, whichever comes first — tell the user, in their language, something close to this:
+
+> "Heads up on one thing: in a moment Claude Code will pause and ask you to approve the tools we're installing. It may warn that they come from third parties or are not verified by Anthropic. That is Claude Code's normal safety check for anything that did not come from Anthropic itself, not a sign that anything is wrong. It is safe to approve. Everything being added is listed, with licenses, in the project's README. Go ahead and approve it when you see it, and I'll keep going."
+
+Adapt the wording to the user and the moment; do not read it robotically. The non-negotiable part: before they read the prompt themselves, the user must KNOW it is coming, that it is expected, and that approving is the normal choice. Never let the trust prompt be the first time they hear of it — an unframed trust prompt is the single most common reason a non-technical install gets abandoned.
 
 ---
 
@@ -49,8 +61,8 @@ If the user reached /setup-brain WITHOUT running bootstrap first (rare), the rep
 | Graphify | graphifyy Python package + `graphify install` (platform binary) |
 | Sub-skills | graphify, meeting-todos, patterns, insights, deconstruct, daily-journal, repurpose-talk, nano-banana (skill folder only; plugin install is deferred) |
 | Humanizer | cloned from its own public fork (idempotent, never touched on re-run) |
-| MCPs | chatprd (registered in ~/.claude/.mcp.json with backup) |
-| Marketplaces / plugins | obsidian-skills (kepano); enables: obsidian, context7, playwright (registered in ~/.claude/settings.json with backup) |
+| MCPs | granola + chatprd (registered in ~/.claude/.mcp.json with backup) |
+| Marketplaces / plugins | obsidian-skills (kepano), enabling obsidian/context7/playwright; PLUS seven vendor skill-pack marketplaces (getsentry, trailofbits, stripe, cloudflare, AgriciDaniel/claude-seo, obra/superpowers, coreyhaines31/marketingskills), skippable with SKIP_VENDOR_SKILLS=1. These third-party marketplaces are what trigger Claude Code's trust prompt — pre-frame it per Step 0.0b. |
 
 **Bootstrap does NOT touch:**
 - The user's vault CLAUDE.md (vault path isn't known until Phase 5)

--- a/tests/integration/test_trust_prompt_preframing.sh
+++ b/tests/integration/test_trust_prompt_preframing.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Regression test: the install must pre-frame Claude Code's built-in trust
+# prompt for third-party plugins, marketplaces, and MCP servers.
+#
+# Bug class: a non-technical installer hits Claude Code's trust prompt
+# (approve these third-party tools / they are not verified by Anthropic)
+# with no warning, reads it as malware sneaking onto the machine, panics,
+# and abandons the install. The trust prompt itself is correct and is NOT
+# suppressed. The fix is to get ahead of it so the user expects it and
+# knows approving is the normal, safe choice.
+#
+# Source incident: a real installer of the free public ai-brain-starter
+# saw the trust prompt mid-install and messaged the maintainer, worried
+# that malicious agents were being slipped onto the machine. At the time
+# the README promised the install "just runs, no questions" and the
+# maintainer guide told the installing assistant not to surface warnings,
+# so the prompt arrived completely unframed.
+#
+# This test fails if any pre-framing surface is removed, or if the false
+# "no questions, it just runs" promise returns to the README.
+#
+# Self-contained. Exit 0 = pass. Exit 1 = fail with details.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+README="$REPO_ROOT/README.md"
+PHASE00="$REPO_ROOT/phases/phase-00-install.md"
+BOOTSTRAP_SH="$REPO_ROOT/bootstrap.sh"
+BOOTSTRAP_PS1="$REPO_ROOT/bootstrap.ps1"
+
+FAILED=0
+
+# must_contain <file> <failure-label> <literal-substring>
+must_contain() {
+  local file="$1" label="$2" needle="$3"
+  if [ ! -f "$file" ]; then
+    echo "FAIL: $label" >&2
+    echo "  file not found: $file" >&2
+    FAILED=$((FAILED + 1))
+    return 0
+  fi
+  if ! grep -qF -- "$needle" "$file"; then
+    echo "FAIL: $label" >&2
+    echo "  expected to find in $(basename "$file"): \"$needle\"" >&2
+    FAILED=$((FAILED + 1))
+  fi
+  return 0
+}
+
+# must_not_contain <file> <failure-label> <literal-substring>
+must_not_contain() {
+  local file="$1" label="$2" needle="$3"
+  if [ -f "$file" ] && grep -qF -- "$needle" "$file"; then
+    echo "FAIL: $label" >&2
+    echo "  banned string is back in $(basename "$file"): \"$needle\"" >&2
+    echo "  the install must not promise a friction-free run it cannot deliver." >&2
+    FAILED=$((FAILED + 1))
+  fi
+  return 0
+}
+
+# 1. The README explains the trust prompt to the human reader, EN + ES.
+must_contain "$README" \
+  "README is missing the English 'What Claude will ask you' section" \
+  "What Claude will ask you"
+must_contain "$README" \
+  "README is missing the Spanish trust-prompt section" \
+  "Qué te va a preguntar Claude"
+
+# 2. The README must NOT promise a no-questions install. That false promise
+#    is what turned a routine safety prompt into an ambush.
+must_not_contain "$README" \
+  "README regressed to the false English 'no questions' promise" \
+  "No questions first"
+must_not_contain "$README" \
+  "README regressed to the false Spanish 'no questions' promise" \
+  "Sin preguntas primero"
+
+# 3. The maintainer guide must require the installing assistant to pre-frame
+#    the trust prompt. It used to tell the assistant not to surface warnings.
+must_contain "$README" \
+  "README maintainer guide no longer requires pre-framing the trust prompt" \
+  "Pre-framing it is part of the install"
+
+# 4. phase-00 carries the assistant-facing pre-framing step.
+must_contain "$PHASE00" \
+  "phase-00-install.md is missing the trust-prompt pre-framing step (Step 0.0b)" \
+  "Step 0.0b"
+
+# 5. Both bootstrap scripts print the heads-up before registering marketplaces.
+must_contain "$BOOTSTRAP_SH" \
+  "bootstrap.sh is missing the trust-prompt heads-up line" \
+  "may pause to ask you to approve these tools"
+must_contain "$BOOTSTRAP_PS1" \
+  "bootstrap.ps1 is missing the trust-prompt heads-up line" \
+  "may pause to ask you to approve these tools"
+
+if [ "$FAILED" -gt 0 ]; then
+  echo "" >&2
+  echo "$FAILED trust-prompt pre-framing check(s) failed." >&2
+  echo "The install must keep getting ahead of Claude Code's built-in trust prompt:" >&2
+  echo "suppress nothing, surprise no one. See phases/phase-00-install.md Step 0.0b." >&2
+  exit 1
+fi
+
+echo "PASS: trust-prompt pre-framing intact. README (EN+ES), maintainer guide, phase-00 Step 0.0b, bootstrap.sh, and bootstrap.ps1 all carry it."


### PR DESCRIPTION
## Summary

A non-technical user installing ai-brain-starter hit Claude Code's built-in trust prompt for the third-party plugins, marketplaces, and MCP servers the bootstrap registers, and nearly abandoned the install thinking malicious software was being slipped onto the machine. The README promised the install "just runs, no questions" and the maintainer guide told the installing assistant not to surface warnings, so the prompt arrived with no framing at all.

The trust prompt is correct and is **not** suppressed. This PR gets ahead of it on every surface the installer sees:

- **README** drops the false "no questions, it just runs" promise and adds a "What Claude will ask you" section (EN + ES) that names the prompt, explains it is Claude Code's normal safety check for anything not from Anthropic, and tells the user approving is the right move.
- **README maintainer guide**: the "do not surface warnings" instruction now carries a required exception to pre-announce the trust prompt before it appears.
- **phase-00-install.md**: new Step 0.0b directs the installing assistant to tell the user the prompt is coming before bootstrap runs. Also corrects a doc drift where the install table claimed one marketplace when bootstrap.sh registers eight.
- **bootstrap.sh / bootstrap.ps1**: a calm heads-up line prints before the marketplace step, matching the existing macOS-password heads-up.
- **New CI test** `test_trust_prompt_preframing.sh` fails if any pre-framing surface is removed or the false promise returns.

## Test plan

- [x] `test_trust_prompt_preframing.sh` passes locally
- [x] `test_bootstrap_dry_run.sh` passes (dry-run clean, all 11 skills, commands section fires)
- [x] `bash -n bootstrap.sh` clean
- [x] `bootstrap.ps1` em-dash-free (CI no-em-dash-ps1 parity)
- [x] `lint.yml` valid YAML
- [x] personal-data scrub clean on the full diff
- [ ] CI green on all lint.yml jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)