### PR TITLE
fix(meeting-cascade): wire "I just had a meeting" trigger to actually fire

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,33 @@ description: What's new in AI Brain Starter — plain English, no jargon
 
 ---
 
+## 2026-05-27: "I just had a meeting" now actually fires the cascade
+
+**Who this affects:** every user. If you've said "I just had a meeting" or "pull the transcript" and Claude shrugged instead of pulling the transcript and updating your to-dos, this is the fix.
+
+**The bug:** `templates/rules/meeting-workflow.md` shipped with a `trigger:` frontmatter field listing the phrases — "I just had a meeting", "pull meeting notes", "pull the transcript", "[name] meeting is done". The README and POWER_TOOLS.md both promised the rule "fires" on those phrases. But the `trigger:` field was just informational text — nothing in `hooks.json` actually pattern-matched the phrases. The only thing surfacing the rule to Claude was a single bullet in the once-per-session `session-start-context.py` dump ("- meeting-workflow.md for meetings"). If the user said "I just had a meeting" any time after the first prompt of the session, the rule wasn't in context and Claude had no way to know to read it. Cascade silently no-op'd. Bug class: **ARTIFACT-WITHOUT-AUTOMATION-WIRING**.
+
+**What's new:**
+
+**`hooks/inject-meeting-workflow-on-trigger.py`** — a UserPromptSubmit hook that pattern-matches "I just had a meeting" + variants (EN and ES, accent-insensitive), reads the user's vault `⚙️ Meta/rules/meeting-workflow.md` (so Phase 11's per-tool customization is preserved), and injects the full rule as `additionalContext`. Fires on every matching prompt, not just the first one of the session. Same proven pattern as `inject-best-of-best-on-consulting.py` and `inject-love-language-context.py`.
+
+Trigger regex is temporal-anchored to avoid false positives — "I just had a meeting" fires, "I have a meeting tomorrow" does not. Bilingual coverage:
+
+- EN: *"I just had a meeting"*, *"the meeting just ended"*, *"meeting with John just ended"*, *"pull the transcript"*, *"pull my meeting notes"*, *"process today's meeting"*, *"[name]'s meeting is done"*, *"done with my interview"*, *"wrapped up the sync"*, and more.
+- ES: *"acabo de tener una reunión"*, *"la reunión ya terminó"*, *"ya terminé la reunión"*, *"trae las notas de la reunión"*, *"saca el transcript"*, *"reunión con María ya terminó"*, etc. Works whether the user types accents or not.
+
+If the rule file doesn't exist in the vault (user skipped Phase 4), the hook falls back to an embedded summary so the cascade still fires — never silent.
+
+**Bypass:** set `MEETING_WORKFLOW_BYPASS=1` env var, or include the literal `MEETING_WORKFLOW_BYPASS=1` token in the prompt.
+
+**`tests/integration/test_meeting_workflow_trigger_hook.sh`** — regression test asserting (1) hook is present, (2) hook is wired into `hooks.json` under `UserPromptSubmit`, (3) 13 EN positive triggers fire, (4) 12 ES positive triggers fire, (5) 14 negative cases (future/past-week/planning/asking-about) do NOT fire, (6) injected payload references the rule body, (7) bypass env var works, (8) in-prompt bypass token works, (9) empty prompt produces no output, (10) fallback summary fires when no vault rule exists.
+
+**`hooks.json`** — added the new hook to the `UserPromptSubmit` chain between `inject-love-language-context.py` and `email-gate-hook.py`. `scripts/install-hooks-user-level.py` ABS_FINGERPRINTS list updated so the migrator owns the new hook on subsequent installs.
+
+**What you should do:** nothing. The SessionStart auto-update flow picks this up on your next session (or `git pull` manually in `~/.claude/skills/ai-brain-starter/` to grab it immediately). Existing `settings.local.json` files will be offered the update via the standard auto-update prompt.
+
+---
+
 ## 2026-05-19: close the commit-time race for reconcile-worktree-shared
 
 **Who this affects:** anyone using git worktrees inside an Obsidian vault with the `reconcile-worktree-shared.py` SessionEnd hook, who has ALSO seen the worktree-archive prompt fire "N uncommitted changes will be discarded" warnings on byte-identical-to-main files.

