### PR TITLE
ci: add scripts/ci.sh as canonical unit/type gate shared by lint.yml + ci-test

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,16 +1,19 @@
 name: lint
 
-# Catches the bug class that historically slipped through:
-#   - bash syntax errors in bootstrap.sh and other shell scripts
-#   - PowerShell parser errors in bootstrap.ps1, drift-check.ps1, update-check.ps1
-#   - missing UTF-8 BOM on .ps1 files (Windows PS 5.1 reads BOM-less as Windows-1252,
-#     crashes on first non-ASCII byte: em dash, the gear emoji, box-drawing chars)
-#   - em dashes in shell/PS scripts (defense-in-depth + matches voice rules)
-#   - invalid JSON in hooks.json and any *.mcp.json
-#   - phase docs that reference scripts which do not exist
+# Two kinds of check live here:
 #
-# Runs on every push and PR. ~60 seconds. $0 on public repos.
-# No untrusted user input used in any run: command (safe by construction).
+#   1. Pure-lint jobs (below): bash syntax, PowerShell parse, UTF-8 BOM on .ps1,
+#      no em dashes in .ps1, JSON validity, private-context tokens, phase-doc
+#      references, and the no-remote-pipe-install guard.
+#
+#   2. The unit/type gate: the `ci` job, which runs `bash scripts/ci.sh`. That
+#      script is the SINGLE source of truth for the unit/type gate - it runs
+#      (a) py_compile over every tracked *.py under Python 3.9 (the PEP 604
+#      `X | None` crash class) and (b) the 8 named tests in tests/integration/.
+#      The local pre-push gate (~/.local/bin/ci-test) runs the SAME
+#      `bash scripts/ci.sh`, so CI and the laptop gate cannot drift.
+#
+# Runs on every push and PR. No untrusted user input is used in any run: command.
 
 on:
   push:
@@ -102,32 +105,6 @@ jobs:
           done < <(find . -name '*.ps1' -not -path './.git/*')
           exit $fail
 
-  python-syntax:
-    name: Python syntax (3.9 - macOS system default)
-    runs-on: ubuntu-latest
-    # macOS ships /usr/bin/python3 as Python 3.9. Many users invoke hooks via
-    # that exact path. PEP 604 union syntax (X | None) in annotations crashes
-    # 3.9 at module load time. `from __future__ import annotations` is the
-    # canonical fix and works on 3.7+. This job catches the regression class
-    # before merge. No untrusted input used in any run: command.
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
-        with:
-          python-version: "3.9"
-      - name: py_compile every .py
-        run: |
-          set -e
-          fail=0
-          while IFS= read -r f; do
-            if ! python3 -m py_compile "$f" 2>err; then
-              echo "::error file=$f::python3 -m py_compile failed on Python 3.9"
-              cat err | sed "s|^|  |"
-              fail=1
-            fi
-          done < <(find . -name '*.py' -not -path './.git/*' -not -path './node_modules/*' -not -path '*/__pycache__/*')
-          exit $fail
-
   json:
     name: JSON validity (hooks.json, *.mcp.json)
     runs-on: ubuntu-latest
@@ -210,79 +187,6 @@ jobs:
           fi
           echo "Private-context scan passed (added lines only)."
 
