### PR TITLE
ci(lint): add shellcheck gate over every tracked .sh

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,10 @@ name: lint
 
 # Two kinds of check live here:
 #
-#   1. Pure-lint jobs (below): bash syntax, PowerShell parse, UTF-8 BOM on .ps1,
-#      no em dashes in .ps1, JSON validity, private-context tokens, phase-doc
-#      references, and the no-remote-pipe-install guard.
+#   1. Pure-lint jobs (below): bash syntax, shellcheck (shell static analysis),
+#      PowerShell parse, UTF-8 BOM on .ps1, no em dashes in .ps1, JSON validity,
+#      private-context tokens, phase-doc references, and the no-remote-pipe-install
+#      guard.
 #
 #   2. The unit/type gate: the `ci` job, which runs `bash scripts/ci.sh`. That
 #      script is the SINGLE source of truth for the unit/type gate - it runs
@@ -40,6 +41,26 @@ jobs:
             fi
           done < <(find . -name '*.sh' -not -path './.git/*' -not -path './node_modules/*')
           exit $fail
+
+  shellcheck:
+    name: shellcheck (.sh, -S warning)
+    runs-on: ubuntu-latest
+    # `bash -n` (the `shell` job) is syntax-only. shellcheck adds the portability /
+    # quoting / correctness layer over every tracked *.sh: BSD-only flags, unquoted
+    # expansions (SC2086), unset vars, exit codes masked by a pipe. A real GNU-vs-BSD
+    # `stat -c` / `stat -f` mtime bug once passed macOS-local + `bash -n` and only
+    # failed on the ubuntu runner; this job catches that class. scripts/shellcheck.sh
+    # is the SINGLE
+    # source of truth - scripts/ci.sh runs the SAME script locally so the laptop
+    # pre-push gate and CI cannot drift. The severity gate starts at error + warning
+    # (info/style excluded) to match the real ship/hold boundary, not the strictest
+    # possible signal. No untrusted user input is referenced in any run: command.
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - name: ensure shellcheck present
+        run: command -v shellcheck >/dev/null || { sudo apt-get update && sudo apt-get install -y shellcheck; }
+      - name: run the canonical shellcheck gate
+        run: bash scripts/shellcheck.sh
 
   powershell:
     name: PowerShell parse (.ps1)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,9 @@ Same thing — open an issue. Describe the problem you're trying to solve, not j
 2. Make your changes
 3. Open a pull request with a one-sentence description of what changed and why
 
-Before opening the PR, run the full CI gate locally: `bash scripts/ci.sh` (the same `py_compile` over every tracked `*.py` plus the integration tests that CI runs).
+Before opening the PR, run the full CI gate locally: `bash scripts/ci.sh` (the same `py_compile` over every tracked `*.py`, the integration tests, and `shellcheck` over every tracked `*.sh` that CI runs).
+
+**Shell scripts must run on macOS AND Linux** (users install on both; CI is ubuntu). `bash scripts/shellcheck.sh` is wired into the gate above and into CI as its own job. For the GNU-vs-BSD differences shellcheck cannot catch (`stat`, `date`, `sed -i`, bash 3.2), see [`scripts/PORTABILITY.md`](scripts/PORTABILITY.md).
 
 **For SKILL.md changes:** The most important thing is that instructions stay prescriptive and complete. Vague instructions like "ask about habits" produce inconsistent results across different users and models. If you're changing how the skill behaves, spell out exactly what Claude should do, in what order, and with what fallbacks. See the existing phases for the right level of detail.
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -474,15 +474,14 @@ PY
       -H "content-type: application/json" \
       -d "$QM_PAYLOAD" 2>/dev/null)"
     set -e
-    QM_TOKEN="$(printf '%s' "${QM_RESP:-}" | python3 <<'PY' 2>/dev/null
+    QM_TOKEN="$(printf '%s' "${QM_RESP:-}" | python3 -c '
 import json, sys
 try:
     d = json.load(sys.stdin)
     print(d.get("token","") if d.get("ok") else "")
 except Exception:
     print("")
-PY
-)"
+' 2>/dev/null)"
     if [[ -z "$QM_TOKEN" || ! "$QM_TOKEN" =~ ^[a-f0-9]{32}$ ]]; then
       err "$(t "Inline mint failed. Falling back to form." \
               "Falló la generación inline. Caemos al formulario.")"
