### PR TITLE
docs: add token-economics teaching doc + measurement script

### DIFF
--- a/docs/token-economics.md
+++ b/docs/token-economics.md
@@ -1,0 +1,91 @@
+# Token economics — measure at install, scope by frequency
+
+Plugins, MCP servers, and `SessionStart` hooks all add **always-on** context cost to every session. Each new install incrementally eats your context budget, even when the new capability is rarely used. This document codifies the discipline for keeping that load lean **without losing capability**.
+
+## The bug class
+
+**`ARTIFACT-WITHOUT-MEASUREMENT`.** Installing something without measuring its always-on cost.
+
+A real measurement from one user's environment:
+
+- Total always-on plugin load: **~19,000 tokens per session** (about 10% of a 200K context).
+- Two domain-bundle plugins (a marketing pack + an SEO pack) accounted for **~10,000** of that — roughly half.
+- Both were used less than once a week. Disabling them with a one-command re-enable saved ~10K per session with **zero capability loss**.
+
+The pattern repeats: tools accumulate, indexes inflate, capability is mostly there but the cost is silent. The fix is not "use fewer plugins." The fix is **measure at install**, **decide by frequency**, **document the choice**, and **never lose capability** in the trade.
+
+## The hard rule
+
+Every install gets:
+
+1. **Measurement first.** Run `claude plugin details <name>` before `claude plugin install <name>`. Note the "Always-on" line.
+2. **Apply the decision tree** (below).
+3. **Document the choice.** A short note in your install/audit memory: which scoping, why, and the re-enable command if disabled.
+4. **Quality stays the bar.** Disabling is only legitimate if capability stays available (per-session enable, keyword-triggered reminder, vault skill that wraps the most-used capability, etc.).
+
+## Decision tree
+
+```
+always-on cost?
+├── ≤500 tok                   → install globally (cheap, no scoping needed)
+└── >500 tok
+    ├── used ≥ weekly          → install globally (cost amortizes against use)
+    └── used < weekly
+        ├── high-friction       → install globally + keyword-trigger reminder
+        └── normal              → install disabled + document the re-enable command
+```
+
+`500` is a starting threshold; tune for your context budget. On a 200K window, 500 tokens per plugin × 50 plugins is 25K — meaningful. On a 1M window, the same load is noise.
+
+## Skills vs MCPs vs hooks
+
+Each component type has different cost behavior:
+
+- **Skill metadata** (name + description) loads always-on; **skill bodies** load only when the skill fires. An idle skill is ~100 tokens of index. A fired skill is index + body. Domain bundles with 40+ skills can hit 5K+ tokens of always-on index for capability you may not touch this session.
+- **MCP server tool schemas** are often deferred in Claude Code (loaded on search rather than always-on) — the harness-level win that makes MCP servers feasible at scale. The deferred-tool **name list** still contributes a smaller per-session cost, so unused MCP servers in `.mcp.json` should be pruned.
+- **`SessionStart` hooks** inject context at every session start. Measure the injection size before adding a new hook. Cache long-running checks (24h TTL pattern works well): `echo "$msg" > ~/.claude/.<my-hook>-cache` and skip the network call when the cache is fresh.
+
+## Measuring
+
+This repo ships `scripts/measure-plugin-load.py`. It runs `claude plugin details` over every installed plugin in parallel, parses the always-on cost, and flags plugins above a threshold.
+
+```bash
+# Show a sorted table + flag plugins >500 tok always-on
+python3 scripts/measure-plugin-load.py --threshold 500
+
+# Write a Markdown report to a file (good for quarterly review):
+python3 scripts/measure-plugin-load.py --report plugin-token-report.md
+
+# JSON output for downstream tooling:
+python3 scripts/measure-plugin-load.py --json
+```
+
+The output ranks plugins by always-on cost and flags candidates exceeding the threshold for the decision tree above.
+
+## Periodic review
+
+- **Quarterly**, or whenever sessions feel heavy: re-run the measurement script. Catches drift — plugins that grew, new installs that bumped the total without anyone noticing.
+- **Every install**: measure first, decide, document.
+- **`/usage` in Claude Code 2.1.149+**: per-category breakdown for skills, subagents, plugins, and per-MCP-server cost. Use it to cross-check the script's numbers.
+
+## Quality floor — the non-negotiable
+
+This rule reduces **token load**, never **capability**. Disabled plugins are one command away from being enabled, and you'll have written that command in your install memory.
+
+The point is that big domain bundles — marketing, SEO, error tracking, fuzzing, language servers you only use in one codebase — shouldn't pay rent in every session when you use them once a month.
+
+If your decision tree starts cutting capability you actually use weekly, you've gone too far. Re-enable. Find a smaller lever:
+
+- A hookify keyword-trigger that surfaces the disabled plugin when domain keywords appear in your prompt.
+- A vault skill that wraps the most-used capability from the disabled bundle.
+- A different, lighter bundle from a different marketplace.
+
+## Companion artifacts
+
+- `scripts/measure-plugin-load.py` — the measurement tool. Generic; works for any user with the `claude` CLI installed.
+- `docs/installing-new-skills.md` (your own install playbook) — extend it so the token-cost measurement is **Decision 0** in your install flow.
+- A note in your CLAUDE.md or AGENTS.md pointing future sessions at this discipline.
+
+## Bug class registered
+
+**`ARTIFACT-WITHOUT-MEASUREMENT`.** The fix is the measurement step, not the disable. Disabling is just what the measurement reveals; the discipline is making the cost visible at install time, every time.

