### PR TITLE
chore(install): Spanish polish, macOS-vs-Windows note, .gitignore .codegraph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ secrets.json
 *.duckdb.wal
 *.duckdb.tmp
 **/health-mcp-extract/
+
+# codegraph local index (per-clone, 100MB+, regenerated on demand).
+.codegraph/

--- a/README.md
+++ b/README.md
@@ -99,6 +99,13 @@ Bootstrap touches your `~/.claude/` directory and registers third-party content.
 | `coreyhaines31/marketingskills` | marketing-skills (41 marketing sub-skills) | MIT |
 | `kepano/obsidian-skills` | obsidian, context7, playwright | MIT |
 
+> **macOS vs Windows.** All eight marketplaces install via `bootstrap.sh` on macOS. On Windows, `bootstrap.ps1` installs only `obsidian-skills` plus the two MCP servers below; the seven vendor skill-packs are not ported yet. To add any of them manually after install, paste this into Claude Code (substituting names from the table above):
+>
+> ```
+> /plugin marketplace add <owner>/<repo>
+> /plugin install <plugin>@<marketplace-id>
+> ```
+
 **MCP servers wired in `~/.claude/.mcp.json`:** `granola` (meeting transcription), `chatprd` (PRD drafting). Existing MCPs you wired yourself are preserved.
 
 **System tools (skipped if already present):** Homebrew, Python 3.10+, Node, npm, pipx, gh, fastmcp, graphify (via pipx), skill-seekers (via pipx), Obsidian.
@@ -201,30 +208,30 @@ Instalá ai-brain-starter para mí. Leé https://github.com/adelaidasofia/ai-bra
 
 Ese es el prompt entero. Después de pegarlo, lo que pasa:
 
-- Claude corre el instalador por vos. Configura Homebrew, Python, Node, Obsidian, y las skills y herramientas que el sistema usa. Tarda unos minutos.
-- **Algo que vas a ver:** durante la instalación, Claude Code va a pausar y pedirte que apruebes las herramientas que se están agregando. Esa pausa es normal. Es el chequeo de seguridad propio de Claude Code, el mismo que te protege de software realmente malo. La sección de abajo, "Qué te va a preguntar Claude", lo explica en lenguaje simple. Aprobarlo es lo correcto, y podés leer exactamente qué se está agregando primero.
-- La entrevista de setup arranca automáticamente. Abre preguntándote en qué idioma querés hacerlo, y de ahí te guía por el setup.
-- Cerca del final, Claude te pregunta una vez, opcional, si querés novedades ocasionales de la instalación y una auditoría gratis de tu flujo de trabajo por email. Decí que sí o saltala. La instalación está completa y es tuya igual.
+- Claude corre el instalador por vos. Instala Homebrew, Python, Node, Obsidian, y las skills y herramientas que el sistema usa. Toma unos minutos.
+- **Una cosa con la que vas a cruzarte:** durante la instalación, Claude Code va a frenar un momento para pedirte que apruebes las herramientas que se están agregando. Es su chequeo de seguridad normal, el mismo que te cuida cuando se instala algo que no viene de Anthropic. La sección de abajo, "Qué te va a preguntar Claude", lo explica con calma. Cuando aparezca, dale aprobar tranquilo; y si querés, podés revisar antes qué se está agregando.
+- La entrevista de setup arranca automáticamente. Empieza preguntándote en qué idioma querés hacerlo, y de ahí te guía por todo el resto.
+- Cerca del final, Claude te pregunta una sola vez, y es opcional, si querés que te lleguen las novedades importantes y una auditoría gratis de tu flujo de trabajo para founders. Decí que sí o decí que no. La instalación está completa y es tuya igual.
 
