### PR TITLE
docs(frontend-taste): Framer Motion x/y/scale not hardware-accelerated gotcha

### DIFF
--- a/skills/frontend-taste/SKILL.md
+++ b/skills/frontend-taste/SKILL.md
@@ -430,6 +430,7 @@ When the brief is editorial / clean / quiet premium:
 | Magnetic hover collapses performance on mobile | Framer Motion `useMotionValue` + `useTransform`, NOT `useState`. |
 | Tailwind v4 syntax in v3 project | Check `package.json` first. v4: `@tailwindcss/postcss` or Vite plugin. |
 | Layout jumps from animating top/left/width/height | EXCLUSIVELY `transform` + `opacity`. |
+| Framer Motion `x`/`y`/`scale` props drop frames under load | These shorthands run on rAF/main thread, NOT the GPU. Use the full string: `animate={{ transform: "translateX(100px)" }}`, not `animate={{ x: 100 }}`. CSS animations stay smooth when the main thread is busy; Framer shorthands don't. |
 | Grain/noise filters tank scroll FPS | Filters EXCLUSIVELY on fixed `pointer-events-none` overlays. |
 | `'use client'` everywhere | Default Server Components. Extract interactive leaves. |
 | `backdrop-blur` everywhere kills scroll FPS | ONLY fixed/sticky elements. |


### PR DESCRIPTION
## What

Adds one row to `frontend-taste` §15 Stack-specific gotchas: Framer Motion's `x`/`y`/`scale` shorthand props are NOT hardware-accelerated — they run on `requestAnimationFrame` on the main thread, so they drop frames when the main thread is busy (page load, hydration, heavy scripts). Fix is the full `transform` string.

## Why

Surfaced in a repo-evaluation of `emilkowalski/skill` (Emil Kowalski's firsthand design-engineering skill). This gotcha was absent from the entire motion stack (`frontend-taste`, `design-motion-principles`, `impeccable`) — and our cookbook actively uses the shorthand props without the warning, so generated code can ship frame-drops. Real-world: the Vercel dashboard tab animation dropped frames on page loads until it moved off the main thread.

Source: Emil Kowalski (animations.dev), reimplemented in our voice + attributed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)