### PR TITLE
hooks: warn-recreate-deleted-file — enforce Reliability Manifesto Pillar 6

### DIFF
--- a/hooks/warn-recreate-deleted-file.py
+++ b/hooks/warn-recreate-deleted-file.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""warn-recreate-deleted-file.py — Reliability Manifesto Pillar 6 enforcement.
+
+PreToolUse(Write) hook. When the agent is about to Write a NEW file at a path
+that a prior commit DELETED, warn: an intentional removal and an accidental loss
+look identical from the outside and demand opposite responses. Read that
+deletion commit before recreating the file.
+
+WHY (Pillar 6 — verify external state before acting):
+  An agent that sees a "missing" file and restores it can be undoing a
+  deliberate cleanup. The git history is the deterministic source of truth for
+  intent: if the last thing that happened to this path was a deletion, the agent
+  must consult that commit (its message often says "remove X as stale/orphan")
+  before recreating. This is the enforcement layer for the manifesto principle —
+  high-precision because it checks git history, not model judgment.
+
+SCOPE (deliberately narrow, to stay high-precision / low-false-positive):
+  - Fires ONLY on Write (not Edit/MultiEdit — those target existing files).
+  - Fires ONLY when the target path does NOT currently exist AND git history
+    shows a commit that deleted exactly that path.
+  - Overwriting a live file, creating a genuinely new file, or any path outside
+    a git repo: silent.
+
+WARN-ONLY. Never blocks. A false positive costs one informational line; a missed
+intentional-delete-undo costs a silent regression (the asymmetry the manifesto
+names). Bypass: RECREATE_DELETED_BYPASS=1.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _emit(ctx: str | None) -> None:
+    """PreToolUse contract: print JSON. additionalContext = inline warning."""
+    if ctx:
+        print(json.dumps({"continue": True, "additionalContext": ctx}))
+    else:
+        print(json.dumps({"continue": True, "suppressOutput": True}))
+
+
+def _deletion_commit(repo: Path, rel: str) -> tuple[str, str] | None:
+    """Return (sha, subject) of the most recent commit that DELETED `rel`, or None.
+
+    Uses --diff-filter=D so only deletions count. Most-recent-first; we take the
+    first hit. If a later commit re-added and re-deleted, the newest deletion is
+    the relevant one — which is exactly what `log` returns first.
+    """
+    try:
+        r = subprocess.run(
+            ["git", "-C", str(repo), "log", "-1", "--diff-filter=D",
+             "--format=%h\t%s", "--", rel],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+    if r.returncode != 0:
+        return None
+    line = r.stdout.strip()
+    if not line:
+        return None
+    sha, _, subject = line.partition("\t")
+    return (sha, subject) if sha else None
+
+
+def main() -> int:
+    if os.environ.get("RECREATE_DELETED_BYPASS") == "1":
+        _emit(None)
+        return 0
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        _emit(None)
+        return 0
+
+    if data.get("tool_name") != "Write":
+        _emit(None)
+        return 0
+
+    file_path = (data.get("tool_input") or {}).get("file_path", "")
+    if not file_path:
+        _emit(None)
+        return 0
+
+    target = Path(file_path)
+    # Only a genuine RE-creation: the path must not currently exist.
+    if target.exists():
+        _emit(None)
+        return 0
+
+    # Locate the enclosing git repo (the path itself doesn't exist, so walk parents).
+    start = target.parent
+    try:
+        r = subprocess.run(
+            ["git", "-C", str(start), "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (subprocess.SubprocessError, OSError):
+        _emit(None)
+        return 0
+    if r.returncode != 0:
+        _emit(None)  # not in a git repo → no history to consult
+        return 0
+    repo = Path(r.stdout.strip())
+
+    try:
+        rel = str(target.resolve().relative_to(repo.resolve()))
+    except ValueError:
+        _emit(None)
+        return 0
+
+    hit = _deletion_commit(repo, rel)
+    if not hit:
+        _emit(None)  # never deleted in history → genuinely new, silent
+        return 0
+
+    sha, subject = hit
+    _emit(
+        f"[Pillar 6 — verify before recreate] You are about to Write `{rel}`, "
+        f"but commit {sha} DELETED this exact path:\n"
+        f"    {subject}\n"
+        f"An intentional removal and an accidental loss look identical from here. "
+        f"Read that commit first (`git -C {repo} show {sha}`) — if the deletion was "
+        f"deliberate (cleanup/orphan/deprecation), recreating it re-introduces what "
+        f"was removed on purpose; finish the cleanup instead. If it was accidental, "
+        f"proceed. Bypass: RECREATE_DELETED_BYPASS=1."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/warn-recreate-deleted-file.test.py
+++ b/hooks/warn-recreate-deleted-file.test.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Tests for warn-recreate-deleted-file.py (Reliability Manifesto Pillar 6 enforcement).
+
+Self-contained: builds throwaway git repos in a temp dir, drives the hook via
+subprocess with realistic PreToolUse(Write) payloads, asserts on stdout JSON.
+Run: python3 warn-recreate-deleted-file.test.py   (exit 0 = all pass)
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HOOK = str(Path(__file__).with_name("warn-recreate-deleted-file.py"))
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo), *args], check=True,
+                   capture_output=True, text=True)
+
+
+def _init_repo(repo: Path) -> None:
+    repo.mkdir(parents=True, exist_ok=True)
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "t@t.t")
+    _git(repo, "config", "user.name", "t")
+    _git(repo, "commit", "-q", "--allow-empty", "-m", "root")
+
+
+def run(payload: dict) -> dict:
+    r = subprocess.run([sys.executable, HOOK], input=json.dumps(payload),
+                       capture_output=True, text=True)
+    assert r.returncode == 0, f"hook must always exit 0, got {r.returncode}: {r.stderr}"
+    out = r.stdout.strip()
+    return json.loads(out) if out else {}
+
+
+def fired(payload: dict) -> bool:
+    """A warning fired iff stdout carries non-empty additionalContext."""
+    return bool(run(payload).get("additionalContext"))
+
+
+def main() -> int:
+    passed = failed = 0
+    cases = []
+
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+
+        # Repo A: a file was committed then DELETED in a later commit.
+        repo = tmp / "repo"
+        _init_repo(repo)
+        f = repo / "orphan.py"
+        f.write_text("print('hi')\n")
+        _git(repo, "add", "orphan.py")
+        _git(repo, "commit", "-q", "-m", "add orphan")
+        f.unlink()
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-q", "-m", "cleanup: delete orphan.py as stale")
+
+        # Case 1: recreating the deleted file at its old path → MUST fire.
+        cases.append(("recreate deleted file fires", True, fired({
+            "tool_name": "Write",
+            "tool_input": {"file_path": str(repo / "orphan.py"), "content": "x"},
+        })))
+
+        # Case 2: a brand-new file never in history → MUST NOT fire.
+        cases.append(("new file silent", False, fired({
+            "tool_name": "Write",
+            "tool_input": {"file_path": str(repo / "brand_new.py"), "content": "x"},
+        })))
+
+        # Case 3: editing/overwriting a file that currently EXISTS → MUST NOT fire.
+        live = repo / "live.py"
+        live.write_text("v1\n")
+        _git(repo, "add", "live.py")
+        _git(repo, "commit", "-q", "-m", "add live")
+        cases.append(("overwrite live file silent", False, fired({
+            "tool_name": "Write",
+            "tool_input": {"file_path": str(live), "content": "v2"},
+        })))
+
+        # Case 4: non-Write tool (Edit) → MUST NOT fire (Edit targets existing files).
+        cases.append(("edit tool silent", False, fired({
+            "tool_name": "Edit",
+            "tool_input": {"file_path": str(repo / "orphan.py"), "new_string": "x"},
+        })))
+
+        # Case 5: path outside any git repo → MUST NOT fire (no history to consult).
+        outside = tmp / "no_repo" / "f.py"
+        outside.parent.mkdir(parents=True, exist_ok=True)
+        cases.append(("non-repo path silent", False, fired({
+            "tool_name": "Write",
+            "tool_input": {"file_path": str(outside), "content": "x"},
+        })))
+
+        # Case 6: malformed payload → MUST NOT crash, MUST NOT fire.
+        cases.append(("malformed silent", False, fired({"tool_name": "Write"})))
+
+        # Case 7: the deletion-commit subject appears in the warning (actionable evidence).
+        warn = run({
+            "tool_name": "Write",
+            "tool_input": {"file_path": str(repo / "orphan.py"), "content": "x"},
+        }).get("additionalContext", "")
+        cases.append(("warning cites deletion commit", True,
+                      "cleanup: delete orphan.py" in warn))
+
+    for name, want, got in cases:
+        ok = want == got
+        print(f"  {'✓' if ok else '✗'} {name}  want={want} got={got}")
+        if ok:
+            passed += 1
+        else:
+            failed += 1
+
+    print(f"\n{passed}/{passed+failed} pass")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

