### PR TITLE
cloud-sync: machine-wide machinery audit + the cure for an already-pegged sync daemon

### DIFF
--- a/docs/CLOUD_SYNC.md
+++ b/docs/CLOUD_SYNC.md
@@ -109,6 +109,7 @@ judgment.
 | SessionStart | `worktree-footprint-signal.py` | warns early on worktree count, orphan dirs, low free disk, and the dangerous vault-in-a-cloud-sync-folder combo |
 | SessionStart | `remediate-runaway-procs.py` | reaps orphaned runaway processes (the `yes`-pileup class), pure waste with zero recoverable output |
 | weekly cron | `scripts/worktree-prune.sh` | backstop: safe reclaim of orphan dirs + merged-branch cleanup + snapshot retention |
+| on-demand / weekly | `hooks/check-sync-folder-machinery.py` | audits **every** cloud-synced root (iCloud Drive, iCloud Desktop & Documents, OneDrive, Dropbox, Box, Google Drive) for machinery — `.git`, `node_modules`, build dirs, any 5k+-file dir — *anywhere on the machine*, not just the vault. Broader than the per-session `worktree-footprint-signal.py` (which only checks the vault's own location). Advisory, never blocks; `--self-test` proves it fires. |
 
 **The non-destructive contract.** Auto-remediation fixes only reconstructible
 things: a scratch worktree directory (recreatable from its branch), an orphaned
@@ -136,6 +137,68 @@ synced, and indexed. The `block-secret-in-note.py` write guard refuses a
 Write/Edit that would put a high-confidence credential (AWS / GitHub PAT /
 provider keys / database-URL passwords) into a `.md`/`.txt` note. Store it in
 the keychain or a gitignored secrets file and reference it by name instead.
+
+## Already melting? Rebuild the sync DB
+
+If a sync daemon is *already* pinned — on macOS, iCloud's `fileproviderd` and
+`bird` at 70-130% CPU for hours, a Finder that beachballs, files that won't
+download — the damage is usually a **corrupted local sync database**: it
+references hundreds of thousands of items that no longer exist and retries them
+forever. Removing the churn (above) stops it getting *worse*; it does **not**
+drain a backlog that already exists. You have to rebuild the database.
+
+Do it in this order, and **measure before and after each step — don't guess.**
+Stop at whichever step drops the CPU.
+
+**0. Confirm the diagnosis** (macOS):
+
+```bash
+# how many phantom entries is the File Provider DB retrying?
+fileproviderctl dump 2>/dev/null | grep -c itemNotFound
+# is fileproviderd actually pegged? (watch several samples, not one)
+top -l 4 -s 12 -o cpu -stats command,cpu | grep -E 'fileproviderd|bird'
+```
+
+A six-figure `itemNotFound` count plus sustained high CPU is the signature.
+
+**1. Remove the cause first.** Run the machinery audit and move anything it flags
+out of every sync folder. A rebuild only stays clean if nothing is still feeding
+it:
+
+```bash
+python3 ~/.claude/skills/ai-brain-starter/hooks/check-sync-folder-machinery.py
+```
+
+**2. Try the in-place repair (non-destructive).** macOS ships a consistency
+checker/repairer for the File Provider DB:
+
+```bash
+fileproviderctl check  -P -o /tmp/fpck-check.txt    # read-only: see the breakage
+fileproviderctl repair -P -o /tmp/fpck-repair.txt   # attempt an in-place reconcile
+```
+
+Re-measure. If the `itemNotFound` count and CPU drop, you're done. If `repair`
+finishes with `FPCKDomain Code=65` and the counts **don't** move, the domain is
+too corrupted for in-place repair — go to step 3.
+
+**3. Rebuild from the server (the supported reset).** System Settings → your
+Apple Account → iCloud → **iCloud Drive** → turn it **off**, choosing **"Keep a
+Copy"** of files on this Mac. Reboot. Turn iCloud Drive back **on**, and do
+**not** re-enable "Desktop & Documents folders". This discards the corrupt local
+DB and re-fetches a clean one from Apple's servers.
+
+- Expect a CPU spike and a long re-sync afterward — that part is normal; let it
+  run (hours, on a large drive).
+- **Back up first** (next section). Your local files are kept, but a tested backup
+  is the only safe way into an irreversible iCloud operation.
+
+> Heads-up: some users report Calendar/Contacts duplication after toggling iCloud,
+> and especially after signing out of the **whole** Apple Account. Toggle **only
+> iCloud Drive** — it's the narrower, safer move — and avoid a full account
+> sign-out unless step 3 alone doesn't take.
+
+Verify success the way you diagnosed it: the `itemNotFound` count collapses and
+`fileproviderd` settles to near-zero at idle.
 
 ## Order matters: back up before you move
 

--- a/hooks/check-sync-folder-machinery.py
+++ b/hooks/check-sync-folder-machinery.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""
+check-sync-folder-machinery.py
+
+Detect the failure class where high-churn / high-count directories (git repos,
+node_modules, build output, or any dir with thousands of files) live INSIDE a
+cloud File-Provider-synced folder — iCloud "Desktop & Documents", iCloud Drive,
+OneDrive, Dropbox, Box, or Google Drive.
+
+WHY: consumer cloud File Providers (iCloud `bird`/`fileproviderd`, Google
+`DriveFS`, OneDrive, Dropbox) sync documents well but choke catastrophically on
+machinery. Git rewrites `.git/index.lock` and pack objects on every operation,
+so the daemon can never converge -> a retry storm (fileproviderd pinned at
+70-130% CPU for hours) + silent repo/vault corruption. The phantom-error backlog
+can grow into the hundreds of thousands and survives even after you move the
+churn out, until the sync DB is rebuilt.
+
+This is a BROADER check than the per-session vault-location signal
+(`worktree-footprint-signal.py`, which asks "is THE VAULT in a cloud folder?").
+This one asks "is there ANY machinery in ANY synced root?" — so it also catches
+side repos, build trees, and caches that aren't the vault but still melt the
+daemon. It does a bounded filesystem walk, so it runs as a standalone audit /
+periodic (weekly) check, NOT as a per-session hook.
+
+RULE: machinery lives at a local home-root path (e.g. ~/dev, ~/code, ~/<vault>),
+backed up by git remotes + a real, restored-and-verified backup. Cloud sync is
+for documents only. Sync is not a backup.
+
+Advisory ONLY — always exits 0. Never blocks. Runnable standalone as a
+Mac-health audit.
+
+Usage:
+  check-sync-folder-machinery.py             # scan, human report
+  check-sync-folder-machinery.py --json      # machine-readable findings
+  check-sync-folder-machinery.py --self-test # negative control (proves it fires)
+"""
+import json
+import os
+import subprocess
+import sys
+import time
+
+HOME = os.path.expanduser("~")
+
+# Directory names that mean "machinery, never sync this"
+MARKER_DIRS = {".git", "node_modules", ".venv", "venv", "target",
+               "__pycache__", ".next", "dist", "build", ".tox", ".gradle"}
+# A plain folder this big is also too much for a File Provider to live-sync
+FILE_COUNT_THRESHOLD = 5000
+# Per-root safety budget so a streamed Google Drive can't hang the scan
+ROOT_TIME_BUDGET_S = 6.0
+MAX_DEPTH = 7
+
+
+def _defaults_bool(domain, key):
+    try:
+        out = subprocess.run(["defaults", "read", domain, key],
+                             capture_output=True, text=True, timeout=5)
+        return out.returncode == 0 and out.stdout.strip() == "1"
+    except Exception:
+        return False
+
+
+def synced_roots():
+    """Return [(path, provider)] of folders currently under cloud File Provider sync."""
+    roots = []
+    if _defaults_bool("com.apple.finder", "FXICloudDriveDesktop"):
+        roots.append((os.path.join(HOME, "Desktop"), "iCloud Desktop&Documents"))
+    if _defaults_bool("com.apple.finder", "FXICloudDriveDocuments"):
+        roots.append((os.path.join(HOME, "Documents"), "iCloud Desktop&Documents"))
+    icd = os.path.join(HOME, "Library/Mobile Documents/com~apple~CloudDocs")
+    if os.path.isdir(icd):
+        roots.append((icd, "iCloud Drive"))
+    cs = os.path.join(HOME, "Library/CloudStorage")
+    if os.path.isdir(cs):
+        for entry in sorted(os.listdir(cs)):
+            if entry.startswith("GoogleDrive-") or entry.startswith("Dropbox") \
+               or entry.startswith("OneDrive") or entry.startswith("Box"):
+                roots.append((os.path.join(cs, entry), entry.split("-")[0]))
+    return [(p, prov) for p, prov in roots if os.path.isdir(p)]
+
+
+def scan_root(root, provider):
+    """Bounded walk: flag machinery markers + oversized plain dirs. Prunes into markers."""
+    findings = []
+    start = time.monotonic()
+    base_depth = root.rstrip("/").count("/")
+    for dirpath, dirnames, filenames in os.walk(root, topdown=True):
+        if time.monotonic() - start > ROOT_TIME_BUDGET_S:
+            findings.append({"path": root, "provider": provider,
+                             "reason": "scan-time-budget-exceeded (large/streamed tree)",
+                             "severity": "info"})
+            break
+        if dirpath.count("/") - base_depth >= MAX_DEPTH:
+            dirnames[:] = []
+            continue
+        hit = MARKER_DIRS.intersection(dirnames)
+        for h in sorted(hit):
+            findings.append({"path": os.path.join(dirpath, h), "provider": provider,
+                             "reason": f"machinery dir '{h}' inside synced folder",
+                             "severity": "high"})
+        # don't descend into machinery we already flagged
+        dirnames[:] = [d for d in dirnames if d not in MARKER_DIRS]
+        if len(filenames) >= FILE_COUNT_THRESHOLD:
+            findings.append({"path": dirpath, "provider": provider,
+                             "reason": f"{len(filenames)}+ files in one synced dir",
+                             "severity": "high"})
+    return findings
+
+
+def run_scan():
+    findings = []
+    for root, provider in synced_roots():
+        findings.extend(scan_root(root, provider))
+    return findings
+
+
+def self_test():
+    """Negative control: build a synced-like tree with a .git, prove we flag it."""
+    import tempfile
+    ok = True
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = os.path.join(tmp, "myproject", ".git")
+        os.makedirs(repo)
+        big = os.path.join(tmp, "hugedir")
+        os.makedirs(big)
+        for i in range(FILE_COUNT_THRESHOLD + 5):
+            open(os.path.join(big, f"f{i}"), "w").close()
+        f = scan_root(tmp, "TEST")
+        got_marker = any(x["reason"].startswith("machinery dir '.git'") for x in f)
+        got_big = any("files in one synced dir" in x["reason"] for x in f)
+        # control: a clean docs tree must produce NOTHING
+        clean = os.path.join(tmp, "clean_docs")
+        os.makedirs(clean)
+        open(os.path.join(clean, "notes.md"), "w").close()
+        f2 = scan_root(clean, "TEST")
+        print(f"[self-test] detects .git inside synced folder: {got_marker}")
+        print(f"[self-test] detects oversized synced dir:      {got_big}")
+        print(f"[self-test] clean docs tree -> no findings:    {len(f2) == 0}")
+        ok = got_marker and got_big and len(f2) == 0
+    print("[self-test] PASS" if ok else "[self-test] FAIL")
+    return 0 if ok else 1
+
+
+def main():
+    if "--self-test" in sys.argv:
+        return self_test()
+    findings = run_scan()
+    high = [f for f in findings if f["severity"] == "high"]
+    if "--json" in sys.argv:
+        print(json.dumps({"findings": findings, "high_count": len(high)}, indent=2))
+        return 0
+    if not high:
+        print("[sync-guard] clean — no machinery found in any cloud-synced folder.")
+        for f in findings:
+            print(f"[sync-guard] note: {f['reason']} @ {f['path']}")
+        return 0
+    print("[sync-guard] ⚠️  MACHINERY FOUND IN CLOUD-SYNCED FOLDERS")
+    print("[sync-guard] This is the fileproviderd-storm + corruption risk class.")
+    for f in high:
+        print(f"[sync-guard]   • [{f['provider']}] {f['reason']}")
+        print(f"[sync-guard]     {f['path']}")
+    print("[sync-guard] FIX: move it to a local home-root path (e.g. ~/dev, ~/code),")
+    print("[sync-guard]      back up via git remote + a verified backup. Cloud sync is")
+    print("[sync-guard]      for documents only — and sync is not a backup.")
+    return 0  # advisory: never block
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/phases/phase-01-welcome.md
+++ b/phases/phase-01-welcome.md
@@ -246,7 +246,7 @@ Then say: *"I just installed Obsidian for you. Let's create your vault now."*
 
 **Never** ask the user to "go download Obsidian" — that breaks the one-command promise and assumes they know what Obsidian is and how to install a desktop app.
 
-7. "Now open Obsidian and choose 'Create new vault.' Name it whatever feels right — your name, 'Brain,' 'Notes,' whatever. Put it somewhere easy to find, like your Desktop. Let me know when it's created."
+7. "Now open Obsidian and choose 'Create new vault.' Name it whatever feels right — your name, 'Brain,' 'Notes,' whatever. Save it in your home folder (like `~/Brain` or `~/Notes`) — **not** Desktop or Documents, because those are cloud-synced (iCloud on Mac, OneDrive on Windows) and a vault should never live inside a sync folder; the churn melts the sync daemon (see `docs/CLOUD_SYNC.md`). Let me know when it's created."
 
 **Wait for confirmation before continuing.**
 

--- a/templates/rules/cloud-sync-machinery.md
+++ b/templates/rules/cloud-sync-machinery.md
@@ -1,0 +1,27 @@
+# Cloud sync = documents, not machinery
+
+Consumer cloud-sync folders (iCloud Drive, iCloud "Desktop & Documents", OneDrive, Dropbox, Box, Google Drive) sync DOCUMENTS well and choke on MACHINERY.
+
+**Machinery** = `.git`, `node_modules`, `.venv`/`venv`, build output (`dist`/`build`/`target`/`.next`/`.gradle`), caches (`.smart-env`, `.smart-connections`, `.codegraph`), any directory with thousands of files.
+
+**Why it breaks:** machinery rewrites files constantly (git rewrites `.git/index.lock` + pack objects every operation). The sync daemon (macOS `fileproviderd`/`bird`) can never converge → retry storm at 70-130% CPU for hours + silent repo/vault corruption. The phantom-error backlog grows into the hundreds of thousands and survives even after you move the churn out — until the sync DB is rebuilt.
+
+## Rules
+
+- Vault + repos + machinery live at a LOCAL home-root path (`~/dev`, `~/code`, `~/<vault>`). NEVER inside a sync folder. On macOS that means NOT `~/Desktop` or `~/Documents` when iCloud "Desktop & Documents" is on (both are synced); on Windows NOT inside `OneDrive\`.
+- Cloud sync is NOT a backup. Back up with a versioned git remote + an encrypted backup whose restore you have ACTUALLY tested. A backup you have never restored is a hope, not a backup.
+- Already on a sync path? Move it out, leave a symlink behind (the daemon follows the few-byte symlink, not the contents). Back up and verify the restore BEFORE relocating.
+- Don't put a `.git/` inside a cloud mirror. Mirror documents only; keep the repo's `.git` at the local home-root path.
+
+## Detect
+
+```bash
+# audit ANY machine for machinery in ANY synced root (broader than the per-session vault check)
+python3 ~/.claude/skills/ai-brain-starter/hooks/check-sync-folder-machinery.py
+```
+
+The per-session `worktree-footprint-signal.py` only checks whether THE VAULT sits in a sync folder. This audit walks every synced root for machinery anywhere — side repos, build trees, caches — and is the one to run on a machine that already feels broken.
+
+## Cure (daemon already pegged)
+
+See `docs/CLOUD_SYNC.md` § "Already melting? Rebuild the sync DB": confirm with `fileproviderctl dump | grep -c itemNotFound` → remove the cause (audit above) → `fileproviderctl repair` → if it errors `Code=65` and counts don't move, rebuild via iCloud Drive off ("Keep a Copy") → reboot → on. Measure before/after; never claim fixed without the number dropping.


### PR DESCRIPTION
## What
Closes the prevention→remediation gap for the cloud-sync / fileproviderd-storm failure class, and removes a wrong-steer in onboarding.

## Why
A real incident: a churning git+vault tree on iCloud accumulated **941K phantom `itemNotFound` entries** and pinned `fileproviderd` at 88-120% CPU for hours. The repo already documents PREVENTION (do not put machinery in a sync folder) but had: no CURE for a daemon already pegged, no machine-wide audit (only a per-session vault-location check), and `phase-01` still told new users to save the vault on the Desktop (iCloud-synced).

## Changes
- **`hooks/check-sync-folder-machinery.py`** (new): machine-wide audit of every cloud-synced root (iCloud Drive, iCloud Desktop & Documents, OneDrive, Dropbox, Box, Google Drive) for machinery (`.git`, `node_modules`, build dirs, 5k+-file dirs). Bounded walk, advisory (never blocks), `--self-test` negative control. Complements — does not duplicate — the per-session `worktree-footprint-signal.py` (vault-only).
- **`docs/CLOUD_SYNC.md`**: new "Already melting? Rebuild the sync DB" section — `fileproviderctl check/repair` then iCloud Drive off/on rebuild, with the `FPCK Code=65` escalation signal and measure-before/after discipline. Plus a guardrails-table row.
- **`phases/phase-01-welcome.md`**: vault-location guidance now points to a local home-root path, explicitly NOT Desktop/Documents (iCloud on Mac / OneDrive on Windows).
- **`templates/rules/cloud-sync-machinery.md`** (new): agent rule card.

## Verification
- `check-sync-folder-machinery.py --self-test` → PASS (flags `.git` + oversized dir in a synthetic synced tree; clean docs tree → 0 findings).
- Live run flags real machinery on the incident machine.
- Personal-data scrub: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)