### PR TITLE
fix(closing-signals): guard 'later' false-positives in error text + code fences

### DIFF
--- a/templates/closing-signals/en.json
+++ b/templates/closing-signals/en.json
@@ -71,7 +71,15 @@
     },
     {
       "_comment": "Don't match inside code fences",
-      "pattern": "```[\\s\\S]*?\\b(bye|done|ttyl)\\b[\\s\\S]*?```"
+      "pattern": "```[\\s\\S]*?\\b(bye|done|ttyl|later)\\b[\\s\\S]*?```"
+    },
+    {
+      "_comment": "Don't match 'try again later' / 'try later' — common in error messages pasted as content, not a sign-off",
+      "pattern": "\\btry\\s+(it\\s+|again\\s+)?later\\b"
+    },
+    {
+      "_comment": "Don't match 'X later' inside indented / quoted blocks (4-space or > prefix) — pasted error text or quoted message",
+      "pattern": "(^|\\n)(?:    |>\\s).*\\blater\\b"
     },
     {
       "_comment": "Don't match 'done with X' — user describing state, not closing",


### PR DESCRIPTION
## Summary

The high-confidence `\blater[!.\s]*$` trigger fires on any pasted text ending in "later." — observed twice in succession on the Tauri updater error `Update could not be applied. Try again later.` The session-close cascade auto-injected, pre-built an empty session stub, and the bug-report turn was mis-handled as a session close.

## What changed

Three additions to `false_positive_guards` in `templates/closing-signals/en.json`:

1. Extended the existing code-fence guard from `(bye|done|ttyl)` to also cover `later`
2. New "try (it/again) later" guard — catches the canonical error-message form
3. New indented/quoted-block guard — catches `later` inside 4-space or `> `-prefixed blocks

## Test plan

- [x] JSON validates (parse-check passes)
- [x] 5 legit closes still fire: bare `later.`, `see you later`, `ok bye`, `wrapping up`, `let's close this session`
- [x] 3 false-positive shapes guarded: `Try again later.`, `later` in code fence, error in code fence
- [x] Smoke-tested with the actual misfire message verbatim — now guarded

🤖 Generated with [Claude Code](https://claude.com/claude-code)