### PR TITLE
fix(worktree-reclaim): reclaim relocation-orphans instead of keeping them forever

### DIFF
--- a/hooks/_lib/worktree_safety.py
+++ b/hooks/_lib/worktree_safety.py
@@ -298,10 +298,107 @@ def list_orphan_dirs(main_repo: Path) -> list[Path]:
     return orphans
 
 
+def _gitfile_target(orphan: Path) -> Path | None:
+    """If `orphan/.git` is a `gitdir: <path>` pointer file, return <path>, else None.
+
+    A worktree's `.git` is a one-line pointer file (not a dir). A relocation
+    copies it verbatim, so it still points at the OLD location's gitdir.
+    """
+    gitfile = orphan / ".git"
+    try:
+        if not gitfile.is_file():
+            return None
+        txt = gitfile.read_text(encoding="utf-8", errors="replace").strip()
+    except OSError:
+        return None
+    if not txt.startswith("gitdir:"):
+        return None
+    target = txt[len("gitdir:"):].strip()
+    if not target:
+        return None
+    p = Path(target)
+    if not p.is_absolute():
+        p = orphan / p
+    return p
+
+
+def _is_relocation_orphan(orphan: Path, main_repo: Path) -> bool:
+    """True iff `orphan/.git` points at a gitdir that is DANGLING (gone) or
+    EXTERNAL (outside this repo's `.git`) — the vault-relocation / copied-checkout
+    class that `git status` can't evaluate but the MAIN object DB still can.
+
+    Conservative: no clear pointer → False (keep, unknown provenance).
+    """
+    target = _gitfile_target(orphan)
+    if target is None:
+        return False
+    try:
+        main_git = (main_repo / ".git").resolve()
+    except OSError:
+        return False
+    if not target.exists():
+        return True  # dangling: original gitdir is gone (the relocation case)
+    try:
+        target.resolve().relative_to(main_git)
+        return False  # inside this repo's own .git tree — a real registration
+    except (ValueError, OSError):
+        return True  # external: points at a different/foreign .git tree
+
+
+def _reclaim_disconnected_orphan(main_repo: Path, orphan: Path, slug: str) -> tuple[str, int]:
+    """Reclaim a relocation-orphan whose own git metadata is unusable.
+
+    A worktree is a checkout of commits in the MAIN repo's shared object store,
+    so `unrecoverable_content(main_repo, ...)` stays a definitive recoverability
+    oracle even when the orphan's `.git` pointer is dead. Snapshot the
+    genuinely-unique files (uncommitted work that survived the move), then remove.
+    Fails SAFE: never deletes a file whose content isn't provably in the object DB
+    (unrecoverable_content over-preserves on any hiccup), and never removes the
+    dir if any unique file could not be copied out first.
+    """
+    files: list[Path] = []
+    try:
+        for root, dirs, fs in os.walk(orphan):
+            dirs[:] = [d for d in dirs if d not in EXHAUST]
+            for f in fs:
+                if f in EXHAUST:  # skip the .git pointer file, .DS_Store, etc.
+                    continue
+                files.append(Path(root) / f)
+    except OSError:
+        return ("kept-unsafe", 0)
+    uniq = unrecoverable_content(main_repo, files)
+    snap_root = snapshot_dir_for(main_repo) / slug
+    snapped = 0
+    all_safe = True
+    for src in uniq:
+        if not src.is_file():
+            continue
+        try:
+            rel = src.relative_to(orphan)
+        except ValueError:
+            all_safe = False
+            continue
+        dst = snap_root / rel
+        try:
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dst)
+            snapped += 1
+        except OSError:
+            all_safe = False
+    if not all_safe:
+        return ("kept-unsafe", snapped)
+    try:
+        shutil.rmtree(orphan)
+    except OSError:
+        return ("kept-unsafe", snapped)
+    return ("relocation-orphan+removed" if snapped else "relocation-orphan-removed", snapped)
+
+
 def reclaim_orphan_dir(main_repo: Path, orphan: Path, idle_min: int = 60) -> tuple[str, int]:
     """Safely reclaim one orphan worktree dir. Returns (action, snapshotted).
 
-    action ∈ {removed, snapshot+removed, kept-active, kept-unsafe, kept-dangling}.
+    action ∈ {removed, snapshot+removed, kept-active, kept-unsafe, kept-dangling,
+              relocation-orphan-removed, relocation-orphan+removed}.
 
     Fast + fail-safe — never `rm -rf` a dir we can't reason about:
       * idle gate: a dir touched < idle_min ago is left (a live/paused session).
@@ -310,9 +407,12 @@ def reclaim_orphan_dir(main_repo: Path, orphan: Path, idle_min: int = 60) -> tup
           - dirty       → snapshot ONLY the dirty set (small; definitive object-DB
                           recoverability test) then rm iff every unsaved file was
                           safely copied.
-          - git errors  → the dir is disconnected from git; KEEP it and report
-                          `kept-dangling` for manual review. Never delete a dir
-                          whose recoverability we cannot establish.
+          - git errors  → the dir is disconnected from git. If its `.git` pointer
+                          is dangling/external (the vault-RELOCATION copied-checkout
+                          class that let `.claude/worktrees` reach 100k+ files), the
+                          MAIN repo's object DB is still a definitive recoverability
+                          oracle: snapshot the genuinely-unique files, then remove.
+                          Otherwise (unknown provenance) KEEP + report `kept-dangling`.
 
     Unlike the bash prune's section-2 (`rm -rf` with no snapshot), this can lose
     nothing: the only dirs deleted are clean checkouts or dirs whose unsaved
@@ -323,9 +423,15 @@ def reclaim_orphan_dir(main_repo: Path, orphan: Path, idle_min: int = 60) -> tup
         return ("kept-active", 0)
     try:
         st = git(orphan, ["status", "--porcelain", "-z"], timeout=60)
+        status_rc = st.returncode
     except (subprocess.TimeoutExpired, OSError):
-        return ("kept-dangling", 0)
-    if st.returncode != 0:
+        status_rc = -1
+    if status_rc != 0:
+        # git can't evaluate this dir. A relocation-orphan (dangling/external
+        # .git pointer — copied during a vault move; original gitdir gone) is
+        # still reclaimable against the MAIN object DB; anything else stays kept.
+        if _is_relocation_orphan(orphan, main_repo):
+            return _reclaim_disconnected_orphan(main_repo, orphan, slug)
         return ("kept-dangling", 0)
     dirty = [
         orphan / e[3:].decode("utf-8", "replace")

--- a/hooks/test_relocation_orphan_reclaim.py
+++ b/hooks/test_relocation_orphan_reclaim.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Regression test: worktree_safety.reclaim_orphan_dir handles RELOCATION-ORPHANS.
+
+Bug class VAULT-MACHINERY-BLOAT-CHOKES-OBSIDIAN (root: worktree auto-cleanup not
+keeping up). When a vault is relocated (e.g. iCloud Drive -> a local disk),
+`.claude/worktrees/` is copied wholesale and each copied worktree's `.git` pointer
+still references the GONE old path, so `git status` fails and the safe reclaim
+classified them `kept-dangling` and NEVER removed them — letting `.claude/worktrees`
+reach 100k+ files and melt Obsidian's file watcher. Fix: a dangling/external `.git`
+pointer is the relocation / pruned-registration class; the MAIN repo's object DB is
+still a definitive recoverability oracle, so snapshot the genuinely-unique files
+then remove.
+
+NEGATIVE CONTROLS (the guard must FAIL on the thing it catches):
+  - unsaved-unique file MUST be snapshotted before the dir is deleted (no work loss)
+  - garbage / unknown-provenance `.git` -> KEPT
+  - active dir (touched < idle_min) -> KEPT
+Run: python3 hooks/test_relocation_orphan_reclaim.py
+"""
+import os, subprocess, sys, tempfile, time, shutil
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _lib.worktree_safety import (  # noqa: E402
+    reclaim_orphan_dir, _is_relocation_orphan, snapshot_dir_for,
+)
+
+
+def sh(repo, *args):
+    return subprocess.run(["git", "-C", str(repo), *args], capture_output=True, check=False)
+
+
+def make_main():
+    d = Path(tempfile.mkdtemp(prefix="wt-main-"))
+    sh(d, "init", "-q"); sh(d, "config", "user.email", "t@t"); sh(d, "config", "user.name", "t")
+    (d / "committed.md").write_text("COMMITTED CONTENT\n")
+    (d / "⚙️ Meta").mkdir(parents=True, exist_ok=True)  # snapshot_dir_for -> vault path
+    sh(d, "add", "committed.md"); sh(d, "commit", "-qm", "init")
+    (d / ".claude" / "worktrees").mkdir(parents=True)
+    return d
+
+
+def make_orphan(main, slug, gitdir, unique=False, idle=True):
+    o = main / ".claude" / "worktrees" / slug
+    o.mkdir(parents=True)
+    (o / "committed.md").write_text("COMMITTED CONTENT\n")          # recoverable (in object DB)
+    if unique:
+        (o / "UNSAVED.md").write_text("UNIQUE UNSAVED WORK %s\n" % slug)  # NOT in object DB
+    if gitdir is not None:
+        (o / ".git").write_text("gitdir: %s\n" % gitdir)
+    if idle:
+        old = time.time() - 7200
+        for root, _, fs in os.walk(o):
+            for f in fs:
+                os.utime(os.path.join(root, f), (old, old))
+        os.utime(o, (old, old))
+    return o
+
+
+fails = []
+def check(name, cond):
+    print(("PASS" if cond else "FAIL"), name)
+    if not cond:
+        fails.append(name)
+
+
+def main():
+    # T1: relocation-orphan, all content recoverable -> removed, nothing snapshotted
+    m = make_main()
+    o = make_orphan(m, "reloc-clean", "/nonexistent/Desktop/.git/worktrees/reloc-clean")
+    check("T1 _is_relocation_orphan==True", _is_relocation_orphan(o, m))
+    act, snap = reclaim_orphan_dir(m, o, idle_min=60)
+    check("T1 action relocation-orphan-removed", act == "relocation-orphan-removed")
+    check("T1 dir gone", not o.exists())
+    check("T1 snapped==0", snap == 0)
+    shutil.rmtree(m, ignore_errors=True)
+
+    # T2: relocation-orphan WITH unique unsaved file -> snapshot THEN remove (key safety)
+    m = make_main()
+    o = make_orphan(m, "reloc-dirty", "/nonexistent/old/.git/worktrees/reloc-dirty", unique=True)
+    act, snap = reclaim_orphan_dir(m, o, idle_min=60)
+    check("T2 action relocation-orphan+removed", act == "relocation-orphan+removed")
+    check("T2 snapped>=1", snap >= 1)
+    check("T2 dir gone", not o.exists())
+    sf = snapshot_dir_for(m) / "reloc-dirty" / "UNSAVED.md"
+    check("T2 unique file SNAPSHOTTED before delete", sf.is_file())
+    check("T2 snapshot content preserved", sf.is_file() and "UNIQUE UNSAVED WORK" in sf.read_text())
+    shutil.rmtree(m, ignore_errors=True)
+
+    # T3 (NEG): garbage .git (no gitdir pointer) -> unknown provenance -> KEPT
+    m = make_main()
+    o = m / ".claude" / "worktrees" / "garbage"; o.mkdir(parents=True)
+    (o / "committed.md").write_text("COMMITTED CONTENT\n")
+    (o / "UNSAVED.md").write_text("UNIQUE\n")
+    (o / ".git").write_text("this is not a gitdir pointer\n")
+    old = time.time() - 7200
+    for root, _, fs in os.walk(o):
+        for f in fs:
+            os.utime(os.path.join(root, f), (old, old))
+    os.utime(o, (old, old))
+    check("T3 _is_relocation_orphan==False (garbage .git)", not _is_relocation_orphan(o, m))
+    act, snap = reclaim_orphan_dir(m, o, idle_min=60)
+    check("T3 action kept-dangling", act == "kept-dangling")
+    check("T3 dir KEPT (not deleted)", o.exists())
+    shutil.rmtree(m, ignore_errors=True)
+
+    # T4 (NEG): relocation-orphan but ACTIVE -> kept-active, never deleted
+    m = make_main()
+    o = make_orphan(m, "reloc-active", "/nonexistent/.git/worktrees/reloc-active", unique=True, idle=False)
+    act, snap = reclaim_orphan_dir(m, o, idle_min=60)
+    check("T4 action kept-active", act == "kept-active")
+    check("T4 dir KEPT (active not deleted)", o.exists())
+    shutil.rmtree(m, ignore_errors=True)
+
+    # T5 (NEG): .git -> EXISTING dir inside main .git = live registration, not relocation
+    m = make_main()
+    o = m / ".claude" / "worktrees" / "realish"; o.mkdir(parents=True)
+    tgt = m / ".git" / "worktrees" / "realish"; tgt.mkdir(parents=True)
+    (o / ".git").write_text("gitdir: %s\n" % tgt)
+    check("T5 _is_relocation_orphan==False (existing dir inside main .git)", not _is_relocation_orphan(o, m))
+    # T5b: dangling pointer INTO own .git (pruned registration) IS reclaimable (classic orphan)
+    o2 = m / ".claude" / "worktrees" / "pruned"; o2.mkdir(parents=True)
+    (o2 / ".git").write_text("gitdir: %s\n" % (m / ".git" / "worktrees" / "pruned-GONE"))
+    check("T5b _is_relocation_orphan==True (dangling into own .git)", _is_relocation_orphan(o2, m))
+    shutil.rmtree(m, ignore_errors=True)
+
+    print()
+    if fails:
+        print("FAILED:", fails)
+        return 1
+    print("ALL TESTS PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Problem
Complements #157 (which hid machine-generated folders from the Obsidian index). That fix stopped Obsidian from *indexing* the bloat; this fix stops the bloat from *existing*.

When a vault is relocated (e.g. iCloud Drive → a local disk), `.claude/worktrees/` is copied wholesale. Each copied worktree keeps a `.git` pointer to the **gone** old gitdir, so `git status` fails inside it. The safe reclaim (`reclaim_orphan_dir`) then classified these `kept-dangling` and **never removed them** — letting `.claude/worktrees` reach 100k+ files and melt Obsidian's file watcher (400-500% CPU).

## Fix
A dangling or external `.git` pointer is the relocation / pruned-registration class. The **main** repo's object DB is still a definitive recoverability oracle (a worktree is a checkout of commits in the shared store), so:
- snapshot the genuinely-unique files (uncommitted work that survived the move), then remove the dir.
- **Fails SAFE**: unknown-provenance (garbage `.git`), active (touched < idle_min), and uncopyable dirs are KEPT.
- Bonus: also reclaims the classic **pruned-registration** orphan (dangling pointer into the repo's own `.git`), which the old code likewise kept forever.

## Tests
`hooks/test_relocation_orphan_reclaim.py` — positive paths + negative controls (unsaved-unique file must be snapshotted before delete; garbage/active dirs KEPT). All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)