### PR TITLE
feat: prompt-caching default ON in _claude_router + ship rule + hookify

### DIFF
--- a/scripts/_claude_router.py
+++ b/scripts/_claude_router.py
@@ -190,13 +190,34 @@ def _call_via_api(
     user: str,
     model: str,
     max_tokens: int,
+    cache_system: bool = True,
 ) -> str:
-    """POST to api.anthropic.com Messages API. Returns the first text block."""
+    """POST to api.anthropic.com Messages API. Returns the first text block.
+
+    When `cache_system=True` (default), wraps the system prompt in a single
+    `cache_control=ephemeral` block so the Anthropic prompt cache is reused
+    across calls with the same prefix. The API silently no-ops when the
+    prefix is below the model's cache minimum (1K tokens for Sonnet 4.5 /
+    Opus 4.1, 4K for Opus 4.7 / Sonnet 4.6 / Haiku 4.5), so opt-in is
+    safe at any size.
+
+    Logs `cache_read_input_tokens` / `cache_creation_input_tokens` from the
+    response so logs can confirm caching fires on repeated calls.
+    """
+    system_payload: object
+    if cache_system:
+        system_payload = [{
+            "type": "text",
+            "text": system,
+            "cache_control": {"type": "ephemeral"},
+        }]
+    else:
+        system_payload = system
     payload = json.dumps(
         {
             "model": model,
             "max_tokens": max_tokens,
-            "system": system,
+            "system": system_payload,
             "messages": [{"role": "user", "content": user}],
         }
     ).encode()
@@ -210,7 +231,7 @@ def _call_via_api(
         },
         method="POST",
     )
-    _log(f"calling via API key ({model})")
+    _log(f"calling via API key (model={model}, cache_system={cache_system})")
     try:
         with urllib.request.urlopen(req, timeout=API_TIMEOUT_SECONDS) as resp:
             body = json.loads(resp.read())
@@ -220,6 +241,12 @@ def _call_via_api(
         ) from e
     except urllib.error.URLError as e:
         raise RouterUnavailable(f"Anthropic network error: {e}") from e
+    # Cache metrics. Non-zero read means a hit (0.1x cost for those tokens).
+    usage = body.get("usage", {}) or {}
+    cache_read = usage.get("cache_read_input_tokens", 0) or 0
+    cache_write = usage.get("cache_creation_input_tokens", 0) or 0
+    if cache_read or cache_write:
+        _log(f"cache: read={cache_read} tok, write={cache_write} tok")
     blocks = body.get("content", [])
     if not blocks:
         return ""
@@ -231,6 +258,7 @@ def call_claude_text(
     user: str,
     model: str = "haiku",
     max_tokens: int = 4096,
+    cache_system: bool = True,
 ) -> str:
     """Call Claude and return the response text.
 
@@ -239,6 +267,11 @@ def call_claude_text(
 
     Model aliases: "haiku", "sonnet", "opus", or any full model ID
     (e.g., "claude-haiku-4-5-20251001"). The CLI accepts both forms.
+
+    `cache_system` controls Anthropic prompt caching on the API path. Default
+    True. The CLI path caches automatically — Claude Code handles it
+    transparently and the flag is ignored there. Set False only when the
+    caller varies the system prompt per call (benchmarks, evals, sweeps).
     """
     prefer_api = os.environ.get("CLAUDE_ROUTER_PREFER_API_KEY") == "1"
 
