### PR TITLE
fix(close-detection): stop hook-feedback retry loop spawning N stubs

### DIFF
--- a/hooks/detect-closing-signal.py
+++ b/hooks/detect-closing-signal.py
@@ -705,11 +705,25 @@ def main() -> int:
         # spawning stubs at T10-55, T11-00 on each retry. Same bug class as
         # CASCADE-PHASE-SILENT-SKIP: hook-feedback re-injection is not a
         # user-prompt event and must be filtered before any signal detection.
-        if (
-            prompt.startswith("Stop hook feedback:")
-            or prompt.startswith("Hook feedback:")
-            or "BLOCKED by " in prompt[:300]
-        ):
+        #
+        # Expanded 2026-05-24 (T14 round): the original `startswith` check
+        # missed re-injections that arrived with prepended system-reminder
+        # context, and `BLOCKED by` was bounded to the first 300 chars which
+        # also missed wrapped messages. Now we scan the first ~2KB for any
+        # of the distinctive markers, including verifier-hook names that
+        # uniquely identify Claude Code feedback re-injection. Same session
+        # spawned 6 spurious stubs (T14-16, T14-20, T14-23, T14-25, T14-27,
+        # T14-30) before the broader filter shipped.
+        prefix = prompt[:2000]
+        feedback_markers = (
+            "Stop hook feedback:",
+            "Hook feedback:",
+            "BLOCKED by ",
+            "verify-session-close-cascade",
+            "verify-discoverability-on-close",
+            "verify-cascade",
+        )
+        if any(m in prefix for m in feedback_markers):
             log_debug("Stop-hook-feedback prompt, skipping close detection")
             emit_passthrough()
             return 0

--- a/templates/closing-signals/en.json
+++ b/templates/closing-signals/en.json
@@ -4,7 +4,7 @@
 
   "explicit": [
     "^/(close|wrap-?up|bye|done|finish)\\b",
-    "\\b/(close|wrap-?up|bye|done|finish)\\b"
+    "(?:^|\\s)/(close|wrap-?up|bye|done|finish)\\b"
   ],
 
   "high_confidence": [

--- a/templates/closing-signals/es.json
+++ b/templates/closing-signals/es.json
@@ -4,7 +4,7 @@
 
   "explicit": [
     "^/(cerrar|terminar|bye|chao)\\b",
-    "\\b/(cerrar|terminar|bye|chao)\\b"
+    "(?:^|\\s)/(cerrar|terminar|bye|chao)\\b"
   ],
 
   "high_confidence": [

--- a/templates/closing-signals/pt.json
+++ b/templates/closing-signals/pt.json
@@ -4,7 +4,7 @@
 
   "explicit": [
     "^/(fechar|encerrar|bye|tchau)\\b",
-    "\\b/(fechar|encerrar|bye|tchau)\\b"
+    "(?:^|\\s)/(fechar|encerrar|bye|tchau)\\b"
   ],
 
   "high_confidence": [


### PR DESCRIPTION
## Summary
- Stop hook feedback re-injections were spawning fresh `Sessions/{ts}-{worktree}.md` stubs at every Stop block, creating a retry loop (observed: 6 spurious stubs in one session — T14-16, T14-20, T14-23, T14-25, T14-27, T14-30).
- Bug 1: explicit slash-command regex `\b/(close|wrap-?up|bye|done|finish)\b` could match inside file paths. Tightened to `(?:^|\s)/(close|wrap-?up|bye|done|finish)\b` across en/es/pt language packs.
- Bug 2: Stop-hook-feedback filter used `startswith` + 300-char `BLOCKED by` check. Broadened to scan first 2KB for six markers including verifier-hook names.

## Test plan
- [x] `python3 -m py_compile hooks/detect-closing-signal.py` passes
- [x] All three JSON language packs parse
- [x] Regex behavior test: `/close`, `/done`, `/bye`, `\\n/finish`, `okay /done now` all match; `~/.claude/hooks/foo.py`, `bash /path/to/done.sh`, `verify-session-close-cascade`, `/usr/bin/python3 /Users/done` all reject
- [x] Personal-data scrub clean (`scrub-or-die` hook passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)