### PR TITLE
feat(cloud-sync): machinery-sidecar mode — keep the vault in iCloud safely

### DIFF
--- a/docs/CLOUD_SYNC.md
+++ b/docs/CLOUD_SYNC.md
@@ -1,86 +1,108 @@
-# Keep your brain local-first
+# Your vault can live in iCloud. Its machinery can't.
 
 Your brain is a living git repository. Claude Code works inside it with
 per-session git **worktrees** — fast, throwaway checkouts under
 `.claude/worktrees/`. That design is what makes parallel sessions safe. It
 also means the directory churns constantly: thousands of files created and
-deleted as you work.
+deleted as you work, a `.git` that a single `git gc` rewrites wholesale, and
+search-index caches that rebuild on the fly.
 
-**Consumer cloud-sync tools — iCloud Drive, OneDrive, Dropbox, Google Drive,
-Box — are built for documents, not for a churning git tree.** Point one at
-your brain and it tries to upload every worktree file, every `.git` object,
-every search-index cache, in real time. On an active machine that compounds
-into hundreds of thousands of files and a sync daemon pinned at full CPU for
-hours. It is the single most common way to make a healthy brain feel broken.
+Point a consumer cloud-sync daemon — iCloud Drive, OneDrive, Dropbox, Google
+Drive, Box — at that churn and it tries to upload every worktree file, every
+`.git` object, every cache, in real time. On an active machine that compounds
+into hundreds of thousands of file events and a sync daemon pinned at full CPU
+for hours. It is the single most common way to make a healthy brain feel broken.
 
-So the rule is simple, and it is a design principle, not a workaround:
+The storm hides one fact: your *notes* are not the problem. Markdown is tiny
+and barely changes. The freeze comes entirely from the **machinery** — `.git`,
+worktrees, caches — living inside the synced tree. So the rule is not "never
+sync your brain." The rule is:
 
-> **The vault lives on a local disk. The index lives server-side. Neither
-> belongs in a consumer cloud-sync folder.**
+> **The vault may be synced. The machinery never is.**
 
-The footprint signal at session start will warn you if it detects your vault
-inside a sync folder. Here is how to fix it.
+That gives you two supported shapes, both first-class. Pick by whether you want
+your notes on your phone. The footprint signal at session start will warn you if
+it sees machinery inside a sync folder; here is how to set up either shape.
 
 ---
 
-## The fix, in order of preference
+## Two supported shapes
 
-### 1. Best: keep the vault outside every sync folder
+### Shape A — vault fully local (simplest)
 
-Put the vault on a normal local path — `~/brain`, `~/vaults/<name>`,
-anywhere that is **not** inside a sync root. On macOS that specifically means
-**not** `~/Desktop` or `~/Documents` when iCloud "Desktop & Documents
-folders" is on (both are synced). On Windows, not inside `OneDrive\`. Anywhere
-else under your home directory is fine.
+Put the vault on a normal local path — `~/brain`, `~/vaults/<name>`, anywhere
+**not** inside a sync root. On macOS that means **not** `~/Desktop` or
+`~/Documents` when iCloud "Desktop & Documents" is on (both are synced); on
+Windows, not inside `OneDrive\`. The index lives server-side; backups are a
+deliberate off-machine choice (below). Nothing to configure — this is the
+default.
 
-Already living in a sync folder? Move it out and leave a symlink behind so
-every tool that points at the old path keeps working:
+Already inside a sync folder and you don't need phone access? Move it out and
+leave a symlink so every tool that points at the old path keeps working:
 
 ```bash
-# macOS / Linux — example moving a vault off the iCloud-synced Desktop
 mv ~/Desktop/MyVault ~/MyVault
 ln -s ~/MyVault ~/Desktop/MyVault   # old path still resolves; iCloud syncs only the tiny symlink
 ```
 
-Then re-open the vault in Obsidian from the new location and confirm your
-tools still resolve. Sync daemons follow the *symlink file* (a few bytes),
-not the target's contents — so the churn leaves iCloud's scope entirely.
+Sync daemons follow the *symlink file* (a few bytes), not the target's
+contents — so the churn leaves the sync scope entirely.
 
-### 2. If you truly cannot move it: exclude the machine-exhaust
+### Shape B — vault synced, machinery in a local sidecar (notes on every device)
 
-If the vault must stay inside a sync folder, exclude the three directories
-that actually churn. This stops the storm even if the notes keep syncing.
+This is the mode that lets you **keep your notes in iCloud and edit them on your
+iPhone**, two-way, without the storm. It relocates every churning machinery dir
+OUT of the synced tree into a local sidecar and leaves only tiny static pointers
+behind:
 
-- **iCloud Drive (macOS):** iCloud has no per-subfolder toggle. Rename the
-  exhaust dirs with a `.nosync` suffix and symlink them back, or — simpler and
-  what we recommend — move the *whole vault* out per option 1. Excluding
-  subfolders under iCloud is fiddly and easy to get wrong; relocation is the
-  honest fix.
-- **Dropbox:** Selective Sync (Preferences → Sync) → uncheck
-  `.claude`, `.git`, `.smart-env`.
-- **OneDrive (Windows/Mac):** right-click the folder → "Always keep on this
-  device" off is not enough; use OneDrive settings → "Choose folders" to
-  exclude `.claude`, `.git`, `.smart-env`.
-- **Google Drive / Box:** use the desktop client's selective-sync / ignore
-  settings to exclude the same three.
+- `.git` → a real git directory outside the tree, via
+  `git init --separate-git-dir`, leaving a one-line `.git` **pointer file** in
+  the vault (static, safe to sync).
+- `.claude/worktrees/` and the caches (`.smart-env`, `.codegraph`, graph output,
+  session logs, snapshots) → relocated to the sidecar with a symlink back. The
+  sync daemon follows the symlink (a few bytes), never the target's churn.
 
-### 3. Always: keep machine-exhaust out of git too
+One command sets it up. Run it with **all Claude sessions closed and no scratch
+worktrees live** — separating the git directory orphans live worktrees, so the
+script refuses unless the window is clean (`--force` to override):
 
-Separate concern, same dirs. `.gitignore` stops you *committing* the exhaust;
-it does **not** stop a cloud daemon from *syncing* it (that's option 1/2).
-Your vault `.gitignore` should contain at least:
-
-```gitignore
-.claude/worktrees/
-.smart-env/
-.codegraph/
-⚙️ Meta/Worktree Snapshots/
-⚙️ Meta/logs/
+```bash
+# preview first (changes nothing)
+bash scripts/relocate-machinery-sidecar.sh "/path/to/vault" --dry-run
+# do it (default sidecar: ~/.brain-sidecar; override with --sidecar or $BRAIN_SIDECAR)
+bash scripts/relocate-machinery-sidecar.sh "/path/to/vault"
+# fully reversible — restores a normal local repo
+bash scripts/relocate-machinery-sidecar.sh "/path/to/vault" --rollback
 ```
