### PR TITLE
fix(close-cascade): strict_guards suppress meta-discussion of session close

### DIFF
--- a/hooks/detect-closing-signal.py
+++ b/hooks/detect-closing-signal.py
@@ -111,7 +111,14 @@ def find_repo_root() -> Path:
 
 
 def load_language_packs(langs: list[str]) -> dict:
-    """Load JSON language packs and merge into a single rule set."""
+    """Load JSON language packs and merge into a single rule set.
+
+    strict_guards (codified 2026-05-25): override ALL tiers including
+    explicit + high_confidence. Used for unambiguous non-close contexts
+    (meta-discussion of close cascade, debugging, technical references)
+    where false positives are very costly. The original false_positive_guards
+    only suppress weak tiers (ambiguous / emoji_only).
+    """
     repo = find_repo_root()
     pack_dir = repo / "templates" / "closing-signals"
     merged = {
@@ -120,6 +127,7 @@ def load_language_packs(langs: list[str]) -> dict:
         "ambiguous": [],
         "emoji_only": [],
         "false_positive_guards": [],
+        "strict_guards": [],
     }
     for lang in langs:
         path = pack_dir / f"{lang.strip()}.json"
@@ -195,6 +203,16 @@ def classify_signal(prompt: str, packs: dict, custom: list[str]) -> tuple[str | 
     # an "Okay, let's close this session" prompt was silently suppressed by the
     # `^ok(ay)?[,.\s]+(let'?s|now)...` guard despite high_confidence pattern
     # `\b(let'?s\s+)?close\s+(this|the)\s+session\b` also matching.
+
+    # STRICT guards (codified 2026-05-25): override EVERYTHING, including
+    # explicit/high_confidence/custom. Use only for unambiguous non-close
+    # contexts where false positives are very costly. Checked FIRST so
+    # meta-discussion of close cascade never fires a stub. The original
+    # FP guards remain for weak-tier-only suppression — strict guards do
+    # NOT override the user's custom patterns, those still win.
+    if is_false_positive(text, packs.get("strict_guards", [])):
+        log_debug("strict guard matched, suppressing ALL tiers")
+        return (None, None)
 
     # User custom patterns are highest authority — always win, FP guard skipped
     for pattern in custom:
@@ -639,10 +657,20 @@ PHASE 2 — Batch writes (one tool-call block, append never overwrite):
   • Append journal seeds to Captures.
   • Personal vs team firewall: never let personal content leak to a team vault.
 
-The post-Stop hook handles ONLY the mechanical pieces: aggregators
-(aggregate-sessions.py / aggregate-decisions.py), retention cleanup
-(stubs >7d), git snapshot (vault-safe-commit.sh), worktree-archive-prep.
-Don't run those yourself — they fire automatically after your turn ends.
+PHASE 2b — vault-safe-commit IS YOUR MANUAL JOB (codified 2026-05-25
+after the cascade double-fire incident). You MUST run vault-safe-commit.sh
+with explicit paths for every session-close artifact you wrote (session
+file + decisions + captures + time-tracking + any rule/inventory edits)
+BEFORE drafting the goodbye. The verify-session-close-cascade Stop hook
+checks for uncommitted session-close artifacts and BLOCKS the close if
+any are present — earlier docs said the post-Stop hook would auto-commit
+this, which was wrong: the verify hook fires BEFORE the post-Stop hook,
+so trusting auto-commit causes a hard block + forced re-run.
+
+The post-Stop hook handles ONLY: aggregators (aggregate-sessions.py /
+aggregate-decisions.py), retention cleanup (stubs >7d), worktree-archive
+preparation. It does NOT auto-commit; that is Phase 2b above and it is
+your job before goodbye.
 
 Phases 0c/0d/0e and the Phase 3 audit are MODEL-SIDE. The post-Stop hook
 does NOT run them.

--- a/templates/closing-signals/en.json
+++ b/templates/closing-signals/en.json
@@ -89,5 +89,29 @@
       "_comment": "Don't match question-form prompts ending in '?'",
       "pattern": "\\b(bye|ttyl|cya|done|good\\s+night|wrapping|signing\\s+off)\\b[^?]*\\?\\s*$"
     }
