### PR TITLE
harden(funnel): validate marker before telemetry POST + disclose what the install sends + lock ADR-0003

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -63,6 +63,23 @@ If Claude asks for permission to do something and you are not sure what it does,
 
 ---
 
+## 5. What the install sends to our servers (and what it never sends)
+
+Local-first by default. Your vault, journals, notes, and files never leave your machine. The install does not require an email and does not phone home about your content.
+
+There is exactly one opt-in. At the end of setup you may choose to give an email (for occasional update notes and a free workflow audit). If you do, an install token is minted: `myceliumai.co/api/install/quick-mint` receives the email, name, and language you gave, plus a short OS label (e.g. `mac-arm`). That is the email submission you chose to make.
+
+While that token exists on your machine, three best-effort, fail-open events may be sent. Each carries only the token and a coarse signal — never any content:
+
+- **install started** and **install completed** — the token plus an OS string (e.g. `Darwin 24.5.0 arm64`).
+- **first journal saved** (one time only) — the token plus the calendar date. Not the journal text. Not a word of it.
+
+If you never give an email, or you decline the ask, none of these fire. A decline is recorded locally and nothing is sent.
+
+What is **never** sent, under any path: journal text, note contents, file contents, file names, your contacts, or anything from your vault. Only the opaque token tied to the email you chose to give, an OS label, and (once) a single date. The token is local to your machine; delete `~/.claude/.ai-brain-starter-email-on-file` to stop all of the above.
+
+---
+
 ## Non-goals: what this security model deliberately does NOT do
 
 A useful security model is also a fence around what it does not try to handle. Listing non-goals stops over-trust ("the vault must be doing X for me, since X is a security thing") and over-fear ("the vault is missing X, so it's insecure") simultaneously.

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -820,7 +820,10 @@ Write-Host ""
 if ((Test-Path $emailMarker) -and -not $DryRun) {
     try {
         $recordedToken = (Get-Content -Path $emailMarker -TotalCount 1).Trim()
-        if ($recordedToken) {
+        # Only a real 32-char hex token is a funnel token. The marker may
+        # instead hold "declined" or "recorded"; in those cases send nothing
+        # (a declined user's machine must not ping the server).
+        if ($recordedToken -match '^[a-f0-9]{32}$') {
             $os = "$([System.Environment]::OSVersion.VersionString) $env:PROCESSOR_ARCHITECTURE"
             $sigPath = "$env:USERPROFILE\.claude\.ai-brain-starter-hmac-secret"
             $signature = $null

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1624,7 +1624,11 @@ fi
 
 if [[ -f "$EMAIL_MARKER" && $DRY_RUN -eq 0 ]]; then
   RECORDED_TOKEN="$(head -1 "$EMAIL_MARKER" 2>/dev/null | tr -d '[:space:]')"
-  if [[ -n "$RECORDED_TOKEN" ]]; then
+  # Only a real 32-char hex token is a funnel token. The marker may instead
+  # hold "declined" or "recorded" (the user declined, or opted in but the
+  # server returned no token). In those cases send nothing — a declined user's
+  # machine must not ping the server, and a non-token must never be POSTed.
+  if [[ "$RECORDED_TOKEN" =~ ^[a-f0-9]{32}$ ]]; then
     OS_INFO="$(uname -srm 2>/dev/null || echo unknown)"
     # Sign the completion request with HMAC if we have a secret. The shared
     # secret can ship with the bootstrap (it's only meaningful as a key for

--- a/tests/integration/test_installer_retires_email_gate.sh
+++ b/tests/integration/test_installer_retires_email_gate.sh
@@ -80,4 +80,9 @@ OUT3="$(python3 "$INSTALLER" --hooks-source "$HOOKS_SRC" --settings "$SETTINGS" 
 echo "$OUT3" | grep -q "0 stale hook(s) removed" || { echo "$OUT3"; fail "5: clean config must retire 0 (no false removal)"; }
 grep -q "CUSTOM_HOOK_SENTINEL" "$SETTINGS" || fail "5: custom hook dropped on a clean config"
 
-echo "PASS: installer retires the dead email-gate hook, wires the replacement, preserves siblings + custom hooks, idempotent, no false retire"
+# --- 6. executable ADR-0003 invariant: the SHIPPED template never re-introduces
+#        a retired every-session email gate, and keeps the gated replacement. ---
+grep -q "email-gate-hook.py" "$HOOKS_SRC" && fail "6: retired email-gate-hook.py reappeared in hooks.json (ADR-0003 violated)"
+grep -q "post-update-email-ask.py" "$HOOKS_SRC" || fail "6: the gated replacement hook is not wired in hooks.json"
+
+echo "PASS: installer retires the dead email-gate hook, wires the replacement, preserves siblings + custom hooks, idempotent, no false retire, template stays gate-free (ADR-0003)"


### PR DESCRIPTION
Follow-up audit of [#152](https://github.com/adelaidasofia/ai-brain-starter/pull/152) (the three-state `email-on-file` marker). Three gaps on surfaces that change touched:

## 1. Bogus-token telemetry on both bootstraps
`bootstrap.sh` and `bootstrap.ps1` re-read the marker **content as a token** and POST it to `/api/install/complete`. With the new three-state marker, a `declined` / `recorded` value was sent as a bogus token — and a *declined* user's machine pinging the server is exactly the wrong behavior. Both now require a 32-hex token before POSTing (parity with the `daily-journal` guard shipped in #152). I hardened the journal in #152 but missed both bootstrap paths.

## 2. The privacy claim was untrue
`README` says *"the email is the only thing that touches our servers, and only what's listed in `SECURITY.md`."* But the funnel sends `{token, os}`, `{token, os, completed}`, and `{token, journalDate}` — and `SECURITY.md` disclosed **none** of it. New `SECURITY.md` section 5 states exactly what is and is never sent (token + OS label + one date; never journal text, note contents, file names, or vault data). Makes the claim true; serves the local-only privacy guardrail tracked in MYC-419.

## 3. Executable ADR-0003 invariant
`test_installer_retires_email_gate` now asserts the **shipped** `hooks.json` never re-introduces the retired every-session gate and keeps the gated replacement — so the exact regression that caused this can't silently come back.

## Tests
Full local gate green: `py_compile` (248 files) + 10 integration tests. `bash -n bootstrap.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)