### PR TITLE
feat(backup): a brain can no longer reach daily use with zero off-machine backup, silently

### DIFF
--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -1,0 +1,154 @@
+# Back up your brain (off-machine, in one command)
+
+Your vault is the one irreplaceable thing here. Everything else — the skills, the
+hooks, this repo — is reinstallable. Your notes and journals are not.
+
+Local-disk-only is the silent killer. The vault works perfectly right up until
+the disk dies, and then it is all gone at once: no warning, no degraded mode. A
+real person hit exactly this — about 1,100 notes, no Time Machine, no cloud copy,
+no git remote, a single drive. One hardware failure away from losing everything,
+and nothing ever said so out loud.
+
+This page is how the brain makes sure that can't happen to you quietly.
+
+> **The rule: a brain in daily use has at least one off-machine copy, and you
+> have restored from it at least once.** Anything less is a hope, not a backup.
+
+---
+
+## What "backup" is NOT
+
+- **The hourly git auto-snapshot is not a backup.** It is *local-only* by design
+  (it refuses to run if a remote exists) — brilliant rollback history, zero
+  protection against the disk failing. See `scripts/auto-snapshot.sh`.
+- **A cloud-synced vault is a backup, but the wrong kind.** A live copy in
+  iCloud / OneDrive / Dropbox helps if the disk dies — but pointing a sync daemon
+  at the churning vault (worktrees, `.git` objects) is the machine-melting
+  failure `docs/CLOUD_SYNC.md` exists to prevent. The fix below gives you the
+  off-machine copy *without* the churn: one compressed file per day, not a live
+  mirror of a million tiny objects.
+
+---
+
+## The one command
+
+```bash
+bash ~/.claude/skills/ai-brain-starter/scripts/vault-backup.sh setup
+```
+
+(Windows: `pwsh ~/.claude/skills/ai-brain-starter/scripts/vault-backup.ps1 setup`)
+
+It asks you one thing: **where the backup should go.** Pick a destination you
+already have, off this machine:
+
+- an external drive (`/Volumes/Backup`, `D:\Backup`), or
+- a cloud folder you already sync (Google Drive / Dropbox / OneDrive / Box).
+
+A cloud folder is fine *as a destination* — the backup is **one compressed file
+that gets replaced once a day**, so there is no sync storm. It is the live vault
+that must never live in a sync folder, not a single daily archive.
+
+Then `setup`:
+
+1. writes the **first snapshot immediately** (so you are protected right away),
+2. installs a **daily schedule** (launchd on macOS, cron on Linux, a Scheduled
+   Task on Windows) at 03:00 local,
+3. **excludes the regenerable machine-exhaust** (`.claude/worktrees`,
+   `.smart-env`, `.codegraph`, caches) — your notes and `.git` history are kept,
+   the bloat is not.
+
+Provider-agnostic: the destination is just a folder path. Nothing is hard-wired
+to one cloud.
+
+### Sensitive vault? Encrypt it.
+
+If your vault holds journals, health data, or client/CRM notes, add `--encrypt`:
+
+```bash
+bash ~/.claude/skills/ai-brain-starter/scripts/vault-backup.sh setup --encrypt
+```
+
+It encrypts each archive with AES-256 (via `gpg`, or `openssl` as a fallback) and
+stores the passphrase in your **OS keychain** (macOS Keychain / libsecret /
+Windows DPAPI), never in plaintext on disk. The daily run reads it from there
+with no prompt.
+
+---
+
+## Prove it restores (do this once)
+
+A backup you have never restored is a hope, not a backup. This actually extracts
+the newest archive to a temp directory and confirms your notes come back:
+
+```bash
+bash ~/.claude/skills/ai-brain-starter/scripts/vault-backup.sh verify
+```
+
+It records the verification date. The session-start signal will nudge you to
+re-verify periodically — restoring is the only thing that proves the chain works
+end to end.
+
+---
+
+## Check status any time
+
+```bash
+bash ~/.claude/skills/ai-brain-starter/scripts/vault-backup.sh status
+```
+
+Shows the destination, whether it is reachable, how fresh the snapshots are, when
+you last verified a restore, and the canonical verdict from the detector.
+
+---
+
+## How the brain keeps you honest
+
+You do not have to remember any of this. Two surfaces keep it visible:
+
+- **At session start**, `surface-backup-status.py` checks for *any* off-machine
+  copy — our `vault-backup`, a configured Time Machine destination, a cloud copy,
+  or a pushed git remote. If there is **none**, it prints a loud line *every
+  session* until one exists. It is advisory and never blocks; it just does not go
+  quiet. (Bypass for a session with `VAULT_BACKUP_BYPASS=1`.)
+- **`/diagnose`** (section 12) reports the same verdict in the health check, and
+  the onboarding interview (`phases/phase-01-welcome.md`, step 8.6) establishes a
+  backup — or makes you decline it on purpose — before setup is called done.
+
+The single source of truth for all of these is
+`scripts/check-vault-backup.py` — run it directly any time:
+
+```bash
+python3 ~/.claude/skills/ai-brain-starter/scripts/check-vault-backup.py "<vault-path>"
+```
+
+---
+
+## If you'd rather use restic (offsite, incremental, advanced)
+
+`vault-backup.sh` is the zero-config default: one file, one command, any folder.
+If you want incremental dedup + an offsite repo (S3, B2, an SFTP box) with
+point-in-time history, [restic](https://restic.net) is the heavier-duty tool:
+
+```bash
+# one-time
+restic init --repo /Volumes/Backup/brain-restic        # or s3:..., b2:..., sftp:...
+# each run (cron it): keep the notes, skip the machine-exhaust
+restic backup "<vault-path>" \
+  --exclude .claude/worktrees --exclude .smart-env --exclude .codegraph \
+  --repo /Volumes/Backup/brain-restic
+restic restore latest --target /tmp/restore-check --repo /Volumes/Backup/brain-restic  # verify!
+```
+
+restic encrypts the whole repo by default and is the right call for an offsite,
+versioned copy. The two compose: `vault-backup.sh` for the always-on local-disk
+snapshot, restic for the offsite tier when you want it.
+
+---
+
+## See also
+
+- **`docs/CLOUD_SYNC.md`** — why the live vault must stay out of cloud-sync
+  folders (the sync-storm failure), and how to move it out safely. Back up *with
+  this page* before you relocate.
+- **`docs/MAINTENANCE.md`** — the ongoing hygiene scans (worktrees, naming,
+  graphify rotation) that keep the vault healthy over time.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,27 @@ description: What's new in AI Brain Starter — plain English, no jargon
 
 ---
 
+## 2026-06-06: your brain can no longer end up with zero off-machine backup, silently
+
+**Who this affects:** everyone. If your vault lives on one disk with no off-machine copy, one hardware failure loses everything — every note, every journal entry — with no warning. A real person hit exactly this: about 1,100 notes, no Time Machine, no cloud copy, no git remote, a single drive. The product never said a word about it.
+
+### The problem
+
+The hourly git auto-snapshot is *local-only* by design (it refuses to run with a remote), so "I have snapshots" still meant one disk away from total loss. Nothing detected the no-backup state, nothing offered a fix, and onboarding actively waved backup off — the old Phase 15 told the installer "your normal backup habits already cover it, no special setup needed." For anyone whose normal habits were *nothing*, that was the bug, encoded into setup.
+
+### The fix
+
+- **A loud, repeated session-start signal.** When no off-machine backup of any kind is detected — not our backup, not Time Machine, not a cloud copy, not a pushed git remote — every session opens with a warning and the one command to fix it. It is advisory (it never blocks) but it does not go quiet until a backup exists.
+- **One-command backup.** `bash scripts/vault-backup.sh setup` asks one thing — a destination you already have (an external drive, or a Google Drive / Dropbox / OneDrive folder) — then writes one compressed daily snapshot there (a single file, not the churning git tree, so a cloud folder syncs it fine), schedules it daily, and excludes the regenerable machine-exhaust. `--encrypt` for a vault with journals or client notes (AES-256, passphrase in your OS keychain). `verify` does a real restore to prove it works — a backup you have never restored is a hope, not a backup. Windows parity ships (`vault-backup.ps1`).
+- **Onboarding now establishes a backup** (Phase 1, step 8.6) and **confirms it before setup is called done** (the rewritten Phase 15), or makes you decline on purpose with the consequence stated plainly.
+- **`/diagnose`** gained a backup check (section 12), and `docs/BACKUP.md` is the full guide (cross-linked from `docs/CLOUD_SYNC.md` and `docs/MAINTENANCE.md`).
+
+### Verification
+
+Two new self-tests ship with it, both with negative controls. The detector test proves a bare local vault reports NO_BACKUP (exit 1) and that every real off-machine-copy path reports BACKED_UP (exit 0) — so the guard is not just always-firing or always-silent. The round-trip test runs the whole loop on a fixture vault: one archive written, machine-exhaust excluded, the detector flips to backed-up, a real restore extracts the notes back, rotation honors the keep count, and the encrypted path round-trips without leaking plaintext.
+
+---
+
 ## 2026-06-05: stop SessionStart hooks from piling up and freezing your machine
 
 **Who this affects:** anyone who runs more than one Claude Code session at a time (a common, intended workflow). Two SessionStart hooks could pile up under concurrency and peg every CPU core.

--- a/docs/CLOUD_SYNC.md
+++ b/docs/CLOUD_SYNC.md
@@ -86,10 +86,11 @@ Your vault `.gitignore` should contain at least:
   the session ends; a session-start cap reclaims any that a crash left behind;
   unsaved work is snapshotted first and committed work is preserved on its
   branch. You never accumulate a pile. (See `docs/HOOKS_INSTALL.md`.)
-- **Backups are a deliberate, encrypted choice** — restic to an encrypted
-  remote, with a restore you actually verify — not a side effect of a sync
-  daemon that also happens to hold your secrets in plaintext. (See
-  `docs/MAINTENANCE.md`.)
+- **Backups are a deliberate, off-machine choice** — one compressed daily
+  snapshot to a destination you pick, with a restore you actually verify — not a
+  side effect of a sync daemon that also happens to hold your secrets in
+  plaintext. One command sets it up: `bash scripts/vault-backup.sh setup`
+  (encrypted with `--encrypt`). (See `docs/BACKUP.md`.)
 - **The index is server-side.** For Mycelium runtime users, the searchable
   index lives in the runtime, not in a synced local folder. Your laptop holds
   the source notes on a local disk; the heavy index never touches your
@@ -203,10 +204,12 @@ Verify success the way you diagnosed it: the `itemNotFound` count collapses and
 ## Order matters: back up before you move
 
 Relocating the vault out of a sync folder is the right fix, but the vault is
-often the one irreplaceable asset, so **stand up an encrypted backup and pull a
+often the one irreplaceable asset, so **stand up an off-machine backup and pull a
 real restore from it FIRST, then relocate.** A backup you have never restored is
-a hope, not a backup. Encrypted restic to a local repo gets you protected
-immediately; add an offsite copy when you can. (See `docs/MAINTENANCE.md`.)
+a hope, not a backup. One command gets you protected immediately —
+`bash scripts/vault-backup.sh setup` (add `--encrypt` for a sensitive vault),
+then `bash scripts/vault-backup.sh verify` to prove the restore. Full guide,
+including the restic option for an offsite tier: `docs/BACKUP.md`.
 
 A brain that melts the machine it runs on isn't a brain you'll keep. Local
 disk for the source, server-side for the index, encrypted-and-verified for

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -2,6 +2,23 @@
 
 Automated hygiene checks to keep your vault clean over time. These complement the one-time setup from `bootstrap.sh` with ongoing maintenance.
 
+## Off-machine backup (read this first)
+
+The single most important piece of ongoing maintenance is making sure the vault
+is not your only copy. The hourly git auto-snapshot is *local-only* — rollback
+history, not a backup. One disk failure with no off-machine copy loses
+everything.
+
+Set up a daily off-machine backup in one command (provider-agnostic destination,
+optional encryption, with a real restore check):
+
+```bash
+bash scripts/vault-backup.sh setup     # then: ... verify   to prove the restore
+```
+
+The session-start signal (`surface-backup-status.py`) and `/diagnose` (section
+12) both nag until a backup exists. Full guide: **[docs/BACKUP.md](BACKUP.md)**.
+
 ## Scripts
 
 ### vault_maintenance.py

--- a/hooks.json
+++ b/hooks.json
@@ -205,6 +205,11 @@
           },
           {
             "type": "command",
+            "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/surface-backup-status.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'",
+            "statusMessage": "Checking off-machine backup..."
+          },
+          {
+            "type": "command",
             "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/enforce-worktree-cap.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'",
             "statusMessage": "Enforcing worktree cap (reclaim-then-allow)..."
           },