-Sin pestaña del navegador. Sin Terminal. Sin email para instalar. Sólo pegás, y aprobás el chequeo de seguridad cuando aparezca.
+Sin pestaña del navegador. Sin Terminal. Sin email para instalar. Pegás el prompt, le das aprobar al chequeo de seguridad cuando aparezca, y eso es todo.
 
 *Instalación local. Los datos de tu vault no salen de tu máquina. El email — si elegís darlo — es lo único que toca nuestros servidores, y sólo lo que está listado en [`SECURITY.md`](SECURITY.md) y la [política de privacidad](https://myceliumai.co/privacy).*
 
 ### Qué te va a preguntar Claude, y por qué es seguro
 
-En algún momento de la instalación, Claude Code frena y te muestra un aviso de seguridad. Te pide que apruebes los plugins y herramientas que se están agregando, y te advierte, en un tono bastante fuerte, que vienen de terceros y que Anthropic no los verificó.
+En algún momento de la instalación, Claude Code va a frenar para mostrarte un aviso de seguridad. Te pide aprobar los plugins y herramientas que se están agregando, y te avisa, en un tono bien firme, que vienen de terceros y que Anthropic no los verificó.
 
-**Esto es esperado, y leerlo con cuidado fue el instinto correcto.** Claude Code muestra ese aviso para *cualquier* herramienta que no venga de Anthropic. No es señal de que algo esté mal. Es el mismo chequeo que te protege de software realmente dañino, haciendo su trabajo en una instalación normal.
+**Esto es esperado, y hacés bien en leerlo con calma.** Claude Code muestra ese aviso para *cualquier* herramienta que no venga de Anthropic. No es señal de que algo esté mal. Es el mismo chequeo que te cuida cuando se está instalando algo de afuera, haciendo su trabajo en una instalación normal.
 
 Esto es lo que estás aprobando:
 
-- **El plugin ai-brain-starter.** Este proyecto. Licencia MIT, público, cada archivo se puede leer en GitHub.
-- **Un grupo chico de packs de skills de nombres establecidos.** Trail of Bits (una firma de seguridad), Stripe, Cloudflare, Sentry, y algunos autores de skills independientes. Cada uno, con su licencia y lo que hace, está listado en [Before you paste](#before-you-paste--what-gets-installed) más arriba.
-- **Dos servidores MCP.** Granola (notas de reuniones) y ChatPRD (borradores). Ayudantes opcionales que podés remover después.
+- **El plugin ai-brain-starter.** Este proyecto. MIT, público, todos los archivos visibles en GitHub.
+- **Un grupo pequeño de packs de skills de nombres conocidos.** Trail of Bits (firma de seguridad), Stripe, Cloudflare, Sentry, y algunos autores independientes. Cada uno, con su licencia y para qué sirve, está en [Before you paste](#before-you-paste--what-gets-installed) más arriba.
+- **Dos servidores MCP.** Granola (notas de reuniones) y ChatPRD (borradores). Opcionales, los quitás cuando quieras.
 
-Nada de esto manda tus archivos a ningún lado. La instalación es local y tu vault se queda en tu máquina. Si preferís saltarte los packs de terceros del todo, podés: poné `SKIP_VENDOR_SKILLS=1`, descrito en [Before you paste](#before-you-paste--what-gets-installed).
+Nada de esto manda tus archivos a ningún lado. Es una instalación local; tu vault no sale de tu máquina. Si preferís saltarte los packs de terceros, poné `SKIP_VENDOR_SKILLS=1`. Está descrito en [Before you paste](#before-you-paste--what-gets-installed).
 
-Cuando aparezca el aviso, aprobarlo es la opción normal. Y si alguna vez querés deshacer todo, `bash bootstrap.sh --uninstall` lo remueve completo.
+Cuando aparezca el aviso, dale aprobar. Es lo normal. Y si alguna vez querés deshacer todo, `bash bootstrap.sh --uninstall` lo quita completo.
 
 <details>
 <summary>Usuarios existentes (re-corriendo después de un `git pull`)</summary>

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -625,9 +625,9 @@ if (Test-Path $humDir) { Ok "humanizer skill installed" } else { Err "humanizer 
 # Claude Code's built-in trust prompt. Pre-frame it so non-technical installers
 # don't panic. Pairs with phase-00-install.md Step 0.0b.
 Write-Host ""
-Write-Host ("  " + (T "HEADS UP: Claude Code may pause to ask you to approve these tools." "AVISO: Claude Code puede pausar para pedirte que apruebes estas herramientas."))
-Write-Host ("  " + (T "That prompt is its normal safety check for anything not from Anthropic." "Ese aviso es su chequeo normal de seguridad para algo que no viene de Anthropic."))
-Write-Host ("  " + (T "It is expected and safe to approve. The README explains what gets added." "Es esperado y seguro aprobarlo. El README explica todo lo que se instala."))
+Write-Host ("  " + (T "HEADS UP: Claude Code may pause to ask you to approve these tools." "AVISO: Claude Code puede frenar en un momento para pedirte que apruebes estas herramientas."))
+Write-Host ("  " + (T "That prompt is its normal safety check for anything not from Anthropic." "Ese aviso es su chequeo de seguridad normal para cualquier cosa que no viene de Anthropic."))
+Write-Host ("  " + (T "It is expected and safe to approve. The README explains what gets added." "Es esperado, y aprobarlo es lo normal. El README explica todo lo que se esta agregando."))
 Write-Host ""
 
 # ─── Granola MCP ─────────────────────────────────────────────────────────────

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1243,11 +1243,11 @@ if [[ "${SKIP_VENDOR_SKILLS:-0}" != "1" ]]; then
   # don't panic. Pairs with phase-00-install.md Step 0.0b.
   log ""
   log "  ℹ️  $(t "HEADS UP: Claude Code may pause to ask you to approve these tools." \
-                  "AVISO: Claude Code puede pausar para pedirte que apruebes estas herramientas.")"
+                  "AVISO: Claude Code puede frenar en un momento para pedirte que apruebes estas herramientas.")"
   log "  ℹ️  $(t "That prompt is its normal safety check for anything not from Anthropic." \
-                  "Ese aviso es su chequeo normal de seguridad para algo que no viene de Anthropic.")"
+                  "Ese aviso es su chequeo de seguridad normal para cualquier cosa que no viene de Anthropic.")"
   log "  ℹ️  $(t "It is expected and safe to approve. The README explains what gets added." \
-                  "Es esperado y seguro aprobarlo. El README explica qué se agrega.")"
+                  "Es esperado, y aprobarlo es lo normal. El README explica todo lo que se está agregando.")"
   log ""
 
   # Register a marketplace + install a plugin (idempotent + DRY_RUN-safe).

--- a/phases/phase-00-install.md
+++ b/phases/phase-00-install.md
@@ -26,6 +26,10 @@ So get ahead of it. **Before** you invoke the bootstrap (or the instant you see 
 
 > "Heads up on one thing: in a moment Claude Code will pause and ask you to approve the tools we're installing. It may warn that they come from third parties or are not verified by Anthropic. That is Claude Code's normal safety check for anything that did not come from Anthropic itself, not a sign that anything is wrong. It is safe to approve. Everything being added is listed, with licenses, in the project's README. Go ahead and approve it when you see it, and I'll keep going."
 
+For Spanish-speaking installs, the same beat in voseo register (peer-to-peer, not a translation):
+
+> "Ojo con una cosa: Claude Code va a frenar en un momento para pedirte que apruebes las herramientas que estamos instalando. Te puede avisar, en un tono firme, que son de terceros o que Anthropic no las verificó. Ese es su chequeo de seguridad normal para cualquier cosa que no venga directo de Anthropic, no una señal de que algo esté mal. Es seguro aprobarlo. Todo lo que se está agregando está listado, con licencias, en el README del proyecto. Cuando aparezca, dale aprobar y seguimos."
+
 Adapt the wording to the user and the moment; do not read it robotically. The non-negotiable part: before they read the prompt themselves, the user must KNOW it is coming, that it is expected, and that approving is the normal choice. Never let the trust prompt be the first time they hear of it. An unframed trust prompt is the single most common reason a non-technical install gets abandoned.
 
 ---

--- a/phases/phase-19-23-finish.md
+++ b/phases/phase-19-23-finish.md
@@ -374,15 +374,15 @@ Tell the user in their PRIMARY_LANGUAGE only. Show one link, matching their lang
 >
 > Tres comandos y un hábito para tu primera semana:
 >
-> 1. `/journal` — todas las noches. Este es el hábito. Construye los datos sobre los que corren los insights semanales y mensuales. Si te saltas una semana, el insight semanal pierde la mayor parte de la semana.
-> 2. `/second-brain-mapping` — cuando hayas traído tus notas activas (en la próxima sesión), corre esto para mapear el vault en lotes pequeños y dejar todo consultable.
-> 3. "¿Qué pensaría el panel?" — pregúntalo antes de cualquier decisión estratégica. Trae de 3 a 5 voces nombradas con disenso incorporado.
+> 1. `/journal` — todas las noches. Este es el hábito. Construye los datos que alimentan los insights semanales y mensuales. Si te saltás una semana, el insight semanal pierde la mayor parte de la semana.
+> 2. `/second-brain-mapping` — cuando hayas traído tus notas activas (en la próxima sesión), corrélo para mapear el vault en lotes pequeños y dejar todo consultable.
+> 3. "¿Qué pensaría el panel?" — preguntalo antes de cualquier decisión estratégica. Trae de 3 a 5 voces nombradas con disenso incorporado.
 >
-> La primera semana se va a sentir callada. Si haces estas tres cosas, para el día ocho vas a sentir para qué sirve el cerebro. Si te las saltas, el vault se queda en tu carpeta de Obsidian sin hacer nada.
+> La primera semana se va a sentir callada. Si hacés estas tres cosas, para el día ocho vas a sentir para qué sirve el cerebro. Si te las saltás, el vault se queda en tu carpeta de Obsidian sin hacer nada.
 >
 > Recorrido más largo: https://perspectivasblog.substack.com/p/tu-primera-semana-con-tu-segundo
 >
-> Léelo esta noche. ¿Atascado en algo? Solo dilo en cualquier sesión."
+> Leelo esta noche. ¿Atascado en algo? Solo decilo en cualquier sesión."
 
 ---
 
@@ -458,7 +458,7 @@ After the handoff link, do a quick verbal pointer to how the close works. This i
 
 **EN:** "One more thing. When you're done with a session, just say 'bye' or 'thanks, that's all' and the system will save everything automatically — your decisions, journal seeds, to-dos, all of it. You don't need to type a special command. If you ever want to be explicit, type `/wrap-up` or `/close`. To roll back the most recent close, run `python3 ~/.claude/skills/ai-brain-starter/scripts/undo-last-close.py`. That's it."
 
-**ES:** "Una última cosa. Cuando termines una sesión, solo di 'chao' o 'listo, gracias' y el sistema guarda todo automáticamente — decisiones, semillas para el diario, to-dos, todo. No tienes que escribir un comando especial. Si quieres ser explícito, escribe `/cerrar` o `/wrap-up`. Para deshacer el último cierre: `python3 ~/.claude/skills/ai-brain-starter/scripts/undo-last-close.py`. Eso es todo."
+**ES:** "Una última cosa. Cuando termines una sesión, solo decí 'chao' o 'listo, gracias' y el sistema guarda todo automáticamente — decisiones, semillas para el diario, to-dos, todo. No tenés que escribir un comando especial. Si querés ser explícito, escribí `/cerrar` o `/wrap-up`. Para deshacer el último cierre: `python3 ~/.claude/skills/ai-brain-starter/scripts/undo-last-close.py`. Eso es todo."
 
 Why this phase matters: the close cascade is the most active piece of the setup, firing on every "bye". If users don't know it exists or don't trust it, they keep typing `/wrap-up` defensively (annoying) or skip closes entirely (lost context). One sentence pointing at the natural-language path is enough to flip default behavior to trust.
 
@@ -474,7 +474,7 @@ After the close walkthrough, set the expectation for how the vault grows AS THEY
 > "One last thing about pacing. The doc you just brought in plus tonight's journal are the first two real things in your vault. Over the next couple of weeks, when you reach for a note in your old system (Apple Notes, Google Docs, Notion, paper, whatever), just bring it in here instead. You don't have to migrate everything at once — let it happen organically. When you have ten or so real notes in, ask me 'can the panel review how my files are organized?' and we'll clean it up together. The `/second-brain-mapping` skill keeps the index fresh as content accumulates — run it weekly per the first-week post. The vault gets smarter the more of your actual life lives in here."
 
 **ES:**
-> "Una última cosa sobre el ritmo. El documento que acabas de traer más el diario de esta noche son las primeras dos cosas reales en tu vault. En las próximas semanas, cuando estés buscando una nota en tu sistema anterior (Apple Notes, Google Docs, Notion, papel, lo que sea), simplemente tráela acá en vez. No tienes que migrar todo de una — déjalo pasar de forma orgánica. Cuando tengas unas diez notas reales adentro, pregúntame '¿puede el panel revisar cómo están organizados mis archivos?' y la limpiamos juntos. El skill `/second-brain-mapping` mantiene el índice fresco a medida que se acumula contenido — córrelo semanalmente como dice el post de la primera semana. El vault se vuelve más inteligente mientras más de tu vida real viva acá adentro."
+> "Una última cosa sobre el ritmo. El documento que acabás de traer más el diario de esta noche son las primeras dos cosas reales en tu vault. En las próximas semanas, cuando estés buscando una nota en tu sistema anterior (Apple Notes, Google Docs, Notion, papel, lo que sea), simplemente traela acá en vez. No tenés que migrar todo de una — dejalo pasar de forma orgánica. Cuando tengas unas diez notas reales adentro, preguntame '¿puede el panel revisar cómo están organizados mis archivos?' y la limpiamos juntos. El skill `/second-brain-mapping` mantiene el índice fresco a medida que se acumula contenido — corrélo semanalmente como dice el post de la primera semana. El vault se vuelve más inteligente mientras más de tu vida real viva acá adentro."
 
 Why this phase matters: install completion is the moment of highest motivation AND highest decision fatigue. The user already did the activation moment in Phase 19.5 (one doc imported). This phase tells them HOW the rest gets brought in — progressively, naturally, not as a homework assignment for a future session that may never happen.
 


### PR DESCRIPTION
## Summary

Polish-pass on the install surface for non-technical bilingual installers. David Gómez (Bien Pensado) panel voice anchored the Spanish work; Jackie Kennedy seated for public-image review.

**Spanish register unified to voseo with rhythm.** The README ES "Después de pegarlo" bullets and "Qué te va a preguntar Claude" section, the new phase-00 ES blockquote, phase-19-23-finish.md Phases 24 / 24.5 / 24.6, and the trust-prompt heads-up in `bootstrap.sh` + `bootstrap.ps1` all converted from pure-tú or translation-stiff forms to consistent peer-to-peer voseo (`te saltás`, `preguntalo`, `leelo`, `corrélo`, `hacés bien en leerlo con calma`, `los quitás cuando quieras`). The substrate's Spanish now reads in one register.

**macOS-vs-Windows note** next to the marketplaces table. Windows bootstrap installs `obsidian-skills` + 2 MCPs but not the seven vendor skill-packs. The note documents the gap and gives the manual `/plugin marketplace add` recipe for adding any of them after install. A bash-to-PowerShell port of the vendor block is deferred — shipping ~150 lines of untested PowerShell ahead of a live demo is the opposite of hardening what fails.

**`.codegraph/`** added to `.gitignore`. Prevents accidental commit of codegraph's local 100MB+ index.

No functional code changes. The trust-prompt regression test still passes (all EN markers and the ES heading preserved exactly).

## Test plan

- [x] `test_trust_prompt_preframing.sh` passes locally
- [x] `test_bootstrap_dry_run.sh` passes
- [x] `bash -n bootstrap.sh` clean
- [x] `bootstrap.ps1` em-dash-free + UTF-8 BOM intact
- [x] Personal-data scrub clean on the full diff (word-boundary, CI privacy parity)
- [ ] CI green on all lint.yml jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)