+
+Then turn on iCloud Drive (or Desktop & Documents) for that folder. The docs
+sync to every device; the machinery never leaves your Mac. Verify the calm
+yourself: run a `git gc` plus a full session and watch Activity Monitor —
+`fileproviderd`/`bird` stay idle.
+
+> **Second Mac?** The `.git` pointer syncs as static text but points at *this*
+> Mac's sidecar. On another Mac, re-run the helper there to stand up its own
+> sidecar. On iPhone there is no git, so the pointer is harmless — you just see
+> your notes.
+
+> **`.gitignore` is not enough.** It stops you *committing* the machinery; it
+> does **not** stop a cloud daemon from *syncing* it. The bytes must physically
+> leave the synced tree (Shape B) or be flagged `.nosync` (the helper's
+> `--nosync` mode renames caches to `<name>.nosync`, which iCloud ignores by
+> name). Keep the machinery out of git too — your `.gitignore` should contain at
+> least:
+>
+> ```gitignore
+> .claude/worktrees/
+> .smart-env/
+> .codegraph/
+> ⚙️ Meta/Worktree Snapshots/
+> ⚙️ Meta/logs/
+> ```
 
 ---
 
-## What the brain does instead of cloud sync
+## What the brain does for sync safety
 
 - **Worktree hygiene is automatic.** Each session's worktree is removed when
   the session ends; a session-start cap reclaims any that a crash left behind;
@@ -184,9 +206,11 @@ too corrupted for in-place repair — go to step 3.
 
 **3. Rebuild from the server (the supported reset).** System Settings → your
 Apple Account → iCloud → **iCloud Drive** → turn it **off**, choosing **"Keep a
-Copy"** of files on this Mac. Reboot. Turn iCloud Drive back **on**, and do
-**not** re-enable "Desktop & Documents folders". This discards the corrupt local
-DB and re-fetches a clean one from Apple's servers.
+Copy"** of files on this Mac. Reboot. Turn iCloud Drive back **on**. Leave
+"Desktop & Documents folders" off *unless* you have set up Shape B above (the
+machinery sidecar) — once the machinery is out of the synced tree, re-enabling
+D&D is safe. This discards the corrupt local DB and re-fetches a clean one from
+Apple's servers.
 
 - Expect a CPU spike and a long re-sync afterward — that part is normal; let it
   run (hours, on a large drive).
@@ -211,6 +235,7 @@ a hope, not a backup. One command gets you protected immediately —
 then `bash scripts/vault-backup.sh verify` to prove the restore. Full guide,
 including the restic option for an offsite tier: `docs/BACKUP.md`.
 
-A brain that melts the machine it runs on isn't a brain you'll keep. Local
-disk for the source, server-side for the index, encrypted-and-verified for
-the backup. That's the whole policy.
+A brain that melts the machine it runs on isn't a brain you'll keep. Whichever
+shape you pick — fully local, or synced with the machinery in a sidecar — the
+invariant is the same: notes can sync, machinery never does, the index lives
+server-side, and the backup is encrypted-and-verified. That's the whole policy.

--- a/phases/phase-01-welcome.md
+++ b/phases/phase-01-welcome.md
@@ -246,7 +246,7 @@ Then say: *"I just installed Obsidian for you. Let's create your vault now."*
 
 **Never** ask the user to "go download Obsidian" — that breaks the one-command promise and assumes they know what Obsidian is and how to install a desktop app.
 
-7. "Now open Obsidian and choose 'Create new vault.' Name it whatever feels right — your name, 'Brain,' 'Notes,' whatever. Save it in your home folder (like `~/Brain` or `~/Notes`) — **not** Desktop or Documents, because those are cloud-synced (iCloud on Mac, OneDrive on Windows) and a vault should never live inside a sync folder; the churn melts the sync daemon (see `docs/CLOUD_SYNC.md`). Let me know when it's created."
+7. "Now open Obsidian and choose 'Create new vault.' Name it whatever feels right — your name, 'Brain,' 'Notes,' whatever. The simplest spot is your home folder (like `~/Brain` or `~/Notes`) — **not** Desktop or Documents, because those are cloud-synced (iCloud on Mac, OneDrive on Windows) and a *raw* vault there melts the sync daemon. **If you want these notes on your iPhone**, that's supported too — pick Documents/Desktop and tell me, and I'll set up the safe sync mode that keeps the notes in iCloud while moving the machinery out (see `docs/CLOUD_SYNC.md`). Let me know when it's created."
 
 **Wait for confirmation before continuing.**
 
@@ -254,14 +254,24 @@ Then say: *"I just installed Obsidian for you. Let's create your vault now."*
 
 Save the vault path — you'll use it for all file operations.
 
-8.5. **GUARD — before saving the path, verify it is NOT inside a cloud-sync folder.** This is mandatory: a git-backed vault inside iCloud / OneDrive / Dropbox / Google Drive / Box melts the OS sync daemon (pegged CPU, frozen machine). Run:
+8.5. **GUARD — before saving the path, check whether it is inside a cloud-sync folder.** A *raw* git-backed vault inside iCloud / OneDrive / Dropbox / Google Drive / Box melts the OS sync daemon (pegged CPU, frozen machine). Run:
 
 ```bash
 python3 ~/.claude/skills/ai-brain-starter/scripts/check-cloud-sync.py --porcelain "<VAULT_PATH>"
 ```
 
 - Output starts with `OK_LOCAL` → good, continue.
