### PR TITLE
fix(detect-closing-signal): skip detection on Stop-hook-feedback prompts

### DIFF
--- a/hooks/detect-closing-signal.py
+++ b/hooks/detect-closing-signal.py
@@ -692,6 +692,28 @@ def main() -> int:
             emit_passthrough()
             return 0
 
+        # Skip detection on Stop-hook-feedback prompts. Claude Code injects
+        # blocking-hook stderr output as the next "user message" so the model
+        # can self-correct. These are NOT user-initiated close signals; letting
+        # them through creates a retry-loop where every Stop-hook block spawns
+        # a new pre-built session file at a new timestamp.
+        #
+        # Codified 2026-05-24 after verify-session-close-cascade kept blocking
+        # the session close (legitimately — uncommitted session artifacts), and
+        # its feedback message contained "claims to close the session" which
+        # re-fired this hook's `\bclose\s+(this|the)\s+session\b` regex,
+        # spawning stubs at T10-55, T11-00 on each retry. Same bug class as
+        # CASCADE-PHASE-SILENT-SKIP: hook-feedback re-injection is not a
+        # user-prompt event and must be filtered before any signal detection.
+        if (
+            prompt.startswith("Stop hook feedback:")
+            or prompt.startswith("Hook feedback:")
+            or "BLOCKED by " in prompt[:300]
+        ):
+            log_debug("Stop-hook-feedback prompt, skipping close detection")
+            emit_passthrough()
+            return 0
+
         # Resolve the vault root. When the close cascade fires from inside a
         # worktree, cwd IS the worktree; resolve_main_vault collapses it back
         # so every session artifact lands in the main vault, never a throwaway


### PR DESCRIPTION
## Summary

The session-close detection hook fires on every UserPromptSubmit. When a Stop hook BLOCKS the close (legitimately — e.g., \`verify-session-close-cascade\` flags uncommitted session artifacts), Claude Code injects the block's stderr output as the next "user message." Those feedback messages frequently contain phrases like \`"claims to close the session"\` which match the close-signal regex (\`\\bclose\\s+(this|the)\\s+session\\b\`), re-firing the hook → spawning a new pre-built session stub at a new timestamp → re-blocking → loop.

Real instance: a session close at \`T10-48\` was blocked, the feedback re-triggered detection, spawning stubs at \`T10-55\` and \`T11-00\` before the user noticed.

## Fix

Filter prompts before signal classification:

- \`prompt.startswith("Stop hook feedback:")\`
- \`prompt.startswith("Hook feedback:")\`
- \`"BLOCKED by " in prompt[:300]\`

Any of those → \`emit_passthrough()\` + return. No new stub, no re-injected cascade context.

## Test plan

- [x] \`Stop hook feedback: ...\` prompt → passthrough (verified locally)
- [x] Genuine \`okay lets close this session\` prompt → still fires close detection (verified locally)
- [ ] CI: existing tests still pass

## Bug class

Same family as \`CASCADE-PHASE-SILENT-SKIP\` (2026-05-19) — hook-feedback re-injection re-triggering the same hook. Codified surface-pattern filter rather than relying on "be more careful next time."

🤖 Generated with [Claude Code](https://claude.com/claude-code)