### PR TITLE
feat(cloud-sync guard): block vault-in-cloud-sync-root at install + diagnose + SessionStart

### DIFF
--- a/hooks/worktree-footprint-signal.py
+++ b/hooks/worktree-footprint-signal.py
@@ -96,14 +96,24 @@ def main() -> int:
 
     lines: list[str] = []
 
-    if cloud and (registered or on_disk):
+    # Fire on ANY git-backed vault inside cloud sync — not only once worktrees
+    # exist. A fresh iCloud install with zero worktrees is ALREADY dangerous: the
+    # `.git/` rewrites on every commit and the sync daemon chokes on that alone
+    # (the .git-in-mirror variant). Catching it at first SessionStart beats
+    # catching it after the machine is already churning.
+    has_git = (main_repo / ".git").exists()
+    if cloud and (has_git or registered or on_disk):
+        if on_disk:
+            wt_note = f"it has {on_disk} worktree checkout(s); "
+        else:
+            wt_note = "even with zero worktrees its `.git/` rewrites on every commit; "
         lines.append(
-            f"⚠️  [footprint] This vault is inside **{cloud}**, and it has "
-            f"{on_disk} worktree checkout(s). Consumer cloud-sync + churning git "
-            f"worktrees = the sync-storm failure mode (millions of files, pegged "
-            f"CPU). The vault belongs on a local disk; the index belongs "
-            f"server-side. Move it out of the sync folder (see docs/CLOUD_SYNC.md), "
-            f"or at minimum keep `.claude/`, `.git/`, `.smart-env/` out of sync scope."
+            f"⚠️  [footprint] This vault is inside **{cloud}** — {wt_note}"
+            f"consumer cloud-sync + git churn = the sync-storm failure mode "
+            f"(millions of file events, pegged CPU, frozen machine). The vault "
+            f"belongs on a local disk; the index belongs server-side. Move it out "
+            f"of the sync folder (see docs/CLOUD_SYNC.md), or at minimum keep "
+            f"`.claude/`, `.git/`, `.smart-env/` out of sync scope."
         )
 
     if registered > warn_at or orphans > 0:

--- a/phases/phase-01-welcome.md
+++ b/phases/phase-01-welcome.md
@@ -254,3 +254,12 @@ Then say: *"I just installed Obsidian for you. Let's create your vault now."*
 
 Save the vault path — you'll use it for all file operations.
 
+8.5. **GUARD — before saving the path, verify it is NOT inside a cloud-sync folder.** This is mandatory: a git-backed vault inside iCloud / OneDrive / Dropbox / Google Drive / Box melts the OS sync daemon (pegged CPU, frozen machine). Run:
+
+```bash
+python3 ~/.claude/skills/ai-brain-starter/scripts/check-cloud-sync.py --porcelain "<VAULT_PATH>"
+```
+
+- Output starts with `OK_LOCAL` → good, continue.
+- Output starts with `CLOUD_SYNC_RISK:` → **STOP. Do not continue the install.** Tell the user plainly: *"That location is inside <service>, which is cloud-synced — a vault there will freeze your machine. Please move the vault (or create a new one) somewhere local like `~/Brain` or `~/vaults/<name>`, then paste the new path."* Re-run this check on the new path. Do not proceed until it returns `OK_LOCAL`. (If the vault is large and already there, see `docs/CLOUD_SYNC.md` for how to move it out safely.)
+