+  ],
+
+  "_strict_guards_comment": "STRICT guards override ALL tiers (including explicit + high_confidence). Use only for unambiguous non-close contexts where false positives are very costly. Codified 2026-05-25 after 139 empty session stubs accumulated from meta-discussion of close cascade matching high_confidence patterns.",
+  "strict_guards": [
+    {
+      "_comment": "Meta-discussion / debugging of the close cascade itself ('why does the session keep firing', 'fix close session', 'diagnose why sessions auto archive').",
+      "pattern": "\\b(why|how|when|fix|diagnose|debug|stop|prevent|disable|broken|wrong|bug|issue|problem|trace|inspect|hook|regex|cascade|firing|trigger|over[\\s-]?fire|over[\\s-]?match|false[\\s-]?positive)\\b.{0,80}\\b(close|archiv|wrap|end|finish)\\b.{0,80}\\b(session|cascade|stub|hook|sessions|markers?)\\b"
+    },
+    {
+      "_comment": "User describing the bug pattern ('sessions keep auto archiving', 'sessions are getting created', 'session keeps firing').",
+      "pattern": "\\bsessions?\\s+(keep|kept|are|is|got|getting|auto|wrongly|always|never|won'?t|don'?t|fir(e|ing)|trigger|create|writ)"
+    },
+    {
+      "_comment": "Backtick/quote-wrapped technical references to close phrases (regex/code/script content).",
+      "pattern": "[`].*\\b(close\\s+(this|the|out|up)\\s+session|bye|ttyl|cya)\\b.*[`]"
+    },
+    {
+      "_comment": "'close out X session' where X is a noun other than this/the (database session, customer session, narrative session, etc.).",
+      "pattern": "\\bclose\\s+(out\\s+|up\\s+|down\\s+)?(my\\s+|the\\s+|a\\s+|that\\s+|each\\s+|every\\s+|some\\s+)?(database|db|customer|client|user|narrative|book|chapter|writing|coaching|terminal|browser|tab|ssh|http|tcp|websocket|connection|stream|pipe|file|tmux|screen|repl|debug|debugger|gdb|lldb|trade|deal|loan|case|ticket|chat|conversation|interview|meeting|class|panel|story|scene)\\s+session"
+    },
+    {
+      "_comment": "Prompt is clearly a question / request about closing behavior rather than a sign-off itself (auto archiv|keep firing|keep creating|keep writing).",
+      "pattern": "\\b(auto[\\s-]?archiv|keep\\s+firing|keep\\s+creating|keep\\s+writing|over[\\s-]?firing|over[\\s-]?triggering|spurious|false[\\s-]?positive|extra\\s+stubs?|empty\\s+stubs?)\\b"
+    }
   ]
 }

--- a/tests/integration/test_detect_closing_signal_strict_guards.sh
+++ b/tests/integration/test_detect_closing_signal_strict_guards.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Test: detect-closing-signal.py strict_guards suppress all tiers (including
+# explicit + high_confidence + custom) for unambiguous non-close contexts.
+#
+# Bug class: high_confidence regex `\b(let'?s\s+)?close\s+(this|the|out|up)\s+session\b`
+# matched meta-discussion of the close cascade itself ("fix close-session regex",
+# "why does session keep firing", "let me close the database session"). The
+# 2026-05-12 fix made strong tiers override false_positive_guards (so legit
+# "okay, let's close this session" wouldn't be suppressed by the "okay let's"
+# transition guard) — but that broke meta-discussion suppression entirely. 139
+# empty session stubs accumulated vault-wide before the strict_guards tier was
+# added.
+#
+# Assertions:
+#   META-DISCUSSION (should NOT fire):
+#     1. "why do my sessions keep auto archiving? please diagnose and fix"
+#     2. "fix the close-this-session regex"
+#     3. "debug why close this session keeps firing"
+#     4. "the regex pattern is `close this session` and it fires too much"
+#     5. "let me close out the database session"
+#     6. "sessions keep getting auto-archived"
+#     7. "sessions keep firing the cascade"
+#   LEGITIMATE CLOSES (should still fire — strict guards must NOT over-suppress):
+#     8. "bye for now"
+#     9. "good night"
+#    10. "let's close this session"
+#    11. "wrap it up"
+#    12. "thanks that's all"
+#    13. "okay let's close this session" (2026-05-12 regression case)
+#
+# Self-contained: tmpdir fake vault, HOME redirected. Exit 0 = pass, 1 = fail.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOK="$REPO_ROOT/hooks/detect-closing-signal.py"
+PACK="$REPO_ROOT/templates/closing-signals/en.json"
+if [ ! -f "$HOOK" ]; then
+  echo "ERROR: $HOOK not found" >&2
+  exit 1
+fi
+if [ ! -f "$PACK" ]; then
+  echo "ERROR: $PACK not found" >&2
+  exit 1
+fi
+
+# Verify pack has strict_guards key — otherwise the test would silently
+# pass against the pre-fix code where strong-tier overrides FP guards.
+if ! python3 -c "import json,sys; d=json.load(open(sys.argv[1])); sys.exit(0 if d.get('strict_guards') else 1)" "$PACK" 2>/dev/null; then
+  echo "ERROR: $PACK missing strict_guards array (fix regressed)" >&2
+  exit 1
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+export HOME="$TMP/fake-home"
+mkdir -p "$HOME/.claude"
+
+VAULT="$TMP/vault"
+META="$VAULT/Meta"
+mkdir -p "$META/Sessions" "$META/Decisions"
+
+run_hook() {
+  local prompt="$1"
+  printf '{"prompt":%s,"session_id":"test-sid","cwd":%s}' \
+    "$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$prompt")" \
+    "$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$VAULT")" \
+    | VAULT_ROOT="$VAULT" python3 "$HOOK"
+}
+
+assert_no_fire() {
+  local prompt="$1"
+  local output
+  output="$(run_hook "$prompt")"
+  # No-fire = passthrough JSON, no SESSION CLOSE / POSSIBLE SESSION CLOSE marker
+  if echo "$output" | grep -qE "SESSION CLOSE|POSSIBLE SESSION CLOSE"; then
+    echo "FAIL [should NOT fire]: $prompt" >&2
+    echo "  output: $output" >&2
+    return 1
+  fi
+  return 0
+}
+
+assert_fires() {
+  local prompt="$1"
+  local output
+  output="$(run_hook "$prompt")"
+  # Should fire = SESSION CLOSE detected (or POSSIBLE for ambiguous)
+  if ! echo "$output" | grep -qE "SESSION CLOSE|POSSIBLE SESSION CLOSE"; then
+    echo "FAIL [should fire]: $prompt" >&2
+    echo "  output: $output" >&2
+    return 1
+  fi
+  return 0
+}
+
+failed=0
+
+# META-DISCUSSION (should NOT fire — strict_guards must suppress)
+for p in \
+  "why do my sessions keep auto archiving? please diagnose and fix" \
+  "fix the close-this-session regex" \
+  "debug why close this session keeps firing" \
+  "the regex pattern is \`close this session\` and it fires too much" \
+  "let me close out the database session" \
+  "sessions keep getting auto-archived" \
+  "sessions keep firing the cascade" \
+; do
+  assert_no_fire "$p" || failed=$((failed+1))
+done
+
+# LEGITIMATE CLOSES (should still fire — strict_guards must not over-suppress)
+for p in \
+  "bye for now" \
+  "good night" \
+  "let's close this session" \
+  "wrap it up" \
+  "thanks that's all" \
+  "okay let's close this session" \
+; do
+  assert_fires "$p" || failed=$((failed+1))
+done
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAIL: $failed assertion(s) failed" >&2
+  exit 1
+fi
+echo "PASS: strict_guards correctly gate meta-discussion vs legitimate closes"


