### PR TITLE
fix(hooks): stop SessionStart hooks piling up + freezing under concurrency (MYC-514)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,9 @@ secrets.json
 
 # codegraph local index (per-clone, 100MB+, regenerated on demand).
 .codegraph/
+
+# scan-prior-sessions-for-secrets.py runtime state (markers + single-instance
+# lock, regenerated each run; never belongs in version control).
+hooks/.last-secret-scan
+hooks/.last-secret-scan-full
+hooks/.secret-scan.lock

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,25 @@ description: What's new in AI Brain Starter — plain English, no jargon
 
 ---
 
+## 2026-06-05: stop SessionStart hooks from piling up and freezing your machine
+
+**Who this affects:** anyone who runs more than one Claude Code session at a time (a common, intended workflow). Two SessionStart hooks could pile up under concurrency and peg every CPU core.
+
+### The problem
+
+The secret-scan hook (`scan-prior-sessions-for-secrets.py`) stamped its 6-hour cooldown marker *after* its slow corpus scan finished, not before. So every session that started while a scan was still running saw no fresh marker and launched its own full scan. Several multi-minute scans running at once pinned the CPU until a machine froze under heavy load. There was no single-instance lock, no incremental mode, and no time budget. The runaway-process reaper (`remediate-runaway-procs.py`) only cleaned up orphaned no-op processes (a dead parent), so it was blind to exactly this kind of stuck hook — one with a live parent.
+
+### The fix
+
+- The secret-scan hook now claims its cooldown marker *first*, holds a single-instance lock so only one scan can run at a time, scans incrementally (only files changed since the last full pass), de-prioritizes itself, caps each pass with a wall-clock budget, and skips oversized transcripts. A second session can no longer start a second scan.
+- The reaper now also clears a stuck hook process — one running under `~/.claude/hooks/` for many minutes at high CPU — which is the exact class that caused the freeze. It is path-scoped with a dual age-and-CPU gate, so a fast hook, a bounded scan, or a busy compiler is never touched. Tune or disable it with `RUNAWAY_HOOK_MIN_AGE_MIN` / `RUNAWAY_HOOK_MIN_CPU` / `RUNAWAY_REMEDIATE_BYPASS=1`.
+
+### Verification
+
+Two new automated tests ship with the fix. The reaper test is a positive-and-negative control over the kill decision (a stuck hook process is reaped; a young one, a low-CPU one, a non-hook program, a non-python process, and the reaper's own process are all left alone). The scan test proves a second concurrent run backs off instead of starting a second scan — with a mutation check confirming the test goes red if the lock is removed. Every other SessionStart hook was audited and found bounded (each works on a small, capped set — worktrees, branches, a single marker file — never the unbounded session corpus the scan hook walks).
+
+---
+
 ## 2026-06-03: stop asking for your email over and over
 
 **Who this affects:** anyone who installed without giving an email, or who declined the optional ask. Previously you could be asked again and again, in every kind of session (even while journaling), and pointed at a "token" to paste.

--- a/hooks/remediate-runaway-procs.py
+++ b/hooks/remediate-runaway-procs.py
@@ -2,15 +2,14 @@
 """Auto-remediation: reap clearly-orphaned runaway processes — SessionStart.
 
 The session-start hooks SURFACE drift (unpushed commits, stashes, orphan
-snapshots) but nothing FIXES it. This is the FIX side of that pair, for one
-safe, high-value class: orphaned runaway processes.
+snapshots) but nothing FIXES it. This is the FIX side of that pair, for two
+safe, high-value classes of runaway process.
 
+CLASS 1 — orphaned no-op processes (PPID == 1).
 The documented incident (2026-05-29): 16 orphaned `yes` processes — real parent
 dead, reparented to launchd/init (PPID 1) — pinned the CPU for ~20h across a
-session. Pure waste, zero recoverable output. This hook reaps that class at
-every SessionStart so it can never silently burn a machine again.
-
-NON-DESTRUCTIVE by construction — it kills a process only when it is ALL of:
+session. Pure waste, zero recoverable output. A process is reaped here only
+when it is ALL of:
   * orphaned (PPID == 1): its real parent already died, so nothing is reading
     its output and no shell will ever reap it;
   * an exact match for a known-noop runaway command (default: `yes`), whose
@@ -18,13 +17,31 @@ NON-DESTRUCTIVE by construction — it kills a process only when it is ALL of:
   * older than RUNAWAY_MIN_AGE_MIN minutes (default 5) — never touches a
     just-spawned process a live pipe might still be consuming.
 
-It NEVER kills by CPU-share guesswork, never touches a process with a living
-parent, and never touches anything off the allowlist. A genuinely-busy
-compiler is not this hook's business — surfacing-only for everything else.
+CLASS 2 — stuck hook processes (added after the 2026-06-05 freeze).
+A SessionStart hook that walks a large corpus piled up several concurrent
+multi-minute copies — they had LIVE parents and comm "Python", so the
+orphan-`yes` reaper above never saw them, and they pegged the CPU until the
+machine froze (load 36). A process running one of OUR OWN hooks
+(`~/.claude/hooks/`) for many minutes at high CPU is stuck by construction —
+hooks finish in seconds and are idempotent (they re-run next session), so
+killing one loses nothing. Reaped here only when it is ALL of:
+  * its command line is under `~/.claude/hooks/` (path-scoped — never a user
+    program or a busy compiler);
+  * it is a python process (the hook runtime);
+  * older than RUNAWAY_HOOK_MIN_AGE_MIN minutes (default 12 — safely above any
+    self-bounded hook's own budget) AND at/above RUNAWAY_HOOK_MIN_CPU percent
+    CPU (default 50). The dual age-AND-cpu gate means a normal fast hook, a
+    legitimately-bounded scan, or an idle process is never touched.
+
+It NEVER kills by CPU-share guesswork on arbitrary processes, never touches a
+process with a living parent outside the hook path, and never touches anything
+off these two narrow classes.
 
 Config:
-  RUNAWAY_PROC_NAMES   comma-separated exact comm basenames (default "yes")
-  RUNAWAY_MIN_AGE_MIN  minimum elapsed minutes before reaping (default 5)
+  RUNAWAY_PROC_NAMES        comma-separated exact comm basenames (default "yes")
+  RUNAWAY_MIN_AGE_MIN       min elapsed minutes before reaping class 1 (default 5)
+  RUNAWAY_HOOK_MIN_AGE_MIN  min elapsed minutes before reaping a stuck hook (default 12)
+  RUNAWAY_HOOK_MIN_CPU      min %CPU before reaping a stuck hook (default 50)
 Bypass: RUNAWAY_REMEDIATE_BYPASS=1
 
 WIRING (SessionStart):
@@ -70,6 +87,42 @@ def _etime_to_min(etime: str) -> float:
     return days * 1440 + h * 60 + m + s / 60.0
 
 
+def _should_reap_hook(
+    command: str,
+    age_min: float,
+    cpu: float,
+    *,
+    hooks_dir: str,
+    pid: int,
+    self_pid: int,
+    min_age: float,
+    min_cpu: float,
+) -> bool:
+    """Pure decision for CLASS 2 (stuck hook process). Returns True only when a
+    process is a stuck `~/.claude/hooks/` python process per the dual age-AND-cpu
+    gate. Factored out so the pos/neg control test can exercise every branch
+    deterministically without spawning or killing real processes.
+
+    A process is reaped ONLY when it is ALL of:
+      * not this very hook (pid != self_pid);
+      * its command line is under hooks_dir (path-scoped);
+      * a python process;
+      * age_min >= min_age AND cpu >= min_cpu (a fast hook OR a low-CPU/idle
+        process is never reaped — the AND is what makes this safe).
+    """
+    if pid == self_pid:
+        return False
+    if hooks_dir not in command:
+        return False
+    if "python" not in command.lower():
+        return False
+    if age_min < min_age:
+        return False
+    if cpu < min_cpu:
+        return False
+    return True
+
+
 def main() -> int:
     if os.environ.get("RUNAWAY_REMEDIATE_BYPASS") == "1":
         return _emit(None)
@@ -79,62 +132,125 @@ def main() -> int:
         for n in os.environ.get("RUNAWAY_PROC_NAMES", "yes").split(",")
         if n.strip()
     }
-    if not names:
-        return _emit(None)
     try:
         min_age = float(os.environ.get("RUNAWAY_MIN_AGE_MIN", "5"))
     except ValueError:
         min_age = 5.0
 
+    # --- CLASS 1: orphaned no-op runaway processes (PPID == 1) ---------------
+    reaped: list[tuple[int, str, float]] = []
+    if names:
+        try:
+            out = subprocess.run(
+                ["ps", "-axo", "pid=,ppid=,etime=,comm="],
+                capture_output=True, text=True, timeout=15,
+            )
+        except (subprocess.TimeoutExpired, OSError):
+            out = None
+        if out is not None and out.returncode == 0:
+            for line in out.stdout.splitlines():
+                parts = line.split(None, 3)
+                if len(parts) < 4:
+                    continue
+                pid_s, ppid_s, etime, comm = parts
+                try:
+                    pid, ppid = int(pid_s), int(ppid_s)
+                except ValueError:
+                    continue
+                if ppid != 1 or os.path.basename(comm) not in names:
+                    continue
+                try:
+                    age = _etime_to_min(etime)
+                except (ValueError, IndexError):
+                    continue
+                if age < min_age:
+                    continue
+                try:
+                    os.kill(pid, signal.SIGKILL)
+                    reaped.append((pid, os.path.basename(comm), age))
+                except (ProcessLookupError, PermissionError):
+                    continue
+
+    # --- CLASS 2: runaway HOOK processes (live parent, comm "Python") --------
+    # The class that froze the machine 2026-06-05 — a SessionStart hook piling
+    # up concurrent multi-minute copies. The orphan-`yes` reaper above never
+    # saw them (live parent, comm "Python"). Path-scoped to ~/.claude/hooks/
+    # with a dual age AND cpu gate so a normal fast hook is never touched.
+    hooks_dir = os.path.expanduser("~/.claude/hooks/")
     try:
-        out = subprocess.run(
-            ["ps", "-axo", "pid=,ppid=,etime=,comm="],
+        hook_age = float(os.environ.get("RUNAWAY_HOOK_MIN_AGE_MIN", "12"))
+    except ValueError:
+        hook_age = 12.0
+    try:
+        hook_cpu = float(os.environ.get("RUNAWAY_HOOK_MIN_CPU", "50"))
+    except ValueError:
+        hook_cpu = 50.0
+    hook_reaped: list[tuple[int, str, float]] = []
+    try:
+        out2 = subprocess.run(
+            ["ps", "-axww", "-o", "pid=,etime=,pcpu=,command="],
             capture_output=True, text=True, timeout=15,
         )
     except (subprocess.TimeoutExpired, OSError):
-        return _emit(None)
-    if out.returncode != 0:
+        out2 = None
+    if out2 is not None and out2.returncode == 0:
+        self_pid = os.getpid()
+        for line in out2.stdout.splitlines():
+            parts = line.split(None, 3)
+            if len(parts) < 4:
+                continue
+            pid_s, etime, cpu_s, command = parts
+            try:
+                pid, cpu = int(pid_s), float(cpu_s)
+            except ValueError:
+                continue
+            try:
+                age = _etime_to_min(etime)
+            except (ValueError, IndexError):
+                continue
+            if not _should_reap_hook(
+                command, age, cpu,
+                hooks_dir=hooks_dir, pid=pid, self_pid=self_pid,
+                min_age=hook_age, min_cpu=hook_cpu,
+            ):
+                continue
+            script = next((t for t in command.split() if t.endswith(".py")), command)
+            try:
+                os.kill(pid, signal.SIGKILL)
+                hook_reaped.append((pid, os.path.basename(script), age))
+            except (ProcessLookupError, PermissionError):
+                continue
+
+    if not reaped and not hook_reaped:
         return _emit(None)
 
-    reaped: list[tuple[int, str, float]] = []
-    for line in out.stdout.splitlines():
-        parts = line.split(None, 3)
-        if len(parts) < 4:
-            continue
-        pid_s, ppid_s, etime, comm = parts
-        try:
-            pid, ppid = int(pid_s), int(ppid_s)
-        except ValueError:
-            continue
-        if ppid != 1 or os.path.basename(comm) not in names:
-            continue
-        try:
-            age = _etime_to_min(etime)
-        except (ValueError, IndexError):
-            continue
-        if age < min_age:
-            continue
-        try:
-            os.kill(pid, signal.SIGKILL)
-            reaped.append((pid, os.path.basename(comm), age))
-        except (ProcessLookupError, PermissionError):
-            continue
-
-    if not reaped:
-        return _emit(None)
-
-    by_name = {}
-    for _, c, _a in reaped:
-        by_name[c] = by_name.get(c, 0) + 1
-    summary = ", ".join(f"{c}×{n}" for c, n in sorted(by_name.items()))
-    oldest_h = max(r[2] for r in reaped) / 60.0
+    msgs: list[str] = []
+    if reaped:
+        by_name: dict[str, int] = {}
+        for _, c, _a in reaped:
+            by_name[c] = by_name.get(c, 0) + 1
+        summary = ", ".join(f"{c}×{n}" for c, n in sorted(by_name.items()))
+        oldest_h = max(r[2] for r in reaped) / 60.0
+        msgs.append(
+            f"Reaped {len(reaped)} orphaned runaway process(es) "
+            f"({summary}; oldest {oldest_h:.1f}h, all PPID=1 — pure CPU waste)."
+        )
+    if hook_reaped:
+        by_script: dict[str, int] = {}
+        for _, s, _a in hook_reaped:
+            by_script[s] = by_script.get(s, 0) + 1
+        hsum = ", ".join(f"{s}×{n}" for s, n in sorted(by_script.items()))
+        oldest_m = max(r[2] for r in hook_reaped)
+        msgs.append(
+            f"Reaped {len(hook_reaped)} stuck hook process(es) "
+            f"({hsum}; oldest {oldest_m:.0f}min at >={hook_cpu:.0f}% CPU — runaway "
+            f"~/.claude/hooks process, idempotent so it re-runs next session). "
+            f"This is the SessionStart pile-up class that can freeze a machine."
+        )
     return _emit(
-        f"[auto-remediate] Reaped {len(reaped)} orphaned runaway process(es) "
-        f"({summary}; oldest {oldest_h:.1f}h, all PPID=1 — pure CPU waste). "
-        f"This is the runaway-process class that pinned the CPU ~20h in the "
-        f"2026-05-29 incident; the reap is non-destructive (their output is "
-        f"never read). Tune RUNAWAY_PROC_NAMES / RUNAWAY_MIN_AGE_MIN; bypass "
-        f"with RUNAWAY_REMEDIATE_BYPASS=1."
+        "[auto-remediate] " + " ".join(msgs) +
+        " Tune RUNAWAY_PROC_NAMES / RUNAWAY_MIN_AGE_MIN / RUNAWAY_HOOK_MIN_AGE_MIN /"
+        " RUNAWAY_HOOK_MIN_CPU; bypass with RUNAWAY_REMEDIATE_BYPASS=1."
     )
 
 

--- a/hooks/scan-prior-sessions-for-secrets.py
+++ b/hooks/scan-prior-sessions-for-secrets.py
@@ -7,6 +7,22 @@ THIS hook catches anything historical that slipped through — from sessions
 that ended before the scrub hook existed, or before a given pattern was
 added to the registry.
 
+Resource governance (added after a 2026-06-05 freeze on the maintainer's
+machine, where the OLD version stamped its 6h cooldown AFTER the slow scan:
+every session that started during the scan window blew past the cooldown
+and launched its OWN full corpus scan, and four concurrent multi-minute
+scans pegged the CPU until the machine froze). The pile-up class is now
+closed by FOUR guards, all in this file:
+
+  * single-instance flock — at most ONE scan runs at a time; a concurrent
+    session backs off immediately instead of starting a second scan;
+  * stamp-at-START — the cooldown marker is claimed BEFORE the work, so a
+    session that starts mid-scan sees the cooldown and skips;
+  * incremental — once a full pass completes, later runs only read files
+    modified since that pass (a handful, not the whole corpus);
+  * wall-clock budget + per-file size cap + os.nice(10) — a single pass can
+    never run away or starve the foreground session.
+
 Behavior:
   - Detect: scans every `~/.claude/projects/**/*.jsonl` against the
     registry (`_lib/secret_patterns.scan`). Rate-limited to one run per 6h
@@ -31,6 +47,8 @@ Environment:
   - `SCAN_PRIOR_AUTO_SCRUB_BYPASS=1` — forensic mode: skip auto-scrub
     even when VAULT_ROOT is set. Useful for inspecting findings before
     scrubbing.
+  - `SECRET_SCAN_BUDGET_SECONDS` — override the per-pass wall-clock budget
+    (applies to both the cold and warm budgets). Ops escape hatch.
 
 Pairs with the other secret-defense layers; see `_lib/secret_patterns.py`
 docstring for the full architecture.
@@ -39,6 +57,7 @@ docstring for the full architecture.
 from __future__ import annotations
 
 import datetime as _dt
+import fcntl
 import json
 import os
 import shutil
@@ -52,8 +71,19 @@ sys.path.insert(0, str(HOOK_DIR))
 
 from _lib.secret_patterns import redact, scan  # noqa: E402
 
-MARKER = HOOK_DIR / ".last-secret-scan"
+MARKER = HOOK_DIR / ".last-secret-scan"            # last ATTEMPT (cooldown, stamped at start)
 COOLDOWN_SECONDS = 6 * 60 * 60  # 6h
+FULL_MARKER = HOOK_DIR / ".last-secret-scan-full"  # last COMPLETED full pass (incremental baseline)
+LOCK = HOOK_DIR / ".secret-scan.lock"              # single-instance guard (flock)
+MAX_FILE_BYTES = 3 * 1024 * 1024                    # skip outsized transcripts (cost without proportional secret risk)
+# Per-pass wall-clock ceiling. COLD start (no completed full pass yet) gets a
+# generous budget so it can finish ONE full pass and prime the incremental
+# baseline — else it truncates forever and silently covers only part of the
+# corpus. WARM runs are incremental (only changed files) so a short budget is
+# ample. Env override wins for ops.
+_BUDGET_OVERRIDE = os.environ.get("SECRET_SCAN_BUDGET_SECONDS")
+COLD_BUDGET_SECONDS = int(_BUDGET_OVERRIDE) if _BUDGET_OVERRIDE else 600
+WARM_BUDGET_SECONDS = int(_BUDGET_OVERRIDE) if _BUDGET_OVERRIDE else 60
 
 # Auto-scrub additions
 AUTO_SCRUB_LOG = Path.home() / ".claude" / "secret-detection-log.jsonl"
@@ -62,21 +92,22 @@ BYPASS_ENV = "SCAN_PRIOR_AUTO_SCRUB_BYPASS"
 BACKUP_SUFFIX_TEMPLATE = ".bak.{date}-secret-scrub"
 
 
-def _within_cooldown() -> bool:
-    if not MARKER.exists():
-        return False
+def _read_epoch(path: Path) -> float | None:
     try:
-        last = float(MARKER.read_text().strip())
+        return float(path.read_text().strip())
     except (ValueError, OSError):
-        return False
-    return (time.time() - last) < COOLDOWN_SECONDS
+        return None
+
+
+def _write_epoch(path: Path) -> None:
+    try:
+        path.write_text(f"{time.time():.0f}\n")
+    except OSError:
+        pass
 
 
 def _stamp() -> None:
-    try:
-        MARKER.write_text(f"{time.time():.0f}\n")
-    except OSError:
-        pass
+    _write_epoch(MARKER)
 
 
 def _vault_root() -> Path | None:
@@ -184,18 +215,62 @@ def _auto_scrub(jsonl: Path) -> tuple[bool, str]:
 
 
 def main() -> int:
-    if _within_cooldown():
+    # Cooldown (fast path): skip if a scan was ATTEMPTED < COOLDOWN_SECONDS ago.
+    # The marker is stamped at the START of a run (below), so a session that
+    # starts mid-scan sees a fresh marker and backs off here.
+    last_attempt = _read_epoch(MARKER)
+    if last_attempt is not None and (time.time() - last_attempt) < COOLDOWN_SECONDS:
         print(json.dumps({"continue": True, "suppressOutput": True}))
         return 0
+
+    # Single-instance lock. If another scan already holds it, back off NOW.
+    # This is the primary guard against the SessionStart pile-up that froze
+    # the maintainer's machine on 2026-06-05: without it, N concurrent
+    # sessions each launched their own full corpus scan.
+    try:
+        _lock_fh = LOCK.open("w")  # noqa: F841 (held open to keep the flock for the process lifetime)
+        fcntl.flock(_lock_fh, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        print(json.dumps({"continue": True, "suppressOutput": True}))
+        return 0
+
+    # Claim the cooldown NOW (before the work) so concurrent starts back off.
+    _stamp()
+
+    # De-prioritise: never starve the foreground session, even mid-scan.
+    try:
+        os.nice(10)
+    except OSError:
+        pass
 
     projects = Path.home() / ".claude" / "projects"
     if not projects.exists():
-        _stamp()
         print(json.dumps({"continue": True, "suppressOutput": True}))
         return 0
 
+    # Incremental: once a full pass has completed, only read files modified
+    # since then (unchanged files were already covered). Turns a 1000+-file
+    # walk into the handful touched in the last 6h. Bounded by a wall-clock
+    # budget and a per-file size cap so a single pass can never run away.
+    full_baseline = _read_epoch(FULL_MARKER)
+    incremental = full_baseline is not None
+    cutoff = (full_baseline or 0) - 5  # small clock-skew buffer
+    deadline = time.time() + (WARM_BUDGET_SECONDS if incremental else COLD_BUDGET_SECONDS)
+    truncated = False
+
     findings: list[tuple[Path, list[tuple[str, int]]]] = []
     for jsonl in projects.rglob("*.jsonl"):
+        if time.time() > deadline:
+            truncated = True
+            break
+        try:
+            st = jsonl.stat()
+        except OSError:
+            continue
+        if incremental and st.st_mtime < cutoff:
+            continue
+        if st.st_size > MAX_FILE_BYTES:
+            continue  # outsized transcript: cost without proportional secret risk
         try:
             text = jsonl.read_text(errors="replace")
         except OSError:
@@ -204,7 +279,10 @@ def main() -> int:
         if hits:
             findings.append((jsonl, hits))
 
-    _stamp()
+    # Advance the incremental baseline only after a pass that finished without
+    # truncation — so a truncated pass never leaves an unscanned hole.
+    if not truncated:
+        _write_epoch(FULL_MARKER)
 
     if not findings:
         print(json.dumps({"continue": True, "suppressOutput": True}))

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -95,6 +95,8 @@ INTEGRATION_TESTS=(
   test_trust_prompt_preframing
   test_post_update_email_ask
   test_installer_retires_email_gate
+  test_remediate_runaway_procs
+  test_scan_prior_single_instance
 )
 echo "==> (b) Shell integration: ${#INTEGRATION_TESTS[@]} tests"
 for t in "${INTEGRATION_TESTS[@]}"; do

--- a/tests/integration/test_remediate_runaway_procs.sh
+++ b/tests/integration/test_remediate_runaway_procs.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Test: remediate-runaway-procs.py — the CLASS 2 "stuck hook process" reaper.
+#
+# Bug class: a SessionStart hook that walks a large corpus piled up several
+# concurrent multi-minute copies (live parent, comm "Python") and froze the
+# machine (2026-06-05, load 36). The orphan-`yes` reaper (CLASS 1) never saw
+# them. CLASS 2 reaps a stuck ~/.claude/hooks/ python process, gated by path
+# scope + a dual age-AND-cpu threshold so a fast/idle/non-hook process is
+# never touched.
+#
+# The reap decision is factored into the pure function `_should_reap_hook`,
+# so this pos+neg control test exercises every branch DETERMINISTICALLY
+# without spawning or killing any real process.
+#
+# Assertions:
+#   POSITIVE control:
+#     1. A high-age, high-CPU python process under ~/.claude/hooks/ IS reaped.
+#   NEGATIVE controls (each must NOT be reaped):
+#     2. Same process but too young (age < min_age).
+#     3. Same process but low CPU (cpu < min_cpu).
+#     4. A high-age, high-CPU python process NOT under the hooks dir.
+#     5. A high-age, high-CPU process under the hooks dir but NOT python.
+#     6. The reaper's own pid (never reaps itself).
+#   END-TO-END:
+#     7. RUNAWAY_REMEDIATE_BYPASS=1 -> no-op, valid JSON, continue:true.
+#     8. main() with no matching process emits valid continue JSON (no crash).
+#
+# Self-contained. Exit 0 = pass, exit 1 = fail.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOK="$REPO_ROOT/hooks/remediate-runaway-procs.py"
+if [ ! -f "$HOOK" ]; then
+  echo "FAIL: reaper hook not found at $HOOK" >&2
+  exit 1
+fi
+
+# --- Assertions 1-6: pure-predicate pos/neg control ----------------------
+HOOK="$HOOK" python3 - <<'PY'
+import importlib.util
+import os
+import sys
+
+hook_path = os.environ["HOOK"]
+spec = importlib.util.spec_from_file_location("reaper_under_test", hook_path)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+HOOKS = os.path.expanduser("~/.claude/hooks/")
+hook_cmd = f"python3 {HOOKS}scan-prior-sessions-for-secrets.py"
+common = dict(hooks_dir=HOOKS, self_pid=999999, min_age=12.0, min_cpu=50.0)
+
+failures = []
+
+def check(label, expected, **kw):
+    got = mod._should_reap_hook(**kw)
+    if got is not expected:
+        failures.append(f"{label}: expected {expected}, got {got}")
+    else:
+        print(f"PASS: {label} -> {got}")
+
+# 1. POSITIVE: stuck hook process — high age + high cpu + hooks path + python.
+check("positive: stuck hook proc reaped", True,
+      command=hook_cmd, age_min=20.0, cpu=80.0, pid=12345, **common)
+
+# 2. NEG: too young (age < min_age).
+check("negative: young hook proc not reaped", False,
+      command=hook_cmd, age_min=2.0, cpu=80.0, pid=12345, **common)
+
+# 3. NEG: low cpu (cpu < min_cpu) — a bounded/idle hook is left alone.
+check("negative: low-cpu hook proc not reaped", False,
+      command=hook_cmd, age_min=20.0, cpu=10.0, pid=12345, **common)
+
+# 4. NEG: not under the hooks dir (a user program / busy compiler).
+check("negative: non-hook path not reaped", False,
+      command="python3 /usr/local/bin/some_user_script.py",
+      age_min=20.0, cpu=80.0, pid=12345, **common)
+
+# 5. NEG: under hooks dir but not python (e.g. a shell hook).
+check("negative: non-python hook proc not reaped", False,
+      command=f"bash {HOOKS}rotate-logs.sh",
+      age_min=20.0, cpu=80.0, pid=12345, **common)
+
+# 6. NEG: the reaper's own pid is never reaped.
+check("negative: self pid not reaped", False,
+      command=hook_cmd, age_min=20.0, cpu=80.0, pid=999999, **common)
+
+if failures:
+    print("PREDICATE CONTROL FAILED:", file=sys.stderr)
+    for f in failures:
+        print("  " + f, file=sys.stderr)
+    sys.exit(1)
+print("All predicate pos/neg controls passed.")
+PY
+
+echo "PASS: _should_reap_hook pos+neg control (assertions 1-6)"
+
+# --- Assertion 7: bypass env -> no-op, valid JSON -------------------------
+OUT="$(RUNAWAY_REMEDIATE_BYPASS=1 printf '{}' | RUNAWAY_REMEDIATE_BYPASS=1 python3 "$HOOK" 2>/dev/null)"
+echo "$OUT" | python3 -c 'import json,sys; d=json.load(sys.stdin); assert d.get("continue") is True, d' \
+  || { echo "FAIL: bypass did not emit continue:true JSON (got: $OUT)" >&2; exit 1; }
+echo "PASS: RUNAWAY_REMEDIATE_BYPASS=1 -> continue:true no-op"
+
+# --- Assertion 8: real run with no match -> valid continue JSON, no crash --
+# Set both gates absurdly high so nothing on the CI box matches; the hook must
+# still emit valid JSON and exit 0.
+OUT="$(printf '{}' | RUNAWAY_HOOK_MIN_AGE_MIN=99999 RUNAWAY_HOOK_MIN_CPU=999 RUNAWAY_PROC_NAMES=__none__ python3 "$HOOK" 2>/dev/null)"
+echo "$OUT" | python3 -c 'import json,sys; d=json.load(sys.stdin); assert d.get("continue") is True, d' \
+  || { echo "FAIL: no-match run did not emit valid continue JSON (got: $OUT)" >&2; exit 1; }
+echo "PASS: no-match run emits valid continue JSON (no crash)"
+
+echo
+echo "All assertions passed. CLASS-2 stuck-hook reaper invariant holds (pos+neg control)."

--- a/tests/integration/test_scan_prior_single_instance.sh
+++ b/tests/integration/test_scan_prior_single_instance.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Test: scan-prior-sessions-for-secrets.py — the single-instance / no-pile-up
+# regression for the 2026-06-05 freeze.
+#
+# Bug class (PRE-fix): the hook stamped its 6h cooldown marker AFTER the slow
+# corpus scan. So every session that started DURING the scan window saw no
+# fresh marker and launched its OWN full scan. N concurrent multi-minute scans
+# pegged the CPU until the machine froze (load 36). There was no single-instance
+# lock, no incremental baseline, no wall-clock budget.
+#
+# The fix this test guards: a flock single-instance lock + stamp-at-START. A
+# second concurrent invocation must back off IMMEDIATELY instead of starting a
+# second corpus scan — that is what "a fresh install on a multi-session machine
+# cannot pile up a corpus scan" means.
+#
+# Hermetic: the hook + its _lib are copied into a temp dir, so HOOK_DIR (and
+# therefore the lock + markers) live in the temp dir. HOME is pointed at the
+# temp dir too, so the scanned corpus is a tiny fixture we control. Nothing
+# touches the real ~/.claude or the repo working tree.
+#
+# Assertions:
+#   POSITIVE control (lock free):
+#     1. A free run completes, emits valid continue JSON, and PRIMES the
+#        incremental baseline (writes .last-secret-scan-full).
+#   NEGATIVE control / the regression (lock held by a concurrent "scan"):
+#     2. With the lock held, a second invocation backs off: it does NOT
+#        re-create the full-pass marker (it never reached the scan), and it
+#        still emits valid continue JSON. This is the no-pile-up guarantee.
+#
+# Exit 0 = pass, exit 1 = fail.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SRC_HOOK="$REPO_ROOT/hooks/scan-prior-sessions-for-secrets.py"
+SRC_LIB="$REPO_ROOT/hooks/_lib"
+if [ ! -f "$SRC_HOOK" ] || [ ! -d "$SRC_LIB" ]; then
+  echo "FAIL: scan hook or _lib not found under $REPO_ROOT/hooks" >&2
+  exit 1
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Hermetic hooks dir: HOOK_DIR := $TMP/hooks  (so lock + markers land here).
+HOOKS="$TMP/hooks"
+mkdir -p "$HOOKS/_lib"
+cp "$SRC_HOOK" "$HOOKS/scan-prior-sessions-for-secrets.py"
+cp "$SRC_LIB/__init__.py" "$SRC_LIB/secret_patterns.py" "$HOOKS/_lib/"
+HOOK="$HOOKS/scan-prior-sessions-for-secrets.py"
+
+# Tiny innocuous corpus under the fake HOME (~/.claude/projects).
+mkdir -p "$TMP/.claude/projects/proj"
+printf '{"type":"user","content":"hello world, nothing secret here"}\n' \
+  > "$TMP/.claude/projects/proj/session.jsonl"
+
+FULL_MARKER="$HOOKS/.last-secret-scan-full"
+MARKER="$HOOKS/.last-secret-scan"
+LOCK="$HOOKS/.secret-scan.lock"
+
+run_hook() {  # args: extra env assignments
+  printf '{}' | env HOME="$TMP" SCAN_PRIOR_AUTO_SCRUB_BYPASS=1 "$@" python3 "$HOOK" 2>/dev/null
+}
+
+# --- Assertion 1: POSITIVE control — a free run primes the baseline -------
+rm -f "$MARKER" "$FULL_MARKER" "$LOCK"
+OUT="$(run_hook)"
+echo "$OUT" | python3 -c 'import json,sys; d=json.load(sys.stdin); assert d.get("continue") is True, d' \
+  || { echo "FAIL: free run did not emit valid continue JSON (got: $OUT)" >&2; exit 1; }
+if [ ! -f "$FULL_MARKER" ]; then
+  echo "FAIL: free run did not prime the incremental baseline (.last-secret-scan-full missing)" >&2
+  exit 1
+fi
+echo "PASS: free run completes + primes incremental baseline"
+
+# --- Assertion 2: REGRESSION — second concurrent run cannot pile up -------
+# Remove the markers so neither the cooldown fast-path nor a primed baseline
+# can be what stops the second run. The ONLY thing that may stop it is the
+# single-instance lock, held below by a stand-in "concurrent scan".
+rm -f "$MARKER" "$FULL_MARKER"
+
+HOME="$TMP" LOCK="$LOCK" HOOK="$HOOK" FULL_MARKER="$FULL_MARKER" python3 - <<'PY'
+import fcntl, json, os, subprocess, sys
+
+lock_path = os.environ["LOCK"]
+hook = os.environ["HOOK"]
+full_marker = os.environ["FULL_MARKER"]
+home = os.environ["HOME"]
+
+# Stand-in for a concurrent scan already running: hold the exclusive lock.
+fh = open(lock_path, "w")
+fcntl.flock(fh, fcntl.LOCK_EX)
+
+env = dict(os.environ, HOME=home, SCAN_PRIOR_AUTO_SCRUB_BYPASS="1")
+proc = subprocess.run(["python3", hook], input="{}", capture_output=True, text=True, env=env)
+
+out = proc.stdout.strip()
+try:
+    d = json.loads(out)
+except Exception as exc:
+    print(f"FAIL: locked run did not emit valid JSON: {exc} (got: {out!r})", file=sys.stderr)
+    sys.exit(1)
+if d.get("continue") is not True:
+    print(f"FAIL: locked run JSON missing continue:true (got: {d})", file=sys.stderr)
+    sys.exit(1)
+# The decisive no-pile-up assertion: the backed-off run never reached the scan,
+# so it must NOT have written the full-pass marker.
+if os.path.exists(full_marker):
+    print("FAIL: locked run wrote the full-pass marker — it ran a second scan "
+          "instead of backing off (pile-up not prevented)", file=sys.stderr)
+    sys.exit(1)
+print("PASS: second concurrent run backed off (no second scan, no pile-up)")
+fcntl.flock(fh, fcntl.LOCK_UN)
+fh.close()
+PY
+
+echo
+echo "All assertions passed. scan single-instance / no-pile-up invariant holds."


### PR DESCRIPTION
## Why

The free product still shipped the OLD versions of two SessionStart hooks that could pile up across concurrent Claude Code sessions and peg every CPU core — the freeze class (heavy load, total lockup) that was fixed only in the maintainer's private copy and never ported here. A paying client whose machine freezes is a trust rupture; closing this in the shipped product is the point.

## What changed

**`scan-prior-sessions-for-secrets.py`** stamped its 6h cooldown *after* its slow corpus scan, so every session that started mid-scan launched its own full scan. Now:
- claim the cooldown marker **first** (stamp-at-START),
- single-instance `fcntl.flock` — a second concurrent session backs off instead of starting a second scan,
- **incremental** pass keyed on a `FULL_MARKER` baseline (only files changed since the last completed full pass),
- `os.nice(10)`, a cold/warm wall-clock budget, and a 3MB per-file cap so a single pass can never run away or starve the foreground.

**`remediate-runaway-procs.py`** only reaped orphaned `PPID=1` no-op procs — blind to a stuck hook with a **live** parent (the exact freeze class). Adds a second class: reap a `~/.claude/hooks/` python process running many minutes at high CPU, path-scoped with a **dual age-AND-cpu gate**. The decision is factored into a pure `_should_reap_hook` so it is testable without killing real processes. Tunable via `RUNAWAY_HOOK_MIN_AGE_MIN` / `RUNAWAY_HOOK_MIN_CPU`, bypass `RUNAWAY_REMEDIATE_BYPASS=1`.

## Wiring status

- `remediate-runaway-procs.py` **is** registered in the SessionStart block of `hooks.json` — its hardening is the live freeze-fix.
- `scan-prior-sessions-for-secrets.py` ships as defense-layer-4 but is **not** currently registered in the SessionStart block. It is hardened here regardless (so a future or user-side wire is safe by construction), and not newly wired — running an unbounded corpus scan on every SessionStart for every install is a separate product decision, and the safer default is to leave it unwired.

## SessionStart hook audit (Done= "every shipped SessionStart hook is bounded")

Every hook registered in `hooks.json` SessionStart was checked for the dangerous profile (unbounded `~/.claude/projects` corpus walk + per-file content read + no single-instance lock). Verdict: only the scan hook had it. All others are bounded — they work on small, capped sets, so N concurrent copies finish in seconds and cannot pile up:

| Hook | Heavy work? | Why bounded |
|---|---|---|
| `lint-claude-settings.py` (+ `--test`) | reads `settings.json` | single file |
| `check-claude-code-version.sh` | one version check | bounded |
| `first-week-checkin.py` | reads a few marker/state files | bounded, no corpus walk |
| `migrate-to-user-level.py` | reads specific files | bounded |
| `surface-orphan-claude-branches.py` | `git` + one-level `iterdir` | branch/worktree count (capped) |
| `surface-stranded-session-artifacts.py` | `git worktree list` + per-worktree `iterdir`, `timeout=15` | worktree count (capped) |
| `surface-orphan-worktree-snapshots.py` | `rglob` over the **snapshot** subtree only | bounded by the 30-day snapshot prune; not the projects corpus |
| `worktree-footprint-signal.py` | one-level `iterdir` | bounded |
| `enforce-worktree-cap.py` | `git` over worktree list | enforces the cap itself |
| `remediate-runaway-procs.py` | two `ps` calls, `timeout=15` | bounded |

No other hook needs a single-instance lock; the scan hook was the only one that walked an unbounded growing corpus and read every file's contents.

## Tests (wired into `scripts/ci.sh`)

- `test_remediate_runaway_procs.sh` — positive + negative control over `_should_reap_hook`: a stuck hook process is reaped; a young one, a low-CPU one, a non-hook program, a non-python process, and the reaper's own pid are all left alone. Plus the bypass env and a no-match end-to-end run.
- `test_scan_prior_single_instance.sh` — a second concurrent run backs off (no second scan) while the lock is held; a free run completes and primes the incremental baseline. A mutation check (lock disabled) was run locally and confirmed the test goes **red**, so the guard fails on the thing it catches.

Full gate green locally: `bash scripts/ci.sh` — py_compile (248 files, Python 3.9 path; both ports use `from __future__ import annotations`) + 12 integration tests.

Closes MYC-514. Pairs with MYC-511 (install/diagnose cloud-sync-root guard) to close both freeze classes in the shipped product.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