--- a/hooks/surface-backup-status.py
+++ b/hooks/surface-backup-status.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Surface vault off-machine-backup status at SessionStart.
+
+The failure this exists for: a brain in active daily use whose only copy is the
+local disk it runs on. It works perfectly right up until the drive dies — silent
+until catastrophic — so it needs a LOUD, REPEATED signal, not a doc. A real
+incident: a 1,100-note brain with no iCloud, no Time Machine, no git remote, one
+disk. One failure from total loss, and nothing in the product ever said so.
+
+This hook routes through the single source of truth (scripts/check-vault-backup.py)
+and reacts:
+
+  * NO off-machine backup at all -> a loud line, EVERY session, until one exists.
+    Distinct from "stale": this is "you have zero copies", the worst case.
+  * backup configured but never run / destination unreachable -> run-it nudge.
+  * our backup present but STALE (older than VAULT_BACKUP_STALE_DAYS, default 3)
+    -> run-it nudge.
+  * our backup present but a restore was NEVER verified -> verify-it nudge
+    (a backup you have never restored is a hope, not a backup).
+  * a real copy exists (fresh vault-backup / Time Machine / cloud / git remote)
+    -> silent. The cloud-sync churn case is owned by worktree-footprint-signal.py,
+    so this hook does not double-warn about it.
+
+Advisory only: it NEVER blocks. Bypass: VAULT_BACKUP_BYPASS=1.
+
+WIRING (SessionStart):
+  {"hooks": [{"type": "command",
+    "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/surface-backup-status.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'"
+  }]}
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+HOOK_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(HOOK_DIR))
+
+try:
+    from _lib.worktree_safety import find_main_repo
+except Exception:  # pragma: no cover - fail open if the lib can't load
+    find_main_repo = None  # type: ignore[assignment]
+
+DETECTOR = HOOK_DIR.parent / "scripts" / "check-vault-backup.py"
+CONF_PATH = Path(os.environ.get(
+    "VAULT_BACKUP_CONF", str(Path.home() / ".claude" / ".vault-backup.conf")
+))
+DEFAULT_STALE_DAYS = 3.0
+VERIFY_STALE_DAYS = 30.0
+
+SETUP_CMD = "bash ~/.claude/skills/ai-brain-starter/scripts/vault-backup.sh setup"
+RUN_CMD = "bash ~/.claude/skills/ai-brain-starter/scripts/vault-backup.sh run"
+VERIFY_CMD = "bash ~/.claude/skills/ai-brain-starter/scripts/vault-backup.sh verify"
+
+
+def _emit(ctx: str | None) -> int:
+    if ctx:
+        print(json.dumps({"continue": True, "additionalContext": ctx}))
+    else:
+        print(json.dumps({"continue": True, "suppressOutput": True}))
+    return 0
+
+
+def _is_brain(repo: Path) -> bool:
+    """Only nag for an actual brain vault, not every code repo with worktrees."""
+    if (repo / "CLAUDE.md").is_file():
+        return True
+    try:
+        return any(c.name.endswith("Meta") and c.is_dir() for c in repo.iterdir())
+    except OSError:
+        return False
+
+
+def _porcelain(repo: Path) -> str | None:
+    if not DETECTOR.is_file():
+        return None
+    try:
+        out = subprocess.run(
+            [sys.executable, str(DETECTOR), "--porcelain", str(repo)],
+            capture_output=True, text=True, timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    return (out.stdout or "").strip().splitlines()[0] if out.stdout.strip() else None
+
+
+def _verify_age_days(repo: Path) -> float | None:
+    """Days since the last verified restore for this vault, or None if never."""
+    try:
+        conf = json.loads(CONF_PATH.read_text())
+    except (OSError, ValueError):
+        return None
+    entry = (conf.get("vaults") or {}).get(str(repo))
+    if not entry:
+        # try the resolved form too
+        try:
+            entry = (conf.get("vaults") or {}).get(str(repo.resolve()))
+        except OSError:
+            entry = None
+    if not entry:
+        return None
+    last = entry.get("last_verify")
+    if not last:
+        return None
+    try:
+        dt = datetime.fromisoformat(str(last).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return (datetime.now(timezone.utc) - dt).total_seconds() / 86400.0
+
+
+def main() -> int:
+    if os.environ.get("VAULT_BACKUP_BYPASS") == "1":
+        return _emit(None)
+    if find_main_repo is None:
+        return _emit(None)
+
+    repo = find_main_repo()
+    if repo is None or not _is_brain(repo):
+        return _emit(None)
+
+    token = _porcelain(repo)
+    if not token:
+        return _emit(None)
+
+    try:
+        stale_days = float(os.environ.get("VAULT_BACKUP_STALE_DAYS", DEFAULT_STALE_DAYS))
+    except ValueError:
+        stale_days = DEFAULT_STALE_DAYS
+
+    # --- the worst case: zero off-machine copies. Loud, every session. ---
+    if token == "NO_BACKUP":
+        return _emit(
+            "⚠️  [backup] Your brain has NO off-machine backup. It lives on one "
+            "disk — one failure and everything is gone (notes, journals, the lot). "
+            "This warning repeats every session until a backup exists. Fix it now, "
+            f"one command:\n      {SETUP_CMD}\n"
+            "Picks a destination you already have (an external disk or a cloud "
+            "folder), writes one compressed daily snapshot (no sync-storm), "
+            "encrypts if you ask. See docs/BACKUP.md."
+        )
+
+    if token == "NO_BACKUP:configured-not-run":
+        return _emit(
+            "⚠️  [backup] Backup is configured but no snapshot exists yet (or the "
+            "destination is unreachable — external disk unplugged?). You are not "
+            f"protected until one lands. Run it:\n      {RUN_CMD}"
+        )
+
+    # --- our archive exists: check freshness + that a restore was ever verified ---
+    if token.startswith("BACKED_UP:vault-backup:"):
+        try:
+            age = float(token.rsplit(":", 1)[1])
+        except (ValueError, IndexError):
+            age = 0.0
+        if age > stale_days:
+            return _emit(
+                f"[backup] Last vault snapshot was {age:.1f} days ago "
+                f"(> {stale_days:.0f}d). Run `{RUN_CMD}` (or check the daily "
+                f"schedule is still installed)."
+            )
+        v_age = _verify_age_days(repo)
+        if v_age is None:
+            return _emit(
+                "[backup] Snapshots are fresh, but you have never verified a "
+                "restore. A backup you have never restored is a hope, not a "
+                f"backup. Prove it once:\n      {VERIFY_CMD}"
+            )
+        if v_age > VERIFY_STALE_DAYS:
+            return _emit(
+                f"[backup] Snapshots are fresh, but the last verified restore was "
+                f"{v_age:.0f} days ago. Re-verify: `{VERIFY_CMD}`."
+            )
+        return _emit(None)
+
+    # BACKED_UP:timemachine / cloud:* / git-remote -> a real copy exists. Silent.
+    # (worktree-footprint-signal.py owns the cloud-sync-churn nag, so no overlap.)
+    return _emit(None)
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        print(json.dumps({"continue": True, "suppressOutput": True}))
+        sys.exit(0)

--- a/phases/phase-01-welcome.md
+++ b/phases/phase-01-welcome.md
@@ -263,3 +263,32 @@ python3 ~/.claude/skills/ai-brain-starter/scripts/check-cloud-sync.py --porcelai
 - Output starts with `OK_LOCAL` → good, continue.
 - Output starts with `CLOUD_SYNC_RISK:` → **STOP. Do not continue the install.** Tell the user plainly: *"That location is inside <service>, which is cloud-synced — a vault there will freeze your machine. Please move the vault (or create a new one) somewhere local like `~/Brain` or `~/vaults/<name>`, then paste the new path."* Re-run this check on the new path. Do not proceed until it returns `OK_LOCAL`. (If the vault is large and already there, see `docs/CLOUD_SYNC.md` for how to move it out safely.)
 
+### Step 8.6 — Establish an off-machine backup (or explicitly defer, with a warning) — BEFORE declaring setup complete
+
+The vault is the one irreplaceable thing here. Local-disk-only is the silent killer: it works perfectly right up until the drive dies, and then everything is gone — every note, every journal entry. The hourly git auto-snapshot is **local-only** (it refuses to run with a remote), so it is rollback history, not a backup. A real person hit exactly this: ~1,100 notes, no iCloud, no Time Machine, no remote, one disk. One failure from total loss.
+
+**So a brand-new vault does not count as "set up" until it has an off-machine backup, or the user has explicitly chosen to defer with eyes open.** Do not skip this silently.
+
+First, check what they already have:
+
+```bash
+python3 ~/.claude/skills/ai-brain-starter/scripts/check-vault-backup.py "<VAULT_PATH>"
+```
+
+- Verdict `OK ...` (Time Machine, a cloud copy, or a pushed git remote already exists) → say so warmly: *"Good — you already have an off-machine copy via <source>, so you're covered. I'll move on."* Done.
+- Verdict `FAIL  ... NO off-machine backup` → set one up now. It is one command and picks a destination the user already has:
+
+```bash
+bash ~/.claude/skills/ai-brain-starter/scripts/vault-backup.sh setup --vault "<VAULT_PATH>"
+```
+
+Walk them through it in their language: it asks for a destination folder — **an external drive, or a Google Drive / Dropbox / OneDrive folder** (a single daily archive syncs fine; it is the churning vault that must never live in cloud sync, not one compressed file). It writes one compressed snapshot immediately, installs a daily schedule, and never touches the machine-exhaust dirs. **For a vault that will hold journals, health data, or client/CRM notes, add `--encrypt`** — it stores the passphrase in the OS keychain, never in plaintext.
+
+Then have them prove it actually restores (a backup nobody has restored is a hope, not a backup):
+
+```bash
+bash ~/.claude/skills/ai-brain-starter/scripts/vault-backup.sh verify --vault "<VAULT_PATH>"
+```
+
+**If the user genuinely wants to defer** (no external disk handy, wants to decide on a cloud folder later): do not fight them, but do not let it pass silently either. Say plainly: *"Okay — just so you know, your brain currently has no off-machine backup, so right now one disk failure would lose everything. I've left it un-set-up at your call. You'll see a reminder at the start of every session until a backup exists, and the one command to fix it is `bash ~/.claude/skills/ai-brain-starter/scripts/vault-backup.sh setup`."* The SessionStart signal (`surface-backup-status.py`) then keeps it visible until it's done — it is advisory and never blocks, but it does not go quiet. See `docs/BACKUP.md`.
+

--- a/phases/phase-12-17-imports-rules.md
+++ b/phases/phase-12-17-imports-rules.md
@@ -94,17 +94,31 @@ type: concept
 
 This is what turns a vault from a filing system into a thinking system. The concepts are the nodes. The links are the edges. The graph becomes navigable.
 
-## Phase 15: Backup confirmation (one sentence, then move on)
+## Phase 15: Backup confirmation (verify before declaring setup done)
 
-**The vault lives on the Desktop. That's the canonical home — set in Phase 1 step 7 ("Put it somewhere easy to find, like your Desktop") and it stays that way.** Do NOT ask the user to pick a backup mechanism. Do NOT push them to move the vault into iCloud / Google Drive / Dropbox. Their normal backup habits (Time Machine, external drive, cloud sync at the OS level, whatever they already do) cover the vault — it's just a folder of markdown files.
+This is the final backup checkpoint. The off-machine backup was established in **Phase 1, step 8.6** (right after the vault path was confirmed local). Here you confirm it actually took — and if step 8.6 was deferred or skipped, this is the last chance to set it up before you call setup complete.
 
-One sentence acknowledgment, then move on. In their PRIMARY_LANGUAGE.
+**Do NOT wave backup off.** The old version of this phase said "whatever you normally use already covers it — no special setup needed." That assumption is exactly what fails people: a real user had ~1,100 notes, no Time Machine, no cloud copy, no remote, one disk — one failure from losing everything, because everyone assumed their "normal habits" had it covered. A markdown folder on a single disk with no off-machine copy is one hardware fault from total loss. Confirm, don't assume.
 
-**EN:** "One thing to mention: your vault is a folder of markdown files. Whatever you normally use to back up your computer (Time Machine, an external drive, a cloud sync, whatever) already covers it. No special backup setup needed. Moving on."
+Run the detector (single source of truth) against their vault path:
 
-**ES:** "Una cosa: tu vault es una carpeta con archivos markdown. Lo que sea que normalmente uses para hacer copias de seguridad de tu computador (Time Machine, un disco externo, una sync en la nube, lo que sea) ya lo cubre. No hace falta una configuración especial. Sigamos."
+```bash
+python3 ~/.claude/skills/ai-brain-starter/scripts/check-vault-backup.py "<VAULT_PATH>"
+```
 
-That's it. Do NOT recommend a specific backup tool, do NOT surface a five-option menu, do NOT trigger an alarm because the vault lives on Desktop. Desktop is correct.
+- **`OK ...`** (vault-backup archive present, or Time Machine / a cloud copy / a pushed git remote already exists) → confirm it warmly in their PRIMARY_LANGUAGE, then nudge the one-time restore check if they haven't done it:
+  - *EN:* "Your brain is backed up off-machine (via <source>) — good. Run `bash ~/.claude/skills/ai-brain-starter/scripts/vault-backup.sh verify` once to prove the restore actually works, and you're set."
+- **`FAIL ... NO off-machine backup`** → do NOT move on. Set it up now (this is the same one command from step 8.6):
+
+```bash
+bash ~/.claude/skills/ai-brain-starter/scripts/vault-backup.sh setup --vault "<VAULT_PATH>"
+```
+
+  It asks for a destination they already have (an external drive, or a Google Drive / Dropbox / OneDrive folder), writes one compressed daily snapshot (no sync-storm), and schedules it. Add `--encrypt` for a vault holding journals / health / client notes. Then have them `verify` the restore.
+
+  If they still choose to defer, say it plainly (do not soften it away): *"Okay — just know your brain has no off-machine backup right now, so one disk failure would lose it. You'll see a reminder at the start of every session until a backup exists. The one command to fix it is `bash ~/.claude/skills/ai-brain-starter/scripts/vault-backup.sh setup`."* The SessionStart signal then keeps it visible until it's done.
+
+Full guide: `docs/BACKUP.md`. Never push the live vault *into* iCloud / Drive / Dropbox as the "backup" — that is the sync-storm failure mode (`docs/CLOUD_SYNC.md`); the backup is a single daily archive *sent to* such a folder, not the churning vault living in one.
 
 Team-vault sharing is handled separately in Phase 20.
 

--- a/scripts/check-vault-backup.py
+++ b/scripts/check-vault-backup.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Guard: detect whether a vault has ANY off-machine backup at all.
+
+The failure this prevents: a brain in active daily use whose ONLY copy is the
+local disk it runs on. One disk failure = everything gone. It is silent — the
+vault works perfectly right up until the drive dies — which is exactly why it
+needs a loud, repeated signal rather than a doc nobody reads.
+
+A vault counts as backed up if ANY of these holds (cheapest checks first):
+
+  1. vault-backup    — `scripts/vault-backup.sh` is configured for this vault
+                       AND a real archive exists in a reachable destination.
+  2. Time Machine    — a destination is configured (macOS `tmutil`). The
+                       OS-default off-machine path; counts even if a disk is
+                       currently unplugged (the strategy exists).
+  3. cloud copy      — the vault path resolves inside a consumer cloud-sync
+                       root (iCloud / OneDrive / Dropbox / Google Drive / Box).
+                       A churny, sub-optimal backup (see docs/CLOUD_SYNC.md and
+                       worktree-footprint-signal.py, which owns nagging about
+                       that combo) — but it IS an off-machine copy, so it
+                       suppresses the no-backup alarm here.
+  4. git remote      — the vault is a git repo with a remote AND the current
+                       HEAD has been pushed (exists on a remote branch).
+
+This is the SINGLE source of truth for "is there a backup" — the SessionStart
+hook (surface-backup-status.py), diagnose.sh/.ps1, and the phase-01 onboarding
+gate all route through it so the surfaces never drift.
+
+Usage:
+  check-vault-backup.py <vault-path>          # human-readable verdict + remedy
+  check-vault-backup.py --porcelain <path>    # one machine-readable line
+
+Exit codes:
+  0  BACKED UP  — at least one off-machine copy/strategy detected
+  1  NO BACKUP  — none detected (the one-disk-failure class)
+  2  USAGE      — bad arguments
+
+Porcelain first token (parse by splitting on ':'):
+  BACKED_UP:vault-backup:<age_days>   — our archive present, <age_days> old
+  BACKED_UP:timemachine               — Time Machine destination configured
+  BACKED_UP:cloud:<service>           — vault inside a cloud-sync root
+  BACKED_UP:git-remote                — vault git HEAD pushed to a remote
+  NO_BACKUP                           — nothing detected
+  NO_BACKUP:configured-not-run        — vault-backup configured, but no archive
+                                        in the destination yet (or dest gone)
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# detect_cloud_sync lives in the shared worktree-safety lib. Resolve it whether
+# this runs from the repo (../hooks/_lib) or the deployed skill dir. Mirror of
+# check-cloud-sync.py's resolution so the two guards stay byte-compatible.
+_HERE = Path(__file__).resolve().parent
+for _cand in (_HERE.parent / "hooks", _HERE.parent):
+    if (_cand / "_lib" / "worktree_safety.py").is_file():
+        sys.path.insert(0, str(_cand))
+        break
+else:
+    _dep = Path.home() / ".claude" / "skills" / "ai-brain-starter" / "hooks"
+    if (_dep / "_lib" / "worktree_safety.py").is_file():
+        sys.path.insert(0, str(_dep))
+
+try:
+    from _lib.worktree_safety import detect_cloud_sync
+except Exception:  # pragma: no cover - import-path failure shouldn't crash the guard
+    def detect_cloud_sync(_p: Path) -> str | None:  # type: ignore[misc]
+        return None
+
+# Canonical config written by vault-backup.sh / vault-backup.ps1. Keyed by the
+# resolved vault path so one config can track several vaults. Overridable for
+# tests via VAULT_BACKUP_CONF.
+CONF_PATH = Path(os.environ.get(
+    "VAULT_BACKUP_CONF", str(Path.home() / ".claude" / ".vault-backup.conf")
+))
+
+# Archive filename stems vault-backup.sh writes (single rotating file per vault).
+ARCHIVE_SUFFIXES = (".tar.gz", ".tar.gz.gpg", ".tar.gz.enc", ".zip", ".zip.gpg")
+
+
+def _now() -> float:
+    import time
+    return time.time()
+
+
+def _read_conf() -> dict:
+    try:
+        return json.loads(CONF_PATH.read_text())
+    except (OSError, ValueError):
+        return {}
+
+
+def _archive_age_days(dest: Path, stem: str) -> float | None:
+    """Newest matching archive's age in days, or None if dest has no archive."""
+    if not dest.is_dir():
+        return None
+    newest: float | None = None
+    try:
+        for child in dest.iterdir():
+            if not child.is_file():
+                continue
+            name = child.name
+            if not name.startswith(stem):
+                continue
+            if not any(name.endswith(sfx) for sfx in ARCHIVE_SUFFIXES):
+                continue
+            try:
+                mt = child.stat().st_mtime
+            except OSError:
+                continue
+            if newest is None or mt > newest:
+                newest = mt
+    except OSError:
+        return None
+    if newest is None:
+        return None
+    return max(0.0, (_now() - newest) / 86400.0)
+
+
+def check_vault_backup(conf_entry: dict | None) -> float | None:
+    """Age (days) of the newest vault-backup archive, or None if no real backup.
+
+    conf_entry is the per-vault dict from the config (dest / stem). A configured
+    entry whose destination is gone or empty returns None (treated as
+    configured-not-run by the caller, NOT as backed up).
+    """
+    if not conf_entry:
+        return None
+    dest = conf_entry.get("dest")
+    if not dest:
+        return None
+    stem = conf_entry.get("archive_stem") or "vault-backup"
+    return _archive_age_days(Path(dest).expanduser(), stem)
+
+
+def check_time_machine() -> bool:
+    """True if a Time Machine destination is configured (macOS only)."""
+    # Test/override hook: lets the negative-control suite assert NO_BACKUP
+    # deterministically on a dev Mac that genuinely has Time Machine set up
+    # (TM is machine-wide, so without this the bare-vault case would flake).
+    if os.environ.get("VAULT_BACKUP_SKIP_TIMEMACHINE") == "1":
+        return False
+    if sys.platform != "darwin":
+        return False
+    try:
+        out = subprocess.run(
+            ["tmutil", "destinationinfo"],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    if out.returncode != 0:
+        return False
+    text = out.stdout or ""
+    if "No destinations configured" in text:
+        return False
+    # A configured destination prints Name / ID / Kind / Mount Point lines.
+    return any(
+        line.strip().split(":", 1)[0].strip() in {"Name", "ID", "Kind", "Mount Point"}
+        for line in text.splitlines()
+    )
+
+
+def check_git_remote_pushed(vault: Path) -> bool:
+    """True if the vault is a git repo with a remote AND HEAD is pushed."""
+    if not (vault / ".git").exists():
+        return False
+    try:
+        remotes = subprocess.run(
+            ["git", "-C", str(vault), "remote"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if remotes.returncode != 0 or not remotes.stdout.strip():
+            return False
+        # HEAD reachable from any remote-tracking branch == it has been pushed.
+        contains = subprocess.run(
+            ["git", "-C", str(vault), "branch", "-r", "--contains", "HEAD"],
+            capture_output=True, text=True, timeout=15,
+        )
+        return contains.returncode == 0 and bool(contains.stdout.strip())
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+
+
+def detect(vault: Path, conf_keys: list[str] | None = None) -> tuple[str, str]:
+    """Return (porcelain_token, human_remedy). Cheapest checks first.
+
+    conf_keys: candidate path strings to look up in the config (the as-given and
+    the resolved form). Matching on both makes the lookup robust when the vault
+    path contains a symlink (e.g. macOS /var -> /private/var), so the detector
+    and vault-backup.sh agree on the key regardless of which form was stored.
+    """
+    conf = _read_conf()
+    vaults = conf.get("vaults") or {}
+    keys = list(conf_keys or [str(vault)])
+    entry = next((vaults[k] for k in keys if k in vaults), None)
+
+    age = check_vault_backup(entry)
+    if age is not None:
+        return (f"BACKED_UP:vault-backup:{age:.1f}",
+                f"vault-backup archive present (~{age:.1f} days old).")
+
+    if check_time_machine():
+        return ("BACKED_UP:timemachine",
+                "Time Machine destination configured.")
+
+    service = detect_cloud_sync(vault)
+    if service:
+        return (f"BACKED_UP:cloud:{service}",
+                f"vault is inside {service} (an off-machine cloud copy — churny "
+                f"but real; see docs/CLOUD_SYNC.md for the safer single-file pattern).")
+
+    if check_git_remote_pushed(vault):
+        return ("BACKED_UP:git-remote",
+                "vault git HEAD is pushed to a remote.")
+
+    if entry:
+        # Configured but no archive landed yet (or destination unreachable).
+        return ("NO_BACKUP:configured-not-run",
+                "backup is configured but no snapshot exists yet (or the "
+                "destination is unreachable). Run `vault-backup.sh run`.")
+
+    return ("NO_BACKUP", "no off-machine backup of any kind detected.")
+
+
+def main(argv: list[str]) -> int:
+    porcelain = "--porcelain" in argv
+    args = [a for a in argv if a != "--porcelain"]
+    if len(args) != 1:
+        print("usage: check-vault-backup.py [--porcelain] <vault-path>", file=sys.stderr)
+        return 2
+
+    raw = Path(args[0]).expanduser()
+    try:
+        vault = raw.resolve()
+    except OSError:
+        vault = raw
+
+    # Look up the conf by both the as-given and resolved path (symlink-robust).
+    conf_keys = list(dict.fromkeys([str(vault), str(raw)]))
+    token, remedy = detect(vault, conf_keys)
+    backed_up = token.startswith("BACKED_UP")
+
+    if porcelain:
+        print(token)
+        return 0 if backed_up else 1
+
+    if backed_up:
+        print(f"OK    {vault} has an off-machine backup: {remedy}")
+        return 0
+
+    print(f"FAIL  {vault} has NO off-machine backup.")
+    print(f"      {remedy}")
+    print(f"      One disk failure = everything gone. Set one up (one command):")
+    print(f"      bash ~/.claude/skills/ai-brain-starter/scripts/vault-backup.sh setup")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -97,6 +97,7 @@ INTEGRATION_TESTS=(
   test_installer_retires_email_gate
   test_remediate_runaway_procs
   test_scan_prior_single_instance
+  test_vault_safety_guards
 )
 echo "==> (b) Shell integration: ${#INTEGRATION_TESTS[@]} tests"
 for t in "${INTEGRATION_TESTS[@]}"; do

--- a/scripts/diagnose.ps1
+++ b/scripts/diagnose.ps1
@@ -317,6 +317,43 @@ if ($checkCloud) {
   Warn "check-cloud-sync.py not found" "Cannot verify the vault is outside a cloud-sync root."
 }
 
+# ----- 12. off-machine backup (the one-disk-failure class) -----
+Section "12. Off-machine backup"
+$checkBackup = $null
+$backupCands = @(
+  (Join-Path $PSScriptRoot "check-vault-backup.py"),
+  (Join-Path $env:USERPROFILE ".claude\skills\ai-brain-starter\scripts\check-vault-backup.py")
+)
+foreach ($c in $backupCands) { if (Test-Path -LiteralPath $c) { $checkBackup = $c; break } }
+if ($checkBackup) {
+  $py = Get-Command python -ErrorAction SilentlyContinue
+  if (-not $py) { $py = Get-Command python3 -ErrorAction SilentlyContinue }
+  if ($py) {
+    $bverdict = "$(& $py.Source $checkBackup --porcelain $Vault 2>$null)".Trim()
+    if ($bverdict -like "BACKED_UP:vault-backup:*") {
+      $age = ($bverdict -split ":")[-1]
+      Ok "Off-machine backup present (vault-backup, ~$age days old)"
+    } elseif ($bverdict -eq "BACKED_UP:timemachine") {
+      Ok "Off-machine backup present (Time Machine destination configured)"
+    } elseif ($bverdict -like "BACKED_UP:cloud:*") {
+      $svc = ($bverdict -replace "^BACKED_UP:cloud:", "")
+      Ok "Off-machine copy present ($svc - a cloud copy; single-file snapshots are safer, see docs/BACKUP.md)"
+    } elseif ($bverdict -eq "BACKED_UP:git-remote") {
+      Ok "Off-machine backup present (git HEAD pushed to a remote)"
+    } elseif ($bverdict -eq "NO_BACKUP:configured-not-run") {
+      Warn "Backup configured but no snapshot exists yet (or destination unreachable)" "Run: pwsh scripts/vault-backup.ps1 run -Vault '$Vault'"
+    } elseif ($bverdict -eq "NO_BACKUP") {
+      Bad "Vault has NO off-machine backup - one disk failure loses everything" "Set one up (one command): pwsh scripts/vault-backup.ps1 setup -Vault '$Vault'. See docs/BACKUP.md."
+    } else {
+      Warn "Could not evaluate backup status" "check-vault-backup.py returned: $bverdict"
+    }
+  } else {
+    Warn "python not found" "Cannot verify the vault has an off-machine backup."
+  }
+} else {
+  Warn "check-vault-backup.py not found" "Cannot verify the vault has an off-machine backup."
+}
+
 # ----- summary -----
 Write-Host ""
 Write-Host "Summary" -ForegroundColor White

--- a/scripts/diagnose.sh
+++ b/scripts/diagnose.sh
@@ -307,6 +307,34 @@ else
   warn "check-cloud-sync.py not found" "Cannot verify the vault is outside a cloud-sync root."
 fi
 
+# ----- 12. off-machine backup (the one-disk-failure class) -----
+section "12. Off-machine backup"
+CHECK_BACKUP=""
+for c in "$(cd "$(dirname "$0")" && pwd)/check-vault-backup.py" \
+         "$HOME/.claude/skills/ai-brain-starter/scripts/check-vault-backup.py"; do
+  [ -f "$c" ] && CHECK_BACKUP="$c" && break
+done
+if [ -n "$CHECK_BACKUP" ]; then
+  bverdict="$(python3 "$CHECK_BACKUP" --porcelain "$VAULT" 2>/dev/null)"
+  case "$bverdict" in
+    BACKED_UP:vault-backup:*)
+      ok "Off-machine backup present (vault-backup, ~${bverdict##*:} days old)" ;;
+    BACKED_UP:timemachine)   ok "Off-machine backup present (Time Machine destination configured)" ;;
+    BACKED_UP:cloud:*)       ok "Off-machine copy present (${bverdict#BACKED_UP:cloud:} — a cloud copy; single-file snapshots are safer, see docs/BACKUP.md)" ;;
+    BACKED_UP:git-remote)    ok "Off-machine backup present (git HEAD pushed to a remote)" ;;
+    NO_BACKUP:configured-not-run)
+      warn "Backup configured but no snapshot exists yet (or destination unreachable)" \
+        "Run: bash scripts/vault-backup.sh run --vault '$VAULT'" ;;
+    NO_BACKUP)
+      bad "Vault has NO off-machine backup — one disk failure loses everything" \
+        "Set one up (one command): bash scripts/vault-backup.sh setup --vault '$VAULT'. See docs/BACKUP.md." ;;
+    *)
+      warn "Could not evaluate backup status" "check-vault-backup.py returned: ${bverdict:-<empty>}" ;;
+  esac
+else
+  warn "check-vault-backup.py not found" "Cannot verify the vault has an off-machine backup."
+fi
+
 # ----- summary -----
 echo
 echo "${B}Summary${N}"