### PR DESCRIPTION
## Summary

- Add `strict_guards` tier to closing-signal language packs — overrides ALL tiers (including `explicit` + `high_confidence` + user custom)
- `classify_signal()` in `detect-closing-signal.py` now checks `strict_guards` FIRST and short-circuits
- 5 patterns target meta-discussion of the close cascade itself, "sessions keep firing" descriptions, backtick-quoted technical references, `close X session` with non-session-mgmt nouns (database, customer, ssh, repl, …), and explicit bug-description vocabulary (auto archiv / spurious / empty stubs)
- New integration test `test_detect_closing_signal_strict_guards.sh` — 13 assertions (7 suppressions + 6 firings), fails on revert

## Bug background

Production evidence: 139 empty session stubs accumulated vault-wide (58% false-positive rate vs 101 filled session files) because the high_confidence regex `\b(let'?s\s+)?close\s+(this|the|out|up)\s+session\b` matched meta-discussion of the cascade — phrases like "fix close-session regex", "let me close the database session", "the regex is \`close this session\`".

The 2026-05-12 fix made strong tiers override `false_positive_guards` (so legitimate "okay, let's close this session" wouldn't be silently suppressed by the "okay let's" transition guard) — but that change broke meta-discussion suppression entirely. `strict_guards` is the surgical layer: only fires for unambiguous non-close contexts, while letting the existing `false_positive_guards` continue to suppress weak-tier matches only.

This PR is companion to a vault-local fix in `session-end-hook.sh` (one-shot marker cleanup). Together they make the cascade fire exactly once per close detection AND prevent meta-discussion from triggering it in the first place.

## Test plan

- [x] `bash tests/integration/test_detect_closing_signal_strict_guards.sh` → PASS (13/13)
- [x] `python3 -m py_compile hooks/detect-closing-signal.py` → OK
- [x] `python3 -c "import json; json.load(open('templates/closing-signals/en.json'))"` → OK
- [x] Manual reproduction of 18 prompt cases (9 meta-discussion + 9 legitimate) — all classified correctly
- [x] Live verification: concurrent session (`relaxed-germain-597e20`) triggered close-detection at 09:42 after fix shipped; marker correctly renamed to `.consumed.json` instead of left for re-firing

🤖 Generated with [Claude Code](https://claude.com/claude-code)