### PR TITLE
feat(footprint): worktree-lifecycle reclaim + auto-remediation + secret guard

### DIFF
--- a/docs/CLOUD_SYNC.md
+++ b/docs/CLOUD_SYNC.md
@@ -95,6 +95,56 @@ Your vault `.gitignore` should contain at least:
   the source notes on a local disk; the heavy index never touches your
   machine's sync scope.
 
+## The guardrails, concretely
+
+These ship as session hooks (install via `docs/HOOKS_INSTALL.md`). They are
+**non-destructive by design**: they reclaim only what is provably
+reconstructible, and they *surface* (never auto-delete) anything that needs
+judgment.
+
+| When | Hook | What it does |
+|---|---|---|
+| SessionEnd | `remove-ended-worktree.py` | removes that session's scratch worktree (committed work stays on its branch, unsaved work is snapshotted first) |
+| SessionStart | `enforce-worktree-cap.py` | caps scratch worktrees (default 12), reclaiming the oldest idle ones a crash left behind |
+| SessionStart | `worktree-footprint-signal.py` | warns early on worktree count, orphan dirs, low free disk, and the dangerous vault-in-a-cloud-sync-folder combo |
+| SessionStart | `remediate-runaway-procs.py` | reaps orphaned runaway processes (the `yes`-pileup class), pure waste with zero recoverable output |
+| weekly cron | `scripts/worktree-prune.sh` | backstop: safe reclaim of orphan dirs + merged-branch cleanup + snapshot retention |
+
+**The non-destructive contract.** Auto-remediation fixes only reconstructible
+things: a scratch worktree directory (recreatable from its branch), an orphaned
+runaway process (no output to lose), git's stale worktree refs. It NEVER
+auto-deletes the judgment calls (unpushed commits, stashes, or a directory
+whose git metadata it cannot reason about); those are *surfaced* for you to
+decide. The discriminator for worktree removal is **location**
+(`.claude/worktrees/` scratch), not branch name: a deliberate
+`~/dev/<repo>-<slug>` sibling worktree is never touched, even when idle and on a
+`claude/*` branch.
+
+**Force a reclaim now** (snapshot-first; classifies each dir, never
+blind-deletes; a dir with genuinely-unsaved work or dangling git metadata is
+kept and reported):
+
+```bash
+# preview what would be reclaimed
+python3 ~/.claude/skills/ai-brain-starter/scripts/worktree-reclaim.py --dry-run
+# do it
+python3 ~/.claude/skills/ai-brain-starter/scripts/worktree-reclaim.py
+```
+
+**Don't write secrets into notes.** A live API key in a note gets committed,
+synced, and indexed. The `block-secret-in-note.py` write guard refuses a
+Write/Edit that would put a high-confidence credential (AWS / GitHub PAT /
+provider keys / database-URL passwords) into a `.md`/`.txt` note. Store it in
+the keychain or a gitignored secrets file and reference it by name instead.
+
+## Order matters: back up before you move
+
+Relocating the vault out of a sync folder is the right fix, but the vault is
+often the one irreplaceable asset, so **stand up an encrypted backup and pull a
+real restore from it FIRST, then relocate.** A backup you have never restored is
+a hope, not a backup. Encrypted restic to a local repo gets you protected
+immediately; add an offsite copy when you can. (See `docs/MAINTENANCE.md`.)
+
 A brain that melts the machine it runs on isn't a brain you'll keep. Local
 disk for the source, server-side for the index, encrypted-and-verified for
 the backup. That's the whole policy.

--- a/hooks.json
+++ b/hooks.json
@@ -121,6 +121,11 @@
             "type": "command",
             "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/validate-skill-frontmatter.py 2>/dev/null || echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"allow\"}}'",
             "statusMessage": "Validating skill frontmatter (skill.json schema)..."
+          },
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/block-secret-in-note.py 2>/dev/null || echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"allow\"}}'",
+            "statusMessage": "Checking for live secrets in note writes..."
           }
         ]
       }
@@ -178,6 +183,11 @@
             "type": "command",
             "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/enforce-worktree-cap.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'",
             "statusMessage": "Enforcing worktree cap (reclaim-then-allow)..."
+          },
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/remediate-runaway-procs.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'",
+            "statusMessage": "Reaping orphaned runaway processes..."
           }
         ]
       }

--- a/hooks/_lib/worktree_safety.py
+++ b/hooks/_lib/worktree_safety.py
@@ -136,6 +136,22 @@ def list_worktrees(repo: Path) -> list[Path]:
     return [p for p in paths if p.resolve() != repo_r]
 
 