--- a/hooks.json
+++ b/hooks.json
@@ -40,6 +40,11 @@
           },
           {
             "type": "command",
+            "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/inject-meeting-workflow-on-trigger.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'",
+            "statusMessage": "Checking for 'I just had a meeting' trigger..."
+          },
+          {
+            "type": "command",
             "command": "python3 ~/.claude/skills/ai-brain-starter/scripts/email-gate-hook.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'",
             "statusMessage": "Checking email-on-file marker..."
           },

--- a/hooks/inject-meeting-workflow-on-trigger.py
+++ b/hooks/inject-meeting-workflow-on-trigger.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""
+UserPromptSubmit hook: detect "I just had a meeting" (and bilingual / phrasing
+variants), then inject the user's meeting-workflow.md rule as additionalContext
+so the full post-meeting cascade fires automatically.
+
+Pre-fix bug class: ARTIFACT-WITHOUT-AUTOMATION-WIRING. The rule existed in the
+user's vault at `⚙️ Meta/rules/meeting-workflow.md` and README/POWER_TOOLS.md
+promised "the rule fires" — but no hook surfaced the rule on the trigger
+phrase. Claude had only a one-time SessionStart bullet to remember it. Users
+reported "I said 'I just had a meeting' and nothing happened" — the cascade
+silently no-op'd because the rule was never in context at the moment of need.
+
+Pattern: inject-best-of-best-on-consulting.py + inject-love-language-context.py.
+UserPromptSubmit -> regex prompt -> read vault rule -> inject additionalContext
+-> exit 0 always (never block).
+
+Vault root auto-detection (in order):
+  1. VAULT_ROOT env var
+  2. Walk up from cwd looking for `⚙️ Meta/Current Priorities.md`
+     (canonical marker) or any `⚙️ Meta/` / `Meta/` folder
+  3. Silent exit if not found
+
+Rule file lookup order (first hit wins):
+  1. <vault>/⚙️ Meta/rules/meeting-workflow.md (canonical, emoji folder)
+  2. <vault>/Meta/rules/meeting-workflow.md (no-emoji fallback)
+  3. ~/.claude/skills/ai-brain-starter/templates/rules/meeting-workflow.md
+     (template fallback — only fires if the user never ran Phase 4)
+  4. Embedded minimal summary (last-resort, keeps the cascade non-silent)
+
+Bypass: set env var MEETING_WORKFLOW_BYPASS=1 (or include the literal token
+in the prompt) to suppress the injection on a single prompt.
+
+Wire into settings.json under hooks.UserPromptSubmit:
+    {
+      "type": "command",
+      "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/inject-meeting-workflow-on-trigger.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'"
+    }
+"""
+import json
+import os
+import re
+import sys
+import unicodedata
+from typing import Optional
+
+MAX_RULE_CHARS = 8000  # truncate very large customized rules
+BYPASS_ENV = "MEETING_WORKFLOW_BYPASS"
+BYPASS_TOKENS = ["MEETING_WORKFLOW_BYPASS=1", "ignore meeting workflow"]
+
+# Trigger regexes. Each requires a temporal "just / done / ended / finished"
+# anchor so generic mentions of "meeting" (future / past-week / planning) do
+# NOT fire. English first, then Spanish — the public starter is bilingual.
+TRIGGERS_EN = [
+    # "I just had / finished / wrapped / got out of (my / a / the) (meeting|call|sync|standup|1:1|interview|...)"
+    r"\bi\s+just\s+(had|finished|wrapped(?:\s+up)?|got\s+out\s+of|came\s+out\s+of|ended)\s+(?:my|a|the|an|our)?\s*"
+    r"(meeting|call|sync|standup|stand-?up|1[:\- ]on[:\- ]1|1[:\- ]1|one[:\- ]?on[:\- ]?one|"
+    r"interview|huddle|conversation|chat\s+with|catch[\-\s]?up)",
+    # "the meeting just ended / wrapped / is done / finished"
+    r"\b(the|that|our|my)\s+(meeting|call|sync|standup|stand-?up|1[:\- ]on[:\- ]1|1[:\- ]1|interview)\s+"
+    r"(just\s+)?(ended|wrapped|finished|is\s+done|was\s+done|just\s+(ended|wrapped|finished))",
+    # "meeting (with X) (just) (ended|done|over)"
+    r"\b(meeting|call|sync|standup|stand-?up|interview)\s+(with\s+\w+\s+)?(just\s+)?(ended|wrapped(?:\s+up)?|is\s+done|is\s+over|over)\b",
+    # "pull (the / my) (meeting notes / transcript)"
+    r"\bpull\s+(the|my|our)?\s*(meeting\s+notes|meeting\s+note|transcript|recording|granola)\b",
+    # "process / file / save (the / my / today's) meeting"
+    r"\b(process|file|save)\s+(the|my|today'?s|that|this)?\s*(meeting|call|sync|interview)\b",
+    # "[name]'s meeting is done / ended" (very common short form)
+    r"\b[\w\-]+(?:'s|s')\s+(meeting|call|sync|interview|1[:\- ]?on[:\- ]?1)\s+(is\s+done|just\s+ended|ended|wrapped|finished)\b",
+    # "done with (my / the / that) meeting"
+    r"\bdone\s+with\s+(my|the|that|our)\s+(meeting|call|sync|standup|interview)\b",
+    # "wrapped (up) (the / my) meeting"
+    r"\bwrapped\s+(up\s+)?(my|the|our|that)\s+(meeting|call|sync|interview)\b",
+]
+
+TRIGGERS_ES = [
+    # "acabo de (tener / terminar / salir de) (una / la / mi) reunion / llamada / sync / entrevista"
+    r"\bacabo\s+de\s+(tener|terminar|salir\s+de|colgar(?:\s+(?:una|la|mi))?)\s+"
+    r"(una|la|mi|nuestra|el|este)?\s*(reunion|llamada|sync|standup|stand-?up|"
+    r"entrevista|conversacion|charla|junta|reu)\b",
+    # "(la / mi / nuestra) reunion (ya / recien) (termino / acabo / se acabo / fue)"
+    r"\b(la|mi|nuestra|esta|esa)\s+(reunion|llamada|junta|reu|entrevista|sync|standup)\s+"
+    r"(ya\s+)?(recien\s+)?(termino|acabo|se\s+acabo|se\s+termino|fue|ya\s+acabo|ya\s+termino)\b",
+    # "ya termine / acabe (la / mi) reunion"
+    r"\bya\s+(termine|acabe)\s+(la|mi|nuestra|esa|esta)?\s*(reunion|llamada|junta|entrevista|sync)\b",
+    # "trae / saca / pull (las / mis) notas / transcript / transcripcion de la reunion"
+    r"\b(trae|saca|pull|busca|consigue)\s+(las|mis|el|la)?\s*(notas|transcript|transcripcion|grabacion|granola)"
+    r"(\s+de\s+(la|mi|nuestra|esa|esta)?\s*(reunion|llamada|junta|entrevista|meeting|call|sync))?\b",
+    # "(meeting / reunion) con X (ya / recien) (termino / acabo)"
+    r"\b(reunion|llamada|junta|entrevista|meeting|call|sync)\s+con\s+\w+\s+(ya\s+)?(termino|acabo|se\s+acabo|ended)\b",
+]
+
+
+def strip_accents(s: str) -> str:
+    return "".join(
+        c for c in unicodedata.normalize("NFD", s)
+        if unicodedata.category(c) != "Mn"
+    )
+
+
+def normalize(s: str) -> str:
+    return strip_accents(s).lower()
+
+
+def matches_trigger(prompt: str) -> Optional[str]:
+    """Return the matched substring if any trigger fires, else None."""
+    p = normalize(prompt)
+    for regex in TRIGGERS_EN + TRIGGERS_ES:
+        m = re.search(regex, p)
+        if m:
+            return m.group(0)
+    return None
+
+
+def find_vault_root() -> Optional[str]:
+    """Walk up from cwd looking for the canonical Current Priorities marker
+    or a Meta/ folder. VAULT_ROOT env var wins if set."""
+    env_root = os.environ.get("VAULT_ROOT")
+    if env_root and os.path.isdir(env_root):
+        return env_root
+    cur = os.getcwd()
+    for _ in range(8):
+        # Canonical marker
+        for meta in ("⚙️ Meta", "Meta"):
+            if os.path.isfile(os.path.join(cur, meta, "Current Priorities.md")):
+                return cur
+            if os.path.isdir(os.path.join(cur, meta, "rules")):
+                return cur
+        parent = os.path.dirname(cur)
+        if parent == cur:
+            break
+        cur = parent
+    return None
+
+
+def find_rule_file(vault_root: Optional[str]) -> Optional[str]:
+    """Locate meeting-workflow.md. First the vault's installed copy
+    (preferred — carries Phase 11 per-tool customization), then the
+    ai-brain-starter template as a fallback."""
+    if vault_root:
+        for meta in ("⚙️ Meta/rules", "Meta/rules"):
+            path = os.path.join(vault_root, meta, "meeting-workflow.md")
+            if os.path.isfile(path):
+                return path
+    template = os.path.expanduser(
+        "~/.claude/skills/ai-brain-starter/templates/rules/meeting-workflow.md"
+    )
+    if os.path.isfile(template):
+        return template
+    return None
+
+
+def read_rule(path: str) -> str:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            content = f.read()
+    except Exception:
+        return ""
+    if len(content) > MAX_RULE_CHARS:
+        content = content[:MAX_RULE_CHARS] + "\n...[truncated — read full file at " + path + "]"
+    return content
+
+
+FALLBACK_SUMMARY = """[meeting-workflow fallback — vault rule file not found]
+
+The user just signaled a meeting ended. Run the standard post-meeting
+cascade WITHOUT asking for clarification:
+
+1. Find the transcript. Check Granola (~/Library/Application Support/
+   com.granola.granola/), Google Meet+Gemini transcripts in Drive,
+   Otter/Fireflies/Zoom export folders, or the Meeting Notes/ folder
+   in the vault — whichever tool the user configured. Search the LAST
+   24 HOURS in parallel.
+2. Read the transcript in full. Never skim. Verbatim transcript wins
+   over post-processed summaries.
+3. Enrich the meeting note in the vault: TL;DR, decisions table,
+   action items, verbatim quotes, meta-observations. Wikilink every
+   named person to their CRM file.
+4. Cascade to canonical docs. Update strategy/vision/target docs
+   the meeting changed. Rule-consistency scan after rule edits.
+5. Update Decision Log. One entry per high-stakes decision: What/
+   Why/Floor/Stakes/Speed.
+6. Update each attendee's CRM file: meeting notes wikilink, refreshed
+   last_interaction / next_step. Read 2 adjacent CRM files first to
+   confirm the pattern. Preserve dataview blocks.
+7. Update to-dos. Business -> team to-do file. Personal -> personal
+   to-do file. Never duplicate. Default personal when ambiguous.
+8. Humanizer pass on any external-facing prose written.
+9. Verify with backlinks: open the CRM file, confirm the meeting
+   note shows up. Open the to-do file, confirm team embeds render.
+10. Report every file changed, flag what the user should eyeball,
+    state which sources were read with byte counts as evidence.
+
+If no transcript or notes file is found in step 1, SAY SO immediately
+— do not invent a meeting note from chat context.
+"""
+
+
+def main() -> int:
+    if os.environ.get(BYPASS_ENV) == "1":
+        return 0
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0
+    prompt = payload.get("prompt", "") or ""
+    if not prompt.strip():
+        return 0
+    for token in BYPASS_TOKENS:
+        if token in prompt:
+            return 0
+
+    match = matches_trigger(prompt)
+    if not match:
+        return 0
+
+    vault_root = find_vault_root()
+    rule_path = find_rule_file(vault_root)
+    if rule_path:
+        rule_body = read_rule(rule_path)
+        if rule_body:
+            header = (
+                "[meeting-workflow auto-injected — trigger matched: "
+                f"{match!r}]\n"
+                "The user just signaled a meeting ended. Run the FULL cascade "
+                "below WITHOUT asking for clarification. Source rule: "
+                f"{rule_path}\n"
+            )
+            body = header + "\n" + rule_body
+        else:
+            body = FALLBACK_SUMMARY
+    else:
+        body = FALLBACK_SUMMARY
+
+    out = {
+        "hookSpecificOutput": {
+            "hookEventName": "UserPromptSubmit",
+            "additionalContext": body,
+        }
+    }
+    sys.stdout.write(json.dumps(out))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/install-hooks-user-level.py
+++ b/scripts/install-hooks-user-level.py
@@ -63,6 +63,7 @@ ABS_FINGERPRINTS = [
     "ai-brain-starter/hooks/first-week-checkin.py",
     "ai-brain-starter/hooks/migrate-to-user-level.py",
     "ai-brain-starter/hooks/inject-love-language-context.py",
+    "ai-brain-starter/hooks/inject-meeting-workflow-on-trigger.py",
     "ai-brain-starter/scripts/session-end-hook.sh",
     "ai-brain-starter/scripts/email-gate-hook.py",
     "ai-brain-starter/⚙️ Meta/scripts/graph-context-hook.sh",

--- a/tests/integration/test_meeting_workflow_trigger_hook.sh
+++ b/tests/integration/test_meeting_workflow_trigger_hook.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Regression test for inject-meeting-workflow-on-trigger.py
+#
+# Bug class: ARTIFACT-WITHOUT-AUTOMATION-WIRING. The meeting-workflow.md
+# rule existed in the vault and README/POWER_TOOLS.md promised the
+# "I just had a meeting" cascade fired automatically — but no
+# UserPromptSubmit hook surfaced the rule on the trigger phrase. Users
+# reported saying "I just had a meeting" and getting nothing back.
+#
+# This test asserts:
+#   1. The hook is present in hooks/.
+#   2. It is wired into hooks.json under UserPromptSubmit.
+#   3. EN trigger phrases fire ("I just had a meeting", variants).
+#   4. ES trigger phrases fire ("acabo de tener una reunión", variants).
+#   5. Non-trigger meeting mentions do NOT fire (future / past-week /
+#      planning / asking about a meeting — temporal-anchor discipline).
+#   6. The injected payload references meeting-workflow.md so the
+#      assistant actually has the cascade in context.
+#   7. The bypass env var suppresses the injection.
+#
+# Self-contained. Exit 0 = pass. Exit 1 = fail with details.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOK="$REPO_ROOT/hooks/inject-meeting-workflow-on-trigger.py"
+HOOKS_JSON="$REPO_ROOT/hooks.json"
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+# 1. Hook present
+[[ -f "$HOOK" ]] || fail "hook missing at $HOOK"
+[[ -x "$HOOK" ]] || chmod +x "$HOOK"
+
+# 2. Wired into hooks.json
+grep -q "inject-meeting-workflow-on-trigger.py" "$HOOKS_JSON" || \
+    fail "hook not wired into hooks.json — add a UserPromptSubmit entry"
+
+# Build a throwaway vault with a real meeting-workflow.md so the hook
+# resolves a rule path (otherwise it falls back to the embedded summary,
+# which is also valid but we want to verify the preferred path works).
+TMP_VAULT="$(mktemp -d)"
+trap 'rm -rf "$TMP_VAULT"' EXIT
+mkdir -p "$TMP_VAULT/Meta/rules"
+cat > "$TMP_VAULT/Meta/rules/meeting-workflow.md" <<'EOF'
+---
+type: rule
+trigger: "I just had a meeting"
+---
+
+# Meeting workflow stub
+
+Find the transcript. Read it. Enrich the meeting note. Update CRM.
+Update to-dos. Update Decision Log. Verify backlinks. Report.
+EOF
+mkdir -p "$TMP_VAULT/Meta"
+touch "$TMP_VAULT/Meta/Current Priorities.md"
+
+run_hook() {
+    local prompt="$1"
+    local extra_env="${2:-}"
+    local payload
+    payload=$(python3 -c "import json,sys; print(json.dumps({'prompt': sys.argv[1]}))" "$prompt")
+    if [[ -n "$extra_env" ]]; then
+        eval "$extra_env" VAULT_ROOT="$TMP_VAULT" python3 "$HOOK" <<<"$payload"
+    else
+        VAULT_ROOT="$TMP_VAULT" python3 "$HOOK" <<<"$payload"
+    fi
+}
+
+# 3. EN triggers FIRE
+EN_POSITIVE=(
+    "I just had a meeting with Sara"
+    "i just finished a call"
+    "I just wrapped up the standup"
+    "I just got out of a 1:1"
+    "The meeting just ended"
+    "the meeting is done"
+    "meeting with John just ended"
+    "pull the transcript"
+    "pull my meeting notes"
+    "process today's meeting"
+    "Diego's meeting is done"
+    "done with my interview"
+    "wrapped up the sync"
+)
+for p in "${EN_POSITIVE[@]}"; do
+    out=$(run_hook "$p")
+    if [[ -z "$out" ]]; then
+        fail "EN trigger did NOT fire: $p"
+    fi
+    echo "$out" | grep -q "meeting-workflow auto-injected" || \
+        fail "EN trigger fired but missing header marker: $p (output: $out)"
+done
+
+# 4. ES triggers FIRE (accent-insensitive)
+ES_POSITIVE=(
+    "Acabo de tener una reunión con Diego"
+    "acabo de tener una reunion"
+    "acabo de terminar la llamada"
+    "acabo de salir de una junta"
+    "la reunión ya terminó"
+    "la reunion ya termino"
+    "mi reunión recién acabó"
+    "ya terminé la reunión"
+    "ya acabé mi llamada"
+    "trae las notas de la reunión"
+    "saca el transcript"
+    "reunión con María ya terminó"
+)
+for p in "${ES_POSITIVE[@]}"; do
+    out=$(run_hook "$p")
+    if [[ -z "$out" ]]; then
+        fail "ES trigger did NOT fire: $p"
+    fi
+done
+
+# 5. Negative cases — must NOT fire
+NEGATIVE=(
+    "I have a meeting tomorrow"
+    "I had a meeting last week"
+    "I'm going to a meeting later"
+    "What was that meeting about?"
+    "Looking forward to the meeting"
+    "I need to prep for a meeting"
+    "Did you join the meeting?"
+    "Cancel my meeting"
+    "Tengo una reunión mañana"
+    "Voy a una reunión luego"
+    "¿De qué se trata la reunión?"
+    "Necesito prepararme para la reunión"
+    "what's on my calendar"
+    "build a new feature"
+)
+for p in "${NEGATIVE[@]}"; do
+    out=$(run_hook "$p" 2>/dev/null || true)
+    if [[ -n "$out" ]]; then
+        fail "negative case incorrectly fired: $p (output: $out)"
+    fi
+done
+
+# 6. Injected payload contains the rule body (vault path preferred)
+out=$(run_hook "I just had a meeting")
+echo "$out" | grep -q "meeting-workflow.md" || \
+    fail "injected payload does not reference meeting-workflow.md (output: $out)"
+echo "$out" | grep -q "Meeting workflow stub" || \
+    fail "injected payload missing rule body from vault (output: $out)"
+
+# 7. Bypass env var
+out=$(run_hook "I just had a meeting" "MEETING_WORKFLOW_BYPASS=1")
+if [[ -n "$out" ]]; then
+    fail "bypass env var did not suppress injection (output: $out)"
+fi
+
+# 8. Bypass via in-prompt token
+out=$(run_hook "MEETING_WORKFLOW_BYPASS=1 I just had a meeting")
+if [[ -n "$out" ]]; then
+    fail "in-prompt bypass token did not suppress injection (output: $out)"
+fi
+
+# 9. Empty / missing prompt -> silent exit
+out=$(printf '{}' | VAULT_ROOT="$TMP_VAULT" python3 "$HOOK")
+if [[ -n "$out" ]]; then
+    fail "empty prompt should produce no output (output: $out)"
+fi
+
+# 10. Fallback path: no vault rule file, no template -> embedded summary still fires
+EMPTY_VAULT="$(mktemp -d)"
+mkdir -p "$EMPTY_VAULT/Meta"
+touch "$EMPTY_VAULT/Meta/Current Priorities.md"
+out=$(printf '{"prompt": "I just had a meeting"}' | \
+    VAULT_ROOT="$EMPTY_VAULT" \
+    HOME="$EMPTY_VAULT" \
+    python3 "$HOOK")
+rm -rf "$EMPTY_VAULT"
+if [[ -z "$out" ]]; then
+    fail "fallback summary did not fire when no rule file exists"
+fi
+echo "$out" | grep -q "meeting-workflow fallback" || \
+    fail "fallback summary missing marker (output: $out)"
+
+echo "PASS: inject-meeting-workflow-on-trigger.py wired + EN/ES triggers fire + negatives don't fire + bypass + fallback"


### PR DESCRIPTION
## Summary
- New `hooks/inject-meeting-workflow-on-trigger.py` UserPromptSubmit hook fires on EN+ES variants of "I just had a meeting" / "pull the transcript" / "the meeting just ended" / "acabo de tener una reunión", reads the vault `⚙️ Meta/rules/meeting-workflow.md`, and injects it as `additionalContext` so the post-meeting cascade actually runs.
- Wired into `hooks.json` between `inject-love-language-context.py` and `email-gate-hook.py`; `scripts/install-hooks-user-level.py` ABS_FINGERPRINTS updated so the migrator owns it.
- Regression test (`tests/integration/test_meeting_workflow_trigger_hook.sh`) — 10 assertions: hook presence + JSON wiring + 13 EN positives + 12 ES positives + 14 negative cases + payload references rule body + bypass env var + in-prompt bypass token + empty prompt silence + fallback summary.

## Why
Bug class: **ARTIFACT-WITHOUT-AUTOMATION-WIRING**. The `meeting-workflow.md` rule shipped with a `trigger:` frontmatter listing the phrases. README and POWER_TOOLS.md both promised it fired. But the `trigger:` field was just informational text — nothing in `hooks.json` actually pattern-matched the phrases. The only thing surfacing the rule to Claude was a single bullet in the once-per-session `session-start-context.py` dump. Users reported saying "I just had a meeting" mid-session and getting nothing back: the cascade silently no-op'd.

Triggers are temporal-anchored (require "just" / "ended" / "done" / "acabo de") so generic mentions like *"I have a meeting tomorrow"* and *"Tengo una reunión mañana"* do NOT fire. Accent-insensitive normalization covers users who type without diacritics.

Bypass: `MEETING_WORKFLOW_BYPASS=1` env var or in-prompt token.

## Test plan
- [x] `bash tests/integration/test_meeting_workflow_trigger_hook.sh` — PASS (all 10 assertions)
- [x] `python3 -c "import json; json.load(open('hooks.json'))"` — valid JSON
- [x] `python3 -m py_compile hooks/inject-meeting-workflow-on-trigger.py` — syntax clean
- [x] Personal-data scrub on diff — clean
- [ ] CI green on this PR (full integration suite)
- [ ] Manual: existing users get the hook on next session via the SessionStart auto-update flow