-- Output starts with `CLOUD_SYNC_RISK:` → **STOP. Do not continue the install.** Tell the user plainly: *"That location is inside <service>, which is cloud-synced — a vault there will freeze your machine. Please move the vault (or create a new one) somewhere local like `~/Brain` or `~/vaults/<name>`, then paste the new path."* Re-run this check on the new path. Do not proceed until it returns `OK_LOCAL`. (If the vault is large and already there, see `docs/CLOUD_SYNC.md` for how to move it out safely.)
+- Output starts with `CLOUD_SYNC_RISK:` → the path is inside `<service>`. This is **supported, but only with the machinery out of the synced tree** — never proceed with a raw synced vault (that is the freeze class). Offer BOTH supported shapes and pick by the user's answer to "do you want these notes on your iPhone?":
+
+  - **Shape A — move it local (simplest; default if they don't need phone sync):** *"That folder is inside <service>. The simplest fix is a local path like `~/Brain`. Paste a new path and I'll re-check."* Re-run the check until it returns `OK_LOCAL`, then continue. (Large vault already there → `docs/CLOUD_SYNC.md` for how to move it out safely.)
+  - **Shape B — keep it synced, notes on every device:** *"I'll keep the vault in <service> and move just the machinery (git + caches) to a local sidecar so the notes sync to your iPhone without the storm."* With all other Claude sessions closed (separating the git dir orphans live worktrees — the script refuses otherwise), run:
+
+    ```bash
+    bash ~/.claude/skills/ai-brain-starter/scripts/relocate-machinery-sidecar.sh "<VAULT_PATH>" --dry-run   # preview
+    bash ~/.claude/skills/ai-brain-starter/scripts/relocate-machinery-sidecar.sh "<VAULT_PATH>"             # apply
+    ```
+
+    Then confirm `<VAULT_PATH>/.git` is now a one-line pointer file (`cat "<VAULT_PATH>/.git"` shows `gitdir: ...`) and continue. The helper is **idempotent and safe to re-run** — run it once more after your first working session to sweep any caches (`.smart-env`, `.codegraph`) that get created later. Fully reversible with `--rollback`. Details: `docs/CLOUD_SYNC.md` Shape B.
 
 ### Step 8.6 — Establish an off-machine backup (or explicitly defer, with a warning) — BEFORE declaring setup complete
 

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -99,6 +99,8 @@ INTEGRATION_TESTS=(
   test_scan_prior_single_instance
   test_vault_safety_guards
   test_resource_aware_session_close
+  test_cloud_sync_guard
+  test_machinery_sidecar
 )
 echo "==> (b) Shell integration: ${#INTEGRATION_TESTS[@]} tests"
 for t in "${INTEGRATION_TESTS[@]}"; do

--- a/scripts/relocate-machinery-sidecar.sh
+++ b/scripts/relocate-machinery-sidecar.sh
@@ -1,0 +1,354 @@
+#!/usr/bin/env bash
+# relocate-machinery-sidecar.sh — make a vault SAFE to keep inside iCloud / a
+# cloud-sync folder by moving every churning machinery dir OUT of the synced
+# tree into a local sidecar, leaving only tiny static pointers/symlinks behind.
+#
+# WHY
+# ---
+# A git-backed Obsidian vault inside iCloud Drive / Desktop & Documents melts the
+# OS sync daemon — NOT because of the notes (markdown is tiny + low-churn) but
+# because of the MACHINERY: a `.git` rewritten wholesale on `git gc`, per-session
+# worktree checkouts (~thousands of files each), and search/index caches. The
+# fix is not "turn iCloud off". The fix is: the vault MAY be synced; the
+# machinery NEVER is. This script relocates the machinery and leaves the docs.
+#
+# CRITICAL: `.gitignore` does NOT stop iCloud. iCloud syncs the folder, not
+# git's view of it. The bytes must physically leave the synced tree (relocate +
+# symlink) or be flagged `.nosync` (iCloud ignores any name ending in .nosync).
+#
+# WHAT IT MOVES
+#   .git              -> <sidecar>/git    via `git init --separate-git-dir`
+#                        (leaves a one-line `.git` POINTER FILE — static, safe)
+#   .claude/worktrees -> <sidecar>/worktrees  (relocate + symlink; MYC-543 layer)
+#   caches            -> <sidecar>/cache/<name> (relocate + symlink, or .nosync)
+#                        .smart-env .codegraph "⚙️ Meta/graphify-out"
+#                        "⚙️ Meta/Sessions" "⚙️ Meta/Worktree Snapshots"
+#                        "⚙️ Meta/logs"  (only those that exist as REAL dirs)
+#
+# SEQUENCING GOTCHA (verified): `git init --separate-git-dir` ORPHANS existing
+# linked worktrees. So this REFUSES to run while any linked worktree or live
+# Claude session exists, unless --force. After relocation it runs
+# `git worktree repair`.
+#
+# SAFETY: idempotent (re-run = no-op report), reversible (--rollback reads the
+# manifest and puts everything back), --dry-run changes nothing, and it never
+# deletes content — only moves it and leaves a symlink/pointer.
+#
+# Pure bash + git + python3 (manifest JSON only). No third-party deps.
+#
+# Usage:
+#   relocate-machinery-sidecar.sh <vault-path> [options]
+#   relocate-machinery-sidecar.sh <vault-path> --rollback
+#
+# Options:
+#   --sidecar <dir>   sidecar root (default: $BRAIN_SIDECAR or ~/.brain-sidecar)
+#   --nosync          keep caches in-tree as <name>.nosync (iCloud-ignored) +
+#                     symlink, instead of relocating them to the sidecar
+#   --dry-run         print intended actions, change nothing
+#   --rollback        reverse a previous relocation using the manifest
+#   --force           proceed even if linked worktrees / live sessions exist
+#                     (DANGEROUS: separate-git-dir orphans live worktrees)
+#   --quiet           only print warnings/errors + the final summary line
+#   -h, --help        this help
+#
+# Exit codes: 0 ok / no-op · 1 refused (live worktree/session) · 2 usage ·
+#             3 not a git vault and could not init · 4 partial failure
+set -euo pipefail
+
+# ---- machinery the script relocates (relative to the vault root) -------------
+CACHE_DIRS=(
+  ".smart-env"
+  ".codegraph"
+  "⚙️ Meta/graphify-out"
+  "graphify-out"
+  "⚙️ Meta/Sessions"
+  "⚙️ Meta/Worktree Snapshots"
+  "⚙️ Meta/logs"
+  ".obsidian/.smart-env"
+)
+WORKTREES_REL=".claude/worktrees"
+
+# ---- arg parse --------------------------------------------------------------
+VAULT="" ; SIDECAR="${BRAIN_SIDECAR:-${MYCELIUM_SIDECAR:-$HOME/.brain-sidecar}}"
+NOSYNC=0 ; DRYRUN=0 ; ROLLBACK=0 ; FORCE=0 ; QUIET=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --sidecar) SIDECAR="${2:?--sidecar needs a path}"; shift 2;;
+    --nosync) NOSYNC=1; shift;;
+    --dry-run|--dryrun) DRYRUN=1; shift;;
+    --rollback) ROLLBACK=1; shift;;
+    --force) FORCE=1; shift;;
+    --quiet) QUIET=1; shift;;
+    -h|--help) sed -n '2,55p' "$0" | sed 's/^# \{0,1\}//'; exit 0;;
+    -*) echo "unknown option: $1" >&2; exit 2;;
+    *) if [ -z "$VAULT" ]; then VAULT="$1"; else echo "unexpected arg: $1" >&2; exit 2; fi; shift;;
+  esac
+done
+[ -n "$VAULT" ] || { echo "usage: $(basename "$0") <vault-path> [options]" >&2; exit 2; }
+[ -d "$VAULT" ] || { echo "not a directory: $VAULT" >&2; exit 2; }
+
+# absolutize (portable realpath: cd + pwd -P)
+VAULT="$(cd "$VAULT" && pwd -P)"
+case "$SIDECAR" in /*) :;; ~*) SIDECAR="${SIDECAR/#\~/$HOME}";; *) SIDECAR="$PWD/$SIDECAR";; esac
+
+# per-vault slug = sanitized basename + short abspath hash (collision-safe)
+_base="$(basename "$VAULT")"
+_slug="$(printf '%s' "$_base" | tr -c 'A-Za-z0-9._-' '-' | sed 's/-\{2,\}/-/g; s/^-//; s/-$//')"
+_hash="$(printf '%s' "$VAULT" | (shasum 2>/dev/null || sha1sum) | cut -c1-8)"
+SLUG="${_slug:-vault}-${_hash}"
+
+SIDE_GIT="$SIDECAR/git/$SLUG"
+SIDE_CACHE="$SIDECAR/cache/$SLUG"
+SIDE_WT="$SIDECAR/worktrees/$SLUG"
+MANIFEST="$SIDECAR/manifests/$SLUG.json"
+
+say()  { [ "$QUIET" = 1 ] || printf '%s\n' "$*"; }
+warn() { printf 'WARN  %s\n' "$*" >&2; }
+err()  { printf 'ERROR %s\n' "$*" >&2; }
+run()  { if [ "$DRYRUN" = 1 ]; then printf 'DRY   %s\n' "$*"; else eval "$@"; fi; }
+
+# ---- manifest helpers (python3 for safe JSON over emoji/space paths) ---------
+PYBIN="$(command -v python3 || command -v python || true)"
+[ -n "$PYBIN" ] || { err "python3 required for the manifest"; exit 4; }
+
+_manifest_records="$(mktemp)"   # TSV staging: type<TAB>vault_rel<TAB>target<TAB>mode
+trap 'rm -f "$_manifest_records"' EXIT
+record() { printf '%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" >> "$_manifest_records"; }
+
+write_manifest() {
+  [ "$DRYRUN" = 1 ] && return 0
+  mkdir -p "$(dirname "$MANIFEST")"
+  VAULT="$VAULT" SIDECAR="$SIDECAR" SLUG="$SLUG" NOSYNC="$NOSYNC" \
+  REC="$_manifest_records" MAN="$MANIFEST" "$PYBIN" - <<'PY'
+import json, os
+recs = []
+with open(os.environ["REC"], encoding="utf-8") as f:
+    for line in f:
+        line = line.rstrip("\n")
+        if not line:
+            continue
+        parts = line.split("\t")
+        while len(parts) < 4:
+            parts.append("")
+        recs.append({"type": parts[0], "vault_rel": parts[1],
+                     "target": parts[2], "mode": parts[3]})
+doc = {
+    "schema": "machinery-sidecar/1",
+    "vault": os.environ["VAULT"],
+    "sidecar": os.environ["SIDECAR"],
+    "slug": os.environ["SLUG"],
+    "nosync": os.environ["NOSYNC"] == "1",
+    "moves": recs,
+}
+os.makedirs(os.path.dirname(os.environ["MAN"]), exist_ok=True)
+with open(os.environ["MAN"], "w", encoding="utf-8") as f:
+    json.dump(doc, f, ensure_ascii=False, indent=2)
+    f.write("\n")
+PY
+}
+
+# ---- live-worktree / live-session guard -------------------------------------
+linked_worktrees() {
+  # Registered LINKED worktrees = every "worktree " porcelain block EXCEPT the
+  # first (the first is always the MAIN worktree). Filtering by "!= $VAULT" is
+  # WRONG after --separate-git-dir: git then reports the main worktree's path as
+  # the separated gitdir, not the vault, so the main would masquerade as linked.
+  git -C "$VAULT" worktree list --porcelain 2>/dev/null \
+    | awk '/^worktree /{n++; if (n>1) print substr($0,10)}'
+}
+live_sessions() {
+  local lock="$VAULT/.claude/.session-lock.json"
+  [ -f "$lock" ] || return 0
+  SELF_PID="$$" LOCK="$lock" "$PYBIN" - <<'PY'
+import json, os, time
+lock = os.environ["LOCK"]
+try:
+    data = json.load(open(lock, encoding="utf-8"))
+except Exception:
+    raise SystemExit(0)
+sessions = data.get("sessions", {}) if isinstance(data, dict) else {}
+cut = time.time() - 35 * 60
+self_pid = int(os.environ.get("SELF_PID", "0") or 0)
+n = 0
+for s in sessions.values():
+    if not isinstance(s, dict):
+        continue
+    pid = s.get("pid")
+    la = s.get("last_activity_at")
+    alive = False
+    if isinstance(pid, int) and pid > 0 and pid != self_pid:
+        try:
+            os.kill(pid, 0); alive = True
+        except ProcessLookupError:
+            alive = False
+        except Exception:
+            alive = True
+    recent = isinstance(la, (int, float)) and la >= cut
+    if alive or recent:
+        n += 1
+print(n)
+PY
+}
+
+guard_no_live() {
+  local wts ; wts="$(linked_worktrees || true)"
+  local sess ; sess="$(live_sessions || echo 0)"; sess="${sess:-0}"
+  if [ -n "$wts" ] || [ "$sess" -gt 0 ] 2>/dev/null; then
+    if [ "$FORCE" = 1 ]; then
+      warn "linked worktrees and/or $sess live session(s) present — proceeding under --force (separate-git-dir will orphan live worktrees)"
+      return 0
+    fi
+    err "refusing: relocation must run in a no-live-worktree window."
+    [ -n "$wts" ] && { err "  linked worktrees still registered:"; printf '    %s\n' "$wts" >&2; }
+    [ "$sess" -gt 0 ] 2>/dev/null && err "  $sess live Claude session(s) in $VAULT/.claude/.session-lock.json"
+    err "  close all sessions + 'git worktree remove' scratch trees, then re-run. Override: --force"
+    return 1
+  fi
+}
+
+# =============================================================================
+# ROLLBACK
+# =============================================================================
+do_rollback() {
+  [ -f "$MANIFEST" ] || { err "no manifest at $MANIFEST — nothing to roll back"; exit 2; }
+  say "Rolling back machinery sidecar for: $VAULT"
+  say "  manifest: $MANIFEST"
+  # iterate moves in REVERSE order
+  MAN="$MANIFEST" "$PYBIN" - <<'PY' > "$_manifest_records"
+import json, os
+doc = json.load(open(os.environ["MAN"], encoding="utf-8"))
+for m in reversed(doc.get("moves", [])):
+    print("\t".join([m.get("type",""), m.get("vault_rel",""),
+                     m.get("target",""), m.get("mode","")]))
+PY
+  local rc=0
+  while IFS=$'\t' read -r typ rel target mode; do
+    [ -n "$typ" ] || continue
+    case "$typ" in
+      git)
+        local ptr="$VAULT/.git"
+        if [ -f "$ptr" ] && [ -d "$target" ]; then
+          run "rm -f \"$ptr\""
+          run "mv \"$target\" \"$ptr\""
+          run "git -C \"$VAULT\" config --unset core.worktree" || true
+          run "git -C \"$VAULT\" worktree repair >/dev/null 2>&1" || true
+          say "  restored .git (dir) from $target"
+        else
+          warn "  git rollback skipped (ptr present=$( [ -f "$ptr" ] && echo y || echo n ), gitdir present=$( [ -d "$target" ] && echo y || echo n ))"
+        fi
+        ;;
+      cache|worktrees)
+        local link="$VAULT/$rel"
+        if [ -L "$link" ]; then run "rm -f \"$link\""; fi
+        if [ "$mode" = "nosync" ]; then
+          local ns="$VAULT/${rel}.nosync"
+          [ -e "$ns" ] && run "mv \"$ns\" \"$link\"" || warn "  missing nosync source: $ns"
+        else
+          [ -e "$target" ] && run "mkdir -p \"$(dirname "$link")\" && mv \"$target\" \"$link\"" \
+                           || warn "  missing sidecar source: $target"
+        fi
+        say "  restored $rel"
+        ;;
+    esac
+  done < "$_manifest_records"
+  if [ "$DRYRUN" != 1 ]; then run "rm -f \"$MANIFEST\""; fi
+  say "Rollback complete."
+  return $rc
+}
+
+# =============================================================================
+# RELOCATE one cache/worktree dir (relocate+symlink, or nosync+symlink)
+# =============================================================================
+relocate_dir() {  # $1 = vault-relative path, $2 = explicit sidecar destination, $3 = record-type
+  local rel="$1" dst="$2" rtype="$3"
+  local src="$VAULT/$rel"
+  if [ -L "$src" ]; then say "  · $rel already a symlink — skip"; return 0; fi
+  if [ ! -e "$src" ]; then return 0; fi          # absent → nothing to do
+  if [ "$NOSYNC" = 1 ]; then
+    local ns="$VAULT/${rel}.nosync"
+    if [ -e "$ns" ]; then warn "  · $rel.nosync already exists — skip"; return 0; fi
+    run "mv \"$src\" \"$ns\""
+    run "ln -s \"$(basename "$rel").nosync\" \"$src\""
+    record "$rtype" "$rel" "$ns" "nosync"
+    say "  · $rel -> ${rel}.nosync (iCloud-ignored) + symlink"
+  else
+    if [ -e "$dst" ]; then run "mv \"$dst\" \"$dst.bak-$(date +%s)\""; warn "  · prior sidecar copy at $dst backed up"; fi
+    run "mkdir -p \"$(dirname "$dst")\""
+    run "mv \"$src\" \"$dst\""
+    run "ln -s \"$dst\" \"$src\""
+    record "$rtype" "$rel" "$dst" "relocate"
+    say "  · $rel -> $dst + symlink"
+  fi
+}
+
+# =============================================================================
+# RELOCATE .git via --separate-git-dir
+# =============================================================================
+relocate_git() {
+  local gitpath="$VAULT/.git"
+  if [ -f "$gitpath" ]; then
+    local cur; cur="$(sed -n 's/^gitdir: //p' "$gitpath" | head -1)"
+    say "  · .git already a pointer (-> ${cur:-?}) — skip"
+    return 0
+  fi
+  if [ -d "$gitpath" ]; then
+    run "mkdir -p \"$(dirname "$SIDE_GIT")\""
+    run "git -C \"$VAULT\" init --separate-git-dir \"$SIDE_GIT\" >/dev/null"
+    if [ "$DRYRUN" != 1 ] && [ ! -f "$gitpath" ]; then
+      err "  separate-git-dir did not produce a .git pointer file"; return 4
+    fi
+    run "git -C \"$VAULT\" worktree repair >/dev/null 2>&1" || true
+    record "git" ".git" "$SIDE_GIT" "separated"
+    say "  · .git -> $SIDE_GIT (pointer file left in vault)"
+    return 0
+  fi
+  # no .git at all → fresh repo with a separated gitdir
+  run "mkdir -p \"$(dirname "$SIDE_GIT")\""
+  run "git -C \"$VAULT\" init --separate-git-dir \"$SIDE_GIT\" >/dev/null"
+  record "git" ".git" "$SIDE_GIT" "fresh-init"
+  say "  · initialized fresh repo with gitdir at $SIDE_GIT"
+}
+
+# =============================================================================
+# MAIN
+# =============================================================================
+if [ "$ROLLBACK" = 1 ]; then do_rollback; exit $?; fi
+
+# detection is informational here — the whole point is iCloud is ALLOWED
+CLOUD=""
+if [ -f "$VAULT/.git" ] || command -v python3 >/dev/null; then :; fi
+_sa="$(cd "$(dirname "$0")" && pwd)"
+if [ -f "$_sa/check-cloud-sync.py" ]; then
+  CLOUD="$(python3 "$_sa/check-cloud-sync.py" --porcelain "$VAULT" 2>/dev/null || true)"
+fi
+
+say "Machinery-sidecar relocation"
+say "  vault   : $VAULT"
+say "  sidecar : $SIDECAR  (slug: $SLUG)"
+case "$CLOUD" in
+  CLOUD_SYNC_RISK*) say "  cloud   : ${CLOUD#CLOUD_SYNC_RISK:} — relocating machinery so the docs can sync safely";;
+  OK_LOCAL)         say "  cloud   : local disk (machinery relocation still valid; reduces in-tree churn)";;
+esac
+[ "$NOSYNC" = 1 ] && say "  mode    : --nosync (caches stay in-tree as .nosync)"
+[ "$DRYRUN" = 1 ] && say "  mode    : --dry-run (no changes)"
+
+guard_no_live || exit 1
+
+say "Relocating .git ..."
+relocate_git || exit 4
+
+say "Relocating worktrees ..."
+relocate_dir "$WORKTREES_REL" "$SIDE_WT" "worktrees" || true
+
+say "Relocating caches ..."
+for rel in "${CACHE_DIRS[@]}"; do
+  relocate_dir "$rel" "$SIDE_CACHE/$rel" "cache" || true
+done
+
+write_manifest
+if [ "$DRYRUN" = 1 ]; then
+  say "DRY-RUN complete — no changes made. Manifest would be: $MANIFEST"
+else
+  say "Done. Manifest: $MANIFEST"
+  say "Reverse anytime: $(basename "$0") \"$VAULT\" --rollback"
+fi

--- a/scripts/test-cloud-sync-guard.sh
+++ b/scripts/test-cloud-sync-guard.sh
@@ -38,6 +38,24 @@ assert_rc "RISK exits 1"       1                  "$TMP/OneDrive/Brain"
 assert    "plain local path"   "OK_LOCAL"         "$TMP/Brain"
 assert_rc "OK exits 0"         0                  "$TMP/Brain"
 
+# iCloud "Desktop & Documents" sync — the realpath-resolved branch (MYC-544
+# Work item 4). A vault under ~/Documents or ~/Desktop is RISK *only when* iCloud
+# D&D is actually on, i.e. ~/Library/Mobile Documents/com~apple~CloudDocs/<folder>
+# exists. Hermetic: override HOME so the real one is never touched.
+FH="$TMP/fakehome"; mkdir -p "$FH/Documents/Brain"
+# negative control FIRST — D&D OFF (no CloudDocs/Documents) must read OK_LOCAL,
+# proving the branch is conditional on iCloud actually syncing, not "any ~/Documents".
+got="$(HOME="$FH" python3 "$CHECK" --porcelain "$FH/Documents/Brain" 2>/dev/null)"
+case "$got" in OK_LOCAL*) echo "PASS  D&D off -> OK_LOCAL ($got)";; *) echo "FAIL  D&D off want=OK_LOCAL got=$got"; fails=$((fails+1));; esac
+# now turn D&D ON for Documents -> RISK
+mkdir -p "$FH/Library/Mobile Documents/com~apple~CloudDocs/Documents"
+got="$(HOME="$FH" python3 "$CHECK" --porcelain "$FH/Documents/Brain" 2>/dev/null)"
+case "$got" in CLOUD_SYNC_RISK*) echo "PASS  D&D on (Documents) -> RISK ($got)";; *) echo "FAIL  D&D on Documents want=RISK got=$got"; fails=$((fails+1));; esac
+# Desktop variant too
+mkdir -p "$FH/Desktop/Notes" "$FH/Library/Mobile Documents/com~apple~CloudDocs/Desktop"
+got="$(HOME="$FH" python3 "$CHECK" --porcelain "$FH/Desktop/Notes" 2>/dev/null)"
+case "$got" in CLOUD_SYNC_RISK*) echo "PASS  D&D on (Desktop) -> RISK ($got)";; *) echo "FAIL  D&D on Desktop want=RISK got=$got"; fails=$((fails+1));; esac
+
 echo
 if [ "$fails" -gt 0 ]; then echo "FAILED: $fails"; exit 1; fi
 echo "ALL TESTS PASSED"

--- a/scripts/test-machinery-sidecar.sh
+++ b/scripts/test-machinery-sidecar.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Negative-control + churn-burst test for relocate-machinery-sidecar.sh.
+#
+# The Done= predicate for the "vault may live in iCloud" mode is: after a full
+# churn burst (worktree create + commits + `git gc`) on a vault, ZERO machinery
+# CONTENT bytes live inside the (synced) vault tree — only static symlinks + the
+# one-line `.git` pointer remain. We can't drive iCloud in CI, so we model
+# "synced scope" as the vault tree itself and assert the heavy machinery content
+# is OUT of it. `find -type f` does not follow symlinks, so relocated content
+# (symlinked to the sidecar) is correctly counted as "out of tree".
+#
+# A guard earns trust only by failing on the thing it catches: the NEGATIVE
+# CONTROL repeats the identical churn on a NON-relocated vault and asserts the
+# machinery IS in-tree there — proving the metric discriminates.
+#
+# Run: bash scripts/test-machinery-sidecar.sh
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+HELPER="$HERE/relocate-machinery-sidecar.sh"
+ROOT="$(mktemp -d)"
+SIDE="$ROOT/sidecar"
+trap 'rm -rf "$ROOT"' EXIT
+fails=0
+pass() { echo "PASS  $1"; }
+fail() { echo "FAIL  $1"; fails=$((fails+1)); }
+
+gitq() { git -C "$1" "${@:2}" >/dev/null 2>&1; }
+
+make_vault() {  # $1 = vault dir
+  local v="$1"
+  mkdir -p "$v"
+  gitq "$v" init
+  gitq "$v" config user.email "t@t.test"
+  gitq "$v" config user.name  "Test"
+  gitq "$v" config commit.gpgsign false
+  mkdir -p "$v/.smart-env" "$v/.codegraph" "$v/.claude/worktrees" "$v/⚙️ Meta/Sessions"
+  printf 'note\n'  > "$v/note.md"
+  printf 'idx\n'   > "$v/.smart-env/index.bin"
+  printf 'cg\n'    > "$v/.codegraph/graph.bin"
+  printf 'sess\n'  > "$v/⚙️ Meta/Sessions/s1.md"
+  gitq "$v" add note.md
+  gitq "$v" commit -m init
+}
+
+# Count REGULAR machinery files physically inside the vault tree (symlinks not
+# followed). Excludes the `.git` POINTER FILE (a tiny static pointer is allowed).
+machinery_files_in_tree() {  # $1 = vault dir
+  local v="$1" n
+  n="$(find "$v" -type f \
+        \( -path '*/.git/*' -o -path '*/.smart-env/*' -o -path '*/.codegraph/*' \
+           -o -path '*/.claude/worktrees/*' -o -path '*/Sessions/*' \) \
+        2>/dev/null | wc -l | tr -d ' ')"
+  echo "${n:-0}"
+}
+
+churn() {  # $1 = vault dir — simulate a real session's git churn
+  local v="$1"
+  # a worktree (lands wherever .claude/worktrees resolves to)
+  gitq "$v" worktree add "$v/.claude/worktrees/wt1" -b churnbranch HEAD || \
+    gitq "$v" worktree add --detach "$v/.claude/worktrees/wt1" HEAD || true
+  # several commits to generate loose objects
+  local i
+  for i in 1 2 3 4 5; do
+    printf 'rev %s\n' "$i" > "$v/note.md"
+    gitq "$v" add note.md
+    gitq "$v" commit -m "rev$i"
+  done
+  gitq "$v" gc --aggressive --prune=now   # the wholesale-rewrite hazard
+}
+
+echo "=== machinery-sidecar: relocate + churn-burst + negative control ==="
+
+# ---------------------------------------------------------------------------
+# A. RELOCATED vault: machinery must be out of the synced tree, even after churn
+# ---------------------------------------------------------------------------
+VA="$ROOT/A"
+make_vault "$VA"
+before="$(machinery_files_in_tree "$VA")"
+[ "$before" -gt 0 ] && pass "A pre-relocate: machinery present in tree ($before files)" \
+                    || fail "A pre-relocate: expected machinery in tree, got $before"
+
+bash "$HELPER" "$VA" --sidecar "$SIDE" --quiet
+rc=$?
+[ "$rc" = 0 ] && pass "A relocate exit 0" || fail "A relocate exit=$rc"
+
+[ -f "$VA/.git" ] && [ ! -d "$VA/.git" ] && pass "A .git is a pointer file" \
+                                         || fail "A .git is not a pointer file"
+grep -q '^gitdir: ' "$VA/.git" 2>/dev/null && pass "A .git pointer well-formed" \
+                                            || fail "A .git pointer malformed"
+for d in ".smart-env" ".codegraph" ".claude/worktrees" "⚙️ Meta/Sessions"; do
+  [ -L "$VA/$d" ] && pass "A $d is a symlink (out of tree)" || fail "A $d not a symlink"
+done
+
+after="$(machinery_files_in_tree "$VA")"
+[ "$after" = 0 ] && pass "A post-relocate: ZERO machinery files in tree" \
+                 || fail "A post-relocate: expected 0, got $after"
+
+gitq "$VA" status && pass "A git still functional after relocation" \
+                  || fail "A git broke after relocation"
+
+churn "$VA"
+churned="$(machinery_files_in_tree "$VA")"
+[ "$churned" = 0 ] && pass "A post-CHURN (gc+worktree+5 commits): STILL zero machinery in tree" \
+                   || fail "A post-churn: machinery leaked into tree ($churned files)"
+
+# worktree content must physically live in the sidecar, not the vault
+find "$SIDE/worktrees" -type f 2>/dev/null | grep -q . \
+  && pass "A churned worktree content lives in sidecar" \
+  || fail "A worktree content not found in sidecar"
+
+# ---------------------------------------------------------------------------
+# B. NEGATIVE CONTROL: identical churn on a NON-relocated vault → machinery IS
+#    in-tree (proves the metric is not trivially always-zero)
+# ---------------------------------------------------------------------------
+VB="$ROOT/B"
+make_vault "$VB"
+churn "$VB"
+ctrl="$(machinery_files_in_tree "$VB")"
+[ "$ctrl" -gt 0 ] && pass "B negative control: machinery IS in tree without relocation ($ctrl files)" \
+                   || fail "B negative control: expected machinery in tree, got $ctrl"
+
+# ---------------------------------------------------------------------------
+# C. IDEMPOTENCY: re-running relocate on a fresh (no-churn) vault is a clean no-op
+#    (A is excluded here: its churn registered a worktree, which the no-live-
+#     worktree guard correctly refuses — that path is covered by block E.)
+# ---------------------------------------------------------------------------
+VF="$ROOT/F"
+make_vault "$VF"
+bash "$HELPER" "$VF" --sidecar "$SIDE" --quiet
+out="$(bash "$HELPER" "$VF" --sidecar "$SIDE" 2>&1)"; rc=$?   # non-quiet: surface "already" skip lines
+[ "$rc" = 0 ] && pass "C re-run exit 0 (idempotent)" || fail "C re-run exit=$rc"
+echo "$out" | grep -q 'already' && pass "C re-run reports already-relocated" \
+                                 || fail "C re-run did not detect existing state"
+still="$(machinery_files_in_tree "$VF")"
+[ "$still" = 0 ] && pass "C re-run kept tree clean" || fail "C re-run dirtied tree ($still)"
+
+# ---------------------------------------------------------------------------
+# D. ROLLBACK: --rollback restores a normal local repo
+# ---------------------------------------------------------------------------
+VC="$ROOT/C"
+make_vault "$VC"
+bash "$HELPER" "$VC" --sidecar "$SIDE" --quiet
+[ -f "$VC/.git" ] && pass "D pre-rollback .git is a pointer" || fail "D pre-rollback .git not a pointer"
+bash "$HELPER" "$VC" --sidecar "$SIDE" --rollback --quiet
+rc=$?
+[ "$rc" = 0 ] && pass "D rollback exit 0" || fail "D rollback exit=$rc"
+[ -d "$VC/.git" ] && pass "D .git is a normal dir again" || fail "D .git not restored to dir"
+[ -d "$VC/.smart-env" ] && [ ! -L "$VC/.smart-env" ] && pass "D .smart-env restored as real dir" \
+                                                       || fail "D .smart-env not restored"
+gitq "$VC" status && pass "D git functional after rollback" || fail "D git broke after rollback"
+
+# ---------------------------------------------------------------------------
+# E. LIVE-WORKTREE GUARD: refuse (exit 1) when a linked worktree exists
+# ---------------------------------------------------------------------------
+VD="$ROOT/D"
+make_vault "$VD"
+gitq "$VD" worktree add "$VD/.claude/worktrees/live" -b livebranch HEAD
+bash "$HELPER" "$VD" --sidecar "$SIDE" --quiet >/dev/null 2>&1
+rc=$?
+[ "$rc" = 1 ] && pass "E refuses with live linked worktree (exit 1)" \
+              || fail "E expected refuse exit 1, got $rc"
+# and --force overrides
+bash "$HELPER" "$VD" --sidecar "$SIDE" --force --quiet >/dev/null 2>&1
+rc=$?
+[ "$rc" = 0 ] && pass "E --force overrides the guard (exit 0)" || fail "E --force exit=$rc"
+
+# ---------------------------------------------------------------------------
+# F. DRY-RUN: changes nothing
+# ---------------------------------------------------------------------------
+VE="$ROOT/E"
+make_vault "$VE"
+bash "$HELPER" "$VE" --sidecar "$SIDE" --dry-run --quiet >/dev/null 2>&1
+[ -d "$VE/.git" ] && [ ! -L "$VE/.smart-env" ] && pass "F dry-run changed nothing" \
+                                               || fail "F dry-run mutated the vault"
+
+echo
+echo "--- MANUAL (operator-gated, cannot automate in CI) ---"
+echo "iPhone round-trip: with the vault in iCloud Drive + this relocation applied,"
+echo "  edit a note on iPhone (Obsidian/Files) → confirm it appears on the Mac, and"
+echo "  vice-versa, while Activity Monitor shows fileproviderd/bird idle during a"
+echo "  Mac-side git gc. (Done= part b.)"
+echo
+
+if [ "$fails" -gt 0 ]; then echo "FAILED: $fails"; exit 1; fi
+echo "ALL TESTS PASSED"

--- a/tests/integration/test_cloud_sync_guard.sh
+++ b/tests/integration/test_cloud_sync_guard.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# CI integration wrapper — runs the cloud-sync detection negative-control suite
+# (scripts/test-cloud-sync-guard.sh, incl. the iCloud Desktop & Documents
+# realpath branch) as part of `scripts/ci.sh`. Thin: logic lives next to the
+# script it exercises.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+exec bash "$ROOT/scripts/test-cloud-sync-guard.sh"

--- a/tests/integration/test_machinery_sidecar.sh
+++ b/tests/integration/test_machinery_sidecar.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# CI integration wrapper — runs the machinery-sidecar churn-burst + negative-
+# control suite (scripts/test-machinery-sidecar.sh) as part of `scripts/ci.sh`.
+# Kept thin so the test logic has ONE home next to the script it exercises.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+exec bash "$ROOT/scripts/test-machinery-sidecar.sh"


### PR DESCRIPTION
## What

Makes "keep my vault in iCloud" a **first-class supported mode**. A vault may live inside a cloud-sync folder (iCloud Drive / Desktop & Documents) with two-way document sync, while every churning machinery dir is relocated to a local sidecar outside the synced tree. The machine never storms because the freeze class came only from the machinery — a `.git` rewritten wholesale on `git gc`, per-session worktree checkouts, and search caches — never the markdown.

Two first-class shapes now: **fully local** (simplest, default) or **synced + sidecar** (notes on every device).

## Surfaces

- `relocate-machinery-sidecar.sh` — relocates `.git` via `git init --separate-git-dir` (leaves a static one-line pointer), and worktrees + caches via relocate-and-symlink (or `--nosync`). Idempotent, reversible (`--rollback`), `--dry-run`, and a no-live-worktree guard because separating the git dir orphans live worktrees.
- `test-machinery-sidecar.sh` — the proof: after a full churn burst (worktree add + 5 commits + `git gc --aggressive`), ZERO machinery content files live in the (synced) vault tree. The **negative control** repeats the identical churn on a non-relocated vault and asserts machinery IS in-tree, so the metric can't be trivially always-zero. Plus rollback, idempotency, live-worktree-guard, and dry-run cases.
- `CLOUD_SYNC.md` — reframed from "keep local, period" to "the vault may be synced; the machinery never is."
- `phase-01-welcome.md` — the installer offers both shapes at vault-path capture instead of hard-stopping on a synced path.
- `test-cloud-sync-guard.sh` — added negative-control coverage for the iCloud Desktop & Documents realpath branch; both shell suites are now wired into `ci.sh`.

## Verification

`scripts/ci.sh` green locally: `py_compile` (254 files) + 16 integration tests, including the two newly wired suites. The iPhone round-trip half (note edited on phone flows back to Mac) is operator-gated and documented as a manual check in the test output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)