+def is_scratch_worktree(wt: Path) -> bool:
+    """True if `wt` is a throwaway scratch worktree under `.claude/worktrees/`.
+
+    The cap + reclaim only AUTO-REMOVE scratch worktrees. A deliberate
+    `~/dev/<repo>-<slug>` sibling worktree (created by the dev-repo-worktrees
+    pattern, often on its own feature branch) is NEVER auto-removed even when
+    idle and on a `claude/*` branch — its lifecycle belongs to that workflow,
+    not to this cap. Location, not branch name, is the safe discriminator.
+    """
+    marker = "/" + WORKTREES_SEG + "/"
+    try:
+        return marker in str(wt.resolve())
+    except OSError:
+        return marker in str(wt)
+
+
 def is_idle(path: Path, idle_min: int = 60) -> bool:
     """True if no work file under `path` was modified in the last idle_min minutes.
 
@@ -248,6 +264,92 @@ def remove_worktree(main_repo: Path, worktree: Path, force: bool = True) -> bool
         return git(main_repo, args).returncode == 0
     except (subprocess.TimeoutExpired, OSError):
         return False
+
+
+def list_orphan_dirs(main_repo: Path) -> list[Path]:
+    """Dirs under `.claude/worktrees/` that git no longer registers.
+
+    These accumulate when a worktree's git registration is pruned (or never
+    completed) but the directory is left on disk — each a full stale checkout.
+    The cap/remove hooks only see REGISTERED worktrees (`git worktree list`),
+    so orphan dirs are invisible to them and need this dedicated sweep. This
+    is the gap that let the vault reach 19 orphan dirs even with the hooks live.
+    """
+    wt_dir = main_repo / WORKTREES_SEG
+    if not wt_dir.is_dir():
+        return []
+    registered = {p.resolve() for p in list_worktrees(main_repo)}
+    orphans: list[Path] = []
+    try:
+        for c in sorted(wt_dir.iterdir()):
+            if c.is_dir() and c.resolve() not in registered:
+                orphans.append(c)
+    except OSError:
+        return []
+    return orphans
+
+
+def reclaim_orphan_dir(main_repo: Path, orphan: Path, idle_min: int = 60) -> tuple[str, int]:
+    """Safely reclaim one orphan worktree dir. Returns (action, snapshotted).
+
+    action ∈ {removed, snapshot+removed, kept-active, kept-unsafe, kept-dangling}.
+
+    Fast + fail-safe — never `rm -rf` a dir we can't reason about:
+      * idle gate: a dir touched < idle_min ago is left (a live/paused session).
+      * `git -C <orphan> status` decides recoverability cheaply (uses the index):
+          - clean       → rm (every file is committed/recoverable from a branch)
+          - dirty       → snapshot ONLY the dirty set (small; definitive object-DB
+                          recoverability test) then rm iff every unsaved file was
+                          safely copied.
+          - git errors  → the dir is disconnected from git; KEEP it and report
+                          `kept-dangling` for manual review. Never delete a dir
+                          whose recoverability we cannot establish.
+
+    Unlike the bash prune's section-2 (`rm -rf` with no snapshot), this can lose
+    nothing: the only dirs deleted are clean checkouts or dirs whose unsaved
+    files were copied out first.
+    """
+    slug = orphan.name
+    if not is_idle(orphan, idle_min):
+        return ("kept-active", 0)
+    try:
+        st = git(orphan, ["status", "--porcelain", "-z"], timeout=60)
+    except (subprocess.TimeoutExpired, OSError):
+        return ("kept-dangling", 0)
+    if st.returncode != 0:
+        return ("kept-dangling", 0)
+    dirty = [
+        orphan / e[3:].decode("utf-8", "replace")
+        for e in st.stdout.split(b"\x00")
+        if len(e) >= 4 and e[3:]
+    ]
+    snapped = 0
+    if dirty:
+        uniq = unrecoverable_content(main_repo, dirty)
+        snap_root = snapshot_dir_for(main_repo) / slug
+        all_safe = True
+        for src in uniq:
+            if not src.is_file():
+                continue
+            try:
+                rel = src.relative_to(orphan)
+            except ValueError:
+                all_safe = False
+                continue
+            dst = snap_root / rel
+            try:
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(src, dst)
+                snapped += 1
+            except OSError:
+                all_safe = False
+        if not all_safe:
+            return ("kept-unsafe", snapped)
+    try:
+        shutil.rmtree(orphan)
+    except OSError:
+        return ("kept-unsafe", snapped)
+    return ("snapshot+removed" if snapped else "removed", snapped)
 
 
 def detect_cloud_sync(path: Path) -> str | None:

--- a/hooks/block-secret-in-note.py
+++ b/hooks/block-secret-in-note.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Block writing a LIVE credential into a note — PreToolUse(Write/Edit/MultiEdit).
+
+Redaction exists at INGEST (the runtime scrubs secrets before they enter the
+index) and at SESSION-END (jsonl scrub). But nothing stopped a live AWS key or
+GitHub PAT from being WRITTEN into a note in the first place — which is exactly
+how plaintext credentials ended up tracked in `⚙️ Meta/Sessions/` + `Handoffs/`.
+This is the WRITE-TIME guard: it denies a Write/Edit that would put a
+high-confidence live credential into a markdown/text note, and points you at the
+keychain / a gitignored secrets file instead.
+
+Only HIGH-CONFIDENCE provider credentials + connection-string passwords block
+(AWS / GitHub / Anthropic / OpenAI / Stripe-secret / Slack / Heroku / HubSpot /
+Google / Resend / Neon / db-URL passwords). The lower-precision heuristics (bare
+JWT, 64-hex, Bearer header, publishable keys) do NOT block a write — they would
+false-trip on legitimate notes; the ingest + session-scrub layers still cover
+them.
+
+Scope: note files only (`.md`, `.markdown`, `.mdx`, `.txt`). Code files are out
+of scope (test fixtures / `.env.example` have legitimate credential shapes and
+other layers cover them).
+
+It only blocks a secret being INTRODUCED: for an Edit it scans the new text, so
+removing/scrubbing a secret is never blocked.
+
+Bypass: SECRET_VAULT_WRITE_BYPASS=1  (self-referential docs: this rule, the hook
+itself, CLAUDE.md quoting the patterns, a note documenting AWS's example key).
+
+WIRING (PreToolUse, matcher "Write|Edit|MultiEdit"):
+  {"type": "command",
+   "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/block-secret-in-note.py 2>/dev/null || echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"allow\"}}'"}
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+HOOK_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(HOOK_DIR))
+
+try:
+    from _lib.secret_patterns import PATTERNS
+except Exception:
+    PATTERNS = ()
+
+# High-confidence provider creds + connection-string passwords that never have a
+# legitimate reason to sit in a note. Names mirror _lib/secret_patterns.py.
+BLOCK_NAMES = {
+    "anthropic-api-key", "openai-api-key", "hubspot-private-app-token",
+    "github-pat-fine-grained", "github-pat-classic", "heroku-api-key",
+    "slack-token", "stripe-secret-key", "aws-access-key-id", "google-api-key",
+    "resend-api-key", "neon-password", "postgres-url-password",
+    "redis-url-password", "mongo-url-password",
+}
+NOTE_EXTS = {".md", ".markdown", ".mdx", ".txt"}
+
+
+def _allow() -> int:
+    print(json.dumps({"hookSpecificOutput": {
+        "hookEventName": "PreToolUse", "permissionDecision": "allow"}}))
+    return 0
+
+
+def _deny(reason: str) -> int:
+    print(json.dumps({"hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": reason}}))
+    return 0
+
+
+def main() -> int:
+    if os.environ.get("SECRET_VAULT_WRITE_BYPASS") == "1":
+        return _allow()
+    try:
+        data = json.loads(sys.stdin.read() or "{}")
+    except json.JSONDecodeError:
+        return _allow()
+
+    ti = data.get("tool_input") or {}
+    fp = ti.get("file_path") or ti.get("path") or ""
+    if Path(fp).suffix.lower() not in NOTE_EXTS:
+        return _allow()
+
+    # The text being INTRODUCED (not pre-existing content): Write.content, or
+    # Edit/MultiEdit new strings. Scanning only the new text means scrubbing a
+    # secret OUT of a note is never blocked.
+    chunks: list[str] = []
+    if "content" in ti:
+        chunks.append(str(ti.get("content") or ""))
+    if "new_string" in ti:
+        chunks.append(str(ti.get("new_string") or ""))
+    for e in ti.get("edits") or []:
+        chunks.append(str((e or {}).get("new_string") or ""))
+    text = "\n".join(chunks)
+    if not text:
+        return _allow()
+
+    for p in PATTERNS:
+        if p.name in BLOCK_NAMES and p.regex.search(text):
+            return _deny(
+                f"Blocked: this write would put a live credential ({p.name}) into "
+                f"the note '{Path(fp).name}'. Plaintext secrets in notes get "
+                f"committed, synced, and indexed. Store it in the macOS keychain "
+                f"or a gitignored secrets file and reference it by name instead. "
+                f"If this is a placeholder / example / doc, set "
+                f"SECRET_VAULT_WRITE_BYPASS=1 for this write."
+            )
+    return _allow()
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        # Fail OPEN: a write-time convenience guard must never block legitimate
+        # note-writing on a bug. Ingest-redaction + session-scrub remain the
+        # real safety net for anything that slips past.
+        print(json.dumps({"hookSpecificOutput": {
+            "hookEventName": "PreToolUse", "permissionDecision": "allow"}}))
+        sys.exit(0)

--- a/hooks/enforce-worktree-cap.py
+++ b/hooks/enforce-worktree-cap.py
@@ -43,6 +43,7 @@ from _lib.worktree_safety import (  # noqa: E402
     find_main_repo,
     git,
     is_idle,
+    is_scratch_worktree,
     list_worktrees,
     remove_worktree,
     snapshot_unrecoverable,
@@ -91,7 +92,10 @@ def main() -> int:
     if main_repo is None:
         return _emit(None)
 
-    wts = list_worktrees(main_repo)
+    # Only SCRATCH worktrees (under .claude/worktrees/) count against the cap
+    # and are eligible for reclaim. Deliberate ~/dev/<repo>-<slug> sibling
+    # worktrees are never auto-removed, even when idle and on a claude/* branch.
+    wts = [w for w in list_worktrees(main_repo) if is_scratch_worktree(w)]
     if len(wts) <= cap:
         return _emit(None)  # healthy
 

--- a/hooks/remediate-runaway-procs.py
+++ b/hooks/remediate-runaway-procs.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Auto-remediation: reap clearly-orphaned runaway processes — SessionStart.
+
+The session-start hooks SURFACE drift (unpushed commits, stashes, orphan
+snapshots) but nothing FIXES it. This is the FIX side of that pair, for one
+safe, high-value class: orphaned runaway processes.
+
+The documented incident (2026-05-29): 16 orphaned `yes` processes — real parent
+dead, reparented to launchd/init (PPID 1) — pinned the CPU for ~20h across a
+session. Pure waste, zero recoverable output. This hook reaps that class at
+every SessionStart so it can never silently burn a machine again.
+
+NON-DESTRUCTIVE by construction — it kills a process only when it is ALL of:
+  * orphaned (PPID == 1): its real parent already died, so nothing is reading
+    its output and no shell will ever reap it;
+  * an exact match for a known-noop runaway command (default: `yes`), whose
+    whole purpose is to emit forever and whose output is never valuable;
+  * older than RUNAWAY_MIN_AGE_MIN minutes (default 5) — never touches a
+    just-spawned process a live pipe might still be consuming.
+
+It NEVER kills by CPU-share guesswork, never touches a process with a living
+parent, and never touches anything off the allowlist. A genuinely-busy
+compiler is not this hook's business — surfacing-only for everything else.
+
+Config:
+  RUNAWAY_PROC_NAMES   comma-separated exact comm basenames (default "yes")
+  RUNAWAY_MIN_AGE_MIN  minimum elapsed minutes before reaping (default 5)
+Bypass: RUNAWAY_REMEDIATE_BYPASS=1
+
+WIRING (SessionStart):
+  "SessionStart": [
+    {"hooks": [{
+      "type": "command",
+      "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/remediate-runaway-procs.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'"
+    }]}
+  ]
+"""
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+
+
+def _emit(ctx: str | None) -> int:
+    print(
+        json.dumps({"continue": True, "additionalContext": ctx})
+        if ctx
+        else json.dumps({"continue": True, "suppressOutput": True})
+    )
+    return 0
+
+
+def _etime_to_min(etime: str) -> float:
+    """Parse `ps` etime ([[dd-]hh:]mm:ss) into minutes."""
+    etime = etime.strip()
+    days = 0
+    if "-" in etime:
+        d, etime = etime.split("-", 1)
+        days = int(d)
+    parts = [int(p) for p in etime.split(":")]
+    if len(parts) == 3:
+        h, m, s = parts
+    elif len(parts) == 2:
+        h, m, s = 0, parts[0], parts[1]
+    else:
+        h, m, s = 0, 0, parts[0]
+    return days * 1440 + h * 60 + m + s / 60.0
+
+
+def main() -> int:
+    if os.environ.get("RUNAWAY_REMEDIATE_BYPASS") == "1":
+        return _emit(None)
+
+    names = {
+        n.strip()
+        for n in os.environ.get("RUNAWAY_PROC_NAMES", "yes").split(",")
+        if n.strip()
+    }
+    if not names:
+        return _emit(None)
+    try:
+        min_age = float(os.environ.get("RUNAWAY_MIN_AGE_MIN", "5"))
+    except ValueError:
+        min_age = 5.0
+
+    try:
+        out = subprocess.run(
+            ["ps", "-axo", "pid=,ppid=,etime=,comm="],
+            capture_output=True, text=True, timeout=15,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return _emit(None)
+    if out.returncode != 0:
+        return _emit(None)
+
+    reaped: list[tuple[int, str, float]] = []
+    for line in out.stdout.splitlines():
+        parts = line.split(None, 3)
+        if len(parts) < 4:
+            continue
+        pid_s, ppid_s, etime, comm = parts
+        try:
+            pid, ppid = int(pid_s), int(ppid_s)
+        except ValueError:
+            continue
+        if ppid != 1 or os.path.basename(comm) not in names:
+            continue
+        try:
+            age = _etime_to_min(etime)
+        except (ValueError, IndexError):
+            continue
+        if age < min_age:
+            continue
+        try:
+            os.kill(pid, signal.SIGKILL)
+            reaped.append((pid, os.path.basename(comm), age))
+        except (ProcessLookupError, PermissionError):
+            continue
+
+    if not reaped:
+        return _emit(None)
+
+    by_name = {}
+    for _, c, _a in reaped:
+        by_name[c] = by_name.get(c, 0) + 1
+    summary = ", ".join(f"{c}×{n}" for c, n in sorted(by_name.items()))
+    oldest_h = max(r[2] for r in reaped) / 60.0
+    return _emit(
+        f"[auto-remediate] Reaped {len(reaped)} orphaned runaway process(es) "
+        f"({summary}; oldest {oldest_h:.1f}h, all PPID=1 — pure CPU waste). "
+        f"This is the runaway-process class that pinned the CPU ~20h in the "
+        f"2026-05-29 incident; the reap is non-destructive (their output is "
+        f"never read). Tune RUNAWAY_PROC_NAMES / RUNAWAY_MIN_AGE_MIN; bypass "
+        f"with RUNAWAY_REMEDIATE_BYPASS=1."
+    )
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        print(json.dumps({"continue": True, "suppressOutput": True}))
+        sys.exit(0)

--- a/hooks/worktree-footprint-signal.py
+++ b/hooks/worktree-footprint-signal.py
@@ -40,6 +40,7 @@ from _lib.worktree_safety import (  # noqa: E402
     WORKTREES_SEG,
     detect_cloud_sync,
     find_main_repo,
+    is_scratch_worktree,
     list_worktrees,
 )
 
@@ -72,7 +73,9 @@ def main() -> int:
     except ValueError:
         free_floor = DEFAULT_FREE_GB
 
-    registered = len(list_worktrees(main_repo))
+    # Count only scratch worktrees for the cap warning; deliberate sibling
+    # worktrees (~/dev/<repo>-<slug>) are not part of the pileup problem.
+    registered = sum(1 for w in list_worktrees(main_repo) if is_scratch_worktree(w))
 
     wt_dir = main_repo / WORKTREES_SEG
     on_disk = 0

--- a/scripts/install-hooks-user-level.py
+++ b/scripts/install-hooks-user-level.py
@@ -46,6 +46,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 import time
 from datetime import datetime
@@ -76,7 +77,34 @@ ABS_FINGERPRINTS = [
     "ai-brain-starter/hooks/remove-ended-worktree.py",
     "ai-brain-starter/hooks/enforce-worktree-cap.py",
     "ai-brain-starter/hooks/worktree-footprint-signal.py",
+    # Auto-remediation (the FIX side of the surfacing hooks):
+    "ai-brain-starter/hooks/remediate-runaway-procs.py",
+    # Write-time secret guard:
+    "ai-brain-starter/hooks/block-secret-in-note.py",
 ]
+
+# Path-divergence-robust matching: an ai-brain-starter hook may be wired at the
+# skill path (~/.claude/skills/ai-brain-starter/hooks/) OR copied into the user
+# hooks dir (~/.claude/hooks/). Dedup must recognize both as the same hook by
+# SCRIPT BASENAME, else a re-run duplicates every hook a hand-maintained config
+# wired at the user-hooks path. Only OUR script basenames are matched this way.
+ABS_OWNED_BASENAMES = {
+    "detect-closing-signal.py", "lint-vault-frontmatter.py", "log-skill-usage.py",
+    "first-week-checkin.py", "migrate-to-user-level.py",
+    "inject-love-language-context.py", "inject-meeting-workflow-on-trigger.py",
+    "session-end-hook.sh", "email-gate-hook.py", "graph-context-hook.sh",
+    "snapshot-pending-work-on-stop.py", "surface-orphan-worktree-snapshots.py",
+    "remove-ended-worktree.py", "enforce-worktree-cap.py",
+    "worktree-footprint-signal.py", "remediate-runaway-procs.py",
+    "block-secret-in-note.py",
+}
+
+_SCRIPT_RE = re.compile(r"([\w.-]+\.(?:py|sh))")
+
+
+def _owned_basenames(cmd: str) -> set[str]:
+    """Owned ai-brain-starter script basenames referenced in a command."""
+    return {os.path.basename(m) for m in _SCRIPT_RE.findall(cmd)} & ABS_OWNED_BASENAMES
 
 
 def find_repo_root() -> Path:
@@ -98,15 +126,20 @@ def load_hooks_template(path: Path) -> dict:
 
 
 def is_abs_owned(command: str) -> bool:
-    return any(fp in command for fp in ABS_FINGERPRINTS)
+    if any(fp in command for fp in ABS_FINGERPRINTS):
+        return True
+    return bool(_owned_basenames(command))
 
 
 def is_same_command(a: str, b: str) -> bool:
-    """Two commands count as the same if they reference the same script and
-    fall under the same ABS fingerprint."""
+    """Two commands count as the same hook if they share an ABS fingerprint OR
+    an owned script basename (so a skill-path entry and a ~/.claude/hooks/ entry
+    for the same script dedup to one), else if the literal text matches."""
     for fp in ABS_FINGERPRINTS:
         if fp in a and fp in b:
             return True
+    if _owned_basenames(a) & _owned_basenames(b):
+        return True
     return a.strip() == b.strip()
 
 

--- a/scripts/worktree-prune.sh
+++ b/scripts/worktree-prune.sh
@@ -1,15 +1,24 @@
 #!/bin/bash
-# Weekly git worktree prune for the vault. Self-locates so it survives a vault move.
+# Weekly git worktree maintenance for the vault. Self-locates so it survives a move.
 #
-# Also prunes orphan snapshot dirs created by the
-# snapshot-pending-work-on-stop hook (when installed): once a worktree is
-# archived AND its snapshot dir has gone untouched for >
-# SNAPSHOT_RETENTION_DAYS, the snapshot is removed. Live-worktree
-# snapshots and recent orphans (still within the recovery window) are
-# kept. SNAPSHOT_RETENTION_DAYS is env-overridable; 30-day default is
-# conservative because work-loss recovery is higher-stakes than
-# session-history archival. The block silently no-ops when no snapshot
-# dir exists, so this is safe to ship before the matching hooks land.
+# Worktree pileup is prevented at the SOURCE by the lifecycle hooks
+# (remove-ended-worktree at SessionEnd, enforce-worktree-cap at SessionStart,
+# worktree-footprint-signal at SessionStart). This weekly job is the BACKSTOP +
+# the orphan/branch/snapshot sweep:
+#   1. Safe reclaim of scratch worktrees over cap + ORPHAN DIRS via
+#      worktree-reclaim.py — snapshot-then-remove. NEVER the unsafe `rm -rf` an
+#      earlier version did: genuinely-unsaved files are copied out first, and a
+#      dir we can't reason about (dangling git metadata) is KEPT and reported.
+#   2. `git worktree prune` for stale refs.
+#   3. Delete orphan claude/ BRANCHES whose worktree is gone AND merged to master
+#      (REFUSE + recover-script pointer for any with unmerged commits — the
+#      worktree session-loss class from issue #65).
+#   4. Prune orphan SNAPSHOT dirs past the recovery-retention window.
+#
+# Only `.claude/worktrees/` scratch + their orphan dirs are auto-removed.
+# Deliberate ~/dev/<repo>-<slug> sibling worktrees and committed branches are
+# never removed. Each block silently no-ops when its tool/dir is absent, so this
+# is safe to ship before the matching hooks land.
 set -u
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VAULT_ROOT="${VAULT_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
@@ -18,33 +27,37 @@ LOG="$LOG_DIR/worktree-prune.log"
 SNAPSHOT_DIR="${SNAPSHOT_DIR:-$VAULT_ROOT/⚙️ Meta/Worktree Snapshots}"
 WT_DIR="${WT_DIR:-$VAULT_ROOT/.claude/worktrees}"
 SNAPSHOT_RETENTION_DAYS="${SNAPSHOT_RETENTION_DAYS:-30}"
+# Safe reclaim engine — first existing of: user hooks, skill install, alongside.
+RECLAIM=""
+for _c in "$HOME/.claude/hooks/worktree-reclaim.py" \
+          "$HOME/.claude/skills/ai-brain-starter/scripts/worktree-reclaim.py" \
+          "$SCRIPT_DIR/worktree-reclaim.py"; do
+  [ -f "$_c" ] && RECLAIM="$_c" && break
+done
 mkdir -p "$(dirname "$LOG")"
 {
   echo "=== $(date '+%Y-%m-%d %H:%M:%S %Z') prune $VAULT_ROOT ==="
   cd "$VAULT_ROOT" || { echo "ERR: cannot cd to vault"; exit 1; }
 
-  # Remove stale worktree refs (directories already deleted)
+  # 1. Safe reclaim: scratch worktrees over cap + orphan dirs (snapshot-first).
+  if [ -n "$RECLAIM" ]; then
+    echo "--- safe reclaim via $(basename "$RECLAIM") ---"
+    /usr/bin/python3 "$RECLAIM" --repo "$VAULT_ROOT" --idle-min 60 2>&1
+  else
+    echo "WARN: worktree-reclaim.py not found; orphan dirs not swept this run"
+  fi
+
+  # 2. Remove stale worktree refs (directories already deleted)
   git worktree prune -v 2>&1
 
-  # Delete claude/ branches whose worktree directory no longer exists AND
-  # whose commits are fully reachable from master.
-  #
-  # Two safety gates (defense-in-depth against the worktree session-loss class
-  # documented in issue #65):
-  #   1. Worktree directory must be gone (active sessions are safe).
-  #   2. Branch must have zero commits not reachable from master. If a
-  #      session committed to claude/<slug> without those commits landing on
-  #      master — which happens when session-end-hook resolves VAULT to the
-  #      worktree path instead of the main vault — deletion would orphan the
-  #      commits. Refuse loudly so a human can recover via reflog or the
-  #      recover-orphan-claude-branches.py script.
+  # 3. Delete orphan claude/ branches whose worktree is gone AND merged to master.
+  #    REFUSE (loudly) any with unmerged commits so a human can recover via reflog
+  #    or recover-orphan-claude-branches.py.
   DELETED=0
   REFUSED=0
   while IFS= read -r branch; do
     slug="${branch#claude/}"
-    wt_dir="$VAULT_ROOT/.claude/worktrees/$slug"
-    [ -d "$wt_dir" ] && continue
-
+    [ -d "$VAULT_ROOT/.claude/worktrees/$slug" ] && continue
     UNMERGED=$(git rev-list --count "master..$branch" 2>/dev/null || echo "?")
     if [ "$UNMERGED" = "0" ]; then
       git branch -D "$branch" 2>&1 && DELETED=$((DELETED + 1))
@@ -56,17 +69,15 @@ mkdir -p "$(dirname "$LOG")"
     fi
   done < <(git branch | grep 'claude/' | sed 's/^[* ]*//')
   echo "Deleted $DELETED orphaned claude/ branch(es)"
-  if [ "$REFUSED" -gt 0 ]; then
-    echo "Refused $REFUSED branch(es) with unmerged commits — run recover-orphan-claude-branches.py"
-  fi
+  [ "$REFUSED" -gt 0 ] && echo "Refused $REFUSED branch(es) with unmerged commits — run recover-orphan-claude-branches.py"
 
   echo "--- remaining worktrees ---"
   git worktree list 2>&1 | wc -l | xargs echo "count:"
   echo "--- remaining claude/ branches ---"
   git branch | grep -c 'claude/' 2>/dev/null | xargs echo "count:" || echo "count: 0"
 
-  # Prune orphan snapshot dirs (worktree archived AND past recovery window).
-  # No-op when SNAPSHOT_DIR doesn't exist (e.g. snapshot hooks not installed).
+  # 4. Prune orphan snapshot dirs (worktree archived AND past recovery window).
+  #    No-op when SNAPSHOT_DIR doesn't exist (snapshot hooks not installed).
   if [ -d "$SNAPSHOT_DIR" ]; then
     echo "--- snapshot prune (retention=${SNAPSHOT_RETENTION_DAYS}d) ---"
     snap_deleted=0

--- a/scripts/worktree-reclaim.py
+++ b/scripts/worktree-reclaim.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""One-shot SAFE worktree reclaim — registered-cap trim + orphan-dir sweep.
+
+Steady-state worktree hygiene is the lifecycle hooks' job (remove-ended-worktree
+at SessionEnd, enforce-worktree-cap at SessionStart). This is the explicit,
+auditable reclaim for an EXISTING pileup — and the engine the auto-remediation
+companion calls. It does two things the hooks alone don't:
+
+  1. Trims registered `claude/<slug>` worktrees over the cap right now (same
+     safety as enforce-worktree-cap, on demand).
+  2. Sweeps ORPHAN DIRS — dirs under `.claude/worktrees/` that git no longer
+     registers. The cap/remove hooks can't see these (they read
+     `git worktree list`), so orphan dirs accumulate invisibly. This is what
+     let the vault reach 19 orphan dirs with the hooks already live.
+
+Non-destructive by construction:
+  * committed work stays on its `claude/<slug>` branch (`git worktree remove`
+    keeps the ref);
+  * genuinely-unsaved files are snapshotted to the canonical snapshot dir BEFORE
+    any removal (definitive object-DB recoverability test, fail-safe);
+  * a worktree/dir we cannot reason about is KEPT and reported, never deleted;
+  * active worktrees (touched < --idle-min ago) and the current session's
+    worktree are never touched;
+  * only `claude/<slug>` scratch worktrees are auto-removed — a deliberate
+    feature-branch worktree is always kept.
+
+Usage:
+  worktree-reclaim.py [--repo PATH] [--cap N] [--idle-min M] [--dry-run] [--json]
+
+  --repo      main checkout to clean (default: resolve from cwd / CLAUDE_PROJECT_DIR)
+  --cap       keep at most N registered worktrees (default: $WORKTREE_MAX or 12)
+  --idle-min  a worktree/dir touched within this many minutes is "active" (default 60)
+  --dry-run   classify + report only; remove nothing
+  --json      machine-readable report
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+# Lib lives at <repo>/hooks/_lib in the ai-brain-starter layout, or colocated
+# next to this script in the flattened ~/.claude/hooks layout.
+for _cand in (_HERE.parent / "hooks", _HERE):
+    if (_cand / "_lib" / "worktree_safety.py").is_file():
+        sys.path.insert(0, str(_cand))
+        break
+
+from _lib.worktree_safety import (  # noqa: E402
+    current_worktree,
+    find_main_repo,
+    git,
+    is_idle,
+    is_scratch_worktree,
+    list_orphan_dirs,
+    list_worktrees,
+    reclaim_orphan_dir,
+    remove_worktree,
+    snapshot_unrecoverable,
+)
+
+
+def _branch(wt: Path) -> str:
+    try:
+        return git(wt, ["rev-parse", "--abbrev-ref", "HEAD"], timeout=15).stdout.decode().strip()
+    except Exception:
+        return ""
+
+
+def _mtime(p: Path) -> float:
+    try:
+        return p.stat().st_mtime
+    except OSError:
+        return 0.0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Safe one-shot worktree reclaim.")
+    ap.add_argument("--repo", default=None)
+    ap.add_argument("--cap", type=int, default=int(os.environ.get("WORKTREE_MAX", 12)))
+    ap.add_argument("--idle-min", type=int, default=60)
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+
+    main_repo = Path(args.repo).expanduser().resolve() if args.repo else find_main_repo()
+    if main_repo is None or not (main_repo / WORKTREES_SEG_LOCAL).is_dir():
+        print(f"no .claude/worktrees under {main_repo}", file=sys.stderr)
+        return 1
+
+    cur = current_worktree()
+    cur_path = cur[0].resolve() if cur else None
+
+    report: dict = {
+        "repo": str(main_repo),
+        "cap": args.cap,
+        "dry_run": args.dry_run,
+        "registered_before": 0,
+        "registered_removed": [],
+        "registered_kept": [],
+        "orphans_before": 0,
+        "orphans": {},
+    }
+
+    # --- 1. registered SCRATCH worktrees: trim idle claude/* over cap, oldest first ---
+    # Deliberate ~/dev/<repo>-<slug> sibling worktrees are never auto-removed.
+    regs = [w for w in list_worktrees(main_repo) if is_scratch_worktree(w)]
+    report["registered_before"] = len(regs)
+    over = max(0, len(regs) - args.cap)
+    removed = 0
+    for wt in sorted(regs, key=_mtime):
+        if removed >= over:
+            break
+        if cur_path and wt.resolve() == cur_path:
+            continue
+        if not _branch(wt).startswith("claude/"):
+            continue
+        if not is_idle(wt, args.idle_min):
+            report["registered_kept"].append(f"{wt.name}: active")
+            continue
+        if args.dry_run:
+            report["registered_removed"].append(f"{wt.name}: would-remove")
+            removed += 1
+            continue
+        snapped, _rec, all_safe = snapshot_unrecoverable(main_repo, wt, wt.name)
+        if not all_safe:
+            report["registered_kept"].append(f"{wt.name}: unsafe-snapshot")
+            continue
+        if remove_worktree(main_repo, wt, force=True):
+            report["registered_removed"].append(f"{wt.name}: removed (snap {snapped})")
+            removed += 1
+        else:
+            report["registered_kept"].append(f"{wt.name}: remove-failed")
+
+    # --- 2. orphan dirs: snapshot-then-remove (or keep+report) ---
+    orphans = list_orphan_dirs(main_repo)
+    report["orphans_before"] = len(orphans)
+    for od in orphans:
+        if cur_path and od.resolve() == cur_path:
+            report["orphans"][od.name] = "kept-current"
+            continue
+        if args.dry_run:
+            if not is_idle(od, args.idle_min):
+                report["orphans"][od.name] = "would-keep-active"
+                continue
+            try:
+                st = git(od, ["status", "--porcelain"], timeout=60)
+                if st.returncode != 0:
+                    report["orphans"][od.name] = "would-keep-dangling"
+                elif st.stdout.strip():
+                    report["orphans"][od.name] = "would-snapshot+remove(dirty)"
+                else:
+                    report["orphans"][od.name] = "would-remove(clean)"
+            except Exception:
+                report["orphans"][od.name] = "would-keep-dangling"
+            continue
+        action, snapped = reclaim_orphan_dir(main_repo, od, args.idle_min)
+        report["orphans"][od.name] = action + (f" (snap {snapped})" if snapped else "")
+
+    # prune dangling git metadata (safe: only clears refs to gone worktrees)
+    if not args.dry_run:
+        try:
+            git(main_repo, ["worktree", "prune"])
+        except Exception:
+            pass
+        report["registered_after"] = len(list_worktrees(main_repo))
+        report["orphans_after"] = len(list_orphan_dirs(main_repo))
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        ra = report.get("registered_after", "(dry)")
+        oa = report.get("orphans_after", "(dry)")
+        print(f"repo: {main_repo}  (cap {args.cap}, idle {args.idle_min}m"
+              + (", DRY-RUN" if args.dry_run else "") + ")")
+        print(f"registered: {report['registered_before']} -> {ra}  "
+              f"(removed {len(report['registered_removed'])}, kept {len(report['registered_kept'])})")
+        for x in report["registered_removed"][:12]:
+            print(f"  - {x}")
+        if len(report["registered_removed"]) > 12:
+            print(f"  - ... +{len(report['registered_removed']) - 12} more")
+        for x in report["registered_kept"][:8]:
+            print(f"  = {x}")
+        print(f"orphans: {report['orphans_before']} -> {oa}")
+        for name, act in list(report["orphans"].items())[:50]:
+            print(f"  {act:30} {name}")
+    return 0
+
+
+# Imported lazily to keep the lib the single source of the segment constant.
+from _lib.worktree_safety import WORKTREES_SEG as WORKTREES_SEG_LOCAL  # noqa: E402
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)