--- a/scripts/test-vault-backup-guard.sh
+++ b/scripts/test-vault-backup-guard.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Negative-control test for check-vault-backup.py (the no-off-machine-backup guard).
+# A guard earns trust only by failing on the thing it catches: this asserts
+# NO_BACKUP (exit 1) for a bare local vault, and BACKED_UP (exit 0) for every
+# real off-machine-copy path (configured archive, cloud-sync location).
+# If it only ever passed, it would be worthless — so we assert BOTH polarities.
+# Run: bash scripts/test-vault-backup-guard.sh
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+CHECK="$HERE/check-vault-backup.py"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+fails=0
+
+# Isolate from the real config + force a clean conf per case via $VAULT_BACKUP_CONF.
+CONF="$TMP/conf.json"
+export VAULT_BACKUP_CONF="$CONF"
+echo '{}' > "$CONF"
+# Neutralize the machine-wide Time Machine probe so "bare vault -> NO_BACKUP"
+# is deterministic even when the test host itself has Time Machine configured.
+export VAULT_BACKUP_SKIP_TIMEMACHINE=1
+
+run() { # path  -> prints porcelain token, sets RC
+  VAULT_BACKUP_CONF="$CONF" python3 "$CHECK" --porcelain "$1" 2>/dev/null
+}
+
+assert_token() { # label  want-prefix  path
+  local label="$1" want="$2" p="$3" got
+  got="$(run "$p")"
+  case "$got" in
+    "$want"*) echo "PASS  $label  ($got)";;
+    *)        echo "FAIL  $label  want=$want got=$got"; fails=$((fails+1));;
+  esac
+}
+
+assert_rc() { # label  want-rc  path
+  local label="$1" want="$2" p="$3"
+  run "$p" >/dev/null 2>&1; local rc=$?
+  [ "$rc" = "$want" ] && echo "PASS  $label (rc=$rc)" || { echo "FAIL  $label want-rc=$want got-rc=$rc"; fails=$((fails+1)); }
+}
+
+# ---- NEGATIVE CONTROL: a bare local vault with no backup of any kind ----
+# The lived-incident case: real notes, a single disk, nothing off-machine.
+BARE="$TMP/Brain"
+mkdir -p "$BARE"
+echo "# a note" > "$BARE/note.md"
+assert_token "bare local vault -> NO_BACKUP"  "NO_BACKUP"  "$BARE"
+assert_rc    "NO_BACKUP exits 1"              1            "$BARE"
+
+# ---- POSITIVE: vault-backup configured WITH a real archive in a reachable dest ----
+DEST="$TMP/backups"
+mkdir -p "$DEST"
+RES="$(cd "$BARE" && pwd)"   # detector resolves the path; key the conf on the resolved form
+# write a fake current archive for this vault
+touch "$DEST/vault-backup-$(date +%Y%m%d).tar.gz"
+cat > "$CONF" <<EOF
+{"vaults": {"$RES": {"dest": "$DEST", "archive_stem": "vault-backup"}}}
+EOF
+assert_token "configured + archive -> BACKED_UP:vault-backup"  "BACKED_UP:vault-backup"  "$BARE"
+assert_rc    "BACKED_UP exits 0"                                0                         "$BARE"
+
+# ---- EDGE: configured but NO archive landed yet (or dest empty) -> still nudges ----
+echo '{}' > "$CONF"
+DEST2="$TMP/empty-dest"
+mkdir -p "$DEST2"
+cat > "$CONF" <<EOF
+{"vaults": {"$RES": {"dest": "$DEST2", "archive_stem": "vault-backup"}}}
+EOF
+assert_token "configured, no archive -> NO_BACKUP:configured-not-run"  "NO_BACKUP:configured-not-run"  "$BARE"
+assert_rc    "configured-not-run still exits 1"                         1                               "$BARE"
+
+# ---- POSITIVE: a vault inside a cloud-sync root counts as an off-machine copy ----
+echo '{}' > "$CONF"
+CLOUD="$TMP/OneDrive/Brain"
+mkdir -p "$CLOUD"
+assert_token "cloud-sync vault -> BACKED_UP:cloud"  "BACKED_UP:cloud"  "$CLOUD"
+assert_rc    "cloud-sync exits 0"                   0                  "$CLOUD"
+
+echo
+if [ "$fails" -gt 0 ]; then echo "FAILED: $fails"; exit 1; fi
+echo "ALL TESTS PASSED"

