### PR TITLE
skill: dev-repo-worktrees — per-session isolation for ~/dev/<repo>

### DIFF
--- a/skills/dev-repo-worktrees/SKILL.md
+++ b/skills/dev-repo-worktrees/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: dev-repo-worktrees
+description: Per-session git worktree pattern for ~/dev/<repo> code repos. Prevents the CONCURRENT-SESSION-HEAD-DRIFT bug class where two Claude Code sessions writing to the same physical checkout collide on the single .git/HEAD pointer + index + working tree. Ships a wrapper script + hookify warn rule + the rule prose. Complements dev-repo-checkpoints (recovery) by preventing the failure at the structural layer (isolation).
+trigger: install the wrapper at ~/.local/bin/claude-dev-worktree + the hookify rule at the vault's .claude/. Call `claude-dev-worktree start <repo> <slug>` at session start when the session is going to write code to ~/dev/<repo>/.
+source: codified after the second concurrent-Claude-session HEAD-drift collision in 16 hours
+---
+
+# Dev-Repo Worktrees
+
+Per-session git worktree pattern for `~/dev/<repo>/` code repos that prevents concurrent Claude Code sessions from colliding on the shared `.git/HEAD`.
+
+## Why this exists
+
+**The failure mode (CONCURRENT-SESSION-HEAD-DRIFT):** Two Claude Code sessions both editing code in `~/dev/<repo>/` share one physical checkout, which means one `.git/HEAD` + one index + one working tree. When session A checks out their feature branch, session B's next `git commit` lands on session A's branch by accident. Recovery requires branch-label manipulation + `git stash` dances + branch-switch-safety hook overrides. Observed multiple times in long-running multi-session workflows.
+
+**The cause:** Bash `cd` is per-command, not per-session. Every invocation re-cds; HEAD-state from prior commands is whatever the last command left it. Bash sessions cannot share filesystem state with other Bash sessions — but git operations on the same checkout absolutely DO share state, and the model can't observe that.
+
+**The fix:** every Claude Code session that writes code in `~/dev/<repo>/` works in its own per-session git worktree at `~/dev/<repo>-<slug>/`. Each worktree has its own HEAD + own index + own working tree, while sharing the underlying object store. Zero collision possible.
+
+```
+~/dev/<repo>/                       NEVER write here in a session
+~/dev/<repo>-<slug>/                YES — session checkout, isolated HEAD
+```
+
+The main checkout stays as the maintenance + reference path — fetches + integration view. Session writes go through the worktree.
+
+## When the pattern DOES apply
+
+- Multi-step feature work in `~/dev/<repo>/`
+- Anything that involves `git commit` or `git push` from the session
+- Any task that runs builds / tests / code modifications
+
+## When the pattern does NOT apply
+
+- Single-file edits (typo fix, README tweak) — overhead exceeds value
+- Read-only audits (`cat`, `grep`, `git log`, `git diff`) — no HEAD writes
+- Vault git (markdown notes / second-brain) — vault has its own worktree mechanism with different semantics (see `superpowers:using-git-worktrees`)
+
+## Install
+
+### 1. Drop the wrapper script
+
+Copy [`claude-dev-worktree`](claude-dev-worktree) to `~/.local/bin/claude-dev-worktree`:
+
+```bash
+cp skills/dev-repo-worktrees/claude-dev-worktree ~/.local/bin/claude-dev-worktree
+chmod +x ~/.local/bin/claude-dev-worktree
+```
+
+Verify on PATH: `which claude-dev-worktree`.
+
+### 2. (Optional) Drop the hookify warn rule
+
+Copy [`hookify.warn-dev-repo-shared-checkout.local.md`](hookify.warn-dev-repo-shared-checkout.local.md) to your vault's `.claude/` directory and customize the `(your-repo-1|your-repo-2|...)` capture group in the pattern to match your actual high-concurrency repos.
+
+The hookify rule fires on `cd ~/dev/<known-shared-repo>` (no worktree suffix) and surfaces the pattern. Action is `warn`, not `block` — false-positive rate is acceptable because every miss-as-warn-only is just a reminder, never a block of legitimate work.
+
+### 3. Reference the rule from your CLAUDE.md
+
+Add to your CLAUDE.md `# Rules` section:
+
+```markdown
+- **External-repo worktrees** (`<your-rules-dir>/external-repo-worktrees.md`):
+  every Claude session that writes code in `~/dev/<repo>/` MUST work in a
+  per-session git worktree at `~/dev/<repo>-<slug>/`, NEVER in the main
+  checkout. Wrapper script `~/.local/bin/claude-dev-worktree start <repo>
+  <slug>` automates creation; `cleanup <repo> <slug>` removes after PR
+  merges. Bypass: `DEV_WORKTREE_BYPASS=1` for read-only audit work.
+```
+
+The rule file itself is documented in this SKILL.md — the wrapper + hookify are the enforcement layers; the CLAUDE.md entry is the discoverability layer.
+
+## Usage
+
+At session start, BEFORE first edit on a `~/dev/<repo>` issue:
+
+```bash
+claude-dev-worktree start <repo> <slug>      # creates ~/dev/<repo>-<slug>/
+cd ~/dev/<repo>-<slug>
+# all work happens here — isolated HEAD, no collision
+```
+
+At session close (after PR merges):
+
+```bash
+claude-dev-worktree cleanup <repo> <slug>    # removes worktree + local branch
+```
+
+Inspect every active worktree across all repos under `~/dev/`:
+
+```bash
+claude-dev-worktree list
+```
+
+## How it compares to other patterns
+
+| Pattern | Mechanism | When it fires |
+|---|---|---|
+| **This skill** (`dev-repo-worktrees`) | Per-session `git worktree add` | Session start, BEFORE first write |
+| `dev-repo-checkpoints` skill | Auto-stash on Stop event | Session end, AFTER work would have been lost |
+| `branch-switch-safety` rule | PreToolUse block on destructive ops with untracked work | When a destructive op is attempted |
+
+The three patterns are complementary:
+- `dev-repo-worktrees` PREVENTS the collision by structural isolation
+- `dev-repo-checkpoints` RECOVERS lost work via auto-stash
+- `branch-switch-safety` BLOCKS the destructive op when work would be lost
+
+A robust setup runs all three. Worktree-per-session is the cheapest insurance — disk cost is ~500MB per worktree (typical Node + Cargo project), trivially less than the cost of one corruption incident.
+
+## Disk cost
+
+Each worktree is a full checkout. With 3 concurrent sessions on a typical fullstack repo (~500MB working tree with build-tool caches like `target/`, `.next/`, `.gradle/`, etc.), worktrees add ~1.5GB. Some package managers share their store across worktrees automatically (e.g. pnpm via `node_modules/.pnpm`); language build caches (cargo `target/`, gradle `.gradle/`) are typically per-worktree and cannot easily share without symlink tricks.
+
+Not a legitimate blocker. Disk is cheap; mid-build corruption is not.
+
+## Bug class
+
+`CONCURRENT-SESSION-HEAD-DRIFT`. Parent class: `ARTIFACT-WITHOUT-ISOLATION-WIRING` — siblings include `ARTIFACT-WITHOUT-UMBRELLA-WIRING` (skill installs without routing wires) and `ARTIFACT-WITHOUT-DEPENDENCY-WIRING` (Linear issues created without blocker relations). All share the same shape: a thing gets created without its required structural connection wired in the same beat.
+
+## Bypass
+
+`DEV_WORKTREE_BYPASS=1` for legitimate single-session work in the main checkout — rare, typically only when fetching + reading without writes.
+
+## Credit
+
+Originally codified in a personal Claude vault as `external-repo-worktrees.md` after the second concurrent-session HEAD-drift collision in 16 hours. The pattern is universal — published to the public substrate so anyone running multi-session Claude Code workflows can install it without rediscovering the failure mode.