-  worktree-session-close:
-    name: worktree session-close invariant (#65)
-    runs-on: ubuntu-latest
-    # Catches the bug class from issue #65: session-end-hook.sh resolving
-    # VAULT to a worktree path instead of the main vault, which routed
-    # session commits to `claude/<slug>` branches that worktree-prune.sh
-    # later deleted. Test spawns a fake vault + worktree and asserts:
-    #   1. resolve_main_vault strips the worktree segment
-    #   2. worktree-prune refuses to delete branches with unmerged commits
-    #   3. worktree-prune still deletes fully-merged orphan branches
-    # No untrusted user input is referenced in any run: command.
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
-      - name: configure git identity
-        run: |
-          git config --global user.email "ci@example.com"
-          git config --global user.name "ci"
-      - name: run integration test
-        run: bash tests/integration/test_worktree_session_close.sh
-
-  bootstrap-dry-run:
-    name: bootstrap.sh end-to-end dry-run (no parse errors, all skills + commands fire)
-    runs-on: ubuntu-latest
-    # End-to-end coverage of the install path. Asserts bootstrap.sh
-    # --dry-run exits 0 (no syntax errors, no unbound variables, no
-    # logic breaks in any of the install sections) AND mentions every
-    # required skill AND fires the commands install section.
-    # Catches the bug class where a new section in bootstrap.sh has an
-    # error that only surfaces when a real install runs.
-    # No untrusted user input referenced.
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
-      - name: run E2E test
-        run: bash tests/integration/test_bootstrap_dry_run.sh
-
-  phase-doc-skills-installed:
-    name: phase-doc slash commands have matching install entries
-    runs-on: ubuntu-latest
-    # Catches the bug class where a phase doc tells the user to "run /foo"
-    # but the bootstrap install loop never copies the skill folder to
-    # ~/.claude/skills/, so /foo doesn't appear in their slash command list.
-    # Source incident: fresh install completed but /second-brain-mapping
-    # was missing because bootstrap.sh's install loop didn't include it.
-    # Test asserts: every user-runnable slash command referenced in phase
-    # docs has (a) a matching skill folder in skills/ AND (b) is in the
-    # bootstrap install loop.
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
-      - name: run integration test
-        run: bash tests/integration/test_phase_doc_slash_commands_installed.sh
-
-  reconcile-ff-invariant:
-    name: reconcile-worktree-shared FF invariant (PR #68)
-    runs-on: ubuntu-latest
-    # Catches the bug class from PR #68: reconcile-worktree-shared.py
-    # committing on the worktree branch instead of fast-forwarding it
-    # to master, which accumulated orphan commits on `claude/*` branches.
-    # Same family as #65, different mechanism. Test asserts:
-    #   1. Hook FF-merges worktree branch to master when files are
-    #      byte-identical and branch is a strict ancestor.
-    #   2. No new commits are created on `claude/<slug>` after FF.
-    #   3. Hook falls back to commit-on-branch when FF is impossible
-    #      (worktree branch diverged with its own commits).
-    # No untrusted user input is referenced in any run: command.
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
-      - name: configure git identity
-        run: |
-          git config --global user.email "ci@example.com"
-          git config --global user.name "ci"
-      - name: run integration test
-        run: bash tests/integration/test_reconcile_ff_invariant.sh
-
   references:
     name: phase docs reference real repo files
     runs-on: ubuntu-latest
@@ -315,63 +219,6 @@ jobs:
           done < <(grep -rn -E '`scripts/[A-Za-z0-9_./-]+\.(sh|ps1|py|plist)`' phases/ 2>/dev/null || true)
           [ -f /tmp/lint-ref-fail ] && exit 1 || exit 0
 
-  detect-closing-signal-worktree:
-    name: detect-closing-signal resolves to main vault from a worktree
-    runs-on: ubuntu-latest
-    # Catches the session-artifact stranding bug class: the UserPromptSubmit
-    # close-cascade hook (hooks/detect-closing-signal.py) set vault_root from
-    # its cwd, so when the cascade fired inside a worktree the session file,
-    # Decisions, Captures and Time Tracking all resolved worktree-side and
-    # were discarded when the worktree was archived. Same class as the
-    # worktree-session-close job (#65) but for Layer 1 of the cascade, not the
-    # Stop hook. Test asserts the resolved session file lands in the MAIN
-    # vault, never under .claude/worktrees/, and the worktree slug is kept.
-    # No untrusted user input is referenced in any run: command.
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
-      - name: run integration test
-        run: bash tests/integration/test_detect_closing_signal_worktree.sh
-
-  stranded-session-artifacts-watchdog:
-    name: stranded-session-artifacts watchdog detects uncommitted worktree writes
-    runs-on: ubuntu-latest
-    # Layer 3 of the stranding defense: hooks/surface-stranded-session-artifacts.py
-    # is a SessionStart watchdog that flags session artifacts left uncommitted
-    # inside a worktree (which the archive step would discard). Test asserts it
-    # detects an uncommitted session file, names the offending worktree, stays
-    # silent when worktrees are clean, and does not flag committed artifacts.
-    # No untrusted user input is referenced in any run: command.
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
-      - name: configure git identity
-        run: |
-          git config --global user.email "ci@example.com"
-          git config --global user.name "ci"
-      - name: run integration test
-        run: bash tests/integration/test_stranded_session_artifacts_watchdog.sh
-
-  session-coordination-guards:
-    name: session-coordination guard hooks (cd-into-main / F821 pre-commit / sibling lock)
-    runs-on: ubuntu-latest
-    # Regression test for the three multi-session guard hooks in hooks/:
-    # check-cd-outside-worktree.py (blocks `cd` into the main checkout from a
-    # worktree-rooted session), check-py-import-precommit.py (blocks committing
-    # F821 / missing-import Python), and session-lock.py (warns when two sessions
-    # share a repo). Asserts block + allow + bypass-env + fail-open for each, so
-    # any logic/bypass/fail-open regression flips an assertion and fails the job.
-    # ruff is installed so the F821 block path is exercised, not just fail-open.
-    # No untrusted user input is referenced in any run: command.
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
-      - name: configure git identity
-        run: |
-          git config --global user.email "ci@example.com"
-          git config --global user.name "ci"
-      - name: install ruff (exercise the F821 block path)
-        run: pipx install ruff || python3 -m pip install --user ruff || true
-      - name: run integration test
-        run: bash tests/integration/test_session_coordination_guards.sh
-
   no-remote-pipe-install:
     name: install docs never pipe remote code into a shell
     runs-on: ubuntu-latest
@@ -401,21 +248,35 @@ jobs:
           done < <(find README.md bootstrap.sh bootstrap.ps1 phases -type f \( -name '*.md' -o -name '*.sh' -o -name '*.ps1' \))
           exit $fail
 
-  trust-prompt-preframing:
-    name: install pre-frames Claude Code's trust prompt
+  ci:
+    name: ci gate (py_compile + integration tests)
     runs-on: ubuntu-latest
-    # Catches the bug class from the May 2026 installer-panic incident: a
-    # non-technical user hit Claude Code's built-in trust prompt for the
-    # third-party plugins, marketplaces, and MCP servers the bootstrap
-    # registers, with no warning, and nearly abandoned the install thinking
-    # malware was being slipped onto the machine. The trust prompt is correct
-    # and is NOT suppressed; the fix is to pre-frame it everywhere the
-    # installer looks. Fails if any pre-framing surface is removed (README
-    # EN+ES sections, the maintainer-guide instruction, phase-00 Step 0.0b,
-    # the bootstrap.sh and bootstrap.ps1 heads-up lines), or if the false
-    # "no questions, it just runs" promise returns to the README.
+    # The repo's unit/type gate, consolidated into ONE command - scripts/ci.sh -
+    # so this workflow and the local pre-push gate (~/.local/bin/ci-test, which
+    # resolves this repo to mode=canon) run the EXACT same thing and cannot drift.
+    #
+    # scripts/ci.sh runs:
+    #   (a) py_compile every tracked *.py. The setup-python step below pins
+    #       Python 3.9 so `python3` is 3.9, catching the PEP 604 `X | None`
+    #       annotation class that crashes 3.9 at module load (many users invoke
+    #       hooks via macOS's system /usr/bin/python3, which is 3.9).
+    #   (b) the 8 named integration tests under tests/integration/, in order.
+    #
+    # The setup mirrors what the old per-test jobs did: setup-python 3.9 for the
+    # py_compile check, a git identity (the tests create temp repos and commit),
+    # and ruff so test_session_coordination_guards exercises the F821 block path
+    # (it fails open and stays green when ruff is absent).
     # No untrusted user input is referenced in any run: command.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
-      - name: run integration test
-        run: bash tests/integration/test_trust_prompt_preframing.sh
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: "3.9"
+      - name: configure git identity (integration tests create temp repos)
+        run: |
+          git config --global user.email "ci@example.com"
+          git config --global user.name "ci"
+      - name: install ruff (exercise the F821 block path in session-coordination-guards)
+        run: pipx install ruff || python3 -m pip install --user ruff || true
+      - name: run the canonical CI gate
+        run: bash scripts/ci.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,8 @@ Same thing — open an issue. Describe the problem you're trying to solve, not j
 2. Make your changes
 3. Open a pull request with a one-sentence description of what changed and why
 
+Before opening the PR, run the full CI gate locally: `bash scripts/ci.sh` (the same `py_compile` over every tracked `*.py` plus the integration tests that CI runs).
+
 **For SKILL.md changes:** The most important thing is that instructions stay prescriptive and complete. Vague instructions like "ask about habits" produce inconsistent results across different users and models. If you're changing how the skill behaves, spell out exactly what Claude should do, in what order, and with what fallbacks. See the existing phases for the right level of detail.
 
 **For `docs/CHANGELOG.md`:** Add an entry in plain English explaining what changed and why it matters to the user — not what file was edited. For user-facing release notes, also add a short summary to `docs/RELEASES.md`.

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# scripts/ci.sh - the canonical, locally-runnable unit/type gate for
+# ai-brain-starter. ONE command, shared by two callers so they can never drift:
+#
+#   1. .github/workflows/lint.yml  - the `ci` job runs `bash scripts/ci.sh`.
+#   2. ~/.local/bin/ci-test        - resolves this repo to mode=canon and runs
+#                                    the same `bash scripts/ci.sh` pre-push.
+#
+# It runs EXACTLY the unit/type gate that lint.yml used to run as separate jobs:
+#   (a) Python syntax     - py_compile every tracked *.py. Catches the PEP 604
+#                           `X | None` annotation class that crashes Python 3.9
+#                           at module load (many users invoke hooks via macOS's
+#                           system /usr/bin/python3, which is 3.9).
+#   (b) Shell integration - the 8 named tests under tests/integration/, in
+#                           order, stopping at the first failure.
+#
+# It does NOT run the pure-lint jobs (bash -n, pwsh ParseFile, BOM, em-dash,
+# JSON, privacy, references, no-remote-pipe-install). Those stay as their own
+# lint.yml jobs - they are lint, not the unit/type gate.
+#
+# Environment the integration tests need (lint.yml provides these in the `ci`
+# job; this script adds a non-invasive fallback so a fresh `bash scripts/ci.sh`
+# works for a contributor too):
+#   - A git identity. The tests create temp repos and commit; they set their own
+#     LOCAL identity, but a fresh box may have no ambient identity at all, so we
+#     export GIT_* defaults only when nothing is configured.
+#   - ruff on PATH is OPTIONAL: test_session_coordination_guards exercises the
+#     F821 block path when ruff is present and fails OPEN (still green) when not.
+#   - Python 3.9 for the py_compile check is IDEAL (it is the version whose crash
+#     class this gate exists to catch). We prefer `python3.9` when present and
+#     fall back to `python3` otherwise. lint.yml pins 3.9 via setup-python, so
+#     CI is always authoritative for the 3.9 check; the local fallback to a newer
+#     interpreter is a weaker superset check (it will not catch 3.9-only crashes).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# Keep generated .pyc out of the working tree. This script runs IN the checkout
+# (ci-test runs it inside the live worktree), so route every child interpreter's
+# bytecode cache to a temp dir instead of littering __pycache__/ across the repo.
+PYCACHE_TMP="$(mktemp -d)"
+export PYTHONPYCACHEPREFIX="$PYCACHE_TMP"
+cleanup() { rm -rf "$PYCACHE_TMP"; }
+trap cleanup EXIT
+
+# Non-invasive git identity fallback - only when nothing is configured. Uses env
+# vars (not `git config --global`) so we never mutate the caller's global config.
+if [ -z "$(git config user.email 2>/dev/null || true)" ]; then
+  export GIT_AUTHOR_NAME="ci" GIT_AUTHOR_EMAIL="ci@example.com"
+  export GIT_COMMITTER_NAME="ci" GIT_COMMITTER_EMAIL="ci@example.com"
+fi
+
+# ---- (a) Python syntax gate ------------------------------------------------
+if command -v python3.9 >/dev/null 2>&1; then
+  PY=python3.9
+else
+  PY=python3
+fi
+echo "==> (a) Python syntax: py_compile every tracked *.py  [$("$PY" --version 2>&1)]"
+err="$(mktemp)"
+fail=0
+count=0
+while IFS= read -r -d '' f; do
+  count=$((count + 1))
+  if ! "$PY" -m py_compile "$f" 2>"$err"; then
+    echo "::error file=$f::python3 -m py_compile failed"
+    sed 's|^|  |' "$err"
+    fail=1
+  fi
+done < <(git ls-files -z -- '*.py')
+rm -f "$err"
+if [ "$fail" != 0 ]; then
+  echo "FAILED: Python syntax gate (see errors above)"
+  exit 1
+fi
+echo "    OK - $count file(s) compiled clean"
+
+# ---- (b) Shell integration gate --------------------------------------------
+# The 8 named tests that constitute lint.yml's integration gate, in order.
+# `set -e` aborts on the first non-zero test, which is the required
+# stop-on-first-failure behavior. This list is the gate's source of truth:
+# tests/integration/ also holds .sh/.py files that are NOT part of this gate, so
+# it must be an explicit allow-list, never a glob over the directory.
+INTEGRATION_TESTS=(
+  test_worktree_session_close
+  test_bootstrap_dry_run
+  test_phase_doc_slash_commands_installed
+  test_reconcile_ff_invariant
+  test_detect_closing_signal_worktree
+  test_stranded_session_artifacts_watchdog
+  test_session_coordination_guards
+  test_trust_prompt_preframing
+)
+echo "==> (b) Shell integration: ${#INTEGRATION_TESTS[@]} tests"
+for t in "${INTEGRATION_TESTS[@]}"; do
+  script="tests/integration/$t.sh"
+  if [ ! -f "$script" ]; then
+    echo "::error::missing integration test $script"
+    exit 1
+  fi
+  echo "--- $t"
+  bash "$script"
+done
+
+echo
+echo "All gates passed: py_compile ($count file(s)) + ${#INTEGRATION_TESTS[@]} integration tests."


### PR DESCRIPTION
## Summary

Adds `scripts/ci.sh` as the single canonical unit/type gate and repoints `lint.yml` at it, so the GitHub workflow and the local pre-push gate (`ci-test`) run the **exact same command** and cannot drift.

`scripts/ci.sh` runs:
- **(a)** `py_compile` over every tracked `*.py` (catches the PEP 604 `X | None` annotation class that crashes Python 3.9 at module load)
- **(b)** the 8 named integration tests in `tests/integration/`, in order, stopping at the first failure: `test_worktree_session_close`, `test_bootstrap_dry_run`, `test_phase_doc_slash_commands_installed`, `test_reconcile_ff_invariant`, `test_detect_closing_signal_worktree`, `test_stranded_session_artifacts_watchdog`, `test_session_coordination_guards`, `test_trust_prompt_preframing`

## Changes

- **New** `scripts/ci.sh` — the canonical gate. Prefers `python3.9` for the `py_compile` check (falls back to `python3`), routes `.pyc` to a temp dir so it stays clean when run in-place, and adds a non-invasive git-identity fallback so a fresh `bash scripts/ci.sh` works for any contributor.
- **`lint.yml`** — the `python-syntax` job and the 8 per-test jobs collapse into one `ci` job that sets up Python 3.9 + a git identity + `ruff`, then runs `bash scripts/ci.sh`. The 8 pure-lint jobs (`shell`, `powershell`, `bom`, `no-em-dash-ps1`, `json`, `privacy`, `references`, `no-remote-pipe-install`) are unchanged — they are lint, not the unit/type gate.
- **`CONTRIBUTING.md`** — notes that `bash scripts/ci.sh` runs the full CI gate locally.

## Why

`ci-test` (the local pre-push CI-parity gate) was just taught to run a repo-declared `scripts/ci.sh` in its `mode=none` path. Declaring one makes the laptop gate run this repo's real `lint.yml` unit/type gate instead of failing open with "nothing ran locally".

Verified locally: `ci-test` resolves this repo to `mode=canon` and runs `bash scripts/ci.sh` green, writing marker `canon ... gates=bash-scripts/ci.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