--- a/scripts/test-vault-backup-roundtrip.sh
+++ b/scripts/test-vault-backup-roundtrip.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Round-trip self-test for vault-backup.sh.
+# A backup you have never restored is a hope, not a backup — so this proves the
+# whole loop on a fixture vault: setup -> ONE archive -> exhaust excluded ->
+# detector flips to BACKED_UP -> a real restore extracts the notes back ->
+# rotation honors --keep -> (if gpg/openssl) the encrypted path round-trips too.
+# Run: bash scripts/test-vault-backup-roundtrip.sh
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+BACKUP="$HERE/vault-backup.sh"
+CHECK="$HERE/check-vault-backup.py"
+ROOT="$(mktemp -d)"
+trap 'rm -rf "$ROOT"' EXIT
+export VAULT_BACKUP_CONF="$ROOT/conf.json"
+export VAULT_BACKUP_MARKER="$ROOT/marker"
+fails=0
+pass() { echo "PASS  $1"; }
+fail() { echo "FAIL  $1"; fails=$((fails+1)); }
+
+# ---- fixture vault: real notes + machine-exhaust that MUST be excluded ----
+V="$ROOT/Brain"
+mkdir -p "$V/⚙️ Meta" "$V/.claude/worktrees/scratch" "$V/.smart-env" "$V/.codegraph"
+printf '# CLAUDE.md\nbrain memory\n' > "$V/CLAUDE.md"
+printf 'a private journal entry\n'   > "$V/journal.md"
+printf 'EXHAUST-should-not-appear\n' > "$V/.claude/worktrees/scratch/junk.md"
+printf 'EXHAUST-cache\n'             > "$V/.smart-env/cache.bin"
+DEST="$ROOT/dest"
+
+# ---- 1. setup (non-interactive: --dest given, no encrypt, no schedule) ----
+bash "$BACKUP" setup --vault "$V" --dest "$DEST" --schedule none >/dev/null 2>&1 \
+  && pass "setup ran" || fail "setup failed"
+
+# ---- 2. exactly ONE archive, and it is a single .tar.gz file ----
+n=$(ls -1 "$DEST"/vault-backup-* 2>/dev/null | wc -l | tr -d ' ')
+[ "$n" = "1" ] && pass "exactly one archive written ($n)" || fail "expected 1 archive, got $n"
+arc=$(ls -1 "$DEST"/vault-backup-* 2>/dev/null | head -1)
+case "$arc" in *.tar.gz) pass "archive is a single .tar.gz" ;; *) fail "archive not .tar.gz: $arc" ;; esac
+
+# ---- 3. notes present, machine-exhaust EXCLUDED ----
+listing="$(tar -tzf "$arc" 2>/dev/null)"
+printf '%s\n' "$listing" | grep -q './CLAUDE.md'  && pass "CLAUDE.md is in the archive" || fail "CLAUDE.md missing from archive"
+printf '%s\n' "$listing" | grep -q './journal.md' && pass "journal.md is in the archive" || fail "journal.md missing"
+if printf '%s\n' "$listing" | grep -q 'worktrees\|smart-env\|codegraph'; then
+  fail "machine-exhaust leaked into the archive"
+else
+  pass "machine-exhaust (.claude/worktrees, .smart-env, .codegraph) excluded"
+fi
+
+# ---- 4. detector now says BACKED_UP (exit 0) ----
+verdict="$(python3 "$CHECK" --porcelain "$V" 2>/dev/null)"; rc=$?
+case "$verdict" in BACKED_UP:vault-backup*) pass "detector -> $verdict (rc=$rc)";; *) fail "detector wrong: $verdict (rc=$rc)";; esac
+
+# ---- 5. a REAL restore extracts the notes back ----
+out="$(bash "$BACKUP" verify --vault "$V" 2>&1)"
+echo "$out" | grep -q "Restore verified" && pass "verify reports a successful restore" || fail "verify did not confirm: $out"
+# last_verify recorded
+lv="$(python3 -c "import json;print((json.load(open('$VAULT_BACKUP_CONF')).get('vaults',{}).get('$(python3 -c "import os;print(os.path.realpath('$V'))")',{}) or {}).get('last_verify',''))" 2>/dev/null)"
+[ -n "$lv" ] && pass "last_verify recorded ($lv)" || fail "last_verify not recorded"
+
+# ---- 6. rotation honors --keep ----
+# Pre-seed 5 older dummy archives, set keep=2, run once -> at most 2 remain.
+for i in 1 2 3 4 5; do : > "$DEST/vault-backup-2000010$i-000000.tar.gz"; done
+python3 - "$VAULT_BACKUP_CONF" "$(python3 -c "import os;print(os.path.realpath('$V'))")" <<'PY'
+import json,sys
+c=json.load(open(sys.argv[1])); c['vaults'][sys.argv[2]]['keep']=2; json.dump(c,open(sys.argv[1],'w'))
+PY
+sleep 1
+bash "$BACKUP" run --vault "$V" >/dev/null 2>&1
+left=$(ls -1 "$DEST"/vault-backup-* 2>/dev/null | wc -l | tr -d ' ')
+[ "$left" -le 2 ] && pass "rotation kept <= keep (=2): $left remain" || fail "rotation kept too many: $left"
+
+# ---- 7. encrypted round-trip (only if gpg or openssl is available) ----
+if command -v gpg >/dev/null 2>&1 || command -v openssl >/dev/null 2>&1; then
+  V2="$ROOT/Brain2"; DEST2="$ROOT/dest2"
+  mkdir -p "$V2"; printf '# CLAUDE.md\n' > "$V2/CLAUDE.md"; printf 'secret journal\n' > "$V2/secret.md"
+  # Feed the passphrase twice on stdin (setup reads it with read -rs).
+  printf 'pw-correct-horse\npw-correct-horse\n' | bash "$BACKUP" setup --vault "$V2" --dest "$DEST2" --encrypt --schedule none >/dev/null 2>&1
+  enc="$(ls -1 "$DEST2"/vault-backup-* 2>/dev/null | head -1)"
+  case "$enc" in
+    *.tar.gz.gpg|*.tar.gz.enc) pass "encrypted archive written ($(basename "$enc"))" ;;
+    *) fail "encrypted archive not produced: $enc" ;;
+  esac
+  # The encrypted blob must NOT contain the plaintext.
+  if grep -qa "secret journal" "$enc" 2>/dev/null; then fail "plaintext leaked into encrypted archive"; else pass "ciphertext does not contain plaintext"; fi
+  vout="$(bash "$BACKUP" verify --vault "$V2" 2>&1)"
+  echo "$vout" | grep -q "Restore verified" && pass "encrypted backup restores" || fail "encrypted restore failed: $vout"
+else
+  echo "SKIP  encrypted round-trip (no gpg/openssl)"
+fi
+
+echo
+if [ "$fails" -gt 0 ]; then echo "FAILED: $fails"; exit 1; fi
+echo "ALL TESTS PASSED"

