### PR TITLE
feat(worktree): event-driven worktree lifecycle + footprint observability

### DIFF
--- a/docs/CLOUD_SYNC.md
+++ b/docs/CLOUD_SYNC.md
@@ -1,0 +1,100 @@
+# Keep your brain local-first
+
+Your brain is a living git repository. Claude Code works inside it with
+per-session git **worktrees** — fast, throwaway checkouts under
+`.claude/worktrees/`. That design is what makes parallel sessions safe. It
+also means the directory churns constantly: thousands of files created and
+deleted as you work.
+
+**Consumer cloud-sync tools — iCloud Drive, OneDrive, Dropbox, Google Drive,
+Box — are built for documents, not for a churning git tree.** Point one at
+your brain and it tries to upload every worktree file, every `.git` object,
+every search-index cache, in real time. On an active machine that compounds
+into hundreds of thousands of files and a sync daemon pinned at full CPU for
+hours. It is the single most common way to make a healthy brain feel broken.
+
+So the rule is simple, and it is a design principle, not a workaround:
+
+> **The vault lives on a local disk. The index lives server-side. Neither
+> belongs in a consumer cloud-sync folder.**
+
+The footprint signal at session start will warn you if it detects your vault
+inside a sync folder. Here is how to fix it.
+
+---
+
+## The fix, in order of preference
+
+### 1. Best: keep the vault outside every sync folder
+
+Put the vault on a normal local path — `~/brain`, `~/vaults/<name>`,
+anywhere that is **not** inside a sync root. On macOS that specifically means
+**not** `~/Desktop` or `~/Documents` when iCloud "Desktop & Documents
+folders" is on (both are synced). On Windows, not inside `OneDrive\`. Anywhere
+else under your home directory is fine.
+
+Already living in a sync folder? Move it out and leave a symlink behind so
+every tool that points at the old path keeps working:
+
+```bash
+# macOS / Linux — example moving a vault off the iCloud-synced Desktop
+mv ~/Desktop/MyVault ~/MyVault
+ln -s ~/MyVault ~/Desktop/MyVault   # old path still resolves; iCloud syncs only the tiny symlink
+```
+
+Then re-open the vault in Obsidian from the new location and confirm your
+tools still resolve. Sync daemons follow the *symlink file* (a few bytes),
+not the target's contents — so the churn leaves iCloud's scope entirely.
+
+### 2. If you truly cannot move it: exclude the machine-exhaust
+
+If the vault must stay inside a sync folder, exclude the three directories
+that actually churn. This stops the storm even if the notes keep syncing.
+
+- **iCloud Drive (macOS):** iCloud has no per-subfolder toggle. Rename the
+  exhaust dirs with a `.nosync` suffix and symlink them back, or — simpler and
+  what we recommend — move the *whole vault* out per option 1. Excluding
+  subfolders under iCloud is fiddly and easy to get wrong; relocation is the
+  honest fix.
+- **Dropbox:** Selective Sync (Preferences → Sync) → uncheck
+  `.claude`, `.git`, `.smart-env`.
+- **OneDrive (Windows/Mac):** right-click the folder → "Always keep on this
+  device" off is not enough; use OneDrive settings → "Choose folders" to
+  exclude `.claude`, `.git`, `.smart-env`.
+- **Google Drive / Box:** use the desktop client's selective-sync / ignore
+  settings to exclude the same three.
+
+### 3. Always: keep machine-exhaust out of git too
+
+Separate concern, same dirs. `.gitignore` stops you *committing* the exhaust;
+it does **not** stop a cloud daemon from *syncing* it (that's option 1/2).
+Your vault `.gitignore` should contain at least:
+
+```gitignore
+.claude/worktrees/
+.smart-env/
+.codegraph/
+⚙️ Meta/Worktree Snapshots/
+⚙️ Meta/logs/
+```
+
+---
+
+## What the brain does instead of cloud sync
+
+- **Worktree hygiene is automatic.** Each session's worktree is removed when
+  the session ends; a session-start cap reclaims any that a crash left behind;
+  unsaved work is snapshotted first and committed work is preserved on its
+  branch. You never accumulate a pile. (See `docs/HOOKS_INSTALL.md`.)
+- **Backups are a deliberate, encrypted choice** — restic to an encrypted
+  remote, with a restore you actually verify — not a side effect of a sync
+  daemon that also happens to hold your secrets in plaintext. (See
+  `docs/MAINTENANCE.md`.)
+- **The index is server-side.** For Mycelium runtime users, the searchable
+  index lives in the runtime, not in a synced local folder. Your laptop holds
+  the source notes on a local disk; the heavy index never touches your
+  machine's sync scope.
+
+A brain that melts the machine it runs on isn't a brain you'll keep. Local
+disk for the source, server-side for the index, encrypted-and-verified for
+the backup. That's the whole policy.

--- a/hooks.json
+++ b/hooks.json
@@ -63,6 +63,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/snapshot-pending-work-on-stop.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'",
+            "statusMessage": "Snapshotting worktree pending work (recovery safety net)..."
+          },
+          {
+            "type": "command",
             "command": "bash '[VAULT_PATH]/⚙️ Meta/scripts/session-end-hook.sh'",
             "statusMessage": "Saving session context..."
           },
