### PR TITLE
chore(memory-api): exclude fastapi 0.136.3 (MAL-2026-4750)

### DIFF
--- a/services/memory-api/requirements.txt
+++ b/services/memory-api/requirements.txt
@@ -1,4 +1,6 @@
-fastapi>=0.110.0
+# != 0.136.3: MAL-2026-4750 — that release ships a malicious 'fastar'
+# typosquat dependency in the [standard] extras (Amazon Inspector, 2026-05-23).
+fastapi>=0.110.0,!=0.136.3
 uvicorn[standard]>=0.27.0
 networkx>=3.0
 pydantic>=2.5.0


### PR DESCRIPTION
The `security-audit` workflow has been red on `main` since 258f946 because
`pip-audit` flags `fastapi` 0.136.3 against MAL-2026-4750. `services/memory-api`
pins `fastapi>=0.110.0` with no upper bound, so installs resolve to the
affected release.

## Advisory shape

OSV record published 2026-05-23 by Amazon Inspector:
`fastapi` 0.136.3 ships an undocumented malicious dependency `fastar>=0.9.0`
in `[project.optional-dependencies].standard`. Anyone running
`pip install "fastapi[standard]"` silently pulls a typosquat-shaped package
and gets install-time code execution. Only 0.136.3 is flagged
(`"versions":["0.136.3"]`); 0.136.3 is also the current PyPI release.

## Fix

Surgical exclusion in `services/memory-api/requirements.txt`:
`fastapi>=0.110.0,!=0.136.3` with a justifying comment naming the OSV id.

Preferred over `--ignore-vuln MAL-2026-4750` in the workflow because the
advisory is genuine (not a typosquat-detection false positive), version-
specific, and a clean future release will resolve automatically with no
workflow waiver to remember to remove.

`memory-api` does not install `fastapi[standard]` (it pins `uvicorn[standard]`
and `fastapi` separately), so no running install would have actually pulled
the malicious `fastar` dep. The exclusion is defense-in-depth plus a clean
CI gate.

Generated with Claude Code.