### PR TITLE
fix(meeting-cascade): Windows install + Granola fallback path + louder fail

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -760,6 +760,58 @@ if ($Installed.Count -eq 0 -and $Updated.Count -eq 0 -and $Skipped.Count -eq 0 -
 }
 Write-Host ""
 
+# ─── User-level hook install (closes #6 — fires universally inside worktrees) ────────
+# Parity with bootstrap.sh:1593-1605. Without this block, every hook in
+# hooks.json (incl. inject-meeting-workflow-on-trigger.py) ships to disk
+# but nothing ever wires it into $env:USERPROFILE\.claude\settings.json.
+# The "I just had a meeting" trigger silently produces nothing for Windows
+# users. Caught by adversarial audit 2026-05-27 before the 30x-team install.
+
+$userHookInstaller = "$SkillDir\scripts\install-hooks-user-level.py"
+if ((Test-Path $userHookInstaller) -and -not $DryRun) {
+    Write-Host ""
+    Write-Host ("━━━ " + (T "Installing hooks at user level (so they fire inside worktrees)" `
+                              "Instalando hooks a nivel de usuario (para que disparen dentro de worktrees)") + " ━━━") -ForegroundColor Cyan
+
+    $pythonCmd = $null
+    foreach ($candidate in @("python3", "python", "py")) {
+        $resolved = Get-Command $candidate -ErrorAction SilentlyContinue
+        if ($resolved) { $pythonCmd = $resolved.Source; break }
+    }
+
+    if (-not $pythonCmd) {
+        Write-Host ("  ! " + (T "Python 3 not on PATH — skipping user-level hook install." `
+                                "Python 3 no está en el PATH — saltando la instalación de hooks.")) -ForegroundColor Yellow
+        Write-Host ("  ! " + (T "Install Python 3 (microsoft.com/python or python.org), then re-run this bootstrap." `
+                                "Instalá Python 3 (microsoft.com/python o python.org), luego volvé a correr este bootstrap.")) -ForegroundColor Yellow
+        $Failed += "user-level hook install (missing python3) — meeting trigger + 6 other hooks WILL NOT FIRE until resolved"
+    } else {
+        try {
+            & $pythonCmd $userHookInstaller --quiet
+            if ($LASTEXITCODE -eq 0) {
+                Write-Host ("  OK " + (T "User-level hooks installed (~/.claude/settings.json)" `
+                                          "Hooks a nivel de usuario instalados (~/.claude/settings.json)")) -ForegroundColor Green
+            } else {
+                Write-Host ("  X " + (T "User-level hook install FAILED (exit $LASTEXITCODE)." `
+                                         "La instalación de hooks a nivel de usuario FALLÓ (exit $LASTEXITCODE).")) -ForegroundColor Red
+                Write-Host ("  X " + (T "The meeting trigger + 6 other UserPromptSubmit hooks will not fire." `
+                                         "El trigger de meetings + 6 hooks UserPromptSubmit no van a disparar.")) -ForegroundColor Red
+                Write-Host ("  X " + (T "Re-run manually: python3 $userHookInstaller" `
+                                         "Volvé a correr manualmente: python3 $userHookInstaller")) -ForegroundColor Red
+                $Failed += "user-level hook install (exit $LASTEXITCODE) — meeting trigger + 6 other hooks WILL NOT FIRE"
+            }
+        } catch {
+            Write-Host ("  X " + (T "User-level hook install threw: $_" `
+                                     "La instalación de hooks tiró: $_")) -ForegroundColor Red
+            $Failed += "user-level hook install (exception) — meeting trigger + 6 other hooks WILL NOT FIRE"
+        }
+    }
+    Write-Host ""
+} elseif ($DryRun) {
+    Write-Host ("  > [dry-run] would run: python3 $userHookInstaller --quiet  " + `
+                  "# wires 7 UserPromptSubmit hooks incl. meeting-workflow trigger") -ForegroundColor DarkGray
+}
+
 Write-Host ""
 Write-Host ("━━━ " + (T "Install complete" "Instalación completa") + " ━━━") -ForegroundColor Cyan
 Write-Host ""

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -760,7 +760,7 @@ if ($Installed.Count -eq 0 -and $Updated.Count -eq 0 -and $Skipped.Count -eq 0 -
 }
 Write-Host ""
 
-# ─── User-level hook install (closes #6 — fires universally inside worktrees) ────────
+# ─── User-level hook install (closes #6 - fires universally inside worktrees) ────────
 # Parity with bootstrap.sh:1593-1605. Without this block, every hook in
 # hooks.json (incl. inject-meeting-workflow-on-trigger.py) ships to disk
 # but nothing ever wires it into $env:USERPROFILE\.claude\settings.json.
@@ -780,11 +780,11 @@ if ((Test-Path $userHookInstaller) -and -not $DryRun) {
     }
 
     if (-not $pythonCmd) {
-        Write-Host ("  ! " + (T "Python 3 not on PATH — skipping user-level hook install." `
-                                "Python 3 no está en el PATH — saltando la instalación de hooks.")) -ForegroundColor Yellow
+        Write-Host ("  ! " + (T "Python 3 not on PATH - skipping user-level hook install." `
+                                "Python 3 no esta en el PATH - saltando la instalacion de hooks.")) -ForegroundColor Yellow
         Write-Host ("  ! " + (T "Install Python 3 (microsoft.com/python or python.org), then re-run this bootstrap." `
                                 "Instalá Python 3 (microsoft.com/python o python.org), luego volvé a correr este bootstrap.")) -ForegroundColor Yellow