@@ -158,6 +163,33 @@
             "type": "command",
             "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/surface-stranded-session-artifacts.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'",
             "statusMessage": "Checking worktrees for stranded session artifacts..."
+          },
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/surface-orphan-worktree-snapshots.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'",
+            "statusMessage": "Surfacing recoverable worktree snapshots..."
+          },
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/worktree-footprint-signal.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'",
+            "statusMessage": "Checking worktree + disk footprint..."
+          },
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/enforce-worktree-cap.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'",
+            "statusMessage": "Enforcing worktree cap (reclaim-then-allow)..."
+          }
+        ]
+      }
+    ],
+
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/remove-ended-worktree.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'",
+            "statusMessage": "Removing ended session worktree (committed + unsaved work preserved)..."
           }
         ]
       }

--- a/hooks/_lib/worktree_safety.py
+++ b/hooks/_lib/worktree_safety.py
@@ -1,0 +1,285 @@
+"""Shared worktree-safety helpers for the worktree-lifecycle hooks.
+
+Why this exists
+---------------
+Git worktrees under `.claude/worktrees/<slug>/` are throwaway per-session
+scratch checkouts. Nothing in stock Claude Code removes them when a session
+ends, so on an active machine they accumulate — each one a FULL checkout of
+the vault. Left alone they reach hundreds of worktrees / millions of files,
+which then melts any cloud-sync daemon (iCloud / OneDrive / Dropbox) pointed
+at the vault and burns disk. This module is the safe-cleanup core shared by:
+
+  - remove-ended-worktree.py      (SessionEnd: clean up the just-ended one)
+  - enforce-worktree-cap.py       (SessionStart: bound the total, reclaim-then-allow)
+  - worktree-footprint-signal.py  (SessionStart: observe before it bloats)
+
+The recoverability guarantee
+----------------------------
+A worktree directory is safe to delete iff every file in it is recoverable:
+
+  * COMMITTED work       -> preserved by the branch ref (`git worktree remove`
+                            keeps the `claude/<slug>` branch; only the working
+                            directory is deleted).
+  * content already in git -> recoverable from the object DB. Worktrees SHARE
+                            the main repo's object store, so `git hash-object`
+                            + `git cat-file --batch-check` is a DEFINITIVE test
+                            of "is this exact content stored anywhere in git?"
+  * genuinely-unsaved    -> content that hashes to a blob NOT in the object DB.
+                            We SNAPSHOT these to the main repo before deletion.
+
+`unrecoverable_content()` returns exactly the genuinely-unsaved set. It fails
+SAFE: on any git hiccup it returns the whole candidate list (over-preserve),
+never the empty set. This is what lets cleanup be aggressive without ever
+losing work — verified on a 102-worktree / 1.29M-file backlog where exactly
+one un-snapshotted file existed across all worktrees and the test caught it.
+
+Portable: no hardcoded paths; resolves the repo from cwd / CLAUDE_PROJECT_DIR.
+Pure stdlib.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+# Canonical snapshot location — MUST match snapshot-pending-work-on-stop.py and
+# surface-orphan-worktree-snapshots.py so orphan-surfacing + weekly prune find
+# snapshots written here. Falls back to a dot-dir for non-vault repos.
+SNAPSHOT_REL = "⚙️ Meta/Worktree Snapshots"
+SNAPSHOT_REL_FALLBACK = ".worktree-snapshots"
+WORKTREES_SEG = ".claude/worktrees"
+
+# Heavy machine-exhaust dirs: never counted as "work" for idle detection.
+EXHAUST = {
+    ".git", ".smart-env", ".claude", "node_modules", ".venv", "__pycache__",
+    ".codegraph", ".mypy_cache", ".pytest_cache", ".ruff_cache", ".obsidian",
+    ".trash", ".DS_Store",
+}
+
+GIT_TIMEOUT = 120
+
+
+def find_main_repo(cwd: Path | None = None) -> Path | None:
+    """Resolve the main checkout that owns `.claude/worktrees/`.
+
+    1. CLAUDE_PROJECT_DIR env var (set by Claude Code) if it's a real dir.
+    2. If cwd is inside `.../.claude/worktrees/<slug>/`, the part before
+       `.claude/worktrees`.
+    3. cwd itself if it contains `.claude/worktrees/`.
+    4. Walk up cwd for a parent containing `.claude/worktrees/`.
+    Returns None if nothing resolves.
+    """
+    cwd = (cwd or Path.cwd()).resolve()
+
+    env_root = os.environ.get("CLAUDE_PROJECT_DIR")
+    if env_root:
+        cand = Path(env_root)
+        if cand.is_dir():
+            return cand.resolve()
+
+    marker = "/" + WORKTREES_SEG + "/"
+    s = str(cwd)
+    if marker in s:
+        return Path(s.split(marker, 1)[0]).resolve()
+
+    if (cwd / WORKTREES_SEG).is_dir():
+        return cwd
+    for parent in cwd.parents:
+        if (parent / WORKTREES_SEG).is_dir():
+            return parent
+    return None
+
+
+def current_worktree(cwd: Path | None = None) -> tuple[Path, str] | None:
+    """If cwd is inside `.../.claude/worktrees/<slug>/`, return (path, slug)."""
+    cwd = (cwd or Path.cwd()).resolve()
+    marker = "/" + WORKTREES_SEG + "/"
+    s = str(cwd)
+    if marker not in s:
+        return None
+    head, tail = s.split(marker, 1)
+    slug = tail.split("/", 1)[0]
+    if not slug:
+        return None
+    return Path(head + marker + slug), slug
+
+
+def snapshot_dir_for(main_repo: Path) -> Path:
+    """Canonical snapshot root for this repo (vault dir if present, else dot-dir)."""
+    vault_meta = main_repo / SNAPSHOT_REL
+    if (main_repo / "⚙️ Meta").is_dir() or vault_meta.exists():
+        return vault_meta
+    return main_repo / SNAPSHOT_REL_FALLBACK
+
+
+def git(repo: Path, args: list[str], timeout: int = GIT_TIMEOUT) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True, timeout=timeout,
+    )
+
+
+def list_worktrees(repo: Path) -> list[Path]:
+    """Registered worktree paths (excluding the main checkout)."""
+    try:
+        out = git(repo, ["worktree", "list", "--porcelain"])
+    except (subprocess.TimeoutExpired, OSError):
+        return []
+    paths = [
+        Path(l[len(b"worktree "):].decode("utf-8", "replace"))
+        for l in out.stdout.splitlines()
+        if l.startswith(b"worktree ")
+    ]
+    repo_r = repo.resolve()
+    return [p for p in paths if p.resolve() != repo_r]
+
+
+def is_idle(path: Path, idle_min: int = 60) -> bool:
+    """True if no work file under `path` was modified in the last idle_min minutes.
+
+    Prunes heavy hidden dirs for speed and early-exits on the first recent file,
+    so active worktrees are detected fast. Uses mtime (not atime), so merely
+    reading files does not mark a worktree active.
+    """
+    cutoff = time.time() - idle_min * 60
+    try:
+        for root, dirs, files in os.walk(path):
+            dirs[:] = [d for d in dirs if d not in EXHAUST]
+            for f in files:
+                try:
+                    if os.path.getmtime(os.path.join(root, f)) > cutoff:
+                        return False
+                except OSError:
+                    continue
+    except OSError:
+        return True
+    return True
+
+
+def dirty_files(worktree: Path) -> list[Path]:
+    """Absolute paths of uncommitted/untracked files in the worktree."""
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(worktree), "status", "--porcelain", "-z"],
+            capture_output=True, timeout=60,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return []
+    if out.returncode != 0:
+        return []
+    res: list[Path] = []
+    for e in out.stdout.split(b"\x00"):
+        if len(e) < 4:
+            continue
+        rel = e[3:].decode("utf-8", "replace")
+        if rel:
+            res.append(worktree / rel)
+    return res
+
+
+def unrecoverable_content(repo: Path, files: list[Path]) -> list[Path]:
+    """Subset of `files` whose exact content is NOT in the repo object DB.
+
+    Definitive recoverability test (worktrees share the object store). Fails
+    SAFE: on any hiccup returns the whole candidate list (over-preserve).
+    """
+    files = [f for f in files if f.is_file()]
+    if not files:
+        return []
+    try:
+        hp = subprocess.run(
+            ["git", "-C", str(repo), "hash-object", "--stdin-paths"],
+            input="\n".join(str(f) for f in files).encode(),
+            capture_output=True, timeout=300,
+        )
+        hashes = hp.stdout.decode().split()
+        if hp.returncode != 0 or len(hashes) != len(files):
+            return files
+        cp = subprocess.run(
+            ["git", "-C", str(repo), "cat-file", "--batch-check"],
+            input="\n".join(hashes).encode(),
+            capture_output=True, timeout=300,
+        )
+        present: dict[str, bool] = {}
+        for line in cp.stdout.decode().splitlines():
+            parts = line.split()
+            if len(parts) >= 2:
+                present[parts[0]] = parts[1] != "missing"
+        return [f for f, h in zip(files, hashes) if not present.get(h, False)]
+    except (subprocess.TimeoutExpired, OSError):
+        return files
+
+
+def snapshot_unrecoverable(main_repo: Path, worktree: Path, slug: str) -> tuple[int, int, bool]:
+    """Snapshot genuinely-unsaved files before removal.
+
+    Returns (snapshotted, recoverable_discarded, all_safe). all_safe is False
+    only if a genuinely-unsaved file could NOT be copied — caller must then
+    refuse to delete the worktree.
+    """
+    files = dirty_files(worktree)
+    uniq = unrecoverable_content(main_repo, files)
+    recoverable = len(files) - len(uniq)
+    snap_root = snapshot_dir_for(main_repo) / slug
+    snapped = 0
+    all_safe = True
+    for src in uniq:
+        try:
+            rel = src.relative_to(worktree)
+        except ValueError:
+            all_safe = False
+            continue
+        dst = snap_root / rel
+        try:
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dst)
+            snapped += 1
+        except OSError:
+            all_safe = False
+    return snapped, recoverable, all_safe
+
+
+def remove_worktree(main_repo: Path, worktree: Path, force: bool = True) -> bool:
+    """`git worktree remove` (keeps the branch ref). True on success."""
+    args = ["worktree", "remove"] + (["--force"] if force else []) + [str(worktree)]
+    try:
+        return git(main_repo, args).returncode == 0
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+
+
+def detect_cloud_sync(path: Path) -> str | None:
+    """Name of a consumer cloud-sync service whose scope contains `path`, else None.
+
+    Cross-platform best-effort: a brain/vault under iCloud / OneDrive / Dropbox /
+    Google Drive / Box is the exact combination that turns worktree churn into a
+    machine-melting sync storm. The index belongs server-side; the local vault
+    belongs on a real local disk, never in a consumer sync folder.
+    """
+    p = str(path.resolve())
+    home = str(Path.home())
+    markers = {
+        "OneDrive": ["/OneDrive", "\\OneDrive"],
+        "Dropbox": ["/Dropbox", "\\Dropbox"],
+        "Google Drive": ["/Google Drive", "/GoogleDrive",
+                          "CloudStorage/GoogleDrive", "\\Google Drive"],
+        "Box": ["/Box/", "\\Box\\", "/Box Sync"],
+        "iCloud Drive": ["/Mobile Documents/com~apple~CloudDocs",
+                         "/Library/Mobile Documents"],
+    }
+    for name, subs in markers.items():
+        if any(sub in p for sub in subs):
+            return name
+    # macOS iCloud "Desktop & Documents" sync: ~/Desktop or ~/Documents are
+    # synced when ~/Library/Mobile Documents/com~apple~CloudDocs/<folder> exists.
+    icloud = Path(home) / "Library/Mobile Documents/com~apple~CloudDocs"
+    for folder in ("Desktop", "Documents"):
+        try:
+            base = (Path(home) / folder).resolve()
+        except OSError:
+            continue
+        if (p == str(base) or p.startswith(str(base) + "/")) and (icloud / folder).exists():
+            return f"iCloud Drive ({folder} sync)"
+    return None

--- a/hooks/enforce-worktree-cap.py
+++ b/hooks/enforce-worktree-cap.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Bound the number of git worktrees — reclaim-then-allow, at SessionStart.
+
+The session-end removal hook (remove-ended-worktree.py) keeps the count low in
+the normal case. This is the BACKSTOP for the abnormal case: a session that
+crashes or is killed before SessionEnd fires leaves its worktree behind. Over
+enough crashes those accumulate again. This hook caps the total.
+
+DESIGN: reclaim-then-ALLOW, never block.
+  Power users run many concurrent sessions; a hard block on worktree creation
+  would break that workflow. So instead of blocking, when a new session starts
+  and the count is over the cap, we reclaim the OLDEST idle `claude/<slug>`
+  scratch worktrees (snapshotting any genuinely-unsaved content first, keeping
+  branch refs) until back under the cap. Active worktrees (touched <60min),
+  the current session's worktree, and deliberate feature-branch worktrees are
+  never touched. If everything over the cap is active, we surface a note and
+  leave them — correctness over the cap.
+
+Cap:    WORKTREE_MAX env (default 12).
+Bypass: WORKTREE_CAP_BYPASS=1.
+
+WIRING (SessionStart):
+  "SessionStart": [
+    {"hooks": [{
+      "type": "command",
+      "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/enforce-worktree-cap.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'"
+    }]}
+  ]
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+HOOK_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(HOOK_DIR))
+
+from _lib.worktree_safety import (  # noqa: E402
+    current_worktree,
+    find_main_repo,
+    git,
+    is_idle,
+    list_worktrees,
+    remove_worktree,
+    snapshot_unrecoverable,
+)
+
+LOG_REL = "⚙️ Meta/logs/worktree-cleanup.log"
+DEFAULT_CAP = 12
+
+
+def _log(main_repo: Path, msg: str) -> None:
+    ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    try:
+        log = main_repo / LOG_REL
+        log.parent.mkdir(parents=True, exist_ok=True)
+        with open(log, "a", encoding="utf-8") as f:
+            f.write(f"[{ts}] cap: {msg}\n")
+    except OSError:
+        pass
+
+
+def _emit(ctx: str | None) -> int:
+    if ctx:
+        print(json.dumps({"continue": True, "additionalContext": ctx}))
+    else:
+        print(json.dumps({"continue": True, "suppressOutput": True}))
+    return 0
+
+
+def _branch(wt: Path) -> str:
+    try:
+        return git(wt, ["rev-parse", "--abbrev-ref", "HEAD"], timeout=15).stdout.decode().strip()
+    except Exception:
+        return ""
+
+
+def main() -> int:
+    if os.environ.get("WORKTREE_CAP_BYPASS") == "1":
+        return _emit(None)
+
+    try:
+        cap = max(1, int(os.environ.get("WORKTREE_MAX", DEFAULT_CAP)))
+    except ValueError:
+        cap = DEFAULT_CAP
+
+    main_repo = find_main_repo()
+    if main_repo is None:
+        return _emit(None)
+
+    wts = list_worktrees(main_repo)
+    if len(wts) <= cap:
+        return _emit(None)  # healthy
+
+    cur = current_worktree()
+    cur_path = cur[0].resolve() if cur else None
+
+    # Cheap sort: oldest dir-mtime first. Deep checks (branch/idle/snapshot)
+    # happen lazily only on the ones we actually try to remove.
+    def _mtime(p: Path) -> float:
+        try:
+            return p.stat().st_mtime
+        except OSError:
+            return 0.0
+
+    candidates = sorted(wts, key=_mtime)
+    need = len(wts) - cap
+    removed: list[str] = []
+    skipped_active = 0
+
+    for wt in candidates:
+        if len(removed) >= need:
+            break
+        if cur_path and wt.resolve() == cur_path:
+            continue
+        if not _branch(wt).startswith("claude/"):
+            continue  # never auto-remove a deliberate worktree
+        if not is_idle(wt, idle_min=60):
+            skipped_active += 1
+            continue
+        slug = wt.name
+        snapped, _recoverable, all_safe = snapshot_unrecoverable(main_repo, wt, slug)
+        if not all_safe:
+            continue
+        if remove_worktree(main_repo, wt, force=True):
+            removed.append(slug)
+            _log(main_repo, f"reclaimed {slug} (over cap {cap}, snapshotted {snapped} unsaved)")
+
+    remaining = len(list_worktrees(main_repo))
+    if not removed:
+        if remaining > cap:
+            return _emit(
+                f"[worktree-cap] {remaining} worktrees (cap {cap}) but all over-cap ones are "
+                f"active or deliberate — none safe to reclaim now. They'll be cleaned at their "
+                f"SessionEnd, or run: python3 scripts/worktree-prune.sh"
+            )
+        return _emit(None)
+
+    note = (f"[worktree-cap] Reclaimed {len(removed)} stale worktree(s) to stay under cap {cap} "
+            f"(branches + any unsaved work preserved): {', '.join(removed[:8])}"
+            + (f" +{len(removed) - 8} more" if len(removed) > 8 else "")
+            + f". Now {remaining} worktree(s).")
+    return _emit(note)
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        print(json.dumps({"continue": True, "suppressOutput": True}))
+        sys.exit(0)

--- a/hooks/remove-ended-worktree.py
+++ b/hooks/remove-ended-worktree.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Remove the just-ended session's scratch worktree — the event-driven fix
+for git-worktree pileup.
+
+THE BUG THIS FIXES
+------------------
+Stock Claude Code creates a fresh worktree under `.claude/worktrees/<slug>/`
+per session but never removes it. The weekly prune script only deletes
+*branches* whose worktree dir is already gone — nothing removes the DIRECTORY.
+So worktrees accumulate, each a full vault checkout, until a cloud-sync daemon
+(iCloud/OneDrive/Dropbox) or the disk falls over (observed: 102 worktrees /
+1.29M files / ~25GB). Scheduled cleanup of an unbounded resource is the
+anti-pattern; this removes each worktree at the moment its session ends.
+
+SAFETY (see _lib/worktree_safety.py for the full guarantee)
+-----------------------------------------------------------
+  * Only acts on `claude/<slug>` SCRATCH branches — never a deliberate
+    feature-branch worktree you created on purpose.
+  * Snapshots any genuinely-unsaved content (not in git's object DB) to
+    `⚙️ Meta/Worktree Snapshots/<slug>/` first. If ANY such file can't be
+    copied, REFUSES to delete (fail safe).
+  * `git worktree remove` keeps the branch ref, so committed work survives.
+  * Runs LAST in the SessionEnd chain (after reconcile/scrub) so it doesn't
+    pull the rug from under sibling hooks.
+
+Bypass: KEEP_WORKTREE_ON_END=1  (keep every worktree — opt back into manual cleanup)
+
+WIRING (SessionEnd, last):
+  "SessionEnd": [
+    {"hooks": [{
+      "type": "command",
+      "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/remove-ended-worktree.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'"
+    }]}
+  ]
+Pairs with snapshot-pending-work-on-stop.py (Stop) and enforce-worktree-cap.py
+(SessionStart, backstop for sessions that crash before SessionEnd fires).
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+HOOK_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(HOOK_DIR))
+
+from _lib.worktree_safety import (  # noqa: E402
+    current_worktree,
+    find_main_repo,
+    git,
+    remove_worktree,
+    snapshot_unrecoverable,
+)
+
+LOG_REL = "⚙️ Meta/logs/worktree-cleanup.log"
+
+
+def _log(main_repo: Path, msg: str) -> None:
+    ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    try:
+        log = main_repo / LOG_REL
+        log.parent.mkdir(parents=True, exist_ok=True)
+        with open(log, "a", encoding="utf-8") as f:
+            f.write(f"[{ts}] {msg}\n")
+    except OSError:
+        pass
+
+
+def _done() -> int:
+    print(json.dumps({"continue": True, "suppressOutput": True}))
+    return 0
+
+
+def main() -> int:
+    if os.environ.get("KEEP_WORKTREE_ON_END") == "1":
+        return _done()
+
+    cw = current_worktree()
+    if cw is None:
+        return _done()  # not in a worktree — nothing to clean
+    worktree, slug = cw
+
+    main_repo = find_main_repo()
+    if main_repo is None or main_repo.resolve() == worktree.resolve():
+        return _done()
+
+    # Only auto-remove throwaway claude/<slug> scratch worktrees. A deliberate
+    # feature-branch worktree is left untouched.
+    try:
+        br = git(worktree, ["rev-parse", "--abbrev-ref", "HEAD"], timeout=15)
+        branch = br.stdout.decode().strip()
+    except Exception:
+        return _done()
+    if not branch.startswith("claude/"):
+        _log(main_repo, f"keep {slug}: branch {branch!r} is not claude/* scratch")
+        return _done()
+
+    snapped, recoverable, all_safe = snapshot_unrecoverable(main_repo, worktree, slug)
+    if not all_safe:
+        _log(main_repo, f"REFUSE remove {slug}: a genuinely-unsaved file could "
+                        f"not be snapshotted (snapped={snapped}). Worktree kept.")
+        return _done()
+
+    # chdir out of the worktree before removing it.
+    try:
+        os.chdir(main_repo)
+    except OSError:
+        pass
+
+    if remove_worktree(main_repo, worktree, force=True):
+        _log(main_repo, f"removed {slug} (branch {branch} kept; "
+                        f"snapshotted {snapped} unsaved, {recoverable} recoverable-from-git)")
+    else:
+        _log(main_repo, f"WARN: git worktree remove failed for {slug}")
+    return _done()
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        # Never let cleanup break session teardown.
+        print(json.dumps({"continue": True, "suppressOutput": True}))
+        sys.exit(0)

--- a/hooks/worktree-footprint-signal.py
+++ b/hooks/worktree-footprint-signal.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Observe local footprint before it bloats — SessionStart signal.
+
+The 102-worktree pileup was discovered only when the machine fell over. That
+is the real failure: it was invisible until catastrophic. This hook makes the
+footprint observable at every SessionStart so "12 worktrees and climbing" is
+seen early, not "102, machine dead" later. Cheap: a couple of git/stat calls,
+no per-worktree filesystem walk.
+
+Surfaces (only when something warrants attention — silent when healthy):
+  * worktree count over the soft threshold (WORKTREE_WARN, default 8)
+  * on-disk worktree dirs git no longer tracks (orphans)
+  * low free disk on the vault's volume
+  * THE DANGEROUS COMBO: vault sitting inside a consumer cloud-sync folder
+    (iCloud / OneDrive / Dropbox / Google Drive / Box) — worktree/.git churn
+    there is what melts the sync daemon. Flagged loudly with the remedy.
+
+Bypass: WORKTREE_FOOTPRINT_BYPASS=1.
+
+WIRING (SessionStart):
+  "SessionStart": [
+    {"hooks": [{
+      "type": "command",
+      "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/worktree-footprint-signal.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'"
+    }]}
+  ]
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+HOOK_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(HOOK_DIR))
+
+from _lib.worktree_safety import (  # noqa: E402
+    WORKTREES_SEG,
+    detect_cloud_sync,
+    find_main_repo,
+    list_worktrees,
+)
+
+DEFAULT_WARN = 8
+DEFAULT_FREE_GB = 5.0
+
+
+def _emit(ctx: str | None) -> int:
+    if ctx:
+        print(json.dumps({"continue": True, "additionalContext": ctx}))
+    else:
+        print(json.dumps({"continue": True, "suppressOutput": True}))
+    return 0
+
+
+def main() -> int:
+    if os.environ.get("WORKTREE_FOOTPRINT_BYPASS") == "1":
+        return _emit(None)
+
+    main_repo = find_main_repo()
+    if main_repo is None:
+        return _emit(None)
+
+    try:
+        warn_at = max(1, int(os.environ.get("WORKTREE_WARN", DEFAULT_WARN)))
+    except ValueError:
+        warn_at = DEFAULT_WARN
+    try:
+        free_floor = float(os.environ.get("WORKTREE_FREE_GB", DEFAULT_FREE_GB))
+    except ValueError:
+        free_floor = DEFAULT_FREE_GB
+
+    registered = len(list_worktrees(main_repo))
+
+    wt_dir = main_repo / WORKTREES_SEG
+    on_disk = 0
+    if wt_dir.is_dir():
+        try:
+            on_disk = sum(1 for c in wt_dir.iterdir() if c.is_dir())
+        except OSError:
+            on_disk = 0
+    orphans = max(0, on_disk - registered)
+
+    free_gb = None
+    try:
+        free_gb = shutil.disk_usage(main_repo).free / 1024 ** 3
+    except OSError:
+        pass
+
+    cloud = detect_cloud_sync(main_repo)
+
+    lines: list[str] = []
+
+    if cloud and (registered or on_disk):
+        lines.append(
+            f"⚠️  [footprint] This vault is inside **{cloud}**, and it has "
+            f"{on_disk} worktree checkout(s). Consumer cloud-sync + churning git "
+            f"worktrees = the sync-storm failure mode (millions of files, pegged "
+            f"CPU). The vault belongs on a local disk; the index belongs "
+            f"server-side. Move it out of the sync folder (see docs/CLOUD_SYNC.md), "
+            f"or at minimum keep `.claude/`, `.git/`, `.smart-env/` out of sync scope."
+        )
+
+    if registered > warn_at or orphans > 0:
+        bits = [f"{registered} registered worktree(s) (soft cap {warn_at})"]
+        if orphans:
+            bits.append(f"{orphans} orphan dir(s) git no longer tracks")
+        lines.append(
+            f"[footprint] {'; '.join(bits)}. Each worktree is ~a full checkout. "
+            f"They auto-trim at SessionEnd + via the cap; force now with "
+            f"`python3 scripts/worktree-prune.sh` or the reclaim tool."
+        )
+
+    if free_gb is not None and free_gb < free_floor:
+        lines.append(f"⚠️  [footprint] Low free disk: {free_gb:.1f} GB on the vault volume.")
+
+    return _emit("\n".join(lines) if lines else None)
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        print(json.dumps({"continue": True, "suppressOutput": True}))
+        sys.exit(0)

--- a/scripts/install-hooks-user-level.py
+++ b/scripts/install-hooks-user-level.py
@@ -70,6 +70,12 @@ ABS_FINGERPRINTS = [
     # Legacy session-start context loaders shipped via ai-brain-starter:
     "SESSION START: CLAUDE.md is already auto-loaded",
     ".ai-brain-starter-last-update",
+    # Worktree-lifecycle hooks (cleanup + footprint observability):
+    "ai-brain-starter/hooks/snapshot-pending-work-on-stop.py",
+    "ai-brain-starter/hooks/surface-orphan-worktree-snapshots.py",
+    "ai-brain-starter/hooks/remove-ended-worktree.py",
+    "ai-brain-starter/hooks/enforce-worktree-cap.py",
+    "ai-brain-starter/hooks/worktree-footprint-signal.py",
 ]
 
 


### PR DESCRIPTION
Stock Claude Code creates a per-session git worktree under .claude/worktrees/ but never removes it; the weekly prune only deletes branches whose worktree dir is already gone. Nothing removes the directory, so on an active machine worktrees accumulate (each a full vault checkout) until a consumer cloud-sync daemon or the disk falls over (observed in the field: 100+ worktrees, >1M files, tens of GB).

Cleanup becomes event-driven, not scheduled. `remove-ended-worktree.py` (SessionEnd) removes the just-ended claude/* scratch worktree, snapshotting genuinely-unsaved content first and keeping the branch ref. `enforce-worktree-cap.py` (SessionStart) is a reclaim-then-allow backstop for sessions that crash before SessionEnd, and never blocks creation. `worktree-footprint-signal.py` (SessionStart) surfaces worktree count, free disk, and the dangerous cloud-sync-root combo before it bloats. `_lib/worktree_safety.py` holds the shared fail-safe recoverability core: a file is safe to delete iff its exact content is in git's object DB; over-preserve on any doubt.

Wires `snapshot-pending-work-on-stop` (Stop) plus the three new hooks into `hooks.json`, and registers their fingerprints in `install-hooks-user-level.py` for idempotent install/uninstall. Adds `docs/CLOUD_SYNC.md`: local-first guidance covering iCloud, OneDrive, Dropbox, Google Drive, Box (the index is server-side; the vault belongs on a local disk).

Verified end-to-end on a throwaway worktree: worktree removed, branch preserved, unsaved file snapshotted.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
