### PR TITLE
fix(instinct-engine): wire inject-instinct-context.py into template hooks.json

### DIFF
--- a/hooks.json
+++ b/hooks.json
@@ -25,6 +25,12 @@
           },
           {
             "type": "command",
+            "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/inject-instinct-context.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'",
+            "once": true,
+            "statusMessage": "Loading project-scoped instincts..."
+          },
+          {
+            "type": "command",
             "command": "bash '[VAULT_PATH]/⚙️ Meta/scripts/graph-context-hook.sh'",
             "statusMessage": "Checking graph routing..."
           },


### PR DESCRIPTION
## What

PR #134 shipped both `inject-instinct-context.py` and `observe-tool-calls.py`, but only `observe-tool-calls.py` got wired into the template `hooks.json` (the two `PreToolUse` tool-matcher groups). The project-scoped instinct loader `inject-instinct-context.py` was never added to `hooks.json`.

Result for a fresh install: the 100% observe-loop fires, but the session-start instinct injection does not, so the project-scoping + isolation half of the Instinct Engine silently never runs for other users.

## Fix

Add `inject-instinct-context.py` as a `once: true` `UserPromptSubmit` entry, mirroring `session-start-context.py` and placed immediately after it (both are once-per-session context loaders). Same fail-open `|| echo` passthrough as every sibling hook, so a missing engine or an empty result is a neutral no-op.

The maintainer's own live `settings.json` already had this hook wired manually; this brings the public template to parity so other installs get the same behavior.

Validated with `json.load` (native parse: valid) and confirmed the entry appears exactly once at the expected position. See `docs/instinct-engine.md` for the engine.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)