### PR TITLE
docs(prompt-caching): document N x M doc-outer iteration pattern

### DIFF
--- a/templates/rules/prompt-caching.md
+++ b/templates/rules/prompt-caching.md
@@ -138,6 +138,29 @@ text = call_claude_text(system=variant, user=q, cache_system=False)
 
 First call is cached by default. Second call opts out, e.g. for a benchmark.
 
+## N x M reviews: iterate doc-outer, column-inner
+
+For tabular-review style work (N columns × M documents = N×M LLM calls) the cache architecture is:
+
+- `system` block: cached, stable across the entire review (1 write, N×M−1 reads)
+- `user[0]` text block: document_text, cached PER DOCUMENT (M writes, M×(N−1) reads)
+- `user[1]` text block: per-column directive + JSON reply ask, varies per column (no cache)
+
+This only works with `for document in documents: for column in columns:` iteration. The reverse order (column-outer) invalidates the document cache on every iteration because the document varies in the inner loop. Always iterate doc-outer. Break-even on per-document caching: N ≥ 2 columns (i.e. every real review).
+
+If your runtime assembles the prompt server-side, return the parts separately so the client can apply `cache_control` to each layer. Example response shape:
+
+```json
+{
+  "prompt": "<full assembled string, deprecated for new code>",
+  "system": "<stable instruction template, cache anchor>",
+  "column_directive": "<question + format suffix, varies per column>",
+  "document_text": "<echoed back so clients don't have to track>"
+}
+```
+
+Keep the legacy `prompt` field so old clients keep working until they migrate.
+
 ## New-code rule (enforced by hookify)
 
 Any new file that imports `anthropic.Anthropic` / calls `messages.create` / imports `@anthropic-ai/sdk` ships with `cache_control` on the system block from the start.


### PR DESCRIPTION
## Summary

- Extends `templates/rules/prompt-caching.md` with the **N x M reviews: iterate doc-outer, column-inner** section.
- Documents the cache architecture for tabular-review style work (N columns × M documents): `system` cached across the whole review, `user[0]` document_text cached per-document, `user[1]` per-column directive varies and is not cached.
- Calls out the critical iteration order: doc-outer / column-inner. Reverse order (column-outer) invalidates the document cache on every iteration.
- Includes the recommended runtime endpoint response shape (`prompt` + `system` + `column_directive` + `document_text`) so server-side prompt-assembly endpoints can support client-side caching without breaking old single-string clients.

## Why now

The tabular-review skill family lives downstream of a `memory-runtime-pro` endpoint that previously returned a single assembled `prompt` string with the question BEFORE the document — uncacheable in the N×M case. The runtime now returns the parts split; the template captures the architecture so anyone building the same shape downstream doesn't re-discover the lesson.

## Test plan

- [ ] CI green (lint, security-audit, bootstrap dry-run, all worktree invariants)
- [ ] No personal-data scrub hits on the diff (already verified locally by `scrub-or-die`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)