@@ -251,7 +284,7 @@ def call_claude_text(
 
     api_key = _resolve_api_key()
     if api_key is not None:
-        return _call_via_api(api_key, system, user, model, max_tokens)
+        return _call_via_api(api_key, system, user, model, max_tokens, cache_system)
 
     raise RouterUnavailable(
         "no claude CLI and no ANTHROPIC_API_KEY — install `claude` "
@@ -267,14 +300,17 @@ def call_claude_json(
     user: str,
     model: str = "haiku",
     max_tokens: int = 4096,
+    cache_system: bool = True,
 ) -> dict | list:
     """Call Claude and parse the response as JSON.
 
     Strips markdown code fences if the model adds them. Raises
     `RouterUnavailable` if no transport is available, or `ValueError`
     if the response is not valid JSON.
+
+    See `call_claude_text` for `cache_system` semantics (default True).
     """
-    text = call_claude_text(system, user, model, max_tokens)
+    text = call_claude_text(system, user, model, max_tokens, cache_system)
     stripped = text.strip()
     fence_match = _FENCE_RE.match(stripped)
     if fence_match:

--- a/templates/hookify-rules/hookify.warn-claude-call-without-cache.local.md
+++ b/templates/hookify-rules/hookify.warn-claude-call-without-cache.local.md
@@ -1,0 +1,61 @@
+---
+name: warn-claude-call-without-cache
+enabled: true
+event: file
+action: warn
+conditions:
+  - field: file_path
+    operator: regex_match
+    pattern: \.(py|ts|tsx|mjs|js)$
+  - field: new_text
+    operator: regex_match
+    pattern: (messages\.create\s*\(|messages\.stream\s*\(|@anthropic-ai/sdk|anthropic\.Anthropic\s*\(|new Anthropic\s*\()
+---
+
+**Anthropic Messages API call detected.** Per the prompt-caching rule (template at `templates/rules/prompt-caching.md`): every Claude-calling surface ships with `cache_control` on the system block from the start. Default ON, even when today's prefix is below the model minimum — the API silently no-ops if too small, so opt-in is free and future-proofs the surface.
+
+**If you went through `_claude_router.py`** (or any wrapper that exposes a `cache_system` flag): caching is on by default. Nothing to do.
+
+**If you're calling the SDK / API directly** (`client.messages.create(...)` or POST to `/v1/messages`): wrap the system prompt in a cache block.
+
+Python:
+
+```python
+response = client.messages.create(
+    model="claude-haiku-4-5-20251001",
+    max_tokens=2048,
+    system=[
+        {
+            "type": "text",
+            "text": SYSTEM_PROMPT,
+            "cache_control": {"type": "ephemeral"},
+        }
+    ],
+    messages=[{"role": "user", "content": user_input}],
+)
+```
+
+TypeScript:
+
+```ts
+const response = await client.messages.create({
+  model: MODEL,
+  max_tokens: 2048,
+  system: [
+    { type: "text", text: SYSTEM_PROMPT, cache_control: { type: "ephemeral" } },
+  ],
+  messages: [{ role: "user", content: userContent }],
+});
+```
+
+**Tools:** put `cache_control` on the LAST tool to cache the entire tools block.
+
+**Verification:** read `response.usage.cache_read_input_tokens` and `cache_creation_input_tokens` on the first two calls. Second call within TTL should show `read > 0, write = 0`.
+
+**Already-cached files don't need re-action** — this warn fires on any matching API call, including ones already caching. If you see the pattern + `cache_control` on the same block, ignore.
+
+**Legitimate opt-out** (benchmark, model sweep, A/B prompt test): pass `cache_system=False` (router) or add a comment `# no-cache: <reason>` / `// no-cache: <reason>` next to the call so future audits know it was deliberate.
+
+**Bypass for a one-off:** `PROMPT_CACHE_RULE_BYPASS=1` on the failing tool call. The rule itself stays on; never weaken the regex.
+
+Pairs with `_claude_router.py` (`cache_system: bool = True` default) and the `prompt-caching.md` rule template. Together they push caching to ON by default for every new surface without requiring caller awareness.

--- a/templates/rules/prompt-caching.md
+++ b/templates/rules/prompt-caching.md
@@ -1,0 +1,147 @@
+---
+type: rule
+applies_to: every code surface that calls the Anthropic Messages API
+---
+
+Default ON for every Claude-calling surface. The Anthropic API silently no-ops when the prefix is below the model minimum, so opt-in is free and future-proofs the surface against later prompt growth.
+
+## When to cache
+
+| Situation | Cache it? |
+|---|---|
+| Stable system prompt + repeated calls | YES (default) |
+| Tool definitions shared across calls | YES — `cache_control` on the last tool |
+| Large document analyzed many times | YES — cache the doc, not the question |
+| Per-call prompt is unique (benchmarks, sweeps) | NO — pass `cache_system=False` |
+| Tiny system today (< minimum), might grow later | YES anyway — API no-ops if too small, no cost |
+
+## Minimum cacheable size
+
+| Model | Minimum |
+|---|---|
+| Sonnet 4.5, Opus 4.1 | 1,024 tokens |
+| Opus 4.7, Sonnet 4.6, Haiku 4.5 | 4,096 tokens |
+| Haiku 3.5 (Vertex only) | 2,048 tokens |
+
+Below minimum → cache silently no-ops. Caching anyway is free.
+
+## Pricing (multipliers on base input price)
+
+| Operation | Cost |
+|---|---|
+| 5m cache write | 1.25× |
+| 1h cache write | 2× |
+| Cache read | 0.1× |
+
+Break-even on a reused prefix: 2 calls. Compounds from there.
+
+## Cache hierarchy + invalidation
+
+Levels: `tools → system → messages`. Change at any level invalidates that level AND all below.
+
+| Change | Invalidates |
+|---|---|
+| Tool definitions | EVERYTHING |
+| Web search / citations / speed toggle | system + messages |
+| `tool_choice` change | messages |
+| Images added/removed | messages |
+| Thinking parameters | messages |
+
+## Patterns
+
+### Stable system prompt (the common case)
+
+```python
+response = client.messages.create(
+    model="claude-haiku-4-5-20251001",
+    max_tokens=2048,
+    system=[
+        {
+            "type": "text",
+            "text": SYSTEM_PROMPT,
+            "cache_control": {"type": "ephemeral"},
+        }
+    ],
+    messages=[{"role": "user", "content": user_input}],
+)
+```
+
+### Stable system + per-call appendix (e.g., locale directive)
+
+Cache the stable block. Append uncached blocks AFTER the cache marker so per-call variation doesn't invalidate.
+
+```python
+system_blocks = [
+    {"type": "text", "text": SYSTEM_PROMPT, "cache_control": {"type": "ephemeral"}},
+    {"type": "text", "text": locale_directive(lang)},
+]
+```
+
+### Large document + many questions
+
+Cache the doc on the user message, not the question.
+
+```python
+messages=[{
+    "role": "user",
+    "content": [
+        {"type": "text", "text": document_text, "cache_control": {"type": "ephemeral"}},
+        {"type": "text", "text": question},
+    ],
+}]
+```
+
+### Tools
+
+`cache_control` on the LAST tool caches the entire tools block.
+
+```python
+tools = [
+    {"name": "search", "description": "...", "input_schema": "..."},
+    {"name": "fetch", "description": "...", "input_schema": "...",
+     "cache_control": {"type": "ephemeral"}},
+]
+```
+
+### 1-hour TTL for bursty cadence
+
+```python
+"cache_control": {"type": "ephemeral", "ttl": "1h"}
+```
+
+Use when calls cluster in bursts > 5 min apart (operator backlog catch-up, daily cron, multi-stage agent flows). 2× write cost, but worth it when default 5m would expire between calls.
+
+### Pre-warming
+
+Load cache before users arrive: `max_tokens=0`, dummy user message, normal system. Cache populates; the real request reads it.
+
+## Verification (REQUIRED on first deploy)
+
+Read `usage.cache_read_input_tokens` and `usage.cache_creation_input_tokens` off the response.
+
+- First call within TTL: `write > 0, read = 0`
+- Second call within TTL: `write = 0, read > 0`
+- Second call writes too → prefix is varying per call. Audit it.
+
+If you ship a Claude router, log cache metrics on every API call so cron logs can confirm caching fires on repeats.
+
+For TypeScript / Anthropic Node SDK, `response.usage.cache_read_input_tokens` and `response.usage.cache_creation_input_tokens` are surfaced the same way.
+
+## Router pattern: cache-on by default
+
+The shipped `_claude_router.py` (in `scripts/`) exposes `cache_system: bool = True`. Set False ONLY when the caller varies the system prompt per call (benchmarks, evals, model sweeps, A/B tests on the prompt itself).
+
+```python
+text = call_claude_text(system=PROMPT, user=q, model="haiku")
+text = call_claude_text(system=variant, user=q, cache_system=False)
+```
+
+First call is cached by default. Second call opts out, e.g. for a benchmark.
+
+## New-code rule (enforced by hookify)
+
+Any new file that imports `anthropic.Anthropic` / calls `messages.create` / imports `@anthropic-ai/sdk` ships with `cache_control` on the system block from the start.
+
+The shipped hookify rule `warn-claude-call-without-cache` (in `templates/hookify-rules/`) warns on file edits matching the pattern. Override path: pass `cache_system=False` (router) or add a comment `# no-cache: <reason>` (direct call) so future audits know the omission was deliberate.
+
+Bypass for unusual cases: `PROMPT_CACHE_RULE_BYPASS=1` on the failing tool call. Never weaken the regex.


### PR DESCRIPTION
## Summary

- Adds `cache_system: bool = True` to `call_claude_text` and `call_claude_json` in `scripts/_claude_router.py`. API path wraps the system prompt in `cache_control=ephemeral` by default; CLI path is unchanged (Claude Code handles caching transparently). Logs cache_read / cache_creation tokens.
- Ships a new rule template at `templates/rules/prompt-caching.md` covering when to cache, model minimums, pricing multipliers, cache hierarchy, invalidation matrix, 5 canonical patterns, verification, and the router pattern.
- Ships a new hookify rule template at `templates/hookify-rules/hookify.warn-claude-call-without-cache.local.md` that flags new files matching the Anthropic API call signature without `cache_control`.

## Why this matters

Opt-in is free: the Anthropic API silently no-ops when the prefix is below the model minimum (1K tokens for Sonnet 4.5 / Opus 4.1, 4K for Opus 4.7 / Sonnet 4.6 / Haiku 4.5), so caching ON by default has zero downside. Future-proofs every surface against later prompt growth without paying upfront.

## Test plan

- [ ] CI green (Python type/lint, no integration regressions)
- [ ] Manual: call `call_claude_text` twice within 5 min with the same large system prompt, confirm second call's `cache_read_input_tokens > 0` in router logs
- [ ] Manual: call with `cache_system=False`, confirm both calls show `cache_read_input_tokens = 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)