### PR TITLE
test(install): guard anti-menu directive against silent removal

### DIFF
--- a/tests/integration/test_trust_prompt_preframing.sh
+++ b/tests/integration/test_trust_prompt_preframing.sh
@@ -96,6 +96,20 @@ must_contain "$BOOTSTRAP_PS1" \
   "bootstrap.ps1 is missing the trust-prompt heads-up line" \
   "may pause to ask you to approve these tools"
 
+# 6. The README must tell the installing assistant NOT to put up a menu.
+#    Sibling install-UX regression class to the trust-prompt ambush above:
+#    a fresh Claude reading the README would respond to "install this for me"
+#    with a 3-option menu (show me the script / just the skill / don't install)
+#    instead of installing, stalling non-technical conversions. The fix is a
+#    VISIBLE anti-menu directive at the top of each Install section (EN + ES);
+#    these assertions guard it against silent removal. Source: PR #146.
+must_contain "$README" \
+  "README is missing the English anti-menu install directive (run now, no menu)" \
+  "Do not put up a menu"
+must_contain "$README" \
+  "README is missing the Spanish anti-menu install directive (correr ya, sin menú)" \
+  "No armes un menú"
+
 if [ "$FAILED" -gt 0 ]; then
   echo "" >&2
   echo "$FAILED trust-prompt pre-framing check(s) failed." >&2
@@ -104,4 +118,4 @@ if [ "$FAILED" -gt 0 ]; then
   exit 1
 fi
 
-echo "PASS: trust-prompt pre-framing intact. README (EN+ES), maintainer guide, phase-00 Step 0.0b, bootstrap.sh, and bootstrap.ps1 all carry it."
+echo "PASS: trust-prompt pre-framing intact (README EN+ES, maintainer guide, phase-00 Step 0.0b, bootstrap.sh, bootstrap.ps1) + anti-menu install directive present (README EN+ES)."


### PR DESCRIPTION
Follow-up to #146 (which removed the README install menu-gate). Adds the regression assertion so a future README edit cannot silently delete the anti-menu directive and bring the 3-option menu back.

Sibling install-UX guard to the trust-prompt pre-framing checks already in `test_trust_prompt_preframing.sh`, same bug family as the `no-remote-pipe-install` CI job. Asserts the EN ("Do not put up a menu") and ES ("No armes un menú") directives are present.

Negative-control verified: removing either directive opener turns the test red (exit 1); restoring it returns green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)