### PR TITLE
feat(instinct-engine): wire inject-instinct-context into template hooks.json

### DIFF
--- a/hooks.json
+++ b/hooks.json
@@ -25,6 +25,12 @@
           },
           {
             "type": "command",
+            "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/inject-instinct-context.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'",
+            "once": true,
+            "statusMessage": "Loading project-scoped instincts..."
+          },
+          {
+            "type": "command",
             "command": "bash '[VAULT_PATH]/⚙️ Meta/scripts/graph-context-hook.sh'",
             "statusMessage": "Checking graph routing..."
           },


### PR DESCRIPTION
Wires the project-scoped instinct loader hook into the template hooks.json (MYC-253 follow-up; the hook file already shipped, only observe-tool-calls was wired). One-line template addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)