--- a/scripts/check-cloud-sync.py
+++ b/scripts/check-cloud-sync.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Guard: refuse a vault path that resolves inside a consumer cloud-sync root.
+
+A git-backed Obsidian vault placed inside iCloud / OneDrive / Dropbox / Google
+Drive / Box melts the OS sync daemon (fileproviderd/bird/cloudd on macOS): the
+high-churn `.git/` + per-session worktree checkouts generate millions of file
+events the sync client tries to upload, pegging CPU and freezing the machine.
+The vault belongs on a real local disk; the index belongs server-side.
+
+This is the SINGLE source of truth for that check — install (phase-01-welcome),
+diagnose.sh/.ps1, and the SessionStart footprint signal all route through the
+same `detect_cloud_sync()` so there is no drift between surfaces.
+
+Usage:
+  check-cloud-sync.py <vault-path>          # human-readable verdict + remedy
+  check-cloud-sync.py --porcelain <path>    # one machine-readable line
+
+Exit codes:
+  0  OK    — path is on a local disk
+  1  RISK  — path resolves inside a consumer cloud-sync root (the freeze class)
+  2  USAGE — bad arguments
+
+Porcelain first token: OK_LOCAL | CLOUD_SYNC_RISK:<service>
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# detect_cloud_sync lives in the shared worktree-safety lib. Resolve it whether
+# this script runs from the repo (hooks/_lib) or the deployed skill dir.
+_HERE = Path(__file__).resolve().parent
+for _cand in (_HERE.parent / "hooks", _HERE.parent):
+    if (_cand / "_lib" / "worktree_safety.py").is_file():
+        sys.path.insert(0, str(_cand))
+        break
+else:
+    # deployed layout: ~/.claude/skills/ai-brain-starter/hooks/_lib
+    _dep = Path.home() / ".claude" / "skills" / "ai-brain-starter" / "hooks"
+    if (_dep / "_lib" / "worktree_safety.py").is_file():
+        sys.path.insert(0, str(_dep))
+
+try:
+    from _lib.worktree_safety import detect_cloud_sync
+except Exception as e:  # pragma: no cover - import-path failure is itself a finding
+    print(f"CHECK_UNAVAILABLE: could not import detect_cloud_sync ({e})", file=sys.stderr)
+    # Fail OPEN on import error (don't block an install over a path glitch), but
+    # say so loudly so it isn't a silent no-op.
+    print("OK_LOCAL")
+    sys.exit(0)
+
+
+def _file_count(p: Path) -> int:
+    """Cheap-ish file count (capped) so a big existing vault reads louder."""
+    n = 0
+    try:
+        for _root, _dirs, files in __import__("os").walk(p):
+            n += len(files)
+            if n > 50000:
+                return n
+    except OSError:
+        pass
+    return n
+
+
+def main(argv: list[str]) -> int:
+    porcelain = False
+    args = [a for a in argv if a != "--porcelain"]
+    if "--porcelain" in argv:
+        porcelain = True
+    if len(args) != 1:
+        print("usage: check-cloud-sync.py [--porcelain] <vault-path>", file=sys.stderr)
+        return 2
+
+    raw = Path(args[0]).expanduser()
+    try:
+        path = raw.resolve()
+    except OSError:
+        path = raw
+
+    service = detect_cloud_sync(path)
+
+    if service:
+        if porcelain:
+            print(f"CLOUD_SYNC_RISK:{service}")
+            return 1
+        count = _file_count(path) if path.is_dir() else 0
+        size_note = f" It already holds ~{count} files." if count > 0 else ""
+        print(f"FAIL  This path is inside {service}, a consumer cloud-sync folder.{size_note}")
+        print(f"      A git-backed vault here melts the sync daemon (pegged CPU / frozen machine).")
+        print(f"      Move it to a real local path, e.g. ~/Brain or ~/vaults/<name>.")
+        print(f"      Already installed there? See docs/CLOUD_SYNC.md to move it out safely.")
+        return 1
+
+    if porcelain:
+        print("OK_LOCAL")
+        return 0
+    print(f"OK    {path} is on a local disk (not a consumer cloud-sync root).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/diagnose.ps1
+++ b/scripts/diagnose.ps1
@@ -289,6 +289,34 @@ if (Test-Path -LiteralPath (Join-Path $absDir ".git") -PathType Container) {
   Warn "ai-brain-starter is not a git repo" "Re-run bootstrap.ps1 to clone it."
 }
 
+# ----- 11. cloud-sync location (the freeze class) -----
+Section "11. Cloud-sync location"
+$checkCloud = $null
+$cloudCands = @(
+  (Join-Path $PSScriptRoot "check-cloud-sync.py"),
+  (Join-Path $env:USERPROFILE ".claude\skills\ai-brain-starter\scripts\check-cloud-sync.py")
+)
+foreach ($c in $cloudCands) { if (Test-Path -LiteralPath $c) { $checkCloud = $c; break } }
+if ($checkCloud) {
+  $py = Get-Command python -ErrorAction SilentlyContinue
+  if (-not $py) { $py = Get-Command python3 -ErrorAction SilentlyContinue }
+  if ($py) {
+    $verdict = "$(& $py.Source $checkCloud --porcelain $Vault 2>$null)".Trim()
+    if ($verdict -like "OK_LOCAL*") {
+      Ok "Vault is on a local disk (not a consumer cloud-sync root)"
+    } elseif ($verdict -like "CLOUD_SYNC_RISK:*") {
+      $svc = ($verdict -replace "^CLOUD_SYNC_RISK:", "")
+      Bad "Vault is inside $svc (a consumer cloud-sync folder)" "A git-backed vault here melts the sync engine (pegged CPU / frozen machine). Move it local. See docs/CLOUD_SYNC.md."
+    } else {
+      Warn "Could not evaluate cloud-sync location" "check-cloud-sync.py returned: $verdict"
+    }
+  } else {
+    Warn "python not found" "Cannot verify the vault is outside a cloud-sync root."
+  }
+} else {
+  Warn "check-cloud-sync.py not found" "Cannot verify the vault is outside a cloud-sync root."
+}
+
 # ----- summary -----
 Write-Host ""
 Write-Host "Summary" -ForegroundColor White

--- a/scripts/diagnose.sh
+++ b/scripts/diagnose.sh
@@ -285,6 +285,28 @@ else
   warn "~/.claude/skills/ai-brain-starter is not a git repo" "Re-run bootstrap.sh to clone it."
 fi
 
+# ----- 11. cloud-sync location (the freeze class) -----
+section "11. Cloud-sync location"
+CHECK_CLOUD=""
+for c in "$(cd "$(dirname "$0")" && pwd)/check-cloud-sync.py" \
+         "$HOME/.claude/skills/ai-brain-starter/scripts/check-cloud-sync.py"; do
+  [ -f "$c" ] && CHECK_CLOUD="$c" && break
+done
+if [ -n "$CHECK_CLOUD" ]; then
+  verdict="$(python3 "$CHECK_CLOUD" --porcelain "$VAULT" 2>/dev/null)"
+  case "$verdict" in
+    OK_LOCAL)
+      ok "Vault is on a local disk (not a consumer cloud-sync root)" ;;
+    CLOUD_SYNC_RISK:*)
+      bad "Vault is inside ${verdict#CLOUD_SYNC_RISK:} — a consumer cloud-sync folder" \
+        "A git-backed vault here melts the sync daemon (pegged CPU / frozen machine). Move it local (e.g. ~/Brain). See docs/CLOUD_SYNC.md." ;;
+    *)
+      warn "Could not evaluate cloud-sync location" "check-cloud-sync.py returned: ${verdict:-<empty>}" ;;
+  esac
+else
+  warn "check-cloud-sync.py not found" "Cannot verify the vault is outside a cloud-sync root."
+fi
+
 # ----- summary -----
 echo
 echo "${B}Summary${N}"