### PR DESCRIPTION
## What
Permanently bounds the local footprint that melts machines (102 worktrees / 1.29M files / ~25GB observed in the wild) and adds the FIX layer the surfacing hooks lacked.

## Why
The substrate already shipped the worktree-lifecycle hooks but: (a) the orphan-DIR case had no safe reclaim (the weekly prune `rm -rf`'d them with no snapshot); (b) the cap counted/removed deliberate `~/dev/<repo>-<slug>` sibling worktrees; (c) nothing auto-FIXED runaway processes (a `yes` pileup pinned a core ~20h); (d) nothing stopped a live API key being written into a note.

## Changes
- **Safe orphan reclaim** (`worktree_safety.reclaim_orphan_dir` + `scripts/worktree-reclaim.py`): snapshot-then-remove; a dir with genuinely-unsaved work or dangling git metadata is KEPT and reported, never blind-deleted.
- **Scratch-only scope** (`enforce-worktree-cap` + `footprint-signal`): only auto-act on `.claude/worktrees/` scratch; deliberate sibling worktrees are never touched.
- **prune.sh** delegates to the safe engine (drops the unsafe `rm -rf`).
- **Auto-remediation** (`remediate-runaway-procs.py`): reaps orphaned (PPID=1) known-noop runaway procs, age-gated, never by CPU guesswork.
- **Write-time secret guard** (`block-secret-in-note.py`): denies a Write/Edit putting a high-confidence live credential into a `.md`/`.txt` note (scrubbing OUT is never blocked).
- **Installer**: fingerprints the new hooks + dedups by SCRIPT BASENAME so user-path and skill-path configs converge instead of duplicating.
- **CLOUD_SYNC.md**: guardrail table + non-destructive contract + back-up-before-you-move ordering.

## Verification
- All Python compiles; `bash -n` clean; `hooks.json` valid.
- `worktree-reclaim.py` dry-run + real run verified on a live 20-orphan vault (19 removed cleanly, 1 dangling correctly kept, 0 data at risk).
- Reaper: etime parser unit-tested, ignores non-allowlist PPID=1 daemons, safe passthrough.
- Secret guard: 6 deny/allow cases pass.
- Installer basename-dedup unit-tested; dry-run shows worktree hooks matched (not duplicated).
- Personal-data scrub: clean.

Bug classes: UNBOUNDED-WORKTREE-PILEUP, RUNAWAY-PROCESS-CPU-BURN, SECRET-WRITTEN-TO-NOTE, DRIFT-SURFACED-BUT-NEVER-FIXED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