@@ -590,7 +589,7 @@ do_cmd() {
 backup_file() {
   local f="$1"
   [[ ! -f "$f" ]] && return 0
-  local bak="${f}.bak-$(date +%Y-%m-%d-%H%M)"
+  local bak; bak="${f}.bak-$(date +%Y-%m-%d-%H%M)"
   if [[ $DRY_RUN -eq 1 ]]; then
     dry "would back up: $f → $bak"
   else

--- a/scripts/PORTABILITY.md
+++ b/scripts/PORTABILITY.md
@@ -1,0 +1,94 @@
+# Portable shell idioms (macOS + Linux)
+
+ai-brain-starter ships ~80 `*.sh` that users run on **macOS** (bash 3.2, BSD
+coreutils) and **Linux** (bash 4+/5, GNU coreutils). CI runs on **ubuntu**. A
+script that is green on a Mac can still fail on a user's Linux box, or on CI.
+
+`scripts/shellcheck.sh` (run in CI by the `shellcheck` job in
+`.github/workflows/lint.yml`, and locally by `scripts/ci.sh`) catches most of the
+quoting and correctness class. It does **not** catch the GNU-vs-BSD flag
+differences below. Those are on you. Each has a reference implementation in this
+repo.
+
+## 1. File mtime: `stat`
+
+GNU and BSD `stat` take different flags, and the failure mode is SILENT:
+
+- GNU/Linux: `stat -c %Y FILE`  gives the epoch mtime
+- BSD/macOS: `stat -f %m FILE`  gives the epoch mtime
+
+The trap: GNU `stat -f` means `--file-system`. So `stat -f %m FILE` on Linux
+**exits 0** and prints non-numeric filesystem text instead of failing. Relying on
+`||` (the exit code) hands you garbage, not a fallback. Validate that the result
+is numeric after each attempt.
+
+Reference: `scripts/_session_close_guard.sh`, function `_close_lock_mtime`:
+
+```bash
+m=$(stat -c %Y "$1" 2>/dev/null)                                   # GNU/Linux
+case "$m" in ''|*[!0-9]*) m=$(stat -f %m "$1" 2>/dev/null) ;; esac # BSD/macOS
+case "$m" in ''|*[!0-9]*) m="" ;; esac   # neither gave a plain integer -> empty
+```
+
+## 2. Date arithmetic: `date`
+
+- BSD/macOS: `date -v-7d +%Y-%m-%d`
+- GNU/Linux: `date -d '7 days ago' +%Y-%m-%d`
+
+Detect support, do not guess the platform:
+
+Reference: `scripts/session-end-hook.sh`:
+
+```bash
+if date -v-7d +%Y-%m-%d >/dev/null 2>&1; then
+  CUTOFF=$(date -v-7d +%Y-%m-%d)             # BSD/macOS
+else
+  CUTOFF=$(date -d '7 days ago' +%Y-%m-%d)   # GNU/Linux
+fi
+```
+
+## 3. In-place edit: `sed -i`
+
+`sed -i` is NOT portable. GNU is `sed -i 's/x/y/' f`; BSD requires an explicit
+backup-suffix argument, `sed -i '' 's/x/y/' f`. Mixing the two either errors or
+silently writes a stray backup file.
+
+Do not use `sed -i` at all. Write to a temp file and `mv`:
+
+```bash
+sed 's/PLACEHOLDER/value/' template > "$tmp" && mv "$tmp" dest
+```
+
+Reference: `scripts/install-closed-loop-daemon.sh` and
+`scripts/install-vault-daily-maintenance.sh` both substitute placeholders via a
+temp file precisely because `sed -i` differs across macOS and GNU.
+
+## 4. bash 3.2 (macOS ships it)
+
+macOS ships **bash 3.2** (2007) as `/bin/bash`, and many users invoke hooks and
+scripts under it. Avoid bash-4-only features, or guard them:
+
+- No `mapfile` / `readarray -d` (the `-d` delimiter flag is bash 4.4+). Build
+  arrays with a NUL-delimited read loop instead:
+  `files=(); while IFS= read -r -d '' f; do files+=("$f"); done < <(... -print0)`.
+  Reference: `scripts/shellcheck.sh` and `scripts/ci.sh` both build their file
+  lists this way.
+- `"${arr[@]}"` on an **empty** array under `set -u` errors on bash 3.2/4.3.
+  Guard with `if [ "${#arr[@]}" -eq 0 ]; then ...; fi` before expanding.
+- No associative arrays (`declare -A`).
+- No `${var^^}` / `${var,,}` case conversion (bash 4+). Use `tr`.
+
+## What shellcheck DOES catch (so you do not have to memorize it)
+
+Unquoted expansions (SC2086), `cd` without `|| exit` (SC2164), useless `eval`
+(SC2294), redirection ordering (SC2069), masked return values (SC2155), and more,
+at error + warning severity. Run it before you push:
+
+```bash
+bash scripts/shellcheck.sh
+# or the full local gate (py_compile + integration tests + shellcheck):
+bash scripts/ci.sh
+```
+
+A genuine false-positive is silenced at the source line with an inline shellcheck
+disable directive carrying a one-line reason, never by lowering the severity gate.

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -14,10 +14,18 @@
 #                           system /usr/bin/python3, which is 3.9).
 #   (b) Shell integration - the named tests under tests/integration/, in
 #                           order, stopping at the first failure.
+#   (c) Shell static analysis - scripts/shellcheck.sh, the SAME script lint.yml's
+#                           dedicated `shellcheck` job runs, so the local pre-push
+#                           gate and CI cannot drift on shell quality. Skipped here
+#                           when running inside GitHub Actions (the dedicated job
+#                           already covers it); locally it is warn-and-skipped
+#                           when the shellcheck binary is absent (CI enforces it).
 #
-# It does NOT run the pure-lint jobs (bash -n, pwsh ParseFile, BOM, em-dash,
+# It does NOT run the OTHER pure-lint jobs (bash -n, pwsh ParseFile, BOM, em-dash,
 # JSON, privacy, references, no-remote-pipe-install). Those stay as their own
-# lint.yml jobs - they are lint, not the unit/type gate.
+# lint.yml jobs - they are lint, not the unit/type gate. shellcheck is the one
+# exception: it is the cross-platform CORRECTNESS gate (it catches the GNU-vs-BSD
+# `stat` mtime class), so it is worth enforcing pre-push, not only in CI.
 #
 # Environment the integration tests need (lint.yml provides these in the `ci`
 # job; this script adds a non-invasive fallback so a fresh `bash scripts/ci.sh`
@@ -113,5 +121,27 @@ for t in "${INTEGRATION_TESTS[@]}"; do
   bash "$script"
 done
 
+# ---- (c) Shell static analysis gate ----------------------------------------
+# Runs the SAME canonical gate as lint.yml's `shellcheck` job - scripts/shellcheck.sh
+# - so the local pre-push gate (~/.local/bin/ci-test) and CI cannot drift on shell
+# quality. In CI we skip it here because the dedicated `shellcheck` job already runs
+# scripts/shellcheck.sh; running it again in this job would only duplicate work and
+# muddy failure attribution. Locally there is no such job, so this is where the
+# pre-push gate gets shellcheck coverage. If shellcheck is not installed locally we
+# warn and skip (CI still enforces it) rather than blocking the python + integration
+# gates a contributor can still run.
+if [ -n "${GITHUB_ACTIONS:-}" ]; then
+  shellcheck_note="skipped in CI (dedicated lint.yml 'shellcheck' job runs scripts/shellcheck.sh)"
+  echo "==> (c) shellcheck: $shellcheck_note"
+elif command -v shellcheck >/dev/null 2>&1; then
+  echo "==> (c) shellcheck: bash scripts/shellcheck.sh"
+  bash scripts/shellcheck.sh
+  shellcheck_note="passed"
+else
+  shellcheck_note="skipped (shellcheck not installed locally; CI enforces it)"
+  echo "==> (c) shellcheck: $shellcheck_note"
+  echo "    install: brew install shellcheck  (macOS)  /  sudo apt-get install -y shellcheck  (Debian/Ubuntu)"
+fi
+
 echo
-echo "All gates passed: py_compile ($count file(s)) + ${#INTEGRATION_TESTS[@]} integration tests."
+echo "All gates passed: py_compile ($count file(s)) + ${#INTEGRATION_TESTS[@]} integration tests + shellcheck [$shellcheck_note]."

--- a/scripts/diagnose.sh
+++ b/scripts/diagnose.sh
@@ -80,6 +80,7 @@ fi
 section "3. Claude Code skills"
 SKILLS_DIR="$HOME/.claude/skills"
 if [ -d "$SKILLS_DIR" ]; then
+  # shellcheck disable=SC2088  # literal ~ in user-facing message, not a path
   ok "~/.claude/skills/ exists"
   # ai-brain-starter itself
   if [ -d "$SKILLS_DIR/ai-brain-starter" ]; then
@@ -94,6 +95,7 @@ if [ -d "$SKILLS_DIR" ]; then
     warn "daily-journal skill not installed" "/setup-brain Phase 10a creates it."
   fi
 else
+  # shellcheck disable=SC2088  # literal ~ in user-facing message, not a path
   bad "~/.claude/skills/ missing" "Claude Code may not be installed, or the skills dir was deleted."
 fi
 
@@ -181,7 +183,7 @@ fi
 
 # ----- 8. .ps1 sanity (if any exist) -----
 section "8. PowerShell files (Windows compat)"
-ps1_files=$(find "$VAULT" "$HOME/.claude/skills/ai-brain-starter" 2>/dev/null \
+ps1_files=$(find "$VAULT" "$HOME/.claude/skills/ai-brain-starter" \
   -name '*.ps1' -not -path '*/.git/*' 2>/dev/null | head -20)
 if [ -z "$ps1_files" ]; then
   ok "No .ps1 files to check"
@@ -266,7 +268,7 @@ fi
 section "10. ai-brain-starter freshness"
 ABS_DIR="$HOME/.claude/skills/ai-brain-starter"
 if [ -d "$ABS_DIR/.git" ]; then
-  cd "$ABS_DIR"
+  cd "$ABS_DIR" || exit 1
   local_sha=$(git rev-parse HEAD 2>/dev/null | cut -c1-7)
   if git fetch origin main --quiet 2>/dev/null; then
     remote_sha=$(git rev-parse origin/main 2>/dev/null | cut -c1-7)
@@ -280,8 +282,9 @@ if [ -d "$ABS_DIR/.git" ]; then
   else
     warn "Could not fetch from origin (offline?)"
   fi
-  cd - >/dev/null
+  cd - >/dev/null || exit 1
 else
+  # shellcheck disable=SC2088  # literal ~ in user-facing message, not a path
   warn "~/.claude/skills/ai-brain-starter is not a git repo" "Re-run bootstrap.sh to clone it."
 fi
 

--- a/scripts/drift-check.sh
+++ b/scripts/drift-check.sh
@@ -143,7 +143,7 @@ is_ignored() {
     pat="${pat#"${pat%%[![:space:]]*}"}"  # strip leading whitespace
     pat="${pat%"${pat##*[![:space:]]}"}"  # strip trailing whitespace
     [[ -z "$pat" ]] && continue
-    # shellcheck disable=SC2254 — intentional unquoted glob match
+    # shellcheck disable=SC2254  # intentional unquoted glob match
     case "$path" in
       $pat) return 0 ;;
     esac

--- a/scripts/fix-plugin-hooks.sh
+++ b/scripts/fix-plugin-hooks.sh
@@ -22,7 +22,6 @@ fi
 fixed=0
 while IFS= read -r hooks_file; do
     if grep -q 'CLAUDE_PLUGIN_ROOT' "$hooks_file" 2>/dev/null; then
-        plugin_dir=$(dirname "$hooks_file")
         echo "Fixing: $hooks_file"
         python3 -c "
 import sys

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -49,10 +49,10 @@ t() { [[ "$LANG_CODE" == "es" ]] && echo "$2" || echo "$1"; }
 
 # ─── Color helpers (suppressed in JSON / quiet mode) ──────────────────────────
 if [[ $JSON_MODE -eq 1 || $QUIET_MODE -eq 1 ]]; then
-  C_RED=""; C_YEL=""; C_GRN=""; C_BLU=""; C_DIM=""; C_BLD=""; C_RST=""
+  C_RED=""; C_YEL=""; C_GRN=""; C_DIM=""; C_BLD=""; C_RST=""
 else
   C_RED=$'\033[31m'; C_YEL=$'\033[33m'; C_GRN=$'\033[32m'
-  C_BLU=$'\033[34m'; C_DIM=$'\033[2m'; C_BLD=$'\033[1m'; C_RST=$'\033[0m'
+  C_DIM=$'\033[2m'; C_BLD=$'\033[1m'; C_RST=$'\033[0m'
 fi
 
 red()    { RED_LINES+=("$1"); RED_COUNT=$((RED_COUNT+1)); [[ $JSON_MODE -eq 0 && $QUIET_MODE -eq 0 ]] && printf "  ${C_RED}✗${C_RST} %s\n" "$1"; }
@@ -79,7 +79,6 @@ section "$(t "Operating system" "Sistema operativo")"
 OS_KIND="$(uname -s)"
 case "$OS_KIND" in
   Darwin)
-    OS_NAME="macOS"
     MACOS_VER="$(sw_vers -productVersion 2>/dev/null || echo unknown)"
     MACOS_MAJOR="${MACOS_VER%%.*}"
     if [[ "$MACOS_MAJOR" =~ ^[0-9]+$ && "$MACOS_MAJOR" -ge 11 ]]; then
@@ -97,7 +96,6 @@ case "$OS_KIND" in
     info "$(t "Architecture: $ARCH" "Arquitectura: $ARCH")"
     ;;
   Linux)
-    OS_NAME="Linux"
     DISTRO=""
     [[ -f /etc/os-release ]] && DISTRO="$(. /etc/os-release && echo "${PRETTY_NAME:-$NAME}")"
     green "$(t "Linux: ${DISTRO:-detected}" "Linux: ${DISTRO:-detectado}")"
@@ -147,13 +145,11 @@ declare -a HOSTS=(
   "https://claude.ai|claude.ai (Claude Code sign-in)"
 )
 
-NET_BLOCKED=0
 for entry in "${HOSTS[@]}"; do
   url="${entry%%|*}"; name="${entry##*|}"
   if reachable "$url"; then
     green "$(t "$name reachable" "$name accesible")"
   else
-    NET_BLOCKED=1
     red "$(t \
       "$name NOT reachable at $url — check VPN / firewall / corporate proxy" \
       "$name NO accesible en $url — revisá VPN / firewall / proxy corporativo")"

--- a/scripts/relocate-machinery-sidecar.sh
+++ b/scripts/relocate-machinery-sidecar.sh
@@ -105,6 +105,7 @@ MANIFEST="$SIDECAR/manifests/$SLUG.json"
 say()  { [ "$QUIET" = 1 ] || printf '%s\n' "$*"; }
 warn() { printf 'WARN  %s\n' "$*" >&2; }
 err()  { printf 'ERROR %s\n' "$*" >&2; }
+# shellcheck disable=SC2294  # run() intentionally evals a command STRING; every caller passes redirections + quoted space/emoji paths that "$@" cannot parse
 run()  { if [ "$DRYRUN" = 1 ]; then printf 'DRY   %s\n' "$*"; else eval "$@"; fi; }
 
 # ---- manifest helpers (python3 for safe JSON over emoji/space paths) ---------

--- a/scripts/shellcheck.sh
+++ b/scripts/shellcheck.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# scripts/shellcheck.sh - the canonical, locally-runnable shellcheck gate for
+# ai-brain-starter. ONE command, shared by two callers so they can never drift:
+#
+#   1. .github/workflows/lint.yml  - the `shellcheck` job runs `bash scripts/shellcheck.sh`.
+#   2. scripts/ci.sh               - section (c) runs `bash scripts/shellcheck.sh`, so the
+#                                    local pre-push gate (~/.local/bin/ci-test) runs the
+#                                    SAME shellcheck. CI and the laptop cannot drift.
+#
+# Why this exists: ai-brain-starter ships ~80 tracked *.sh that must run on macOS
+# AND Linux (users install on both; CI is ubuntu). `bash -n` (the `shell` lint job)
+# is syntax-only - it cannot catch the portability / quoting / correctness class:
+# BSD-only flags, unquoted expansions (SC2086), unset vars, exit codes masked by a
+# pipe. A real `stat -c %Y` (GNU) vs `stat -f %m` (BSD) mtime bug once passed
+# macOS-local + `bash -n` and only failed on the ubuntu CI runner. shellcheck
+# catches that class before it ships.
+#
+# Severity gate: -S warning (error + warning). info/style are NOT failed here, so
+# the gate matches the real ship/hold boundary, not the strictest possible signal
+# (an over-strict gate just teaches people to bypass it). Raise the floor later, on
+# purpose, if the baseline supports it:  SHELLCHECK_SEVERITY=style bash scripts/shellcheck.sh
+#
+# A genuine false-positive is silenced at the source with an inline shellcheck
+# disable directive carrying a one-line reason - never by lowering the gate for
+# every file.
+#
+# Idioms shellcheck does NOT catch (cross-platform stat / date / sed) are
+# documented in scripts/PORTABILITY.md.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+if ! command -v shellcheck >/dev/null 2>&1; then
+  echo "::error::shellcheck not installed." >&2
+  echo "  macOS:         brew install shellcheck" >&2
+  echo "  Debian/Ubuntu: sudo apt-get install -y shellcheck" >&2
+  exit 1
+fi
+
+SEVERITY="${SHELLCHECK_SEVERITY:-warning}"
+
+# Collect every tracked *.sh. git ls-files is the source of truth (same as ci.sh's
+# py_compile gate): it excludes .git/, node_modules/, and untracked cruft for free,
+# and -z is NUL-delimited so paths with spaces / emoji survive. Built bash-3.2-safe
+# (macOS ships bash 3.2): no `mapfile -d`, just a read + append loop.
+files=()
+while IFS= read -r -d '' f; do
+  files+=("$f")
+done < <(git ls-files -z -- '*.sh')
+
+# Empty-array expansion under `set -u` errors on bash 3.2 / 4.3; guard it.
+if [ "${#files[@]}" -eq 0 ]; then
+  echo "no tracked *.sh found - nothing to check"
+  exit 0
+fi
+
+echo "==> shellcheck -S $SEVERITY over ${#files[@]} tracked *.sh  [$(shellcheck --version | awk '/^version:/{print $2}')]"
+
+# GitHub Actions renders one annotation per finding from the gcc format; an
+# interactive run gets shellcheck's readable default.
+fmt="tty"
+[ -n "${GITHUB_ACTIONS:-}" ] && fmt="gcc"
+
+if shellcheck -S "$SEVERITY" -f "$fmt" "${files[@]}"; then
+  echo "    OK - no shellcheck findings at -S $SEVERITY"
+else
+  echo "FAILED: shellcheck found issues at -S $SEVERITY." >&2
+  echo "Fix them, or - for a genuine false-positive - add an inline shellcheck" >&2
+  echo "disable directive with a one-line reason at the source line." >&2
+  echo "Do NOT lower the severity gate to hide a finding (see this script's header)." >&2
+  exit 1
+fi

--- a/scripts/test-hooks-in-worktree.sh
+++ b/scripts/test-hooks-in-worktree.sh
@@ -36,7 +36,7 @@ trap 'rm -rf "$TMP"' EXIT
 
 REPO="$TMP/test-vault"
 mkdir -p "$REPO"
-cd "$REPO"
+cd "$REPO" || exit 1
 git init -b main --quiet 2>/dev/null
 git config user.email "test@example.com"
 git config user.name "test"
@@ -66,7 +66,7 @@ log "Using detector: $DETECTOR"
 
 hdr "Test 1: hook fires from main worktree"
 
-cd "$REPO"
+cd "$REPO" || exit 1
 RESPONSE=$(echo '{"prompt":"bye","session_id":"test-1","cwd":"'"$REPO"'"}' \
   | python3 "$DETECTOR" 2>/dev/null)
 if echo "$RESPONSE" | python3 -c "import json,sys; d=json.loads(sys.stdin.read()); assert 'hookSpecificOutput' in d; assert 'CLOSE detected' in d.get('hookSpecificOutput',{}).get('additionalContext','')" 2>/dev/null; then
@@ -89,7 +89,7 @@ git worktree add .claude/worktrees/test-wt --quiet 2>/dev/null || {
 }
 
 if [[ -d ".claude/worktrees/test-wt" ]]; then
-  cd .claude/worktrees/test-wt
+  cd .claude/worktrees/test-wt || exit 1
   WORKTREE_PWD="$(pwd)"
   log "Worktree cwd: $WORKTREE_PWD"
 
@@ -127,7 +127,7 @@ fi
 
 hdr "Test 3: installer preserves non-ABS hooks"
 
-cd "$TMP"
+cd "$TMP" || exit 1
 cat > test-settings.json <<'EOF'
 {
   "model": "opus",
@@ -165,7 +165,7 @@ else
     fail "hooks.json source not found"
     FAIL=$((FAIL+1))
   else
-    python3 "$INSTALLER" --settings test-settings.json --hooks-source "$HOOKS_SOURCE" --quiet 2>&1 >/dev/null
+    python3 "$INSTALLER" --settings test-settings.json --hooks-source "$HOOKS_SOURCE" --quiet >/dev/null 2>&1
 
     if python3 -c "import json,sys; d=json.load(open('test-settings.json')); cmds=[h['command'] for g in d['hooks']['UserPromptSubmit'] for h in g.get('hooks',[])]; assert any('user custom hook' in c for c in cmds), 'user hook lost'" 2>/dev/null; then
       ok "installer preserved user's custom hook"
@@ -185,7 +185,7 @@ else
 
     # Re-run for idempotency
     BEFORE_HASH=$(python3 -c "import hashlib; print(hashlib.sha256(open('test-settings.json','rb').read()).hexdigest())")
-    python3 "$INSTALLER" --settings test-settings.json --hooks-source "$HOOKS_SOURCE" --quiet 2>&1 >/dev/null
+    python3 "$INSTALLER" --settings test-settings.json --hooks-source "$HOOKS_SOURCE" --quiet >/dev/null 2>&1
     AFTER_HASH=$(python3 -c "import hashlib; print(hashlib.sha256(open('test-settings.json','rb').read()).hexdigest())")
     if [[ "$BEFORE_HASH" == "$AFTER_HASH" ]]; then
       ok "installer is idempotent (re-run produced identical file)"

--- a/scripts/update-check.sh
+++ b/scripts/update-check.sh
@@ -66,7 +66,7 @@ if [[ ! -d "$REPO_DIR/.git" ]]; then
   exit 0
 fi
 
-cd "$REPO_DIR"
+cd "$REPO_DIR" || { echo "STATUS: ERROR"; echo "REASON: cannot enter $REPO_DIR"; exit 0; }
 
 # Fetch quietly. If network is down or auth fails, treat as ERROR but don't crash.
 if ! git fetch --quiet origin main 2>/dev/null; then

--- a/skills/secret-warn/install.sh
+++ b/skills/secret-warn/install.sh
@@ -8,7 +8,6 @@ set -euo pipefail
 
 SKILL_SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DEST="${SECRET_WARN_ROOT:-$HOME/.claude/secret-warn}"
-SETTINGS="$HOME/.claude/settings.json"
 
 echo "[secret-warn] installing to $SKILL_DEST"
 

--- a/tests/integration/test_reconcile_ff_invariant.sh
+++ b/tests/integration/test_reconcile_ff_invariant.sh
@@ -70,6 +70,7 @@ EOF
 # 2. Hookify-auto-commit hook would commit on master. Simulate that:
 git add .claude/hookify.test-rule.local.md
 git commit --quiet -m "auto-commit: hookify rule update"
+# shellcheck disable=SC2034  # snapshot of master after the edit; documents the step (not asserted)
 MASTER_SHA_AFTER_EDIT=$(git rev-parse HEAD)
 
 # 3. The worktree's filesystem ALSO has a copy of this file (because
@@ -148,6 +149,7 @@ git commit --quiet -m "auto-commit: second hookify rule update"
 cp .claude/hookify.another-rule.local.md ".claude/worktrees/diverged-slug/.claude/hookify.another-rule.local.md"
 
 DIVERGED_BRANCH_SHA_PRE=$(git rev-parse refs/heads/claude/diverged-slug)
+# shellcheck disable=SC2034  # snapshot of master pre-fallback; documents the pre-state (not asserted)
 MASTER_SHA_PRE_FALLBACK=$(git rev-parse refs/heads/master)
 
 cd ".claude/worktrees/diverged-slug"

--- a/tests/integration/test_resource_aware_session_close.sh
+++ b/tests/integration/test_resource_aware_session_close.sh
@@ -48,19 +48,24 @@ trap 'rm -rf "$TMP"' EXIT
 echo "PASS: guard sources clean and defines close_{resource_high,load_per_core,mutex_acquire,mutex_release}"
 
 # ─── Assertion 2: load gate is deterministic ───────────────────────────────
+# shellcheck source=/dev/null
 ( . "$GUARD"
+  # shellcheck disable=SC2034  # consumed by close_resource_high in the sourced $GUARD
   CLOSE_MAX_LOAD_PER_CORE=0
   close_resource_high || { echo "thr=0 should be HIGH" >&2; exit 1; }
+  # shellcheck disable=SC2034  # consumed by close_resource_high in the sourced $GUARD
   CLOSE_MAX_LOAD_PER_CORE=99999
   close_resource_high && { echo "thr=99999 should be low" >&2; exit 1; }
   exit 0 ) || fail "load gate threshold logic wrong"
 echo "PASS: load gate defers at threshold 0 and runs at threshold 99999"
 
 # ─── Assertion 3: mutex acquire / contend / release / stale-reclaim ─────────
+# shellcheck source=/dev/null
 ( . "$GUARD"
   export CLOSE_MUTEX="$TMP/mutex3.lock"
   close_mutex_acquire 2 || { echo "acquire#1 failed" >&2; exit 1; }
   # A child trying to acquire while we hold it (live holder) must time out.
+  # shellcheck source=/dev/null
   ( . "$GUARD"; export CLOSE_MUTEX="$TMP/mutex3.lock"
     if close_mutex_acquire 2; then echo "contended acquire wrongly succeeded" >&2; exit 1; fi )
   contend_rc=$?
@@ -85,7 +90,7 @@ echo "PASS: session-end-hook.sh sources the guard and carries the CLOSE_DEFER ga
 make_vault() {
   local v="$1"
   mkdir -p "$v/⚙️ Meta/Sessions"
-  ( cd "$v"
+  ( cd "$v" || exit 1
     git init --quiet --initial-branch=master
     git config user.email "t@example.com"; git config user.name "t"
     echo "# vault" > README.md

--- a/tests/integration/test_scan_prior_single_instance.sh
+++ b/tests/integration/test_scan_prior_single_instance.sh
@@ -58,6 +58,7 @@ FULL_MARKER="$HOOKS/.last-secret-scan-full"
 MARKER="$HOOKS/.last-secret-scan"
 LOCK="$HOOKS/.secret-scan.lock"
 
+# shellcheck disable=SC2120  # run_hook optionally takes extra env assignments; some callers pass none
 run_hook() {  # args: extra env assignments
   printf '{}' | env HOME="$TMP" SCAN_PRIOR_AUTO_SCRUB_BYPASS=1 "$@" python3 "$HOOK" 2>/dev/null
 }

--- a/tests/integration/test_worktree_session_close.sh
+++ b/tests/integration/test_worktree_session_close.sh
@@ -158,6 +158,7 @@ git branch claude/fully-merged-slug master
 # Confirm the directory doesn't exist
 mkdir -p .claude/worktrees  # keep the dir, just no slug subdir
 
+# shellcheck disable=SC2034  # capture silences prune stdout/stderr; the assertion reads $PRUNE_LOG2
 PRUNE_OUTPUT2="$(VAULT_ROOT="$VAULT" LOG_DIR="$TMP/logs2" bash "$PRUNE" 2>&1 || true)"
 PRUNE_LOG2="$TMP/logs2/worktree-prune.log"
 


### PR DESCRIPTION
Adds static shell analysis to CI. `bash -n` (the existing `shell` job) is syntax-only; ~80 tracked `*.sh` ship on macOS AND Linux (CI is ubuntu), so a whole class of portability / quoting / correctness bugs slips past it until a user or the Linux runner hits one.

## What changed
- **`scripts/shellcheck.sh`** — single source of truth: `git ls-files` over every tracked `*.sh`, severity `-S warning` (error + warning; info/style excluded so the gate matches the real ship/hold boundary, not the strictest possible signal). bash-3.2-safe for macOS.
- **`.github/workflows/lint.yml`** — a dedicated `shellcheck` job runs that script.
- **`scripts/ci.sh`** — section (c) runs the SAME script locally, so the pre-push gate (`ci-test`) and CI cannot drift. Skipped inside Actions (the dedicated job covers it); warn-and-skip locally when the `shellcheck` binary is absent (CI still enforces it).
- **`scripts/PORTABILITY.md`** + a `CONTRIBUTING.md` pointer — the GNU-vs-BSD idioms shellcheck cannot catch (`stat`, `date`, `sed -i`, bash 3.2), citing the in-repo reference impls (`_close_lock_mtime` in `_session_close_guard.sh`, `session-end-hook.sh`).

## Baseline triaged: 33 findings → 0 at `-S warning`
Real bugs fixed (not just annotated):
- **`bootstrap.sh`** inline-mint: `python3 <<'PY'` made python read its *program* from the heredoc, so the piped `$QM_RESP` JSON never reached `json.load(sys.stdin)` — the token parse always returned empty and fell back to the form. Switched to `python3 -c` so stdin stays the pipe.
- **`diagnose.sh`**: a `2>/dev/null` placed mid-`find`-args (applied to `find` itself, competing redirections); `cd` without `|| exit`.
- **`test-hooks-in-worktree.sh`**: `--quiet 2>&1 >/dev/null` (stderr leaked) → `>/dev/null 2>&1`; `cd` without `|| exit`.
- **`drift-check.sh`**: a `# shellcheck disable` directive broken by a stray separator (so the disable never applied).

Plus dead-variable removals (`preflight.sh`, `fix-plugin-hooks.sh`, `secret-warn/install.sh`) and reasoned inline `disable` directives for true false-positives (literal `~` in display strings, env vars consumed by a sourced guard, an intentional `eval` of a command string with redirections).

Verified locally: `bash scripts/ci.sh` green — `py_compile` (254 files) + 16 integration tests + `shellcheck` (80 files, 0 findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
