### PR TITLE
feat(router): CLI retry + network refusal markers for unattended callers

### DIFF
--- a/scripts/_claude_router.py
+++ b/scripts/_claude_router.py
@@ -159,6 +159,17 @@ def _call_via_cli(
         "authentication required",
         "authentication failed",
         "session expired",
+        # Transport / connectivity errors. When the network is not ready
+        # (e.g. a launchd-fired job during wake-from-sleep), `claude -p` can
+        # emit "API Error: Unable to connect to API (ConnectionRefused)" on
+        # stdout and exit 1 — the accept-non-zero-with-stdout branch below
+        # would otherwise accept that error string as a 55-char "response".
+        # Treat them as RouterUnavailable so the CLI-retry path (below) has
+        # a chance once the network comes up.
+        "api error",
+        "unable to connect to api",
+        "connectionrefused",
+        "failedtoopensocket",
     )
     if stdout and any(m in stdout.lower() for m in refusal_markers):
         raise RouterUnavailable(
@@ -277,10 +288,21 @@ def call_claude_text(
 
     cli = None if prefer_api else _resolve_cli()
     if cli is not None:
-        try:
-            return _call_via_cli(cli, system, user, model)
-        except RouterUnavailable as e:
-            _log(f"CLI failed, falling back to API: {e}")
+        # One retry: an unattended `claude -p` (cron, launchd, agent) can
+        # intermittently hang or return a stale-OAuth refusal on the first
+        # try and clear on the second. Cheap insurance for unattended
+        # callers; the happy path (first attempt succeeds) is unchanged.
+        cli_attempts = 2
+        for cli_attempt in range(1, cli_attempts + 1):
+            try:
+                return _call_via_cli(cli, system, user, model)
+            except RouterUnavailable as e:
+                if cli_attempt < cli_attempts:
+                    _log(f"CLI attempt {cli_attempt}/{cli_attempts} failed "
+                         f"({e}); retrying")
+                else:
+                    _log(f"CLI failed after {cli_attempts} attempts, "
+                         f"falling back to API: {e}")
 
     api_key = _resolve_api_key()
     if api_key is not None:


### PR DESCRIPTION
## Summary

Two reliability patches for `scripts/_claude_router.py`, both for the case where the local Claude CLI is invoked from cron / launchd / a background agent rather than from an interactive terminal:

1. **CLI retry (2 attempts).** Unattended `claude -p` can intermittently hang or return a stale-OAuth refusal on the first try and clear on the second. Wrap the CLI call in a 2-attempt loop before falling through to the API-key path. Happy path (first attempt succeeds) is unchanged.

2. **Network refusal markers.** When the network is not ready (e.g. a launchd job firing during wake-from-sleep), `claude -p` can emit `"API Error: Unable to connect to API (ConnectionRefused)"` on stdout and exit 1. The accept-non-zero-with-stdout branch would otherwise treat that 55-char error string as a real model response. Add four transport-error tokens to the refusal-marker list (`"api error"`, `"unable to connect to api"`, `"connectionrefused"`, `"failedtoopensocket"`) so the router raises `RouterUnavailable` and the retry has a chance once the network comes up.

Both patterns have been running in private use for ~10 days; porting to the public substrate now so other ai-brain-starter installs inherit the fix instead of independently hitting the same launchd-on-wake regression.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('scripts/_claude_router.py').read())"` parses cleanly
- [x] Personal-data scrub on diff: zero matches
- [ ] CI green
- [ ] Auto-merge once CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)