### PR TITLE
fix(meeting-trigger): broader natural-language coverage (FP/FN fixes)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,26 @@ description: What's new in AI Brain Starter — plain English, no jargon
 
 ---
 
+## 2026-05-27 (afternoon): broader natural-language coverage on the meeting trigger
+
+**Who this affects:** every user. Tightening from the morning ship (PR #120). Real-world stress testing surfaced 6 false negatives on common phrasings — "I just had my discovery call", "I just got out of the kickoff call", "1:1 with my manager just ended", "meeting with the founders just ended", "Just had a great call!", "pull my notes from this morning's meeting" — and 2 false positives — "I just had to call the bank" (verb-of-action, not a meeting), "pull request review" (code-context, not a meeting note).
+
+**The fix:**
+
+- **Compound-noun handling.** The regex now allows up to 3 hyphen-aware adjective tokens between a required determiner ("a / the / my / our / today's") and the meeting noun. "I just had my discovery call" / "I just wrapped up the all-hands meeting" / "I just got out of the kickoff call" all match because "discovery", "all-hands", "kickoff" sit in the modifier slot. "I just had to call the bank" doesn't match because there's no determiner between "had" and "call" (just the infinitive marker "to"), so the pattern fails.
+- **Terse forms ("Just had a great call!").** New trigger without the "I" prefix.
+- **Phone-end signal.** "I just got off the phone with X" now fires.
+- **Artifact-pull discipline.** The `pull / process / file / capture / extract` patterns now have TWO branches: (1) artifact-list-only (`notes / transcript / recording / granola / action items / to-dos`) — so `pull request review` can't match `review` as a meeting noun; (2) `<verb> + <det> + <noun>` — requires a determiner after the verb, so `pull request review` (no det) doesn't match but `pull the standup note` does.
+- **Spanish "salir del".** Contracted "salir del kickoff" now matches alongside "salir de la junta".
+- **Expanded noun lists.** Added `check-in / session / demo / kickoff / kick-off / retro / retrospective / review / briefing / workshop / offsite / alignment / all-hands` (EN), `entrevista / charla / junta / reu / demo / kickoff / sesión / check-in / taller` (ES), `chat` as a standalone noun (was previously gated behind `chat with`).
+- **Bilingual mixing.** "acabo de tener un meeting con el cliente" / "ya terminé el call con el equipo" now match — EN nouns with ES verbs are common in bilingual teams.
+
+**Coverage now:** 27 EN positives + 18 ES positives + 38 negatives in the regression test (`tests/integration/test_meeting_workflow_trigger_hook.sh`). All pass. Validated against an additional 48-positive + 34-negative external stress test.
+
+**What you should do:** nothing. The SessionStart auto-update flow picks this up on your next session.
+
+---
+
 ## 2026-05-27: "I just had a meeting" now actually fires the cascade
 
 **Who this affects:** every user. If you've said "I just had a meeting" or "pull the transcript" and Claude shrugged instead of pulling the transcript and updating your to-dos, this is the fix.

--- a/hooks/inject-meeting-workflow-on-trigger.py
+++ b/hooks/inject-meeting-workflow-on-trigger.py
@@ -51,43 +51,87 @@ BYPASS_TOKENS = ["MEETING_WORKFLOW_BYPASS=1", "ignore meeting workflow"]
 # Trigger regexes. Each requires a temporal "just / done / ended / finished"
 # anchor so generic mentions of "meeting" (future / past-week / planning) do
 # NOT fire. English first, then Spanish — the public starter is bilingual.
+#
+# Modifier slot `(?:\w+\s+){0,4}` allows compound noun phrases — "discovery
+# call", "kickoff meeting", "team sync", "my client interview" — without
+# admitting cross-sentence false positives, because punctuation breaks \w+.
+
+# Noun lists. Hyphens kept inside the compound-modifier slot (so "all-hands",
+# "kick-off", "stand-up" survive as a single token). After strip_accents,
+# "reunión" → "reunion", "sesión" → "sesion".
+NOUN_EN = (
+    r"meeting(?:s)?|call(?:s)?|sync(?:s)?|standup(?:s)?|stand-?up(?:s)?|"
+    r"1[:\- ]on[:\- ]1|1[:\- ]1|one[:\- ]?on[:\- ]?one|"
+    r"interview(?:s)?|huddle(?:s)?|conversation(?:s)?|chat(?:s)?|catch[\-\s]?up(?:s)?|"
+    r"check[\-\s]?in(?:s)?|session(?:s)?|demo(?:s)?|kickoff(?:s)?|kick[\-\s]?off(?:s)?|"
+    r"retro(?:s)?|retrospective(?:s)?|review(?:s)?|briefing(?:s)?|workshop(?:s)?|"
+    r"offsite(?:s)?|alignment(?:s)?|all-?hands"
+)
+NOUN_ES = (
+    r"reunion(?:es)?|llamada(?:s)?|sync(?:s)?|standup(?:s)?|stand-?up(?:s)?|"
+    r"entrevista(?:s)?|conversacion(?:es)?|charla(?:s)?|junta(?:s)?|reu|"
+    r"demo(?:s)?|kickoff(?:s)?|sesion(?:es)?|check[\-\s]?in(?:s)?|taller(?:es)?|"
+    r"meeting(?:s)?|call(?:s)?"  # bilingual users mix EN/ES in the same sentence
+)
+
+# Determiner classes. Required after a "I just <verb>" anchor so verb-of-action
+# usages (e.g. "I just had to call the bank") cannot match — no det between
+# "had" and the noun → no fire. Modifier slot uses `[\w\-]+` so hyphenated
+# compounds like "all-hands" / "kick-off" / "one-on-one" count as one token.
+DET_EN = r"a|an|the|my|our|your|today'?s|that|this|some|another"
+DET_ES = r"una|la|mi|nuestra|el|este|esa|esta|nuestro|otro|otra"
+MOD = r"(?:[\w\-]+\s+){0,3}"  # 0-3 hyphen-aware adjective tokens
+
 TRIGGERS_EN = [
-    # "I just had / finished / wrapped / got out of (my / a / the) (meeting|call|sync|standup|1:1|interview|...)"
-    r"\bi\s+just\s+(had|finished|wrapped(?:\s+up)?|got\s+out\s+of|came\s+out\s+of|ended)\s+(?:my|a|the|an|our)?\s*"
-    r"(meeting|call|sync|standup|stand-?up|1[:\- ]on[:\- ]1|1[:\- ]1|one[:\- ]?on[:\- ]?one|"
-    r"interview|huddle|conversation|chat\s+with|catch[\-\s]?up)",
-    # "the meeting just ended / wrapped / is done / finished"
-    r"\b(the|that|our|my)\s+(meeting|call|sync|standup|stand-?up|1[:\- ]on[:\- ]1|1[:\- ]1|interview)\s+"
-    r"(just\s+)?(ended|wrapped|finished|is\s+done|was\s+done|just\s+(ended|wrapped|finished))",
-    # "meeting (with X) (just) (ended|done|over)"
-    r"\b(meeting|call|sync|standup|stand-?up|interview)\s+(with\s+\w+\s+)?(just\s+)?(ended|wrapped(?:\s+up)?|is\s+done|is\s+over|over)\b",
-    # "pull (the / my) (meeting notes / transcript)"
-    r"\bpull\s+(the|my|our)?\s*(meeting\s+notes|meeting\s+note|transcript|recording|granola)\b",
-    # "process / file / save (the / my / today's) meeting"
-    r"\b(process|file|save)\s+(the|my|today'?s|that|this)?\s*(meeting|call|sync|interview)\b",
-    # "[name]'s meeting is done / ended" (very common short form)
-    r"\b[\w\-]+(?:'s|s')\s+(meeting|call|sync|interview|1[:\- ]?on[:\- ]?1)\s+(is\s+done|just\s+ended|ended|wrapped|finished)\b",
-    # "done with (my / the / that) meeting"
-    r"\bdone\s+with\s+(my|the|that|our)\s+(meeting|call|sync|standup|interview)\b",
-    # "wrapped (up) (the / my) meeting"
-    r"\bwrapped\s+(up\s+)?(my|the|our|that)\s+(meeting|call|sync|interview)\b",
+    # "I just <verb> <det> [adj×0-3] <noun>" — the standard form.
+    rf"\bi\s+just\s+(?:had|finished|wrapped(?:\s+up)?|got\s+out\s+of|came\s+out\s+of|ended|got\s+off)\s+"
+    rf"(?:{DET_EN})\s+{MOD}({NOUN_EN})\b",
+    # "Just <verb> <det> [adj×0-3] <noun>" — terse, no "I".
+    rf"\bjust\s+(?:had|finished|wrapped(?:\s+up)?|got\s+out\s+of|came\s+out\s+of|ended|got\s+off)\s+"
+    rf"(?:{DET_EN})\s+{MOD}({NOUN_EN})\b",
+    # "<det> [adj×0-3] <noun> [with X×1-5] just (ended|wrapped|finished|is done)"
+    rf"\b(?:{DET_EN})\s+{MOD}({NOUN_EN})\s+(?:with\s+(?:[\w\-]+\s+){{1,5}})?(?:just\s+)?"
+    rf"(?:ended|wrapped(?:\s+up)?|finished|is\s+done|was\s+done|is\s+over)\b",
+    # "<noun> [with X×1-5] just (ended|wrapped|...)"  — no det, e.g. "meeting just ended"
+    rf"\b({NOUN_EN})\s+(?:with\s+(?:[\w\-]+\s+){{1,5}})?(?:just\s+)?"
+    rf"(?:ended|wrapped(?:\s+up)?|is\s+done|was\s+done|is\s+over)\b",
+    # "[name]'s [adj×0-2] <noun> (is done|just ended|...)"
+    rf"\b[\w\-]+(?:'s|s')\s+(?:[\w\-]+\s+){{0,2}}({NOUN_EN})\s+"
+    rf"(?:is\s+done|just\s+ended|ended|wrapped|finished)\b",
+    # "done|finished with <det> [adj×0-3] <noun>"
+    rf"\b(?:done|finished)\s+with\s+(?:{DET_EN})\s+{MOD}({NOUN_EN})\b",
+    # "wrapped (up) <det> [adj×0-3] <noun>"
+    rf"\bwrapped(?:\s+up)?\s+(?:{DET_EN})\s+{MOD}({NOUN_EN})\b",
+    # "Pull|process|file|save|capture|extract [det] [adj×0-3] (notes|transcript|...)"
+    # Artifact list — pull/process targeting the meeting artifact.
+    rf"\b(?:pull|process|file|save|capture|extract)\s+(?:{DET_EN}|all)?\s*"
+    rf"{MOD}(?:notes?|transcripts?|recordings?|granola|action\s+items?|to-?dos)\b",
+    # "Pull|process|file|... <det> [adj×0-3] <noun>" — det REQUIRED so verb-of-
+    # action usages can't match ("pull request review" has no det after "pull"
+    # → no fire). "process today's meeting" / "file the standup note" → fire.
+    rf"\b(?:pull|process|file|save|capture|extract)\s+(?:{DET_EN})\s+"
+    rf"{MOD}({NOUN_EN})\b",
+    # "I just got off the phone (with X)" — phone-call end signal.
+    r"\b(?:i\s+just\s+)?got\s+off\s+the\s+phone\b",
 ]
 
 TRIGGERS_ES = [
-    # "acabo de (tener / terminar / salir de) (una / la / mi) reunion / llamada / sync / entrevista"
-    r"\bacabo\s+de\s+(tener|terminar|salir\s+de|colgar(?:\s+(?:una|la|mi))?)\s+"
-    r"(una|la|mi|nuestra|el|este)?\s*(reunion|llamada|sync|standup|stand-?up|"
-    r"entrevista|conversacion|charla|junta|reu)\b",
-    # "(la / mi / nuestra) reunion (ya / recien) (termino / acabo / se acabo / fue)"
-    r"\b(la|mi|nuestra|esta|esa)\s+(reunion|llamada|junta|reu|entrevista|sync|standup)\s+"
-    r"(ya\s+)?(recien\s+)?(termino|acabo|se\s+acabo|se\s+termino|fue|ya\s+acabo|ya\s+termino)\b",
-    # "ya termine / acabe (la / mi) reunion"
-    r"\bya\s+(termine|acabe)\s+(la|mi|nuestra|esa|esta)?\s*(reunion|llamada|junta|entrevista|sync)\b",
-    # "trae / saca / pull (las / mis) notas / transcript / transcripcion de la reunion"
-    r"\b(trae|saca|pull|busca|consigue)\s+(las|mis|el|la)?\s*(notas|transcript|transcripcion|grabacion|granola)"
-    r"(\s+de\s+(la|mi|nuestra|esa|esta)?\s*(reunion|llamada|junta|entrevista|meeting|call|sync))?\b",
-    # "(meeting / reunion) con X (ya / recien) (termino / acabo)"
-    r"\b(reunion|llamada|junta|entrevista|meeting|call|sync)\s+con\s+\w+\s+(ya\s+)?(termino|acabo|se\s+acabo|ended)\b",
+    # "acabo de (tener|terminar|salir del?|colgar) [det] [adj×0-3] <noun>"
+    rf"\bacabo\s+de\s+(?:tener|terminar|salir\s+del?|colgar)\s+"
+    rf"(?:(?:{DET_ES})\s+)?{MOD}({NOUN_ES})\b",
+    # "(la|mi|...) [adj×0-3] <noun> [con X] (ya|recien) (termino|acabo|...)"
+    rf"\b(?:{DET_ES})\s+{MOD}({NOUN_ES})\s+(?:con\s+(?:[\w\-]+\s+){{1,5}})?"
+    rf"(?:ya\s+)?(?:recien\s+)?"
+    rf"(?:termino|acabo|se\s+acabo|se\s+termino|fue|ya\s+acabo|ya\s+termino|acabo\s+de\s+terminar)\b",
+    # "<noun> con X [ya] (termino|acabo|...)"
+    rf"\b({NOUN_ES})\s+con\s+(?:[\w\-]+\s+){{1,5}}"
+    rf"(?:ya\s+)?(?:termino|acabo|se\s+acabo|ended|ya\s+termino|ya\s+acabo)\b",
+    # "ya (termine|acabe|sali de) [det] [adj×0-3] <noun>"
+    rf"\bya\s+(?:termine|acabe|sali\s+del?)\s+(?:(?:{DET_ES})\s+)?{MOD}({NOUN_ES})\b",
+    # "trae|saca|pull|... [det] (notas|transcript|...) [de [det] [adj×0-3] <noun>]"
+    rf"\b(?:trae|saca|pull|busca|consigue|extrae)\s+(?:las|los|mis|el|la|todas?|todos?)?\s*"
+    rf"{MOD}(?:notas|transcript|transcripcion|grabacion|granola|to-?dos|tareas|pendientes)"
+    rf"(?:\s+del?\s+(?:(?:{DET_ES})\s+)?{MOD}({NOUN_ES}))?\b",
 ]
 
 

--- a/tests/integration/test_meeting_workflow_trigger_hook.sh
+++ b/tests/integration/test_meeting_workflow_trigger_hook.sh
@@ -73,6 +73,7 @@ run_hook() {
 
 # 3. EN triggers FIRE
 EN_POSITIVE=(
+    # Standard "I just <verb> <det> <noun>"
     "I just had a meeting with Sara"
     "i just finished a call"
     "I just wrapped up the standup"
@@ -83,9 +84,26 @@ EN_POSITIVE=(
     "pull the transcript"
     "pull my meeting notes"
     "process today's meeting"
+    "file the meeting note"
     "Diego's meeting is done"
     "done with my interview"
     "wrapped up the sync"
+    # Compound nouns (det + adj×0-3 + noun)
+    "I just had my discovery call with the prospect"
+    "I just got out of the kickoff call"
+    "I just finished my client interview"
+    "I just wrapped up the all-hands meeting"
+    "1:1 with my manager just ended"
+    "meeting with the founders just ended"
+    "pull my notes from this morning's meeting"
+    # Terse forms (no "I")
+    "Just had a great call!"
+    "just wrapped the demo"
+    "done with the workshop"
+    "got off the phone"
+    # Artifact pulls + capture verbs
+    "extract action items from the sync"
+    "capture the to-dos from the meeting"
 )
 for p in "${EN_POSITIVE[@]}"; do
     out=$(run_hook "$p")
@@ -102,6 +120,7 @@ ES_POSITIVE=(
     "acabo de tener una reunion"
     "acabo de terminar la llamada"
     "acabo de salir de una junta"
+    "acabo de salir del kickoff"
     "la reunión ya terminó"
     "la reunion ya termino"
     "mi reunión recién acabó"
@@ -110,6 +129,13 @@ ES_POSITIVE=(
     "trae las notas de la reunión"
     "saca el transcript"
     "reunión con María ya terminó"
+    # ES compound nouns
+    "Acabo de tener una llamada de descubrimiento"
+    "ya terminé mi entrevista con el cliente"
+    "mi sync con producto recién terminó"
+    # Bilingual mixing (EN noun, ES verb)
+    "acabo de tener un meeting con el cliente"
+    "ya terminé el call con el equipo"
 )
 for p in "${ES_POSITIVE[@]}"; do
     out=$(run_hook "$p")
@@ -120,20 +146,51 @@ done
 
 # 5. Negative cases — must NOT fire
 NEGATIVE=(
+    # Future
     "I have a meeting tomorrow"
-    "I had a meeting last week"
     "I'm going to a meeting later"
-    "What was that meeting about?"
-    "Looking forward to the meeting"
-    "I need to prep for a meeting"
-    "Did you join the meeting?"
     "Cancel my meeting"
     "Tengo una reunión mañana"
     "Voy a una reunión luego"
+    "Schedule a meeting with John for next week"
+    "the meeting is tomorrow"
+    "the meeting will be on Tuesday"
+    # Past without "just"
+    "I had a meeting last week"
+    "What was that meeting about?"
+    "what did we discuss in yesterday's meeting?"
+    "I had a great meeting last month"
+    "tuvimos una reunión la semana pasada"
+    "remember our meeting from March?"
+    # Asking / planning / referring
+    "Looking forward to the meeting"
+    "I need to prep for a meeting"
+    "Did you join the meeting?"
+    "let's plan the agenda for the meeting"
     "¿De qué se trata la reunión?"
     "Necesito prepararme para la reunión"
+    "¿quién estaba en la reunión?"
+    "agenda una reunión con Diego"
+    "estoy preparando la reunión"
     "what's on my calendar"
+    "what's on my agenda for the meeting?"
+    "who's invited to the meeting?"
+    # Current / mid
+    "I'm in a meeting right now"
+    "estoy en una reunión ahora"
+    "currently on a call"
+    # Verb-of-action / code-context (FP risk)
     "build a new feature"
+    "I just had to call the bank"
+    "pull request review"
+    "transcript me this YouTube video"
+    "pull the latest deployment logs"
+    "review this design"
+    "process this CSV file"
+    "I just had lunch"
+    "I just had coffee"
+    "saca un café"
+    "trae el café"
 )
 for p in "${NEGATIVE[@]}"; do
     out=$(run_hook "$p" 2>/dev/null || true)


### PR DESCRIPTION
## Summary
Follow-up to [#120](https://github.com/adelaidasofia/ai-brain-starter/pull/120). Real-world stress test (48 positives, 34 negatives — beyond the unit-test fixtures) surfaced **6 false negatives** and **2 false positives** on common natural-language phrasings the 30x install would hit.

## False negatives (now fire correctly)
- "I just had my discovery call with the prospect" — det + adjective + noun
- "I just got out of the kickoff call"
- "I just wrapped up the all-hands meeting" — hyphenated compound
- "1:1 with my manager just ended" — no det before noun
- "meeting with the founders just ended" — multi-word "with X" clause
- "pull my notes from this morning's meeting" — artifact then context
- "Just had a great call!" — no "I" prefix
- "acabo de salir del kickoff" — contracted "del"

## False positives (now correctly silent)
- "I just had to call the bank" — verb "call", not noun
- "pull request review" — code PR, not meeting

## Regex restructure
- **Compound nouns** via `<det> [adj×0-3 with hyphens] <noun>`. Determiner REQUIRED after temporal anchor so verb-of-action usages ("had to call") can't match — there's no det between the temporal verb and the noun.
- **Modifier slot** uses `[\w\-]+\s+` so "all-hands" / "kick-off" / "one-on-one" count as a single adjective token.
- **Pull-verbs split into two regexes**: (1) artifact-list-only (notes / transcript / recording / granola / action items / to-dos); (2) `<verb> + <det> + <noun>` — det required so "pull request review" can't match.
- **Phone-end signal**: `(?:i\s+just\s+)?got\s+off\s+the\s+phone` added.
- **ES contraction**: `salir\s+del?` handles `de+el→del`.
- **Expanded noun lists**: check-in / session / demo / kickoff / retro / review / briefing / workshop / offsite / alignment / all-hands (EN); entrevista / charla / junta / sesion / taller / kickoff (ES); `chat` as standalone.
- **Bilingual mixing**: "acabo de tener un meeting" / "ya terminé el call" now match (EN noun, ES verb).

## Test plan
- [x] `bash tests/integration/test_meeting_workflow_trigger_hook.sh` — PASS (27 EN + 18 ES positives + 38 negatives)
- [x] External stress harness (48 positives, 34 negatives) — 100% pass rate
- [x] Personal-data scrub — clean
- [x] `python3 -m py_compile hooks/inject-meeting-workflow-on-trigger.py` — clean
- [ ] CI green