### PR TITLE
setup: exclude machine-generated folders from Obsidian index (prevents 100%+ CPU on mature vaults)

### DIFF
--- a/phases/phase-02-03-plugins-folders.md
+++ b/phases/phase-02-03-plugins-folders.md
@@ -96,6 +96,21 @@ if app_file.exists():
     except Exception:
         app_settings = {}
 app_settings.setdefault("fileSortOrder", "byModifiedTime")
+
+# Exclude machine-generated folders from Obsidian's index. The brain's hooks
+# write thousands of files into these over a vault's lifetime — session stubs,
+# worktree snapshots, rotating logs. They are machinery, not notes. On a mature
+# vault, leaving them indexed pins "Obsidian Helper (Renderer)" at 100%+ CPU and
+# makes the app feel broken. Excluding them keeps the index to your real
+# documents. Merge so we never clobber filters the user set themselves.
+machinery_excludes = [
+    "⚙️ Meta/Worktree Snapshots/",
+    "⚙️ Meta/Sessions/",
+    "⚙️ Meta/logs/",
+]
+existing_filters = app_settings.get("userIgnoreFilters") or []
+app_settings["userIgnoreFilters"] = list(dict.fromkeys(existing_filters + machinery_excludes))
+
 app_file.write_text(json.dumps(app_settings, indent=2))
 
 # Write sortspec.md for custom-sort plugin — sorts ALL folders by the most


### PR DESCRIPTION
## Problem
The starter tells every user to open their vault in Obsidian. Over a vaults lifetime, the brains hooks write **thousands** of machine files into `⚙️ Meta/Worktree Snapshots/`, `⚙️ Meta/Sessions/`, and `⚙️ Meta/logs/`. Obsidian indexes all of them, and on a mature vault that pins **Obsidian Helper (Renderer) at 100%+ CPU** (observed live: **544%** on a ~150K-file vault) — the app feels broken. These are machinery, not notes.

## Fix
`phase-02-03` already writes `.obsidian/app.json` during setup. This adds `userIgnoreFilters` for those three machine-folders, merging so it never clobbers filters the user set themselves. New installs (and any re-run of setup) get a vault whose index covers only real documents.

## Verification
- Confirmed live: adding these three excludes to a choking ~150K-file vaults `app.json` is what tamed it.
- Merge-preserving: existing `userIgnoreFilters` are kept (dedup).
- The three folder names match exactly what the shipped hooks generate (snapshot-pending-work-on-stop, aggregate-sessions, log rotation).

## Existing users
Re-run setup, or add the three folders under **Settings -> Files & links -> Excluded files**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)