--- a/scripts/vault-backup.ps1
+++ b/scripts/vault-backup.ps1
@@ -1,0 +1,280 @@
+﻿#Requires -Version 5.1
+<#
+  vault-backup.ps1 - one-command, provider-agnostic, off-machine backup for a brain vault (Windows).
+
+  Windows parity of vault-backup.sh. The gap it closes: a brain in active daily
+  use whose only copy is the local disk it runs on. One disk failure = everything
+  gone. This writes ONE compressed archive per run to a destination you already
+  have (an external drive, or a OneDrive / Google Drive / Dropbox folder), so it
+  is genuinely off-machine. One file, not the churning git tree, so a cloud
+  folder syncs it without a storm.
+
+    setup   pick a destination (+ optional encryption + a daily scheduled task), take the first snapshot now.
+    run     take one snapshot now (what the scheduled task calls; non-interactive).
+    verify  restore the newest snapshot to a temp dir and confirm it actually extracts.
+    status  show where backups go, how fresh they are, and the canonical verdict.
+
+  Config:  ~/.claude/.vault-backup.conf  (JSON, keyed by resolved vault path - shared with check-vault-backup.py)
+  Marker:  ~/.claude/.vault-backup-last  (ISO8601 of the last successful run)
+
+  Encryption (-Encrypt) uses gpg with the passphrase stored encrypted-at-rest via
+  Windows DPAPI (current user). Excludes regenerable machine-exhaust dirs; keeps
+  notes + .git. Archives are .zip (or .zip.gpg when encrypted).
+#>
+[CmdletBinding()]
+param(
+  [Parameter(Position = 0)][string]$Command = "status",
+  [string]$Vault,
+  [string]$Dest,
+  [switch]$Encrypt,
+  [int]$Keep = 7,
+  [string]$Schedule = "daily"
+)
+
+$ErrorActionPreference = "Stop"
+$Conf   = if ($env:VAULT_BACKUP_CONF) { $env:VAULT_BACKUP_CONF } else { Join-Path $env:USERPROFILE ".claude\.vault-backup.conf" }
+$Marker = if ($env:VAULT_BACKUP_MARKER) { $env:VAULT_BACKUP_MARKER } else { Join-Path $env:USERPROFILE ".claude\.vault-backup-last" }
+$Stem   = "vault-backup"
+$ExcludeDirs = @(".git\worktrees", ".claude\worktrees", ".smart-env", ".codegraph", "node_modules", ".venv", "__pycache__", ".pytest_cache", ".mypy_cache", ".ruff_cache", ".trash")
+
+function Say($m)  { Write-Host $m }
+function Ok($m)   { Write-Host "OK   $m"   -ForegroundColor Green }
+function Warn($m) { Write-Host "WARN $m"   -ForegroundColor Yellow }
+function Die($m)  { Write-Host "ERROR $m"  -ForegroundColor Red; exit 1 }
+function IsoNow   { (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ") }
+
+function Resolve-Vault {
+  param([string]$v)
+  if (-not $v) { $v = if ($env:VAULT_PATH) { $env:VAULT_PATH } else { (Get-Location).Path } }
+  if (-not (Test-Path -LiteralPath $v -PathType Container)) { Die "vault path is not a directory: $v" }
+  return (Resolve-Path -LiteralPath $v).Path
+}
+
+function Read-Conf {
+  if (Test-Path -LiteralPath $Conf) {
+    try { return (Get-Content -Raw -LiteralPath $Conf | ConvertFrom-Json) } catch { return [pscustomobject]@{} }
+  }
+  return [pscustomobject]@{}
+}
+
+function Get-ConfEntry {
+  param([string]$key)
+  $d = Read-Conf
+  if ($d.PSObject.Properties.Name -contains "vaults" -and $d.vaults) {
+    if ($d.vaults.PSObject.Properties.Name -contains $key) { return $d.vaults.$key }
+  }
+  return $null
+}
+
+function Set-ConfEntry {
+  param([string]$key, [hashtable]$fields)
+  $d = Read-Conf
+  if (-not ($d.PSObject.Properties.Name -contains "vaults") -or -not $d.vaults) {
+    $d | Add-Member -NotePropertyName vaults -NotePropertyValue ([pscustomobject]@{}) -Force
+  }
+  $entry = if ($d.vaults.PSObject.Properties.Name -contains $key) { $d.vaults.$key } else { [pscustomobject]@{} }
+  foreach ($k in $fields.Keys) {
+    $entry | Add-Member -NotePropertyName $k -NotePropertyValue $fields[$k] -Force
+  }
+  $d.vaults | Add-Member -NotePropertyName $key -NotePropertyValue $entry -Force
+  $dir = Split-Path -Parent $Conf
+  if (-not (Test-Path -LiteralPath $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
+  $d | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $Conf -Encoding UTF8
+}
+
+function Slug-For { param([string]$p)
+  $base = (Split-Path -Leaf $p) -replace '[ /\\]', '_'
+  $md5  = [System.Security.Cryptography.MD5]::Create()
+  $hash = ($md5.ComputeHash([Text.Encoding]::UTF8.GetBytes($p)) | ForEach-Object { $_.ToString("x2") }) -join ""
+  return "$base-$($hash.Substring(0,8))"
+}
+
+# Passphrase at rest via DPAPI (current-user scoped). Never plaintext on disk.
+function Store-Passphrase { param([string]$slug, [string]$plain)
+  $secure = ConvertTo-SecureString $plain -AsPlainText -Force
+  $enc = $secure | ConvertFrom-SecureString
+  $pf = Join-Path $env:USERPROFILE ".claude\.vault-backup-pass-$slug"
+  Set-Content -LiteralPath $pf -Value $enc -Encoding UTF8
+  return $pf
+}
+function Get-Passphrase { param([string]$slug)
+  $pf = Join-Path $env:USERPROFILE ".claude\.vault-backup-pass-$slug"
+  if (-not (Test-Path -LiteralPath $pf)) { return $null }
+  $secure = (Get-Content -Raw -LiteralPath $pf) | ConvertTo-SecureString
+  $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secure)
+  try { return [Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr) }
+  finally { [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr) }
+}
+
+function New-Archive {
+  param([string]$vault, [string]$outBase, [bool]$enc, [string]$slug)
+  # Stage a copy that excludes machine-exhaust, then zip the staging dir.
+  $stage = Join-Path ([IO.Path]::GetTempPath()) ("vbk-" + [Guid]::NewGuid().ToString("N"))
+  New-Item -ItemType Directory -Force -Path $stage | Out-Null
+  try {
+    $xd = @()
+    foreach ($d in $ExcludeDirs) { $xd += "/XD"; $xd += (Join-Path $vault $d) }
+    # robocopy mirrors the tree minus excluded dirs; /NFL /NDL /NJH /NJS = quiet.
+    & robocopy $vault $stage /E @xd /XF "*.zip" "*.zip.gpg" /NFL /NDL /NJH /NJS /NP | Out-Null
+    # robocopy exit codes 0-7 are success; >=8 is failure.
+    if ($LASTEXITCODE -ge 8) { Die "robocopy staging failed (code $LASTEXITCODE)" }
+    $zip = "$outBase.zip"
+    if (Test-Path -LiteralPath $zip) { Remove-Item -LiteralPath $zip -Force }
+    Compress-Archive -Path (Join-Path $stage "*") -DestinationPath $zip -CompressionLevel Optimal -Force
+    if ($enc) {
+      $gpg = Get-Command gpg -ErrorAction SilentlyContinue
+      if (-not $gpg) { Die "-Encrypt needs gpg (Gpg4win) installed and on PATH" }
+      $pass = Get-Passphrase $slug
+      if (-not $pass) { Die "could not read backup passphrase" }
+      $out = "$outBase.zip.gpg"
+      & $gpg.Source --batch --yes --pinentry-mode loopback --passphrase $pass -c --cipher-algo AES256 -o $out $zip 2>$null
+      Remove-Item -LiteralPath $zip -Force
+      return $out
+    }
+    return $zip
+  } finally {
+    Remove-Item -Recurse -Force -LiteralPath $stage -ErrorAction SilentlyContinue
+  }
+}
+
+function Invoke-Rotate { param([string]$dest, [int]$keep)
+  $arcs = Get-ChildItem -LiteralPath $dest -Filter "$Stem-*" -File -ErrorAction SilentlyContinue | Sort-Object LastWriteTime -Descending
+  if ($arcs.Count -gt $keep) {
+    $arcs | Select-Object -Skip $keep | ForEach-Object { Remove-Item -LiteralPath $_.FullName -Force -ErrorAction SilentlyContinue }
+  }
+}
+
+function Cmd-Setup {
+  $v = Resolve-Vault $Vault
+  Say "Backing up: $v"
+  $d = $Dest
+  if (-not $d) {
+    Say ""
+    Say "Where should the off-machine backup go? Give a folder you already have"
+    Say "somewhere OTHER than this machine's single disk - an external drive, or a"
+    Say "OneDrive / Google Drive / Dropbox folder (one daily file syncs fine)."
+    $d = Read-Host "Destination folder"
+    if (-not $d) { Die "no destination given" }
+  }
+  if (-not (Test-Path -LiteralPath $d)) { New-Item -ItemType Directory -Force -Path $d | Out-Null }
+  $d = (Resolve-Path -LiteralPath $d).Path
+  if ($d.StartsWith($v, [StringComparison]::OrdinalIgnoreCase)) { Die "destination is inside the vault. Pick a folder off this machine." }
+  if ($d -match "OneDrive|Dropbox|Google ?Drive|CloudStorage|Box|[A-Z]:\\\\") { Ok "Destination chosen." } else { Warn "Destination may be on this same disk; an external drive or cloud folder protects against disk failure." }
+
+  $slug = Slug-For $v
+  if ($Encrypt) {
+    if (-not (Get-Command gpg -ErrorAction SilentlyContinue)) { Die "-Encrypt needs gpg (Gpg4win) installed" }
+    $p1 = Read-Host "Set a backup passphrase (stored encrypted via DPAPI)" -AsSecureString
+    $p2 = Read-Host "Confirm passphrase" -AsSecureString
+    $s1 = [Runtime.InteropServices.Marshal]::PtrToStringBSTR([Runtime.InteropServices.Marshal]::SecureStringToBSTR($p1))
+    $s2 = [Runtime.InteropServices.Marshal]::PtrToStringBSTR([Runtime.InteropServices.Marshal]::SecureStringToBSTR($p2))
+    if (-not $s1) { Die "empty passphrase" }
+    if ($s1 -ne $s2) { Die "passphrases do not match" }
+    Store-Passphrase $slug $s1 | Out-Null
+    Ok "Passphrase stored (DPAPI). Daily runs read it with no prompt."
+  }
+
+  Set-ConfEntry $v @{ dest = $d; archive_stem = $Stem; encrypt = [bool]$Encrypt; keep = $Keep; keychain_account = $slug; store_kind = "dpapi" }
+  Ok "Saved config -> $Conf"
+
+  Say ""
+  Say "Taking the first snapshot..."
+  $script:Vault = $v
+  Cmd-Run
+
+  if ($Schedule -eq "daily") {
+    try {
+      $self = $MyInvocation.MyCommand.Path
+      $action  = New-ScheduledTaskAction -Execute "pwsh" -Argument "-NoProfile -File `"$self`" run -Vault `"$v`""
+      $trigger = New-ScheduledTaskTrigger -Daily -At 3am
+      Register-ScheduledTask -TaskName "ai-brain-starter vault-backup $slug" -Action $action -Trigger $trigger -Force | Out-Null
+      Ok "Daily backup scheduled (03:00 local)."
+    } catch { Warn "Could not register a scheduled task; run vault-backup.ps1 run yourself." }
+  }
+  Say ""
+  Ok "Backup is live. Now prove it restores (do this once):"
+  Say "    pwsh `"$($MyInvocation.MyCommand.Path)`" verify -Vault `"$v`""
+}
+
+function Cmd-Run {
+  $v = Resolve-Vault $Vault
+  $e = Get-ConfEntry $v
+  if (-not $e) { Die "vault not configured. Run: vault-backup.ps1 setup -Vault `"$v`"" }
+  $dest = $e.dest
+  if (-not (Test-Path -LiteralPath $dest)) { Die "backup destination unreachable: $dest (external disk unplugged?)" }
+  $slug = if ($e.keychain_account) { $e.keychain_account } else { Slug-For $v }
+  $stamp = (Get-Date).ToString("yyyyMMdd-HHmmss")
+  $outBase = Join-Path $dest "$Stem-$stamp"
+  $out = New-Archive $v $outBase ([bool]$e.encrypt) $slug
+  $info = Get-Item -LiteralPath $out
+  if ($info.Length -lt 256) { Remove-Item -LiteralPath $out -Force; Die "archive is suspiciously small" }
+  $keep = if ($e.keep) { [int]$e.keep } else { 7 }
+  Invoke-Rotate $dest $keep
+  Set-ConfEntry $v @{ last = (IsoNow) }
+  IsoNow | Set-Content -LiteralPath $Marker -Encoding UTF8
+  Ok ("Snapshot: {0} ({1:N1} MB)" -f $out, ($info.Length / 1MB))
+}
+
+function Cmd-Verify {
+  $v = Resolve-Vault $Vault
+  $e = Get-ConfEntry $v
+  if (-not $e) { Die "vault not configured. Run setup first." }
+  $newest = Get-ChildItem -LiteralPath $e.dest -Filter "$Stem-*" -File -ErrorAction SilentlyContinue | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+  if (-not $newest) { Die "no snapshot found in $($e.dest). Run: vault-backup.ps1 run -Vault `"$v`"" }
+  $tmp = Join-Path ([IO.Path]::GetTempPath()) ("vbk-verify-" + [Guid]::NewGuid().ToString("N"))
+  New-Item -ItemType Directory -Force -Path $tmp | Out-Null
+  Say "Restoring $($newest.FullName) to a temp dir to prove it works..."
+  try {
+    if ($newest.Name -like "*.zip.gpg") {
+      $gpg = Get-Command gpg -ErrorAction SilentlyContinue
+      if (-not $gpg) { Die "cannot decrypt: gpg not found" }
+      $slug = if ($e.keychain_account) { $e.keychain_account } else { Slug-For $v }
+      $pass = Get-Passphrase $slug
+      $zip = Join-Path $tmp "restore.zip"
+      & $gpg.Source --batch --yes --pinentry-mode loopback --passphrase $pass -o $zip -d $newest.FullName 2>$null
+      Expand-Archive -LiteralPath $zip -DestinationPath $tmp -Force
+      Remove-Item -LiteralPath $zip -Force
+    } else {
+      Expand-Archive -LiteralPath $newest.FullName -DestinationPath $tmp -Force
+    }
+    $count = (Get-ChildItem -Recurse -File -LiteralPath $tmp -ErrorAction SilentlyContinue).Count
+    if ($count -lt 1) { Die "restore produced ZERO files - the backup is empty/broken" }
+    $sentinel = if (Test-Path -LiteralPath (Join-Path $tmp "CLAUDE.md")) { ", CLAUDE.md present" } else { "" }
+    Set-ConfEntry $v @{ last_verify = (IsoNow) }
+    Ok "Restore verified: extracted $count file(s)$sentinel. Your backup actually restores."
+  } finally {
+    Remove-Item -Recurse -Force -LiteralPath $tmp -ErrorAction SilentlyContinue
+  }
+}
+
+function Cmd-Status {
+  $v = Resolve-Vault $Vault
+  Say "Vault: $v"
+  $e = Get-ConfEntry $v
+  if (-not $e) {
+    Warn "No backup configured for this vault."
+    Say  "Set one up: vault-backup.ps1 setup -Vault `"$v`""
+  } else {
+    $reach = if (Test-Path -LiteralPath $e.dest) { "(reachable)" } else { "(UNREACHABLE)" }
+    Say "Destination: $($e.dest) $reach"
+    Say "Encrypted:   $($e.encrypt)    Keep: $($e.keep)"
+    $n = (Get-ChildItem -LiteralPath $e.dest -Filter "$Stem-*" -File -ErrorAction SilentlyContinue).Count
+    Say "Snapshots:   $n in destination"
+    Say "Last run:    $(if ($e.last) { $e.last } else { 'never' })"
+    Say "Last verify: $(if ($e.last_verify) { $e.last_verify } else { 'never  (run: vault-backup.ps1 verify)' })"
+  }
+  $checker = Join-Path $PSScriptRoot "check-vault-backup.py"
+  if (Test-Path -LiteralPath $checker) {
+    $py = Get-Command python -ErrorAction SilentlyContinue
+    if (-not $py) { $py = Get-Command python3 -ErrorAction SilentlyContinue }
+    if ($py) { Say ""; & $py.Source $checker $v }
+  }
+}
+
+switch ($Command.ToLower()) {
+  "setup"  { Cmd-Setup }
+  "run"    { Cmd-Run }
+  "verify" { Cmd-Verify }
+  "status" { Cmd-Status }
+  default  { Die "unknown command: $Command (use setup|run|verify|status)" }
+}

--- a/scripts/vault-backup.sh
+++ b/scripts/vault-backup.sh
@@ -1,0 +1,425 @@
+#!/usr/bin/env bash
+# vault-backup.sh — one-command, provider-agnostic, off-machine backup for a brain vault.
+#
+# The gap this closes: a brain in active daily use whose only copy is the local
+# disk it runs on. The hourly git auto-snapshot is LOCAL-only (it refuses to run
+# with a remote) — so without this, "I have snapshots" still means one disk
+# failure = everything gone. This writes ONE compressed archive per run to a
+# destination you already have (an external disk, or a Google Drive / Dropbox /
+# OneDrive folder — your choice), so it is genuinely off-machine. One file, not
+# the churning git object tree, so a cloud folder syncs it without a storm.
+#
+#   setup   pick a destination (+ optional encryption + a daily schedule), then
+#           take the first snapshot immediately.
+#   run     take one snapshot now (what the schedule calls; non-interactive).
+#   verify  restore the newest snapshot to a temp dir and confirm it actually
+#           extracts — a backup you have never restored is a hope, not a backup.
+#   status  show where backups go, how fresh they are, and the canonical verdict.
+#
+# Provider-agnostic: the destination is any folder path you give it. Encryption
+# (--encrypt) is optional and uses gpg (or openssl) with the passphrase stored
+# in your OS keychain, never in plaintext. Pure POSIX-ish bash + python3 for the
+# small JSON bits (python3 is already a hard dependency of this repo).
+#
+# Usage:
+#   bash vault-backup.sh setup  [--vault PATH] [--dest DIR] [--encrypt] [--keep N] [--schedule daily|none]
+#   bash vault-backup.sh run    [--vault PATH]
+#   bash vault-backup.sh verify [--vault PATH]
+#   bash vault-backup.sh status [--vault PATH]
+#
+# Config:  ~/.claude/.vault-backup.conf  (JSON, keyed by resolved vault path)
+# Marker:  ~/.claude/.vault-backup-last  (ISO8601 of the last successful run)
+set -uo pipefail
+
+CONF="${VAULT_BACKUP_CONF:-$HOME/.claude/.vault-backup.conf}"
+MARKER="${VAULT_BACKUP_MARKER:-$HOME/.claude/.vault-backup-last}"
+KEYCHAIN_SERVICE="ai-brain-starter-vault-backup"
+ARCHIVE_STEM="vault-backup"
+
+# Dirs that are regenerable machine-exhaust — never worth backing up, and the
+# exact churn that would bloat the archive. Notes + .git history are kept.
+EXCLUDES=(
+  "./.claude/worktrees" "./.smart-env" "./.codegraph" "./node_modules"
+  "./.venv" "./__pycache__" "./.pytest_cache" "./.mypy_cache" "./.ruff_cache"
+  "./.trash" "./.DS_Store"
+)
+
+# ---------- tiny ui helpers (no-op color if not a tty) ----------
+if [ -t 1 ]; then G=$'\033[32m'; Y=$'\033[33m'; R=$'\033[31m'; B=$'\033[1m'; N=$'\033[0m'
+else G=''; Y=''; R=''; B=''; N=''; fi
+say()  { echo "$*"; }
+ok()   { echo "${G}OK${N}   $*"; }
+warn() { echo "${Y}WARN${N} $*"; }
+die()  { echo "${R}ERROR${N} $*" >&2; exit 1; }
+
+iso_now() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+
+# ---------- json conf helpers (python3 is a repo dependency) ----------
+conf_get() { # <vault-key> <field> -> value or empty
+  python3 - "$CONF" "$1" "$2" <<'PY'
+import json, sys
+conf_path, key, field = sys.argv[1], sys.argv[2], sys.argv[3]
+try:
+    d = json.load(open(conf_path))
+except Exception:
+    print(""); sys.exit(0)
+e = (d.get("vaults") or {}).get(key) or {}
+v = e.get(field, "")
+print(v if v is not None else "")
+PY
+}
+
+conf_set() { # <vault-key> <field=value>...  (values are strings unless int/bool-looking)
+  local key="$1"; shift
+  python3 - "$CONF" "$key" "$@" <<'PY'
+import json, os, sys
+conf_path, key = sys.argv[1], sys.argv[2]
+pairs = sys.argv[3:]
+try:
+    d = json.load(open(conf_path))
+except Exception:
+    d = {}
+d.setdefault("vaults", {})
+e = d["vaults"].get(key, {})
+for p in pairs:
+    f, _, v = p.partition("=")
+    if v in ("true", "false"):
+        e[f] = (v == "true")
+    elif v.isdigit():
+        e[f] = int(v)
+    else:
+        e[f] = v
+d["vaults"][key] = e
+os.makedirs(os.path.dirname(conf_path), exist_ok=True)
+tmp = conf_path + ".tmp"
+json.dump(d, open(tmp, "w"), indent=2)
+os.replace(tmp, conf_path)
+PY
+}
+
+realpath_py() { python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$1"; }
+
+slug_for() { # <vault-path> -> stable short slug for keychain acct / plist name
+  local base hash
+  base="$(basename "$1" | tr ' /' '__')"
+  hash="$(printf '%s' "$1" | (md5 2>/dev/null || md5sum 2>/dev/null) | tr -d ' -' | cut -c1-8)"
+  printf '%s-%s' "$base" "$hash"
+}
+
+# ---------- vault resolution ----------
+resolve_vault() { # echoes resolved vault path; dies if not a dir
+  local v="${1:-}"
+  if [ -z "$v" ]; then v="${VAULT_PATH:-$PWD}"; fi
+  [ -d "$v" ] || die "vault path is not a directory: $v"
+  realpath_py "$v"
+}
+
+# ---------- passphrase (keychain-backed) ----------
+store_passphrase() { # <slug> <passphrase>
+  local acct="$1" pass="$2"
+  if command -v security >/dev/null 2>&1; then        # macOS Keychain
+    security add-generic-password -a "$acct" -s "$KEYCHAIN_SERVICE" -w "$pass" -U >/dev/null 2>&1 \
+      && { echo "keychain"; return 0; }
+  fi
+  if command -v secret-tool >/dev/null 2>&1; then      # Linux libsecret
+    printf '%s' "$pass" | secret-tool store --label="$KEYCHAIN_SERVICE" \
+      service "$KEYCHAIN_SERVICE" account "$acct" >/dev/null 2>&1 \
+      && { echo "secret-tool"; return 0; }
+  fi
+  # Fallback: 0600 file. Loud about it — this is weaker than a keychain.
+  local pf="$HOME/.claude/.vault-backup-pass-$acct"
+  ( umask 077; printf '%s' "$pass" > "$pf" )
+  warn "No OS keychain found; passphrase stored in $pf (chmod 600). A keychain is safer." >&2
+  echo "file:$pf"
+}
+
+get_passphrase() { # <slug> <store-kind> -> passphrase on stdout (non-interactive)
+  local acct="$1" kind="$2"
+  case "$kind" in
+    keychain)     security find-generic-password -a "$acct" -s "$KEYCHAIN_SERVICE" -w 2>/dev/null ;;
+    secret-tool)  secret-tool lookup service "$KEYCHAIN_SERVICE" account "$acct" 2>/dev/null ;;
+    file:*)       cat "${kind#file:}" 2>/dev/null ;;
+    *)            return 1 ;;
+  esac
+}
+
+# ---------- the archive ----------
+make_archive() { # <vault> <out-base-no-ext> <encrypt 0|1> <slug> <store-kind> -> echoes final path
+  local vault="$1" outbase="$2" enc="$3" acct="$4" kind="$5"
+  local excl=() e
+  for e in "${EXCLUDES[@]}"; do excl+=("--exclude=$e"); done
+  # Always exclude any prior archives that happen to live under the vault.
+  excl+=("--exclude=./*.tar.gz" "--exclude=./*.tar.gz.gpg" "--exclude=./*.tar.gz.enc")
+
+  if [ "$enc" = "1" ]; then
+    local pass; pass="$(get_passphrase "$acct" "$kind")"
+    [ -n "$pass" ] || die "could not read backup passphrase from $kind"
+    if command -v gpg >/dev/null 2>&1; then
+      local out="$outbase.tar.gz.gpg"
+      tar -cz "${excl[@]}" -C "$vault" . 2>/dev/null \
+        | gpg --batch --yes --pinentry-mode loopback --passphrase "$pass" \
+              -c --cipher-algo AES256 -o "$out" 2>/dev/null \
+        && { echo "$out"; return 0; }
+      die "gpg encryption failed"
+    elif command -v openssl >/dev/null 2>&1; then
+      local out="$outbase.tar.gz.enc"
+      tar -cz "${excl[@]}" -C "$vault" . 2>/dev/null \
+        | openssl enc -aes-256-cbc -pbkdf2 -salt -pass "pass:$pass" -out "$out" 2>/dev/null \
+        && { echo "$out"; return 0; }
+      die "openssl encryption failed"
+    else
+      die "--encrypt needs gpg or openssl; neither found"
+    fi
+  else
+    local out="$outbase.tar.gz"
+    tar -czf "$out" "${excl[@]}" -C "$vault" . 2>/dev/null && { echo "$out"; return 0; }
+    die "tar failed"
+  fi
+}
+
+rotate() { # <dest> <keep>
+  local dest="$1" keep="$2" f
+  # newest-first; delete everything past $keep
+  ls -1t "$dest"/$ARCHIVE_STEM-* 2>/dev/null | tail -n +"$((keep+1))" | while IFS= read -r f; do
+    [ -n "$f" ] && rm -f "$f"
+  done
+}
+
+human_size() { # <file>
+  if [ "$(uname)" = "Darwin" ]; then stat -f %z "$1" 2>/dev/null; else stat -c %s "$1" 2>/dev/null; fi \
+    | awk '{ s=$1; u="B"; if(s>1073741824){s/=1073741824;u="GB"} else if(s>1048576){s/=1048576;u="MB"} else if(s>1024){s/=1024;u="KB"} printf "%.1f%s", s, u }'
+}
+
+# ============================ subcommands ============================
+
+cmd_setup() {
+  local vault="" dest="" encrypt=0 keep=7 schedule="daily"
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --vault) vault="$2"; shift 2;;
+      --dest) dest="$2"; shift 2;;
+      --encrypt) encrypt=1; shift;;
+      --keep) keep="$2"; shift 2;;
+      --schedule) schedule="$2"; shift 2;;
+      *) die "unknown setup arg: $1";;
+    esac
+  done
+  vault="$(resolve_vault "$vault")"
+  say "${B}Backing up:${N} $vault"
+
+  # Destination — prompt if not given.
+  if [ -z "$dest" ]; then
+    say ""
+    say "Where should the off-machine backup go? Give a folder you already have"
+    say "somewhere OTHER than this machine's single disk — an external drive, or a"
+    say "Google Drive / Dropbox / OneDrive folder (one daily file syncs fine; it is"
+    say "the churning vault that must not go in cloud sync, not a single archive)."
+    printf "Destination folder: "
+    read -r dest
+    [ -n "$dest" ] || die "no destination given"
+  fi
+  # Expand ~ and resolve.
+  dest="${dest/#\~/$HOME}"
+  mkdir -p "$dest" 2>/dev/null || die "could not create destination: $dest"
+  dest="$(realpath_py "$dest")"
+
+  # Refuse a destination INSIDE the vault — that is not off-machine at all.
+  case "$dest/" in
+    "$vault/"*) die "destination is inside the vault ($dest). Pick a folder off this machine.";;
+  esac
+  # Nudge (don't block) if the destination is not obviously off-machine.
+  if printf '%s' "$dest" | grep -Eq '/(OneDrive|Dropbox|Google ?Drive|CloudStorage|Box|Mobile Documents)/|/Volumes/'; then
+    ok "Destination looks off-machine (cloud folder or external volume)."
+  else
+    warn "Destination $dest may be on this same disk. That protects against accidental"
+    warn "deletion but NOT against disk failure. An external drive or cloud folder is safer."
+  fi
+
+  local slug store_kind=""; slug="$(slug_for "$vault")"
+
+  # Encryption passphrase (stored in keychain), if requested.
+  if [ "$encrypt" = "1" ]; then
+    command -v gpg >/dev/null 2>&1 || command -v openssl >/dev/null 2>&1 \
+      || die "--encrypt needs gpg or openssl installed"
+    local p1 p2
+    printf "Set a backup passphrase (kept in your OS keychain, never in plaintext): "
+    read -rs p1; echo
+    printf "Confirm passphrase: "
+    read -rs p2; echo
+    [ -n "$p1" ] || die "empty passphrase"
+    [ "$p1" = "$p2" ] || die "passphrases do not match"
+    store_kind="$(store_passphrase "$slug" "$p1")"
+    ok "Passphrase stored ($store_kind). Daily runs read it from there, no prompt."
+  fi
+
+  # Persist config.
+  conf_set "$vault" \
+    "dest=$dest" "archive_stem=$ARCHIVE_STEM" "encrypt=$([ "$encrypt" = 1 ] && echo true || echo false)" \
+    "keep=$keep" "keychain_account=$slug" "store_kind=$store_kind"
+  ok "Saved config -> $CONF"
+
+  # First snapshot immediately, so there is no configured-but-empty gap.
+  say ""
+  say "${B}Taking the first snapshot...${N}"
+  cmd_run --vault "$vault" || die "first snapshot failed"
+
+  # Schedule the daily run.
+  if [ "$schedule" = "daily" ]; then
+    install_schedule "$vault" "$slug" && ok "Daily backup scheduled (03:00 local)." \
+      || warn "Could not install an automatic schedule; run \`vault-backup.sh run\` yourself or add a cron job."
+  else
+    say "No schedule installed (--schedule none). Run \`vault-backup.sh run\` when you want a snapshot."
+  fi
+
+  say ""
+  ok "${B}Backup is live.${N} Now prove it restores (do this once):"
+  say "    bash $0 verify --vault \"$vault\""
+}
+
+cmd_run() {
+  local vault=""
+  while [ $# -gt 0 ]; do case "$1" in --vault) vault="$2"; shift 2;; *) shift;; esac; done
+  vault="$(resolve_vault "$vault")"
+  local dest; dest="$(conf_get "$vault" dest)"
+  [ -n "$dest" ] || die "vault not configured for backup. Run: bash $0 setup --vault \"$vault\""
+  [ -d "$dest" ] || die "backup destination is unreachable: $dest (external disk unplugged?)"
+  local enc encbool keep slug kind
+  encbool="$(conf_get "$vault" encrypt)"; enc=$([ "$encbool" = "True" ] || [ "$encbool" = "true" ] && echo 1 || echo 0)
+  keep="$(conf_get "$vault" keep)"; [ -n "$keep" ] || keep=7
+  slug="$(conf_get "$vault" keychain_account)"; [ -n "$slug" ] || slug="$(slug_for "$vault")"
+  kind="$(conf_get "$vault" store_kind)"
+
+  local stamp outbase out
+  stamp="$(date +%Y%m%d-%H%M%S)"
+  outbase="$dest/$ARCHIVE_STEM-$stamp"
+  out="$(make_archive "$vault" "$outbase" "$enc" "$slug" "$kind")" || exit 1
+
+  # Integrity sanity-check before declaring success.
+  local sz; sz="$(human_size "$out")"
+  if [ "$enc" = "0" ]; then
+    tar -tzf "$out" >/dev/null 2>&1 || { rm -f "$out"; die "archive failed integrity check (corrupt tar.gz)"; }
+  else
+    # Can't list without decrypting; assert it is non-trivially sized.
+    local bytes; bytes="$(if [ "$(uname)" = Darwin ]; then stat -f %z "$out"; else stat -c %s "$out"; fi)"
+    [ "${bytes:-0}" -gt 256 ] || { rm -f "$out"; die "encrypted archive is suspiciously small"; }
+  fi
+
+  rotate "$dest" "$keep"
+  conf_set "$vault" "last=$(iso_now)"
+  ( umask 077; iso_now > "$MARKER" ) 2>/dev/null || true
+  ok "Snapshot: $out ($sz)"
+}
+
+cmd_verify() {
+  local vault=""
+  while [ $# -gt 0 ]; do case "$1" in --vault) vault="$2"; shift 2;; *) shift;; esac; done
+  vault="$(resolve_vault "$vault")"
+  local dest; dest="$(conf_get "$vault" dest)"
+  [ -n "$dest" ] || die "vault not configured. Run setup first."
+  local newest
+  newest="$(ls -1t "$dest"/$ARCHIVE_STEM-* 2>/dev/null | head -1)"
+  [ -n "$newest" ] || die "no snapshot found in $dest. Run: bash $0 run --vault \"$vault\""
+
+  local tmp; tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+  say "Restoring ${B}$newest${N} to a temp dir to prove it actually works..."
+
+  case "$newest" in
+    *.tar.gz)
+      tar -xzf "$newest" -C "$tmp" 2>/dev/null || die "restore FAILED: archive did not extract" ;;
+    *.tar.gz.gpg)
+      local slug kind pass; slug="$(conf_get "$vault" keychain_account)"; kind="$(conf_get "$vault" store_kind)"
+      pass="$(get_passphrase "$slug" "$kind")"; [ -n "$pass" ] || die "no passphrase to decrypt"
+      gpg --batch --yes --pinentry-mode loopback --passphrase "$pass" -d "$newest" 2>/dev/null \
+        | tar -xz -C "$tmp" 2>/dev/null || die "restore FAILED: could not decrypt + extract" ;;
+    *.tar.gz.enc)
+      local slug kind pass; slug="$(conf_get "$vault" keychain_account)"; kind="$(conf_get "$vault" store_kind)"
+      pass="$(get_passphrase "$slug" "$kind")"; [ -n "$pass" ] || die "no passphrase to decrypt"
+      openssl enc -d -aes-256-cbc -pbkdf2 -pass "pass:$pass" -in "$newest" 2>/dev/null \
+        | tar -xz -C "$tmp" 2>/dev/null || die "restore FAILED: could not decrypt + extract" ;;
+    *) die "unrecognized archive type: $newest" ;;
+  esac
+
+  local count; count="$(find "$tmp" -type f 2>/dev/null | wc -l | tr -d ' ')"
+  [ "$count" -gt 0 ] || die "restore produced ZERO files — the backup is empty/broken"
+  # Prefer a meaningful sentinel if the vault has one.
+  local sentinel=""
+  [ -f "$tmp/CLAUDE.md" ] && sentinel="CLAUDE.md"
+  conf_set "$vault" "last_verify=$(iso_now)"
+  ok "Restore verified: extracted $count file(s)${sentinel:+, $sentinel present}. Your backup actually restores."
+}
+
+cmd_status() {
+  local vault=""
+  while [ $# -gt 0 ]; do case "$1" in --vault) vault="$2"; shift 2;; *) shift;; esac; done
+  vault="$(resolve_vault "$vault")"
+  say "${B}Vault:${N} $vault"
+  local dest; dest="$(conf_get "$vault" dest)"
+  if [ -z "$dest" ]; then
+    warn "No backup configured for this vault."
+    say  "Set one up: bash $0 setup --vault \"$vault\""
+  else
+    say "${B}Destination:${N} $dest $([ -d "$dest" ] && echo "(reachable)" || echo "${R}(UNREACHABLE)${N}")"
+    say "${B}Encrypted:${N}   $(conf_get "$vault" encrypt)    ${B}Keep:${N} $(conf_get "$vault" keep)"
+    local last lastv n
+    last="$(conf_get "$vault" last)"; lastv="$(conf_get "$vault" last_verify)"
+    n="$(ls -1 "$dest"/$ARCHIVE_STEM-* 2>/dev/null | wc -l | tr -d ' ')"
+    say "${B}Snapshots:${N}   ${n:-0} in destination"
+    say "${B}Last run:${N}    ${last:-never}"
+    say "${B}Last verify:${N} ${lastv:-never  (run: bash $0 verify)}"
+  fi
+  # Canonical verdict from the single source of truth.
+  local checker; checker="$(cd "$(dirname "$0")" && pwd)/check-vault-backup.py"
+  [ -f "$checker" ] && { say ""; python3 "$checker" "$vault" || true; }
+}
+
+# ---------- scheduling ----------
+install_schedule() { # <vault> <slug>  -> 0 on success
+  local vault="$1" slug="$2" self
+  self="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
+  case "$(uname)" in
+    Darwin)
+      local label="com.ai-brain-starter.vault-backup.$slug"
+      local plist="$HOME/Library/LaunchAgents/$label.plist"
+      mkdir -p "$HOME/Library/LaunchAgents"
+      cat > "$plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>Label</key><string>$label</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string><string>$self</string>
+    <string>run</string><string>--vault</string><string>$vault</string>
+  </array>
+  <key>StartCalendarInterval</key><dict><key>Hour</key><integer>3</integer><key>Minute</key><integer>0</integer></dict>
+  <key>StandardErrorPath</key><string>$HOME/.claude/.vault-backup.log</string>
+  <key>StandardOutPath</key><string>$HOME/.claude/.vault-backup.log</string>
+</dict></plist>
+EOF
+      launchctl bootstrap "gui/$(id -u)" "$plist" >/dev/null 2>&1 \
+        || launchctl load "$plist" >/dev/null 2>&1 || true
+      [ -f "$plist" ]
+      ;;
+    Linux)
+      command -v crontab >/dev/null 2>&1 || return 1
+      local line="0 3 * * * /bin/bash $self run --vault '$vault' >> \$HOME/.claude/.vault-backup.log 2>&1"
+      local cur; cur="$(crontab -l 2>/dev/null)"
+      printf '%s' "$cur" | grep -Fq "vault-backup.sh run --vault '$vault'" && return 0
+      { printf '%s\n' "$cur"; printf '%s\n' "$line"; } | crontab - 2>/dev/null
+      ;;
+    *) return 1;;
+  esac
+}
+
+# ============================ dispatch ============================
+CMD="${1:-status}"; shift 2>/dev/null || true
+case "$CMD" in
+  setup)  cmd_setup "$@";;
+  run)    cmd_run "$@";;
+  verify) cmd_verify "$@";;
+  status) cmd_status "$@";;
+  -h|--help|help)
+    sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//' ;;
+  *) die "unknown command: $CMD (use setup|run|verify|status)";;
+esac

--- a/tests/integration/test_vault_safety_guards.sh
+++ b/tests/integration/test_vault_safety_guards.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Run the vault-safety guard self-tests in CI so they cannot bit-rot.
+#
+# These guards each ship a negative control (they assert the guard FIRES on the
+# thing it catches AND stays silent otherwise) — but a self-test that only ever
+# runs by hand is one refactor away from silently going stale. Wiring them into
+# the canonical `scripts/ci.sh` gate is what makes "a guard earns trust only by
+# failing on the thing it catches" durable instead of aspirational.
+#
+# Covers:
+#   - scripts/test-cloud-sync-guard.sh       (vault-in-cloud-sync detector, #159)
+#   - scripts/test-vault-backup-guard.sh     (no-off-machine-backup detector)
+#   - scripts/test-vault-backup-roundtrip.sh (one-command backup: real restore loop)
+#
+# CI-safe: every guard test is hermetic (temp dirs, isolated config via env),
+# needs no network, and the round-trip test skips its encrypted leg when neither
+# gpg nor openssl is present.
+set -u
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+fails=0
+
+run_guard() { # <relative-script-path>
+  local rel="$1" path="$REPO_ROOT/$1"
+  if [ ! -f "$path" ]; then
+    echo "FAIL  missing guard self-test: $rel"; fails=$((fails+1)); return
+  fi
+  echo "--- $rel"
+  if bash "$path"; then
+    echo "OK    $rel"
+  else
+    echo "FAIL  $rel exited non-zero"; fails=$((fails+1))
+  fi
+}
+
+run_guard "scripts/test-cloud-sync-guard.sh"
+run_guard "scripts/test-vault-backup-guard.sh"
+run_guard "scripts/test-vault-backup-roundtrip.sh"
+
+echo
+if [ "$fails" -gt 0 ]; then
+  echo "VAULT-SAFETY GUARDS FAILED: $fails"
+  exit 1
+fi
+echo "All vault-safety guard self-tests passed."


### PR DESCRIPTION
## The gap

A brain in active daily use whose only copy is the local disk it runs on. It works perfectly right up until the drive dies, then everything is gone at once — no warning. The hourly git auto-snapshot (`auto-snapshot.sh`) is *local-only* by design (it refuses to run with a remote), so "I have snapshots" still meant one disk failure = total loss. Nothing detected the no-backup state, nothing offered a fix, and onboarding actively waved it off (the old Phase 15: "no special backup setup needed").

Bug class: `USER-VAULT-WITHOUT-OFF-MACHINE-BACKUP`.

## What ships

- **`check-vault-backup.py`** — the single source of truth. Reports `BACKED_UP` if any off-machine copy exists (our `vault-backup` archive, a Time Machine destination, a cloud-sync copy, or a pushed git remote), else `NO_BACKUP`. Mirrors the `check-cloud-sync.py` pattern from #159.
- **`surface-backup-status.py`** — SessionStart signal. Loud and *repeated* on `NO_BACKUP` (a message distinct from "stale"), nudges `run`/`verify` when configured, silent when covered. Advisory, never blocks; bypass `VAULT_BACKUP_BYPASS=1`. Wired into `hooks.json` next to `worktree-footprint-signal.py`.
- **`vault-backup.sh`** (+ `vault-backup.ps1` for Windows) — one command. Provider-agnostic destination (external drive or any cloud folder), **one compressed daily archive** instead of the churning git tree, excludes machine-exhaust, optional AES-256 with the passphrase in the OS keychain, installs a daily schedule, and a `verify` that does a real restore-to-temp.
- **Onboarding** — `phase-01-welcome.md` step 8.6 establishes-or-defers a backup; the stale `phase-12-17` Phase 15 (which assumed "normal habits cover it" — the exact assumption that fails) is rewritten into a confirm-before-setup-is-done gate.
- **`diagnose.sh`/`.ps1`** section 12; **`docs/BACKUP.md`** is the canonical guide and fixes the previously-broken `CLOUD_SYNC.md` -> `MAINTENANCE.md` cross-reference (MAINTENANCE had zero backup content despite being pointed at twice — both now point at `BACKUP.md`).

## Verification

Both new guards ship negative controls, now run in CI via `test_vault_safety_guards` in `scripts/ci.sh` (which also retroactively wires #159's previously-standalone `test-cloud-sync-guard.sh`, so none of them can bit-rot):

- `test-vault-backup-guard.sh` — proves a bare vault reports `NO_BACKUP` (exit 1) and every real off-machine-copy path reports `BACKED_UP` (exit 0), so the guard is neither always-firing nor always-silent.
- `test-vault-backup-roundtrip.sh` — runs the whole loop on a fixture vault: one archive written, machine-exhaust excluded, detector flips to backed-up, a real restore extracts the notes back, rotation honors `--keep`, and the encrypted path round-trips without leaking plaintext.

Local: `bash scripts/ci.sh` green (253 `py_compile` + 13 integration tests). Personal-data scrub clean (source + markdown scopes). `vault-backup.ps1` parses cleanly with a UTF-8 BOM and no em dashes; its runtime is Windows-only (`robocopy`, scheduled task, DPAPI) so its round-trip is deferred to a Windows host — logic mirrors the fully-tested bash path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)