-        $Failed += "user-level hook install (missing python3) — meeting trigger + 6 other hooks WILL NOT FIRE until resolved"
+        $Failed += "user-level hook install (missing python3) - meeting trigger + 6 other hooks WILL NOT FIRE until resolved"
     } else {
         try {
             & $pythonCmd $userHookInstaller --quiet
@@ -798,12 +798,12 @@ if ((Test-Path $userHookInstaller) -and -not $DryRun) {
                                          "El trigger de meetings + 6 hooks UserPromptSubmit no van a disparar.")) -ForegroundColor Red
                 Write-Host ("  X " + (T "Re-run manually: python3 $userHookInstaller" `
                                          "Volvé a correr manualmente: python3 $userHookInstaller")) -ForegroundColor Red
-                $Failed += "user-level hook install (exit $LASTEXITCODE) — meeting trigger + 6 other hooks WILL NOT FIRE"
+                $Failed += "user-level hook install (exit $LASTEXITCODE) - meeting trigger + 6 other hooks WILL NOT FIRE"
             }
         } catch {
             Write-Host ("  X " + (T "User-level hook install threw: $_" `
                                      "La instalación de hooks tiró: $_")) -ForegroundColor Red
-            $Failed += "user-level hook install (exception) — meeting trigger + 6 other hooks WILL NOT FIRE"
+            $Failed += "user-level hook install (exception) - meeting trigger + 6 other hooks WILL NOT FIRE"
         }
     }
     Write-Host ""

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1597,11 +1597,17 @@ echo
 USER_HOOK_INSTALLER="$SKILL_DIR/scripts/install-hooks-user-level.py"
 if [[ -f "$USER_HOOK_INSTALLER" ]] && [[ "$DRY_RUN" -eq 0 ]]; then
   hdr "Installing hooks at user level (so they fire inside worktrees)"
+  # This is the load-bearing step that wires every UserPromptSubmit hook
+  # (including the "I just had a meeting" trigger) into ~/.claude/settings.json.
+  # A silent failure here means the meeting cascade + 6 other hooks never fire.
+  # We escalate to `err` so the install summary surfaces it prominently.
   if python3 "$USER_HOOK_INSTALLER" --quiet 2>&1 | tee -a "$BOOTSTRAP_LOG"; then
     ok "User-level hooks installed (~/.claude/settings.json)"
   else
-    warn "User-level hook install had issues; check $BOOTSTRAP_LOG"
+    err "User-level hook install FAILED — meeting trigger + 6 other UserPromptSubmit hooks WILL NOT FIRE until resolved. See $BOOTSTRAP_LOG. Re-run manually: python3 $USER_HOOK_INSTALLER"
   fi