--- a/scripts/measure-plugin-load.py
+++ b/scripts/measure-plugin-load.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""measure-plugin-load.py — Plugin always-on token-cost measurement.
+
+Loops `claude plugin details` over every installed plugin in parallel,
+parses projected always-on tokens + component counts, sums totals, and
+flags plugins exceeding a threshold per the token-economics decision tree.
+
+Enforces the rule documented at `docs/token-economics.md`:
+- ≤500 tok always-on → keep global
+- >500 tok + used ≥ weekly → keep global
+- >500 tok + used < weekly → disable + document per-session re-enable
+
+Usage:
+    python3 measure-plugin-load.py [--threshold N] [--report PATH] [--json]
+
+Example for quarterly review:
+    python3 scripts/measure-plugin-load.py --report plugin-token-report.md
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+
+
+def list_plugins() -> list[str]:
+    """Return the list of installed plugin bare names from `claude plugin list --json`.
+
+    Defensive: handles multiple plausible JSON shapes the CLI might return.
+    """
+    try:
+        r = subprocess.run(
+            ["claude", "plugin", "list", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
+        sys.stderr.write(f"could not run `claude plugin list --json`: {e}\n")
+        return []
+    if r.returncode != 0:
+        sys.stderr.write(
+            f"`claude plugin list --json` failed (rc={r.returncode}): "
+            f"{r.stderr[:200]}\n"
+        )
+        return []
+    try:
+        data = json.loads(r.stdout)
+    except json.JSONDecodeError:
+        sys.stderr.write("could not parse JSON from `claude plugin list --json`\n")
+        return []
+
+    # Try common shapes: {"plugins": [...]}, [...], or {name: {...}, ...}
+    if isinstance(data, dict) and "plugins" in data:
+        items = data["plugins"]
+    elif isinstance(data, list):
+        items = data
+    elif isinstance(data, dict):
+        items = list(data.keys())
+    else:
+        items = []
+
+    names: list[str] = []
+    for item in items:
+        if isinstance(item, dict):
+            name = item.get("name") or item.get("plugin") or item.get("id")
+            if name:
+                names.append(str(name).split("@")[0])
+        elif isinstance(item, str):
+            names.append(item.split("@")[0])
+    return sorted(set(names))
+
+
+def get_details(name: str) -> str:
+    """Run `claude plugin details NAME`, return stdout (empty string on failure)."""
+    try:
+        r = subprocess.run(
+            ["claude", "plugin", "details", name],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        return r.stdout
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return ""
+
+
+def parse_count(text: str, kind: str) -> int:
+    m = re.search(rf"{kind}\s*\((\d+)\)", text)
+    return int(m.group(1)) if m else 0
+
+
+def parse_alwayson(text: str) -> int:
+    m = re.search(r"Always-on:\s*~?([\d,]+)\s*tok", text)
+    return int(m.group(1).replace(",", "")) if m else 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument(
+        "--threshold",
+        type=int,
+        default=500,
+        help="Flag plugins with always-on cost >N tok (default: 500).",
+    )
+    ap.add_argument(
+        "--report",
+        default=None,
+        help="Write Markdown report to PATH (in addition to stdout).",
+    )
+    ap.add_argument("--json", action="store_true", help="Output JSON instead of table.")
+    args = ap.parse_args()
+
+    names = list_plugins()
+    if not names:
+        sys.stderr.write("no plugins found.\n")
+        return 1
+
+    sys.stderr.write(f"measuring {len(names)} plugins (parallel)...\n")
+    out: dict[str, str] = {}
+    with ThreadPoolExecutor(max_workers=8) as ex:
+        for name, text in zip(names, ex.map(get_details, names)):
+            out[name] = text
+
+    rows: list[dict] = []
+    tot_ao = 0
+    tot_sk = tot_ag = tot_hk = tot_mc = 0
+    for name in names:
+        t = out[name]
+        if not t.strip():
+            rows.append(
+                {
+                    "name": name,
+                    "skills": None,
+                    "agents": None,
+                    "hooks": None,
+                    "mcp": None,
+                    "always_on": None,
+                    "status": "no_data",
+                }
+            )
+            continue
+        sk = parse_count(t, "Skills")
+        ag = parse_count(t, "Agents")
+        hk = parse_count(t, "Hooks")
+        mc = parse_count(t, "MCP servers")
+        ao = parse_alwayson(t)
+        tot_sk += sk
+        tot_ag += ag
+        tot_hk += hk
+        tot_mc += mc
+        tot_ao += ao
+        flag = "FLAGGED" if ao > args.threshold else "ok"
+        rows.append(
+            {
+                "name": name,
+                "skills": sk,
+                "agents": ag,
+                "hooks": hk,
+                "mcp": mc,
+                "always_on": ao,
+                "status": flag,
+            }
+        )
+
+    if args.json:
+        report = {
+            "plugins": rows,
+            "totals": {
+                "skills": tot_sk,
+                "agents": tot_ag,
+                "hooks": tot_hk,
+                "mcp": tot_mc,
+                "always_on": tot_ao,
+            },
+            "threshold": args.threshold,
+        }
+        print(json.dumps(report, indent=2))
+        return 0
+
+    rows_sorted = sorted(rows, key=lambda r: r["always_on"] or 0, reverse=True)
+    lines: list[str] = []
+    lines.append(
+        f"{'PLUGIN':<35}{'skills':>7}{'agents':>7}{'hooks':>6}"
+        f"{'mcp':>5}{'always-on/session':>19}  flag"
+    )
+    lines.append("-" * 88)
+    for r in rows_sorted:
+        ao = f"~{r['always_on']:,} tok" if r["always_on"] is not None else "no data"
+        flag = "⚠️" if r["status"] == "FLAGGED" else ""
+        lines.append(
+            f"{r['name']:<35}{str(r['skills']):>7}{str(r['agents']):>7}"
+            f"{str(r['hooks']):>6}{str(r['mcp']):>5}{ao:>19}  {flag}"
+        )
+    lines.append("-" * 88)
+    lines.append(
+        f"{'TOTALS':<35}{tot_sk:>7}{tot_ag:>7}{tot_hk:>6}{tot_mc:>5}"
+        f"{('~' + format(tot_ao, ',') + ' tok'):>19}"
+    )
+    lines.append("")
+    flagged = [r for r in rows if r["status"] == "FLAGGED"]
+    if flagged:
+        lines.append(
+            f"FLAGGED ({len(flagged)} plugins >{args.threshold} tok always-on):"
+        )
+        for r in flagged:
+            lines.append(
+                f"  - {r['name']}: ~{r['always_on']:,} tok — "
+                f"used >= weekly? keep. Else: disable + per-session enable."
+            )
+    else:
+        lines.append(f"All plugins under {args.threshold} tok threshold.")
+
+    print("\n".join(lines))
+
+    if args.report:
+        with open(args.report, "w") as f:
+            f.write("# Plugin token-load report\n\n")
+            f.write(
+                "Generated by `measure-plugin-load.py`. "
+                "Re-run quarterly + at every plugin install.\n\n"
+            )
+            f.write("## Decision rule\n\n")
+            f.write(f"- <= {args.threshold} tok always-on -> install global (cheap).\n")
+            f.write(
+                f"- > {args.threshold} tok + used >= weekly -> install global "
+                f"(amortizes).\n"
+            )
+            f.write(
+                f"- > {args.threshold} tok + used < weekly -> disable + "
+                f"document re-enable command.\n\n"
+            )
+            f.write("## Current state\n\n")
+            f.write("```\n")
+            f.write("\n".join(lines))
+            f.write("\n```\n")
+        sys.stderr.write(f"wrote report -> {args.report}\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- `docs/token-economics.md` — teaching doc on the measure-at-install discipline: decision tree (≤500 / >500 tok × weekly use), capability floor, periodic review pattern. Public-friendly prose, no personal context.
- `scripts/measure-plugin-load.py` — parallel measurement across installed plugins via `claude plugin details`. CLI flags: `--threshold N`, `--report PATH`, `--json`. Generic; works for any vault user with the `claude` CLI installed.

Sourced from a real measurement pass: 24 plugins, ~19K tok/session always-on, 4 disabled saved ~12.6K (~67% reduction) with zero capability loss.

Bug class registered: **ARTIFACT-WITHOUT-MEASUREMENT** — installing a plugin/MCP/hook without measuring its always-on context cost.

## Test plan

- [ ] `python3 scripts/measure-plugin-load.py --threshold 500` returns a sorted table + flag count
- [ ] `python3 scripts/measure-plugin-load.py --json` returns valid JSON
- [ ] `python3 scripts/measure-plugin-load.py --report /tmp/report.md` writes a Markdown report
- [ ] Doc renders cleanly on GitHub (tables + decision tree code block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)