--- a/scripts/test-cloud-sync-guard.sh
+++ b/scripts/test-cloud-sync-guard.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Negative-control test for check-cloud-sync.py (the vault-in-cloud-sync guard).
+# A guard earns trust only by failing on the thing it catches: this asserts RISK
+# for paths inside iCloud / OneDrive / Dropbox AND OK for a plain local path.
+# Run: bash scripts/test-cloud-sync-guard.sh
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+CHECK="$HERE/check-cloud-sync.py"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+fails=0
+
+assert() { # label  expected-token  path
+  local label="$1" want="$2" p="$3" got rc
+  mkdir -p "$p"
+  got="$(python3 "$CHECK" --porcelain "$p" 2>/dev/null)"; rc=$?
+  case "$got" in
+    "$want"*) echo "PASS  $label  ($got, rc=$rc)";;
+    *)        echo "FAIL  $label  want=$want got=$got rc=$rc"; fails=$((fails+1));;
+  esac
+}
+
+assert_rc() { # label  want-rc  path
+  local label="$1" want="$2" p="$3"
+  mkdir -p "$p"; python3 "$CHECK" --porcelain "$p" >/dev/null 2>&1
+  local rc=$?
+  [ "$rc" = "$want" ] && echo "PASS  $label (rc=$rc)" || { echo "FAIL  $label want-rc=$want got-rc=$rc"; fails=$((fails+1)); }
+}
+
+# POSITIVE: cloud-sync roots must be flagged RISK (exit 1)
+assert    "iCloud Drive root"  "CLOUD_SYNC_RISK"  "$TMP/Library/Mobile Documents/com~apple~CloudDocs/Brain"
+assert    "OneDrive root"      "CLOUD_SYNC_RISK"  "$TMP/OneDrive/Brain"
+assert    "Dropbox root"       "CLOUD_SYNC_RISK"  "$TMP/Dropbox/Notes"
+assert_rc "RISK exits 1"       1                  "$TMP/OneDrive/Brain"
+
+# NEGATIVE CONTROL: a plain local path must be OK (exit 0) — proves it is not
+# just always-RISK (a guard that always fires is as useless as one that never does)
+assert    "plain local path"   "OK_LOCAL"         "$TMP/Brain"
+assert_rc "OK exits 0"         0                  "$TMP/Brain"
+
+echo
+if [ "$fails" -gt 0 ]; then echo "FAILED: $fails"; exit 1; fi
+echo "ALL TESTS PASSED"