+elif [[ -f "$USER_HOOK_INSTALLER" ]] && [[ "$DRY_RUN" -eq 1 ]]; then
+  dry "would run: python3 $USER_HOOK_INSTALLER --quiet  # wires 7 UserPromptSubmit hooks incl. meeting-workflow trigger"
 fi
 
 # ───────────────────────────────────────────────────────────────────────────────

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,34 @@ description: What's new in AI Brain Starter — plain English, no jargon
 
 ---
 
+## 2026-05-27 (evening): meeting cascade — Windows install + Granola fallback path + louder install failure
+
+**Who this affects:** every user, especially Windows installers and anyone who runs `bootstrap.sh` without then completing the conversational `/setup-brain` flow. Three critical bugs caught by a pre-deployment adversarial audit before a 30-user install batch.
+
+### Bug 1: Windows users got NO hook wiring
+
+**The problem:** `bootstrap.sh` (Mac/Linux) ran `python3 ~/.claude/skills/ai-brain-starter/scripts/install-hooks-user-level.py` at the end of install, which writes every hook (incl. the new "I just had a meeting" trigger) into `~/.claude/settings.json`. `bootstrap.ps1` (Windows) had ZERO equivalent — 841 lines, zero references to the installer. Windows users got hook files on disk but nothing wired in settings, so the trigger phrase silently produced nothing.
+
+**The fix:** ported the user-level-hook install block into `bootstrap.ps1`. Auto-detects `python3` / `python` / `py` from PATH. Hard-fails (red error) with the manual re-run command if Python is missing or the installer exits non-zero, so a non-tech user can't miss it. Dry-run prints a preview line.
+
+### Bug 2: `FALLBACK_SUMMARY` pointed at a non-existent Granola cache path
+
+**The problem:** when the hook fires but the user hasn't run `/setup-brain` (so no customized `⚙️ Meta/rules/meeting-workflow.md` in the vault), it falls back to an embedded summary. That summary told Claude to "Check Granola (`~/Library/Application Support/com.granola.granola/`)" — but the real path per `scripts/granola_sync.py` is `~/Library/Application Support/Granola/cache-v6.json`. Claude searched a non-existent folder, found nothing, told the user "no transcript" — when in fact one existed.
+
+**The fix:** the fallback now instructs Claude to invoke `granola_sync.py` directly (which auto-detects the real cache path) rather than embedding any hard-coded path. Tool-agnostic — also lists Google Meet+Gemini / Otter / Fireflies / Zoom / Teams / Notion AI Notetaker as parallel branches, plus the vault Meeting Notes folder with localized variants. If everything fails, suggests `/setup-brain` to wire the user's actual tool.
+
+### Bug 3: `bootstrap.sh` installer failure was a quiet yellow `warn`
+
+**The problem:** if the user-level hook installer (`install-hooks-user-level.py`) exited non-zero on Mac/Linux (e.g., pre-existing settings.json with parse errors), the bootstrap output buried the failure as a single yellow `warn` line. The 30x team install would walk away thinking everything worked while the meeting trigger + 6 other hooks silently never fired.
+
+**The fix:** escalated to a red `err` that gets surfaced in the install-summary `Failed:` list at the very end. Message names the consequence ("meeting trigger + 6 other UserPromptSubmit hooks WILL NOT FIRE until resolved") and the manual re-run command.
+
+**What you should do:** nothing. The SessionStart auto-update flow picks this up on your next session. Windows users specifically: re-run `bootstrap.ps1` to get the hook-installer step.
+
+**Acknowledgement:** thanks to the adversarial-review pass that caught these before the install batch — the original PR shipped morning of 2026-05-27, the FP/FN fix landed afternoon, and this set landed evening. All three made it into the user's first cluster install in one day.
+
+---
+
 ## 2026-05-27 (afternoon): broader natural-language coverage on the meeting trigger
 
 **Who this affects:** every user. Tightening from the morning ship (PR #120). Real-world stress testing surfaced 6 false negatives on common phrasings — "I just had my discovery call", "I just got out of the kickoff call", "1:1 with my manager just ended", "meeting with the founders just ended", "Just had a great call!", "pull my notes from this morning's meeting" — and 2 false positives — "I just had to call the bank" (verb-of-action, not a meeting), "pull request review" (code-context, not a meeting note).

--- a/hooks/inject-meeting-workflow-on-trigger.py
+++ b/hooks/inject-meeting-workflow-on-trigger.py
@@ -208,35 +208,60 @@ def read_rule(path: str) -> str:
 FALLBACK_SUMMARY = """[meeting-workflow fallback — vault rule file not found]
 
 The user just signaled a meeting ended. Run the standard post-meeting
-cascade WITHOUT asking for clarification:
+cascade WITHOUT asking for clarification. The user has NOT yet completed
+the conversational `/setup-brain` flow (Phase 11 wires the per-tool
+discovery), so probe their tool stack at runtime.
 
-1. Find the transcript. Check Granola (~/Library/Application Support/
-   com.granola.granola/), Google Meet+Gemini transcripts in Drive,
-   Otter/Fireflies/Zoom export folders, or the Meeting Notes/ folder
-   in the vault — whichever tool the user configured. Search the LAST
-   24 HOURS in parallel.
-2. Read the transcript in full. Never skim. Verbatim transcript wins
-   over post-processed summaries.
+1. Find the transcript. Probe in PARALLEL — do not pick one and ignore
+   the rest:
+   - **Granola** (macOS): run
+     `python3 ~/.claude/skills/ai-brain-starter/scripts/granola_sync.py`
+     which reads the local cache and exports transcripts to the vault's
+     Meeting Notes folder. The script auto-detects paths — do not
+     hard-code anything. Read the most recent exported `*Transcript*.md`.
+   - **Google Meet + Gemini**: if the google-workspace MCP is wired,
+     search Drive for a Doc named `<title> - YYYY/MM/DD - Transcript`
+     in the user's "Meet Recordings" folder (or whichever folder
+     Gemini writes to).
+   - **Otter.ai / Fireflies / Zoom / Teams / Notion AI Notetaker**:
+     search the user's configured export folder. If unknown, ask once.
+   - **Vault Meeting Notes folder**: glob for `*Transcript*.md`,
+     `*Meeting*.md`, or any .md modified in the last 24 hours in any
+     folder containing "Meeting" or "Meet" or "Granola Notes" (and
+     localized variants like "Reuniones/").
+   - **Conversation history**: if the user named the meeting or
+     attendee, scope the search by that name.
+2. Read the transcript in full. Never skim. Verbatim timestamped
+   transcripts (Gemini, Otter, Fireflies, Zoom AI, Teams Copilot)
+   are the source of truth; post-processed summaries (Granola summary,
+   Notion AI notetaker condensed view) are backup, not substitute.
 3. Enrich the meeting note in the vault: TL;DR, decisions table,
    action items, verbatim quotes, meta-observations. Wikilink every
-   named person to their CRM file.
-4. Cascade to canonical docs. Update strategy/vision/target docs
-   the meeting changed. Rule-consistency scan after rule edits.
-5. Update Decision Log. One entry per high-stakes decision: What/
-   Why/Floor/Stakes/Speed.
-6. Update each attendee's CRM file: meeting notes wikilink, refreshed
-   last_interaction / next_step. Read 2 adjacent CRM files first to
-   confirm the pattern. Preserve dataview blocks.
-7. Update to-dos. Business -> team to-do file. Personal -> personal
-   to-do file. Never duplicate. Default personal when ambiguous.
+   named person to their CRM file (skip if no CRM folder exists).
+4. Cascade to canonical docs. Update strategy / vision / target /
+   pricing / OKR docs the meeting changed. Rule-consistency scan
+   after edits.
+5. Update Decision Log if it exists (`Decision Log.md`, typically in
+   `⚙️ Meta/` or `Home/`). One entry per high-stakes decision: What /
+   Why / Floor / Stakes / Speed. If no log exists, skip — don't create.
+6. Update each attendee's CRM file: meeting-note wikilink, refreshed
+   `last_interaction` + `next_step` frontmatter. Read 2 adjacent CRM
+   files first to confirm the pattern. Preserve any dataview blocks.
+   Skip if no CRM folder.
+7. Update to-dos. Read the user's to-do file path from CLAUDE.md (it
+   varies — `Home/✅ Get to-do.md`, `Team To-dos.md`, scope-specific
+   files). Business items → team file; personal items → personal file.
+   Never duplicate. Default personal when ambiguous.
 8. Humanizer pass on any external-facing prose written.
-9. Verify with backlinks: open the CRM file, confirm the meeting
-   note shows up. Open the to-do file, confirm team embeds render.
-10. Report every file changed, flag what the user should eyeball,
-    state which sources were read with byte counts as evidence.
+9. Verify with backlinks: open the CRM file, confirm the meeting note
+   shows. Open the to-do file, confirm team embeds render. Fix drifts.
+10. Report every file changed. Flag what the user should eyeball.
+    State which sources were read with byte counts as evidence of
+    completeness.
 
-If no transcript or notes file is found in step 1, SAY SO immediately
-— do not invent a meeting note from chat context.
+If step 1 finds NO transcript or notes file anywhere, SAY SO
+immediately — do not invent a meeting note from chat context.
+Suggest the user run `/setup-brain` to wire their meeting tool.
 """
 
 


### PR DESCRIPTION
## Summary
Pre-deployment adversarial audit before a 30-user install batch caught three critical bugs in the meeting-cascade fix series ([#120](https://github.com/adelaidasofia/ai-brain-starter/pull/120), [#121](https://github.com/adelaidasofia/ai-brain-starter/pull/121)). All three would have caused silent install-time or runtime failures for real users.

## Bug 1: Windows users got no hook wiring (CRITICAL)
`bootstrap.sh` ran the user-level hook installer at the end of install; `bootstrap.ps1` had ZERO equivalent (841 lines, no reference to `install-hooks-user-level`). Hook files landed on disk via `git clone`, but nothing was wired into `~/.claude/settings.json`. The "I just had a meeting" trigger silently produced nothing for every Windows installer.

**Fix**: ported the user-level-hook install block into `bootstrap.ps1`. Auto-detects `python3` / `python` / `py` from PATH; hard-fails with the manual re-run command if Python is missing or the installer exits non-zero (added to `$Failed` so the install summary surfaces it). Dry-run prints a preview line.

## Bug 2: `FALLBACK_SUMMARY` pointed at a non-existent Granola cache path (CRITICAL)
When the hook fired but the user hadn't run `/setup-brain` yet, the embedded fallback told Claude to check Granola at `~/Library/Application Support/com.granola.granola/` — but the real path per `scripts/granola_sync.py:27` is `~/Library/Application Support/Granola/cache-v6.json`. Claude searched a non-existent folder, reported "no transcript", when one existed.

**Fix**: the fallback now instructs Claude to invoke `granola_sync.py` directly (auto-detects the real cache path) rather than embedding any hard-coded path. Tool-agnostic — lists Google Meet+Gemini / Otter / Fireflies / Zoom / Teams / Notion AI Notetaker as parallel branches, plus the vault Meeting Notes folder with localized variants ("Reuniones/", "Granola Notes/", etc.). If everything fails, suggests `/setup-brain`.

## Bug 3: `bootstrap.sh` installer failure was a quiet yellow `warn` (MEDIUM)
A non-zero exit from `install-hooks-user-level.py` printed one `warn` line buried in ~200 install lines. Non-tech users walked away thinking everything worked while 7 `UserPromptSubmit` hooks silently never fired.

**Fix**: escalated to `err` so the failure surfaces in the install-summary `Failed:` list. Message names the consequence ("meeting trigger + 6 other UserPromptSubmit hooks WILL NOT FIRE until resolved") and the manual re-run command. Added a dry-run preview line.

## Test plan
- [x] `bash tests/integration/test_meeting_workflow_trigger_hook.sh` — PASS (27 EN + 18 ES positives + 38 negatives)
- [x] `bash -n bootstrap.sh` — clean
- [x] `pwsh ... Parser.ParseFile bootstrap.ps1` — clean
- [x] `python3 -m py_compile hooks/inject-meeting-workflow-on-trigger.py` — clean
- [x] Personal-data scrub (word-boundary regex per the spec) — clean
- [ ] CI green on this PR