### PR TITLE
chore(privacy): scrub real third-party names from published markdown

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1051,7 +1051,7 @@ The full session-close cascade, all 14 bundled skills, all the Phase 5 setup, ev
 
 ### Layer 1 — Reliability foundations
 
-- **Vault schema linter.** Same permanent-fix pattern that saved settings.json. New `hooks/lint-vault-frontmatter.py` is a PreToolUse hook that catches malformed YAML in Decisions/, Sessions/, and journal frontmatter before it lands. New `scripts/vault-schema-validator.py` is a standalone validator with 9-fixture self-test, runnable in CI or on-demand. Per-type schemas at `templates/schemas/{decision,session,journal}.json`. Closes the same class of bug that nuked Sergio's CRM 2026-04-27 (silent YAML parse error → empty re-marshal over real content).
+- **Vault schema linter.** Same permanent-fix pattern that saved settings.json. New `hooks/lint-vault-frontmatter.py` is a PreToolUse hook that catches malformed YAML in Decisions/, Sessions/, and journal frontmatter before it lands. New `scripts/vault-schema-validator.py` is a standalone validator with 9-fixture self-test, runnable in CI or on-demand. Per-type schemas at `templates/schemas/{decision,session,journal}.json`. Closes the same class of bug that nuked a real CRM record 2026-04-27 (silent YAML parse error → empty re-marshal over real content).
 - **Bootstrap reliability bundle (closes [#2](https://github.com/adelaidasofia/ai-brain-starter/issues/2), [#3](https://github.com/adelaidasofia/ai-brain-starter/issues/3), [#4](https://github.com/adelaidasofia/ai-brain-starter/issues/4) at once).** New flags: `--restore` for interactive recovery from .bak files, `--smoke-test` for end-to-end install verification, `--detect-partial` for finding half-installed components. Persistent log at `~/.claude/.bootstrap.log` with size-based rotation. Three new scripts: `bootstrap-restore.sh`, `detect-partial-installs.sh`, `post-install-smoke-test.sh`. The smoke test runs Python syntax, bash syntax, JSON validity, hook smoke tests, aggregator smoke tests, schema validator self-test, and the closing-signal fixture harness — 130+ checks in one command.
 
 ### Layer 2 — Telemetry foundation
@@ -1749,7 +1749,7 @@ Existing installs aren't auto-removed — this only affects new `/setup-brain` r
 
 Post-consolidation audit caught three things: a PowerShell parser bug that broke every Windows bootstrap run, bun left in as dead weight, and install verbs that leaked past the phase-file firewall.
 
-- **`bootstrap.ps1`**: `"$sub:"` in two status lines was parsed by PowerShell as a scope accessor (`$scope:name`), erroring on every bundled sub-skill. Fixed with `"${sub}:"`. Sergio (and any Windows user) would have hit this on every install.
+- **`bootstrap.ps1`**: `"$sub:"` in two status lines was parsed by PowerShell as a scope accessor (`$scope:name`), erroring on every bundled sub-skill. Fixed with `"${sub}:"`. Windows users would have hit this on every install.
 - **`bootstrap.sh` + `.ps1`**: removed bun. It was a claude-mem runtime dep that stayed after claude-mem was dropped. Nothing currently depends on it.
 - **`phases/`**: pulled remaining install verbs (brew/winget/snap/flatpak/git-clone/cp -R/mcpServers) out of phase-01, -04, -06-09, -11. Phases now defer to bootstrap for any install recovery.
 - **CHANGELOG**: compressed the top three entries from 3-paragraph templates to 1-paragraph + bullets. Cleanup commits don't need the full template.

--- a/docs/CHANGELOG_archive_2026Q1.md
+++ b/docs/CHANGELOG_archive_2026Q1.md
@@ -689,7 +689,7 @@ Added a new CLAUDE.md template block (`SKILL.md` Phase 0) that tells future Clau
 | "What links to this file?" | `obsidian backlinks file="Name"` | Source of each backlink |
 | Editing a specific file | `Read` the file directly | — |
 
-**Also documented:** when merging duplicate concept nodes (e.g. "Accenture" vs "Accenture Colombia" vs "Accenture LATAM"), always update **aliases in the canonical file's frontmatter**. Never rename or delete — aliases preserve existing `[[Old Name]]` wikilinks automatically. Hit real cases of this during Adelaida's 2026-04-10 runs (Accenture, Anthony Rose).
+**Also documented:** when merging duplicate concept nodes (e.g. "Acme Corp" vs "Acme Corp West" vs "Acme Corp LATAM"), always update **aliases in the canonical file's frontmatter**. Never rename or delete — aliases preserve existing `[[Old Name]]` wikilinks automatically. Hit real cases of this during the 2026-04-10 runs (a corporate-client node and a person node).
 
 ---
 
@@ -701,7 +701,7 @@ Added `scripts/auto-wikilink.py` (v2). The previous version had three critical b
 
 2. **Reached across the team-vault symlink** when building its term list, linking team-vault files to personal-vault concept notes. This violated the team-vault firewall: team members opening the synced docs would see references to private personal-vault folders they don't have access to.
 
-3. **Substitution regex over-matched** when emoji or special characters were near a match. "A VP at Accenture" became "Curiosities/Colombiaccenture]]" because the negative lookbehind `(?<!\[\[)` only checked 2 characters back, and the lookahead `(?!\]\]|[^\[]*\]\])` was fragile around unicode.
+3. **Substitution regex over-matched** when emoji or special characters were near a match. "A VP at Acme Corp" became "Curiosities/Colombiacme Corp]]" because the negative lookbehind `(?<!\[\[)` only checked 2 characters back, and the lookahead `(?!\]\]|[^\[]*\]\])` was fragile around unicode.
 
 **v2 fixes all three:**
 

--- a/phases/phase-01-welcome.md
+++ b/phases/phase-01-welcome.md
@@ -25,7 +25,7 @@ If the file exists and parses cleanly, capture these into your working memory:
 - `RECAP_BRANCH` (informational, used to tune Phase 11 wiring)
 - `RECAP_OS` (informational, used to skip the OS-detection step in Phase 5)
 
-`name` + `email` are facts the user typed themselves on the install page. Reuse them. `lang` is a server-side default from a one-field form (the install page defaults to `"en"` if no language is selected — Sneider's signup hit this default and the recap.lang was `"en"` even though no one ever asked him). Treat it as background context only.
+`name` + `email` are facts the user typed themselves on the install page. Reuse them. `lang` is a server-side default from a one-field form (the install page defaults to `"en"` if no language is selected — an early signup hit this default and the recap.lang was `"en"` even though no one ever asked the user). Treat it as background context only.
 
 If the file is missing or malformed, fall back to the standard interview flow below (ask everything from scratch).
 
@@ -169,7 +169,7 @@ Then store:
 - `PRIMARY_LANGUAGE` — the language they chose to set up in (whatever they answered in / wrote)
 - `SECONDARY_LANGUAGES` — list (possibly empty) of every other language they mentioned. These drive the alias generation later.
 
-**Why the recap.lang cannot drive this:** the install signup form defaults to `lang: "en"` when no field is provided (which is most of the time, because the form prefills it from URL params or browser locale). A user who never picked English ends up with `recap.lang: "en"` and a setup interview that silently runs in English. The first install where this surfaced: Sneider, 2026-05-12, recap-defaulted to English without ever being asked. Don't trust recap.lang as authoritative. Open polyglot. Let the user pick by responding.
+**Why the recap.lang cannot drive this:** the install signup form defaults to `lang: "en"` when no field is provided (which is most of the time, because the form prefills it from URL params or browser locale). A user who never picked English ends up with `recap.lang: "en"` and a setup interview that silently runs in English. The first install where this surfaced recap-defaulted to English without the user ever being asked. Don't trust recap.lang as authoritative. Open polyglot. Let the user pick by responding.
 
 Wait for their answer. Store it as:
 - `PRIMARY_LANGUAGE` — the one language the whole bot runs in


### PR DESCRIPTION
## What

Scrubs three real third-party names from published markdown that the `personal-pii-scrub` CI gate structurally could not catch — its `git grep` excludes `*.md` and `docs/` (the **PII-GATE-MARKDOWN-BLIND-SPOT** bug class).

| File | Was | Now |
|---|---|---|
| `docs/CHANGELOG.md` (×2) | a former collaborator's name | generic ("a real CRM record", "Windows users") |
| `phases/phase-01-welcome.md` (×2) | a real signup name + date | "an early signup" |
| `docs/CHANGELOG_archive_2026Q1.md` (×2 + 1 person) | a real corporate client + person | "Acme Corp" / generic node |

All were throwaway debug / graph-merge examples — the generic placeholders carry the **identical technical meaning**.

## What is NOT touched

Author attribution (`Adelaida Diaz-Roa` in README + changelog history) is intentional and load-bearing per the repo's own `CLAUDE.md`. Published-feature tokens (`Onde` lead-magnet rule, `Colombia` advisory-panel localization, `High-Rise` framework) are deliberate public substrate.

## Follow-up (separate change)

The gate's markdown blind spot itself is fixed in the auto-managed source (`gh-harden-repos.sh` Layer 8): a new markdown-scan tier that catches private-third-party names + vault paths in `.md` while allowlisting author-attribution files. That broadened gate is deployed *after* this content PR merges (per the auto-managed-gate-self-dos rule — the pre-deploy dry-run must see a clean tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)