### PR DESCRIPTION
## Why
A git-backed Obsidian vault placed inside **iCloud / OneDrive / Dropbox / Google Drive / Box** melts the OS sync daemon (`fileproviderd`/`bird`/`cloudd`) — the high-churn `.git/` + per-session worktree checkouts generate millions of file events the sync client tries to upload → pegged CPU → frozen machine. This is **the freeze class downstream users hit** (MYC-511), and it burned the maintainer machine twice.

The substrate already shipped the *detection* (`detect_cloud_sync()`) but nothing **called** it at the surfaces that matter. This wires it in. Complements #157 (Obsidian index exclusions) and #158 (relocation-orphan reclaim) — those reduce churn; this stops the vault from being in the storm zone at all.

## What
- **`scripts/check-cloud-sync.py`** — single source of truth. Resolves a path through `detect_cloud_sync()`, prints a verdict + remedy; `--porcelain` for callers (`exit 1`=RISK, `exit 0`=OK). No drift between surfaces.
- **Install guard** (`phases/phase-01-welcome.md`, step 8.5) — after vault-path capture, run the checker and **BLOCK the install** if the path is in a sync root, steering the user to a local path before continuing.
- **Diagnose check 11** (`scripts/diagnose.sh` + `diagnose.ps1`) — FAIL/RED an existing vault inside a sync root, with a file-count signal. Windows parity is PS 5.1-safe (BOM intact, ASCII only, no em dashes).
- **SessionStart signal** (`hooks/worktree-footprint-signal.py`) — fire the cloud-combo warning on a git-backed vault **even with zero worktrees** (the `.git`-churn-alone case), so a fresh iCloud install is flagged at first SessionStart, not only after churn begins.

## Tests
`scripts/test-cloud-sync-guard.sh` — negative-control: RISK for iCloud/OneDrive/Dropbox paths, **OK for a plain local path** (a guard that always fires is as useless as one that never does). All pass. End-to-end verified: checker returns `OK_LOCAL` on a real local vault, `CLOUD_SYNC_RISK` on a simulated iCloud path.

## Scope
Guard only (the prevention). The relocate-helper port + docs cross-ref are MYC-511 items 4-5 (follow-up PR) so existing-victim recovery ships separately from new-victim prevention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)