### PR TITLE
feat(worktree-cap): liveness-aware per-session backstop (reap dead-session worktrees + sweep orphans)

### DIFF
--- a/hooks/_lib/worktree_safety.py
+++ b/hooks/_lib/worktree_safety.py
@@ -38,6 +38,7 @@ Pure stdlib.
 """
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import subprocess
@@ -500,3 +501,64 @@ def detect_cloud_sync(path: Path) -> str | None:
         if (p == str(base) or p.startswith(str(base) + "/")) and (icloud / folder).exists():
             return f"iCloud Drive ({folder} sync)"
     return None
+
+
+# Optional session-liveness file written by session-lock.py (a sibling hook).
+# Reading it lets the cap reaper distinguish "this scratch worktree belongs to a
+# session that is still running" from "its session is gone" — so a crashed
+# session's worktree can be reclaimed promptly (regardless of the count cap)
+# while a live-but-idle session's worktree is never pulled out from under it.
+SESSION_LOCK_REL = ".claude/.session-lock.json"
+
+
+def _pid_alive(pid: int) -> bool:
+    """True if `pid` names a running process. Errs toward 'alive' (over-preserve)."""
+    if not isinstance(pid, int) or pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # exists, owned by another uid
+    except OSError:
+        return True  # unsure → treat as alive so we never reap a maybe-live session
+
+
+def live_session_cwds(main_repo: Path, grace_min: int = 35) -> set[str] | None:
+    """Resolved cwd paths of currently-LIVE Claude sessions, from the session lock.
+
+    A session counts as live if its PID is running OR it was active within the
+    last `grace_min` minutes (the lock prunes idle entries at ~30 min, so 35 min
+    gives a margin). Both checks err toward "live" — the only safe direction,
+    since the consumer uses this to decide what NOT to reclaim.
+
+    Returns None when liveness is UNKNOWN (lock absent / unreadable / wrong shape).
+    None is distinct from an empty set: callers MUST treat None as "do not reap on
+    liveness" (never interpret a missing lock as "no sessions are live → reap all").
+    """
+    lock = main_repo / SESSION_LOCK_REL
+    try:
+        data = json.loads(lock.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    sessions = data.get("sessions") if isinstance(data, dict) else None
+    if not isinstance(sessions, dict):
+        return None
+    cutoff = time.time() - grace_min * 60
+    live: set[str] = set()
+    for s in sessions.values():
+        if not isinstance(s, dict):
+            continue
+        cwd = s.get("cwd")
+        if not cwd:
+            continue
+        la = s.get("last_activity_at")
+        recent = isinstance(la, (int, float)) and la >= cutoff
+        if recent or _pid_alive(s.get("pid")):
+            try:
+                live.add(str(Path(cwd).resolve()))
+            except OSError:
+                live.add(str(cwd))
+    return live

--- a/hooks/enforce-worktree-cap.py
+++ b/hooks/enforce-worktree-cap.py
@@ -1,23 +1,44 @@
 #!/usr/bin/env python3
-"""Bound the number of git worktrees — reclaim-then-allow, at SessionStart.
+"""Keep the worktree count near the live-session count — at SessionStart.
 
 The session-end removal hook (remove-ended-worktree.py) keeps the count low in
 the normal case. This is the BACKSTOP for the abnormal case: a session that
 crashes or is killed before SessionEnd fires leaves its worktree behind. Over
-enough crashes those accumulate again. This hook caps the total.
+enough crashes those accumulate again — and on a large vault each worktree is a
+FULL checkout (thousands of watched files), so waiting for a blunt count cap to
+fill before reclaiming is far too slow (the file watcher melts long first).
 
-DESIGN: reclaim-then-ALLOW, never block.
-  Power users run many concurrent sessions; a hard block on worktree creation
-  would break that workflow. So instead of blocking, when a new session starts
-  and the count is over the cap, we reclaim the OLDEST idle `claude/<slug>`
-  scratch worktrees (snapshotting any genuinely-unsaved content first, keeping
-  branch refs) until back under the cap. Active worktrees (touched <60min),
-  the current session's worktree, and deliberate feature-branch worktrees are
-  never touched. If everything over the cap is active, we surface a note and
-  leave them — correctness over the cap.
+DESIGN: two layers, reclaim-then-ALLOW, never block.
 
-Cap:    WORKTREE_MAX env (default 12).
-Bypass: WORKTREE_CAP_BYPASS=1.
+  Layer A — per-session backstop (runs EVERY session, regardless of count):
+    * DEAD-SESSION reap — a registered `claude/<slug>` scratch worktree whose
+      owning session is no longer live (per `.claude/.session-lock.json`) is
+      reclaimed promptly, regardless of the cap. Liveness is read from the lock;
+      a live session's worktree (even idle) and the current one are NEVER touched.
+      This is what actually keeps up with crashes — the count tracks live
+      sessions instead of drifting up to the cap.
+    * ORPHAN-DIR sweep — dirs under `.claude/worktrees/` that git no longer
+      registers (relocation-copied / half-created) are reclaimed (relocation-aware,
+      snapshot-safe). The cap loop can't see these (it reads `git worktree list`).
+
+  Layer B — count cap (ceiling for many concurrent LIVE sessions):
+    Power users run many concurrent sessions; a hard block on creation would break
+    that. So when the count is over the cap we reclaim the OLDEST idle `claude/<slug>`
+    scratch worktrees (snapshot first, keep branch refs) until back under it.
+    Active worktrees (touched <60min), the current one, and deliberate
+    feature-branch worktrees are never touched. If everything over the cap is
+    active, we surface a note and leave them — correctness over the cap.
+
+Cap:            WORKTREE_MAX env (default 12).
+Dead-idle gate: WORKTREE_DEAD_IDLE_MIN env (default 60, matching the cap reaper) —
+                a dead-session/orphan worktree must be untouched this long AND its
+                session must be absent from the lock's recency window before reclaim.
+Bypass:         WORKTREE_CAP_BYPASS=1.
+
+LIVENESS NOTE: per session-lock.py, the only trustworthy liveness signal is
+`last_activity_at` recency (the recorded pid is the ephemeral hook pid, dead on
+arrival). live_session_cwds() therefore uses recency; this hook never reaps a cwd
+that is active in that window, nor the current session's worktree.
 
 WIRING (SessionStart):
   "SessionStart": [
@@ -44,7 +65,10 @@ from _lib.worktree_safety import (  # noqa: E402
     git,
     is_idle,
     is_scratch_worktree,
+    list_orphan_dirs,
     list_worktrees,
+    live_session_cwds,
+    reclaim_orphan_dir,
     remove_worktree,
     snapshot_unrecoverable,
 )
@@ -79,6 +103,85 @@ def _branch(wt: Path) -> str:
         return ""
 
 
+def _per_session_backstop(main_repo: Path, cur_path: Path | None) -> tuple[list[str], dict[str, str]]:
+    """Reclaim what the count-cap alone cannot keep up with — runs EVERY session,
+    regardless of the total count. Returns (reaped_dead, swept_orphans).
+
+      1. DEAD-SESSION worktrees: a registered `claude/<slug>` scratch worktree whose
+         owning session is no longer live (machine crash / kill before SessionEnd
+         fired). Reaped regardless of the cap — but ONLY when liveness is knowable
+         (`live_session_cwds` is not None) and the worktree is neither a live
+         session's nor the current one. On a big vault each worktree is a full
+         checkout, so waiting for the cap (12) to trip before reclaiming crashed
+         worktrees is far too slow; liveness lets us reclaim them at the next
+         SessionStart instead.
+      2. ORPHAN DIRS: dirs under `.claude/worktrees/` that git no longer registers
+         (relocation-copied / half-created). `reclaim_orphan_dir` is relocation-aware
+         and fail-safe (snapshots genuinely-unsaved content; keeps anything it cannot
+         reason about). The cap loop can't see these (it reads `git worktree list`).
+
+    Both paths are idle-gated + snapshot-safe. Fail-safe: any error is swallowed so a
+    SessionStart is never blocked by cleanup.
+    """
+    reaped: list[str] = []
+    swept: dict[str, str] = {}
+    # Default 60 min matches the cap reaper's idle threshold (a value this codebase
+    # already trusts as "safe to reclaim"). Liveness here is two gates, both of
+    # which must say "gone": (a) the session's cwd is NOT active in the lock within
+    # live_session_cwds()'s recency window (~35 min; pid is informational only — see
+    # session-lock.py), AND (b) no file modified in dead_idle minutes. A live-but-idle
+    # session trips neither until it has been genuinely silent AND untouched that long.
+    try:
+        dead_idle = max(1, int(os.environ.get("WORKTREE_DEAD_IDLE_MIN", 60)))
+    except ValueError:
+        dead_idle = 60
+
+    # 1. dead-session registered scratch worktrees (liveness-gated)
+    try:
+        live = live_session_cwds(main_repo)
+        if live is not None:  # None = liveness unknown → never reap on this basis
+            for wt in [w for w in list_worktrees(main_repo) if is_scratch_worktree(w)]:
+                try:
+                    rp = wt.resolve()
+                except OSError:
+                    continue
+                if cur_path and rp == cur_path:
+                    continue
+                if str(rp) in live:
+                    continue  # a live session owns it — never pull the rug
+                if not _branch(wt).startswith("claude/"):
+                    continue  # deliberate feature-branch worktree
+                if not is_idle(wt, idle_min=dead_idle):
+                    continue  # touched recently — let it settle / SessionEnd handle it
+                slug = wt.name
+                snapped, _r, all_safe = snapshot_unrecoverable(main_repo, wt, slug)
+                if not all_safe:
+                    continue
+                if remove_worktree(main_repo, wt, force=True):
+                    reaped.append(slug)
+                    _log(main_repo, f"reaped dead-session {slug} (no live owner, "
+                                    f"idle>={dead_idle}m, snapshotted {snapped} unsaved)")
+    except Exception:
+        pass
+
+    # 2. orphan dirs git no longer registers (relocation-aware, fail-safe)
+    try:
+        for od in list_orphan_dirs(main_repo):
+            try:
+                if cur_path and od.resolve() == cur_path:
+                    continue
+            except OSError:
+                continue
+            action, snapped = reclaim_orphan_dir(main_repo, od, idle_min=dead_idle)
+            swept[od.name] = action
+            if "removed" in action:
+                _log(main_repo, f"orphan-dir {od.name}: {action} (snap {snapped})")
+    except Exception:
+        pass
+
+    return reaped, swept
+
+
 def main() -> int:
     if os.environ.get("WORKTREE_CAP_BYPASS") == "1":
         return _emit(None)
@@ -92,18 +195,38 @@ def main() -> int:
     if main_repo is None:
         return _emit(None)
 
-    # Only SCRATCH worktrees (under .claude/worktrees/) count against the cap
-    # and are eligible for reclaim. Deliberate ~/dev/<repo>-<slug> sibling
-    # worktrees are never auto-removed, even when idle and on a claude/* branch.
-    wts = [w for w in list_worktrees(main_repo) if is_scratch_worktree(w)]
-    if len(wts) <= cap:
-        return _emit(None)  # healthy
-
     cur = current_worktree()
     cur_path = cur[0].resolve() if cur else None
 
-    # Cheap sort: oldest dir-mtime first. Deep checks (branch/idle/snapshot)
-    # happen lazily only on the ones we actually try to remove.
+    notes: list[str] = []
+
+    # Per-session backstop (runs regardless of the count): reap worktrees whose
+    # owning session has died + sweep orphan dirs git no longer registers. This is
+    # what keeps the count near the live-session count, instead of letting crashed
+    # worktrees pile up until the cap finally trips — far too slow at a full
+    # checkout each.
+    reaped, swept = _per_session_backstop(main_repo, cur_path)
+    if reaped:
+        notes.append(
+            f"[worktree-backstop] Reclaimed {len(reaped)} dead-session worktree(s) "
+            f"(no live owner; branches + any unsaved work preserved): "
+            + ", ".join(reaped[:8]) + (f" +{len(reaped) - 8} more" if len(reaped) > 8 else "") + "."
+        )
+    swept_removed = [n for n, a in swept.items() if "removed" in a]
+    if swept_removed:
+        notes.append(
+            f"[worktree-backstop] Swept {len(swept_removed)} orphan dir(s) git no longer tracked: "
+            + ", ".join(swept_removed[:8])
+            + (f" +{len(swept_removed) - 8} more" if len(swept_removed) > 8 else "") + "."
+        )
+
+    # Count cap — the ceiling for many concurrent LIVE sessions. Only SCRATCH
+    # worktrees count; deliberate ~/dev/<repo>-<slug> siblings are never touched.
+    wts = [w for w in list_worktrees(main_repo) if is_scratch_worktree(w)]
+    if len(wts) <= cap:
+        return _emit("\n".join(notes) if notes else None)
+
+    # Cheap sort: oldest dir-mtime first. Deep checks happen lazily on removals.
     def _mtime(p: Path) -> float:
         try:
             return p.stat().st_mtime
@@ -113,7 +236,6 @@ def main() -> int:
     candidates = sorted(wts, key=_mtime)
     need = len(wts) - cap
     removed: list[str] = []
-    skipped_active = 0
 
     for wt in candidates:
         if len(removed) >= need:
@@ -123,7 +245,6 @@ def main() -> int:
         if not _branch(wt).startswith("claude/"):
             continue  # never auto-remove a deliberate worktree
         if not is_idle(wt, idle_min=60):
-            skipped_active += 1
             continue
         slug = wt.name
         snapped, _recoverable, all_safe = snapshot_unrecoverable(main_repo, wt, slug)
@@ -133,21 +254,20 @@ def main() -> int:
             removed.append(slug)
             _log(main_repo, f"reclaimed {slug} (over cap {cap}, snapshotted {snapped} unsaved)")
 
-    remaining = len(list_worktrees(main_repo))
-    if not removed:
-        if remaining > cap:
-            return _emit(
-                f"[worktree-cap] {remaining} worktrees (cap {cap}) but all over-cap ones are "
-                f"active or deliberate — none safe to reclaim now. They'll be cleaned at their "
-                f"SessionEnd, or run: python3 scripts/worktree-prune.sh"
-            )
-        return _emit(None)
-
-    note = (f"[worktree-cap] Reclaimed {len(removed)} stale worktree(s) to stay under cap {cap} "
-            f"(branches + any unsaved work preserved): {', '.join(removed[:8])}"
-            + (f" +{len(removed) - 8} more" if len(removed) > 8 else "")
-            + f". Now {remaining} worktree(s).")
-    return _emit(note)
+    remaining = len([w for w in list_worktrees(main_repo) if is_scratch_worktree(w)])
+    if removed:
+        notes.append(
+            f"[worktree-cap] Reclaimed {len(removed)} idle worktree(s) to stay under cap {cap} "
+            f"(branches + any unsaved work preserved): " + ", ".join(removed[:8])
+            + (f" +{len(removed) - 8} more" if len(removed) > 8 else "") + f". Now {remaining}."
+        )
+    elif remaining > cap:
+        notes.append(
+            f"[worktree-cap] {remaining} worktrees (cap {cap}) but all over-cap ones are active "
+            f"or deliberate — none safe to reclaim now. They'll be cleaned at their SessionEnd, "
+            f"or run: python3 scripts/worktree-prune.sh"
+        )
+    return _emit("\n".join(notes) if notes else None)
 
 
 if __name__ == "__main__":

--- a/hooks/test_live_session_reap.py
+++ b/hooks/test_live_session_reap.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Regression test: liveness-aware per-session backstop in enforce-worktree-cap.
+
+Bug class VAULT-MACHINERY-BLOAT-CHOKES-OBSIDIAN (root: worktree auto-cleanup not
+keeping up). A blunt count cap (default 12) lets crashed worktrees pile up — at a
+FULL checkout each, the file watcher melts long before the cap trips. Fix: at every
+SessionStart, reap registered `claude/<slug>` scratch worktrees whose owning session
+is DEAD (per `.claude/.session-lock.json`), regardless of the count cap, so the count
+tracks live sessions instead of drifting up to the cap.
+
+NEGATIVE CONTROLS (the guard must NOT reap what is still in use):
+  - a LIVE session's worktree (even idle) -> KEPT
+  - the CURRENT session's worktree        -> KEPT
+  - a deliberate non-claude/* branch wt    -> KEPT
+  - liveness UNKNOWN (no/garbage lock)     -> reap NOTHING on the dead-session basis
+  - unsaved-unique file in a dead wt       -> SNAPSHOTTED before the dir is removed
+Run: python3 hooks/test_live_session_reap.py
+"""
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import shutil
+from pathlib import Path
+
+HOOK_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(HOOK_DIR))
+from _lib.worktree_safety import live_session_cwds, snapshot_dir_for  # noqa: E402
+
+# Load the hyphenated hook module by path to test its _per_session_backstop().
+_spec = importlib.util.spec_from_file_location("enforce_cap", HOOK_DIR / "enforce-worktree-cap.py")
+enforce_cap = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(enforce_cap)
+
+DEAD_PID = 2 ** 31 - 1  # almost certainly not a running process
+
+
+def sh(repo, *args):
+    return subprocess.run(["git", "-C", str(repo), *args], capture_output=True, check=False, text=True)
+
+
+def make_main():
+    d = Path(tempfile.mkdtemp(prefix="wt-live-"))
+    sh(d, "init", "-q", "-b", "main")
+    sh(d, "config", "user.email", "t@t")
+    sh(d, "config", "user.name", "t")
+    (d / "committed.md").write_text("COMMITTED\n")
+    (d / "⚙️ Meta").mkdir(parents=True, exist_ok=True)  # snapshot_dir_for -> vault path
+    sh(d, "add", "committed.md")
+    sh(d, "commit", "-qm", "init")
+    (d / ".claude" / "worktrees").mkdir(parents=True)
+    return d
+
+
+def add_wt(main, slug, branch):
+    wt = main / ".claude" / "worktrees" / slug
+    sh(main, "worktree", "add", "-q", "-b", branch, str(wt), "HEAD")
+    return wt
+
+
+def make_idle(p, secs=7200):
+    """Backdate every file (incl. the .git pointer file) so is_idle() sees it idle."""
+    old = time.time() - secs
+    for root, _dirs, files in os.walk(p):
+        for f in files:
+            try:
+                os.utime(os.path.join(root, f), (old, old))
+            except OSError:
+                pass
+    try:
+        os.utime(p, (old, old))
+    except OSError:
+        pass
+
+
+def write_lock(main, entries):
+    """entries: {cwd: {"pid":..., "last_activity_at":...}} -> session-lock.json"""
+    lock = main / ".claude" / ".session-lock.json"
+    sessions = {f"sid-{i}": {"cwd": cwd, **meta} for i, (cwd, meta) in enumerate(entries.items())}
+    lock.write_text(json.dumps({"version": 2, "sessions": sessions}))
+
+
+fails = []
+
+
+def check(name, cond):
+    print(("PASS" if cond else "FAIL"), name)
+    if not cond:
+        fails.append(name)
+
+
+def main():
+    now = time.time()
+
+    # ---- live_session_cwds() unit behaviour ----
+    m = make_main()
+    alive = add_wt(m, "alive", "claude/alive")
+    dead = add_wt(m, "dead", "claude/dead")
+    write_lock(m, {
+        str(alive.resolve()): {"pid": os.getpid(), "last_activity_at": now - 9999},   # pid alive
+        str(dead.resolve()): {"pid": DEAD_PID, "last_activity_at": now - 9999},        # pid dead + stale
+    })
+    live = live_session_cwds(m)
+    check("live_session_cwds returns a set", isinstance(live, set))
+    check("live includes alive-pid cwd", str(alive.resolve()) in live)
+    check("live EXCLUDES dead-pid+stale cwd", str(dead.resolve()) not in live)
+
+    # recency overrides a dead pid (recently active => treated live, over-preserve)
+    write_lock(m, {str(dead.resolve()): {"pid": DEAD_PID, "last_activity_at": now - 60}})
+    check("live includes recently-active even if pid dead", str(dead.resolve()) in live_session_cwds(m))
+
+    # missing / garbage lock => None (UNKNOWN), never empty-set
+    (m / ".claude" / ".session-lock.json").unlink()
+    check("no lock -> None (unknown, not empty set)", live_session_cwds(m) is None)
+    (m / ".claude" / ".session-lock.json").write_text("}{ not json")
+    check("garbage lock -> None", live_session_cwds(m) is None)
+    shutil.rmtree(m, ignore_errors=True)
+
+    # ---- _per_session_backstop(): reap dead, keep everything in use ----
+    m = make_main()
+    alive = add_wt(m, "alive", "claude/alive")
+    dead = add_wt(m, "dead", "claude/dead")
+    cur = add_wt(m, "current", "claude/current")
+    delib = add_wt(m, "feature", "feature/keep-me")     # deliberate non-claude branch
+    (dead / "UNSAVED.md").write_text("UNIQUE UNSAVED WORK\n")  # must be snapshotted, not lost
+    for w in (alive, dead, cur, delib):
+        make_idle(w)
+    write_lock(m, {
+        str(alive.resolve()): {"pid": os.getpid(), "last_activity_at": now - 9999},  # LIVE
+        str(dead.resolve()): {"pid": DEAD_PID, "last_activity_at": now - 9999},       # DEAD
+        # 'current' intentionally absent from lock — protected by cur_path, not liveness
+    })
+
+    reaped, swept = enforce_cap._per_session_backstop(m, cur.resolve())
+
+    check("dead-session worktree REAPED", "dead" in reaped)
+    check("dead worktree dir gone", not dead.exists())
+    snap = snapshot_dir_for(m) / "dead" / "UNSAVED.md"
+    check("dead wt unsaved file SNAPSHOTTED before reap", snap.is_file()
+          and "UNIQUE UNSAVED WORK" in snap.read_text())
+    # NEGATIVE CONTROLS
+    check("NEG live-session worktree KEPT", "alive" not in reaped and alive.exists())
+    check("NEG current-session worktree KEPT", "current" not in reaped and cur.exists())
+    check("NEG deliberate non-claude/* worktree KEPT", "feature" not in reaped and delib.exists())
+    shutil.rmtree(m, ignore_errors=True)
+
+    # ---- liveness UNKNOWN => reap NOTHING on the dead-session basis ----
+    m = make_main()
+    d1 = add_wt(m, "looksdead", "claude/looksdead")
+    make_idle(d1)
+    # no session-lock written at all
+    reaped, swept = enforce_cap._per_session_backstop(m, None)
+    check("NEG unknown-liveness reaps nothing (no lock)", reaped == [] and d1.exists())
+    shutil.rmtree(m, ignore_errors=True)
+
+    # ---- orphan-dir sweep is wired into the backstop (relocation-orphan removed) ----
+    m = make_main()
+    orph = m / ".claude" / "worktrees" / "reloc"
+    orph.mkdir(parents=True)
+    (orph / "committed.md").write_text("COMMITTED\n")  # recoverable from main object DB
+    (orph / ".git").write_text("gitdir: /nonexistent/old/.git/worktrees/reloc\n")  # dangling
+    make_idle(orph)
+    reaped, swept = enforce_cap._per_session_backstop(m, None)
+    check("orphan-dir swept by backstop", "reloc" in swept and "removed" in swept["reloc"])
+    check("orphan dir gone", not orph.exists())
+    shutil.rmtree(m, ignore_errors=True)
+
+    print()
+    if fails:
+        print("FAILED:", fails)
+        return 1
+    print("ALL TESTS PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

The worktree count cap alone (default 12) cannot keep up. On a large vault each scratch worktree is a FULL checkout (thousands of watched files), so a session that crashes before `SessionEnd` fires leaves its worktree registered + on disk, and these pile up until the cap of 12 finally trips — by which point the file watcher has long melted. The orphan-dir sweep (`reclaim_orphan_dir`) only ran weekly.

## What

`enforce-worktree-cap.py` now runs a per-session backstop EVERY `SessionStart` (regardless of count), before the existing cap logic:

- **Dead-session reap** — reclaims a registered `claude/<slug>` scratch worktree whose owning session is no longer live, so the count tracks live sessions instead of drifting to the cap. Liveness comes from `.session-lock.json` via the new `live_session_cwds()` helper (recency-based — the recorded pid is informational only, per `session-lock.py`). A live session's worktree (even idle) and the current session's are never touched; gated by both not-in-live-set AND mtime-idle ≥ `WORKTREE_DEAD_IDLE_MIN` (default 60, matching the cap reaper's threshold).
- **Orphan-dir sweep** — `reclaim_orphan_dir` now runs per session (was weekly-only). Relocation-aware and snapshot-safe.

`live_session_cwds()` returns `None` on unknown liveness (lock absent/garbage) and the dead-session reap is skipped entirely in that case — never an empty set, which would wrongly mean "reap everything".

## Coverage

`test_live_session_reap.py` (new) is negative-control-first: live / current / deliberate-branch worktrees KEPT, dead-session reaped, an unsaved-unique file SNAPSHOTTED before its dir is removed, and unknown-liveness reaps nothing. Existing `test_relocation_orphan_reclaim.py` still passes (lib unchanged in behavior).

Authored with Claude Code.