--- a/skills/dev-repo-worktrees/claude-dev-worktree
+++ b/skills/dev-repo-worktrees/claude-dev-worktree
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# claude-dev-worktree — per-session git worktree wrapper for ~/dev/<repo>.
+#
+# Prevents the CONCURRENT-SESSION-HEAD-DRIFT bug class where two concurrent
+# Claude Code sessions writing in the same physical checkout collide on the
+# shared .git/HEAD + index + working tree. Each session gets its own
+# physical directory `~/dev/<repo>-<slug>/`, with its own HEAD + index +
+# working tree, sharing only the underlying object store.
+#
+# Usage:
+#   claude-dev-worktree start <repo> <slug>
+#     Creates ~/dev/<repo>-<slug>/ as a worktree on branch claude/<slug>
+#     based on origin/main, then prints the worktree path on stdout.
+#     Session should `cd` to that path before any further work.
+#
+#   claude-dev-worktree cleanup <repo> <slug>
+#     Removes the worktree directory + deletes the local claude/<slug>
+#     branch. No-op if either is already gone.
+#
+#   claude-dev-worktree list
+#     Lists every active worktree under DEV_ROOT, one path per line.
+#
+# Configuration:
+#   DEV_ROOT      Where your code repos live. Defaults to ~/dev.
+#                 Override per-call: DEV_ROOT=~/projects claude-dev-worktree ...
+#
+# Exit codes:
+#   0  success
+#   1  invalid args / missing repo
+#   2  worktree already exists (start) or doesn't exist (cleanup)
+#   3  git operation failed
+#
+# Pattern source: this skill (dev-repo-worktrees). License: MIT.
+
+set -euo pipefail
+
+DEV_ROOT="${DEV_ROOT:-${HOME}/dev}"
+
+usage() {
+    cat <<'EOF' >&2
+Usage:
+  claude-dev-worktree start <repo> <slug>
+  claude-dev-worktree cleanup <repo> <slug>
+  claude-dev-worktree list
+
+The repo is a directory name under $DEV_ROOT (default ~/dev). The slug
+becomes both the worktree directory suffix ($DEV_ROOT/<repo>-<slug>) AND
+the branch name (claude/<slug>).
+EOF
+    exit 1
+}
+
+cmd_start() {
+    local repo="$1"
+    local slug="$2"
+    local main_path="${DEV_ROOT}/${repo}"
+    local worktree_path="${DEV_ROOT}/${repo}-${slug}"
+    local branch="claude/${slug}"
+
+    if [[ ! -d "$main_path/.git" ]]; then
+        echo "error: $main_path is not a git repo" >&2
+        exit 1
+    fi
+
+    if [[ -e "$worktree_path" ]]; then
+        echo "error: $worktree_path already exists" >&2
+        exit 2
+    fi
+
+    cd "$main_path"
+    git fetch origin --quiet
+
+    # If the branch already exists locally (recovered session, etc.), use
+    # it as-is instead of recreating. Otherwise create from origin/main.
+    if git show-ref --verify --quiet "refs/heads/${branch}"; then
+        git worktree add "$worktree_path" "$branch" >&2
+    else
+        git worktree add "$worktree_path" -b "$branch" origin/main >&2
+    fi
+
+    echo "$worktree_path"
+}
+
+cmd_cleanup() {
+    local repo="$1"
+    local slug="$2"
+    local main_path="${DEV_ROOT}/${repo}"
+    local worktree_path="${DEV_ROOT}/${repo}-${slug}"
+    local branch="claude/${slug}"
+
+    if [[ ! -d "$main_path/.git" ]]; then
+        echo "error: $main_path is not a git repo" >&2
+        exit 1
+    fi
+
+    cd "$main_path"
+
+    if [[ -d "$worktree_path" ]]; then
+        # `--force` covers the case where the worktree has uncommitted
+        # changes. The caller is expected to verify merge BEFORE calling
+        # cleanup; refusing here would strand artifacts.
+        git worktree remove --force "$worktree_path" >&2 || true
+    fi
+
+    # Prune to clean up stale .git/worktrees/<id> records.
+    git worktree prune >&2
+
+    if git show-ref --verify --quiet "refs/heads/${branch}"; then
+        git branch -D "$branch" >&2 || true
+    fi
+}
+
+cmd_list() {
+    # Walk every git repo under DEV_ROOT, dump its worktree list. The first
+    # entry per repo is the main checkout; the rest are session worktrees.
+    for dir in "$DEV_ROOT"/*/.git; do
+        [[ -d "$dir" || -f "$dir" ]] || continue
+        local repo_dir
+        repo_dir="$(dirname "$dir")"
+        (cd "$repo_dir" && git worktree list --porcelain 2>/dev/null) \
+            | grep '^worktree ' \
+            | sed 's/^worktree //'
+    done
+}
+
+if [[ $# -lt 1 ]]; then
+    usage
+fi
+
+case "$1" in
+    start)
+        [[ $# -eq 3 ]] || usage
+        cmd_start "$2" "$3"
+        ;;
+    cleanup)
+        [[ $# -eq 3 ]] || usage
+        cmd_cleanup "$2" "$3"
+        ;;
+    list)
+        cmd_list
+        ;;
+    *)
+        usage
+        ;;
+esac

--- a/skills/dev-repo-worktrees/hookify.warn-dev-repo-shared-checkout.local.md
+++ b/skills/dev-repo-worktrees/hookify.warn-dev-repo-shared-checkout.local.md
@@ -1,0 +1,53 @@
+---
+name: warn-dev-repo-shared-checkout
+enabled: true
+event: bash
+action: warn
+conditions:
+  - field: command
+    operator: regex_match
+    pattern: cd\s+(?:~|\$HOME|/Users/[^/]+|/home/[^/]+)/dev/(your-shared-repo-1|your-shared-repo-2|your-shared-repo-3)(?=[/\s;&|]|$)
+---
+
+**You're cd'ing to a shared `~/dev/<repo>` checkout.** Multiple concurrent Claude sessions running against the same physical checkout collide on the single `.git/HEAD` pointer + index + working tree. Symptoms observed in prior sessions: commits land on a sibling session's branch by accident, sibling reverts edits mid-build, stash-vs-untracked recovery wastes 5+ tool calls.
+
+If this session is going to **write** code to this repo (commit, push, edit), switch to a per-session worktree FIRST:
+
+```bash
+# At session start
+claude-dev-worktree start your-shared-repo-1 my-task-slug
+cd ~/dev/your-shared-repo-1-my-task-slug
+# all work happens here — isolated HEAD, no collision with sibling sessions
+```
+
+At session close (after PR merges):
+
+```bash
+claude-dev-worktree cleanup your-shared-repo-1 my-task-slug
+```
+
+If this session is **read-only** (`git log`, `git diff`, `cat`, `grep`, audit-only) — the main checkout is fine. No need to worktree for read-only access.
+
+If you've already created a worktree but cd'd back to the main checkout by mistake, switch back:
+
+```bash
+cd ~/dev/<repo>-<slug>
+```
+
+## Customize the repo list
+
+Edit the `(your-shared-repo-1|your-shared-repo-2|your-shared-repo-3)` capture group in this file's frontmatter `pattern` to match the repos in your environment where you've observed concurrent Claude sessions. Examples that would belong on the list:
+
+- A monorepo that multiple feature work-streams hit simultaneously
+- A repo where you frequently run parallel Claude sessions on different Linear issues
+- Any repo where you've experienced HEAD-drift corruption before
+
+A repo with a single concurrent-session ceiling (e.g. a personal tool only one session ever touches) does NOT need to be on the list — the warn would be noise.
+
+## Bypass
+
+`DEV_WORKTREE_BYPASS=1 <command>` when you've verified there's no sibling session active (rare — typically only solo audit work where the warn would be noise).
+
+## Lineage
+
+Full rule + wrapper script + lineage in the parent skill `dev-repo-worktrees/SKILL.md`. Bug class: `CONCURRENT-SESSION-HEAD-DRIFT`.


### PR DESCRIPTION
## Summary

New public-substrate skill at `skills/dev-repo-worktrees/` solving the **CONCURRENT-SESSION-HEAD-DRIFT** bug class. Two Claude Code sessions writing in the same physical `~/dev/<repo>/` checkout share one `.git/HEAD` + index + working tree — when session A switches to their branch, session B's next commit lands on session A's branch by accident.

The pattern: each session uses `git worktree add` to create `~/dev/<repo>-<slug>/` as a separate physical directory with its own HEAD, sharing only the underlying object store. Zero collision possible.

## Artifacts

- `SKILL.md` — rule prose, install steps, lineage, complementarity with `dev-repo-checkpoints` (recovery layer) + `branch-switch-safety` (block layer)
- `claude-dev-worktree` — bash wrapper (`start` / `cleanup` / `list`), `DEV_ROOT` env override for non-`~/dev/` layouts
- `hookify.warn-dev-repo-shared-checkout.local.md` — example PreToolUse warn rule with placeholder repo names users customize

## How it complements existing patterns

| Layer | Pattern | When it fires |
|---|---|---|
| Prevent | `dev-repo-worktrees` (this skill) | Session start, BEFORE first write |
| Recover | `dev-repo-checkpoints` | Session end, auto-stash uncommitted work |
| Block | `branch-switch-safety` | PreToolUse on destructive ops with untracked work |

A robust setup runs all three.

## Test plan

- [x] Personal-data scrub clean (no project-specific identifiers)
- [x] Wrapper script `chmod +x` + tested with `claude-dev-worktree list`
- [x] Hookify rule frontmatter validates (regex, conditions, action)
- [ ] CI lint (markdown + shellcheck if configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)