A PreToolUse(Write) hook that turns **Pillar 6** (verify external state before asserting/acting) from a stated principle into an enforced guardrail.

When the agent is about to `Write` a file at a path that a **prior commit deleted**, the hook warns: an intentional removal and an accidental loss look identical from the outside and demand opposite responses. It reads git history (the deterministic source of intent), cites the deletion commit's SHA + subject, and tells the agent to read that commit before recreating.

## Why this shape

The other five pillars each have enforcing machinery; Pillar 6 shipped as prose only. The general form ("did the agent assert any external state unverified?") has no deterministic check and would be low-precision theater in a client install (and a codified anti-pattern: over-strict guards train bypass). So this enforces the **highest-precision deterministic subset**: recreate-a-deleted-file, checkable against git history with near-zero false-positive harm.

This is the exact failure that motivated the pillar: an agent "restoring" a file that was deleted on purpose, re-introducing what was cleaned up.

## Discipline

- **TDD**: 7/7 tests (`warn-recreate-deleted-file.test.py`) — fires on recreate-deleted, silent on new-file / overwrite-live / Edit / non-repo / malformed; asserts the deletion commit is cited.
- **Adversarial doubt-pass** (6 cases): empty stdin, unicode/space paths, relative paths, deleted-then-readded, MultiEdit, perf (48ms).
- **Warn-only**, never blocks. Bypass `RECREATE_DELETED_BYPASS=1`.
- Em dashes in docstrings match existing shipped-hook convention (only `.ps1` em dashes are CI-blocked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)