### PR TITLE
fix(insight-engine): auto-load self-reference names from vault config file

### DIFF
--- a/scripts/vault-insight-engine.py
+++ b/scripts/vault-insight-engine.py
@@ -44,11 +44,33 @@ def _default_output_path():
 OUTPUT_PATH = _default_output_path()
 
 # Names to filter out of person-based insights (self-references).
-# Populate SELF_REFERENCE_NAMES env var (comma-separated) with your own variants.
-# Example: SELF_REFERENCE_NAMES="Jane Doe,Jane,Jane D."
-SELF_REFERENCE_NAMES = set(
-    filter(None, (n.strip() for n in os.environ.get("SELF_REFERENCE_NAMES", "").split(",")))
-)
+# Resolution order:
+#   1. SELF_REFERENCE_NAMES env var (comma-separated) — explicit override
+#   2. <vault>/⚙️ Meta/self-reference-names.txt — vault-side config (one name
+#      per line, blank lines + `#` comments ignored). Portable across installs.
+#      See templates/self-reference-names.txt.example for the template.
+#   3. Empty set — engine still runs, just skips the self-ref filter
+def _load_self_reference_names():
+    env = os.environ.get("SELF_REFERENCE_NAMES", "").strip()
+    if env:
+        return set(filter(None, (n.strip() for n in env.split(","))))
+    config_path = os.path.join(VAULT, "⚙️ Meta", "self-reference-names.txt")
+    if os.path.isfile(config_path):
+        try:
+            with open(config_path, encoding="utf-8") as fh:
+                names = set()
+                for raw in fh:
+                    line = raw.strip()
+                    if not line or line.startswith("#"):
+                        continue
+                    names.add(line)
+                return names
+        except OSError:
+            pass
+    return set()
+
+
+SELF_REFERENCE_NAMES = _load_self_reference_names()
 
 
 def _is_self_reference(name):

--- a/templates/self-reference-names.txt.example
+++ b/templates/self-reference-names.txt.example
@@ -1,0 +1,19 @@
+# Self-reference names — vault owner identity, one per line.
+# Copy this file to <your-vault>/⚙️ Meta/self-reference-names.txt and replace
+# the placeholders below with your own name variants. vault-insight-engine.py
+# uses it to exclude you from person-based insights (cold-contacts, drag-people,
+# lucky-charm, etc.) — otherwise your own name shows up as a "person" to warm.
+#
+# Loader rules:
+#   - Lines starting with # are comments and ignored
+#   - Blank lines ignored
+#   - Each non-comment line is a name variant (exact match OR first-name prefix match)
+#   - SELF_REFERENCE_NAMES env var (if set) takes precedence over this file
+#
+# Adding entries: include your legal name + every spelling variant your vault
+# has used (CRM, journal frontmatter, meeting notes). The engine's prefix-match
+# on first name covers most cases, but listing every spelling is safest.
+
+Jane Doe
+Jane
+Jane D.


### PR DESCRIPTION
## Summary

- `vault-insight-engine.py` read self-reference names from a `SELF_REFERENCE_NAMES` env var that new users would never set, so they appeared on their own cold-contacts + drag-people insights as if they were a separate person to warm.
- Resolution order is now: (1) env var override (unchanged), (2) `<vault>/⚙️ Meta/self-reference-names.txt`, (3) empty set / graceful no-op.
- Template added at `templates/self-reference-names.txt.example` so new installs have a one-step copy-and-edit path.

## Test plan

- [x] Unit-tested `_is_self_reference()` on real + placeholder name variants (exact match, first-name prefix match, non-self pass-through)
- [x] End-to-end: re-ran engine on real vault, owner dropped from cold-contacts (9 → 8 entries) and from drag-people (4th slot freed)
- [x] Graceful fallback: with file missing AND env var unset, engine still runs (filter just no-ops)
- [x] Personal-data scrub: 0 matches against the canonical regex set

🤖 Generated with [Claude Code](https://claude.com/claude-code)