### PR TITLE
fix(hooks): collapse worktree CLAUDE_PROJECT_DIR + block .log/.err writes at worktree paths

### DIFF
--- a/hooks/_lib/worktree_safety.py
+++ b/hooks/_lib/worktree_safety.py
@@ -65,6 +65,11 @@ def find_main_repo(cwd: Path | None = None) -> Path | None:
     """Resolve the main checkout that owns `.claude/worktrees/`.
 
     1. CLAUDE_PROJECT_DIR env var (set by Claude Code) if it's a real dir.
+       If that value itself sits inside `.../.claude/worktrees/<slug>/`
+       (Claude Code commonly sets it to the session cwd, which IS the
+       worktree path), collapse it back to the part before so logs and
+       snapshots written via this helper never strand on a throwaway
+       claude/<slug> branch.
     2. If cwd is inside `.../.claude/worktrees/<slug>/`, the part before
        `.claude/worktrees`.
     3. cwd itself if it contains `.claude/worktrees/`.
@@ -72,14 +77,18 @@ def find_main_repo(cwd: Path | None = None) -> Path | None:
     Returns None if nothing resolves.
     """
     cwd = (cwd or Path.cwd()).resolve()
+    marker = "/" + WORKTREES_SEG + "/"
 
     env_root = os.environ.get("CLAUDE_PROJECT_DIR")
     if env_root:
         cand = Path(env_root)
         if cand.is_dir():
-            return cand.resolve()
+            cand = cand.resolve()
+            s = str(cand)
+            if marker in s:
+                return Path(s.split(marker, 1)[0]).resolve()
+            return cand
 
-    marker = "/" + WORKTREES_SEG + "/"
     s = str(cwd)
     if marker in s:
         return Path(s.split(marker, 1)[0]).resolve()

--- a/hooks/block-worktree-shared-edit.py
+++ b/hooks/block-worktree-shared-edit.py
@@ -22,6 +22,16 @@ at worktree paths, reversing the prior WORKTREE_OK allow-list. Those strand
 on the throwaway claude/<slug> branch and are discarded when the worktree is
 archived. Resolves the contradiction with CLAUDE.md (see canonical rule).
 
+Extended 2026-06-03: same block on the vault's automation log dir,
+`<vault>/⚙️ Meta/logs/*.{log,err}`. Each name has exactly one canonical
+writer (worktree-prune, enforce-worktree-cap, remove-ended-worktree,
+session-end-hook, auto-snapshot, decision-outcome-check, traffic-snapshot).
+A worktree-path write to one of these is either a script computing its log
+path against SCRIPT_DIR (and so anchored at the worktree copy of itself) or
+an LLM hand-writing a line at the wrong root; both lose data when the
+worktree archives. Bug class:
+WORKTREE-CWD-RELATIVE-LOG-PATH-STRANDS-DATA.
+
 Bypass: `WORKTREE_VAULT_EDIT_BYPASS=1` (rare; document why).
 """
 
@@ -68,6 +78,15 @@ SESSION_ARTIFACT_PATTERNS = [
     re.compile(r"^⚙️ Meta/Pending Team Broadcasts/.+\.md$"),
     re.compile(r"^⚙️ Meta/Session Captures\.md$"),
     re.compile(r"^⚙️ Meta/Time Tracking\.md$"),
+]
+
+# Vault automation logs. Each filename has exactly one canonical writer; a
+# worktree-side write is always either a SCRIPT_DIR-relative path bug or an
+# LLM hand-writing at the wrong root. In both cases the entries strand on
+# the claude/<slug> branch and are discarded at archive. Match `*.log` and
+# `*.err` under the canonical logs directory.
+LOG_PATH_PATTERNS = [
+    re.compile(r"^⚙️ Meta/logs/.+\.(log|err)$"),
 ]
 
 
@@ -121,6 +140,25 @@ def main() -> int:
                 f"Edit at the main vault path instead:\n"
                 f"  {main_path}\n"
                 f"Worktree slug: {slug}\n"
+                f"Bypass: WORKTREE_VAULT_EDIT_BYPASS=1 (document why).",
+                file=sys.stderr,
+            )
+            return 2
+
+    for pat in LOG_PATH_PATTERNS:
+        if pat.match(rel):
+            main_path = f"{VAULT_ROOT}/{rel}"
+            print(
+                f"BLOCKED: '{rel}' is a vault automation log. Writes belong "
+                f"at the main vault path so the canonical log accumulates "
+                f"all entries; a worktree-side write strands the entries on "
+                f"the claude/{slug} branch and they are discarded at "
+                f"worktree archive.\n"
+                f"Write at the main vault path instead:\n"
+                f"  {main_path}\n"
+                f"If a script computed this path against SCRIPT_DIR, source "
+                f"scripts/_resolve_main_vault.sh and pass the path through "
+                f"resolve_main_vault before anchoring LOG_DIR.\n"
                 f"Bypass: WORKTREE_VAULT_EDIT_BYPASS=1 (document why).",
                 file=sys.stderr,
             )


### PR DESCRIPTION
## What

Closes the WORKTREE-CWD-RELATIVE-LOG-PATH-STRANDS-DATA bug class:

- **`_lib/worktree_safety.py:find_main_repo()`** trusted `CLAUDE_PROJECT_DIR` verbatim. Claude Code commonly sets that env var to the session cwd, which inside a worktree session IS the worktree path. Downstream callers (`enforce-worktree-cap.py`, `remove-ended-worktree.py`) then wrote their logs at `<worktree>/⚙️ Meta/logs/*.log` and the entries vanished at worktree archive.
- **`block-worktree-shared-edit.py`** covered shared-canonical files and session artifacts at worktree paths but not the vault automation log dir. Any Edit/Write to `<vault>/.claude/worktrees/<slug>/⚙️ Meta/logs/*.{log,err}` slipped through.

## Why now

A real strand surfaced on `memory-runtime-pro/upbeat-euler-087223`: 45 unique lines of `worktree-cleanup.log` that the canonical didn't have, caught only at worktree-archive review. Rescued via merge (sort -u) into the canonical. This PR closes the gap so the same class of strand can't recur via either Python-callsite or LLM-write.

## Diff

- `find_main_repo`: if the resolved env var contains `/.claude/worktrees/`, collapse to the part before. Same path-split the cwd branch already uses. No new logic — only one new conditional.
- `block-worktree-shared-edit`: new `LOG_PATH_PATTERNS = [r"^⚙️ Meta/logs/.+\.(log|err)$"]` + matching block branch. Message points operators at the writer + the bash-side `_resolve_main_vault.sh` helper for SCRIPT_DIR-relative bugs.

## Tests

- Local `ci-test`: 21/21 passed (py_compile 248 files + 8 integration tests, including check-cd-outside-worktree and session-lock).
- Manually exercised find_main_repo across 4 cases (env=worktree path, env=main, env=unset, dev-repo worktree); all resolve to the main checkout.
- Manually exercised the hook with 5 synthetic payloads: worktree `.log` BLOCKED, worktree `.err` BLOCKED, main-vault `.log` ALLOW, worktree `.txt` ALLOW, Read tool ALLOW.

🤖 Generated with [Claude Code](https://claude.com/claude-code)