### PR TITLE
Drop Smart Connections from default + large-vault plugin posture (renderer OOM)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,28 @@ description: What's new in AI Brain Starter — plain English, no jargon
 
 ---
 
+## 2026-06-06: Smart Connections is no longer enabled by default (it could crash Obsidian on large vaults)
+
+**Who this affects:** anyone whose vault grows past a few thousand notes. On a large vault, opening Obsidian crashed the renderer repeatedly — a hard `EXC_BREAKPOINT (SIGTRAP)` V8 fatal, CPU pinned — because heavy "indexer" plugins were building full indexes on open and exhausting Obsidian's single renderer process. Smart Connections is the heaviest of them.
+
+### The problem
+
+Obsidian renders your whole vault in one Electron renderer with a bounded memory heap, and every indexer plugin holds an in-memory index of your notes. Setup used to install **and enable** Smart Connections by default — it builds SQLite-backed embeddings of every note. On a small vault that is invisible; past ~5K notes, that plus the other heavy indexers loading at once can exhaust the heap and crash the app on open, before you can even disable anything from inside Obsidian. The crash needed the heavy combination — core Obsidian and Dataview alone were stable.
+
+### The fix
+
+- **Smart Connections is no longer in the default install.** It is documented as an explicit opt-in, with a large-vault warning and a "scope it to a subset of folders, not the whole vault" instruction. graphify already covers explicit relationships; where the Mycelium runtime is in use, that runtime is the semantic retrieval layer, so Smart Connections is redundant.
+- **Dataview stays default** — it is the lightest indexer and the dashboards depend on it; it opens fine even at 13K+ notes.
+- **A "large-vault plugin posture" guide** (`templates/rules/obsidian-plugins.md`): keep Dataview, scope or disable Tasks + Smart Connections as the vault grows, plus step-by-step crash recovery — quit, set `.obsidian/community-plugins.json` to `[]` (restricted mode), reopen, re-add Dataview only, then add others one at a time watching Activity Monitor. Crash reports live at `~/Library/Logs/DiagnosticReports/*Obsidian*Renderer*.ips`; an `EXC_BREAKPOINT` there means the renderer ran out of memory.
+- This complements the machine-folder index exclusion shipped earlier the same day: that bounded the session/log/snapshot churn; this bounds the plugins that index your real notes.
+- **`/diagnose` gained a renderer-crash check (section 13).** It scans for repeated `Obsidian*Renderer*.ips` crash reports carrying `EXC_BREAKPOINT` (macOS) and, when it finds them, prints the recovery remedy. On a clean machine it stays quiet; off macOS it skips.
+
+### Verification
+
+A negative-control test ships with it (`scripts/test-renderer-crash-guard.sh`, wired into `scripts/ci.sh`): it proves a reports dir with repeated Obsidian-renderer `EXC_BREAKPOINT` reports is flagged (exit 1), and that every negative control stays silent (exit 0) — an empty dir, a different app, a different crash signature, a single isolated crash (below the "repeated" threshold), and crashes outside the time window. So the check is neither always-firing nor always-silent.
+
+---
+
 ## 2026-06-06: your brain can no longer end up with zero off-machine backup, silently
 
 **Who this affects:** everyone. If your vault lives on one disk with no off-machine copy, one hardware failure loses everything — every note, every journal entry — with no warning. A real person hit exactly this: about 1,100 notes, no Time Machine, no cloud copy, no git remote, a single drive. The product never said a word about it.

--- a/phases/phase-02-03-plugins-folders.md
+++ b/phases/phase-02-03-plugins-folders.md
@@ -2,7 +2,7 @@
 
 **AUTO-INSTALL FIRST. Don't make the user click through Obsidian's plugin browser unless the auto-install fails.** Non-technical users miss-click in the plugin UI, install the wrong plugin, or skip the "Enable" step after "Install" — these are the top three Phase 2 support requests.
 
-Tell the user: *"I'm going to install your Obsidian plugins in the background. These power live queries, templates, task tracking, and AI-powered note linking. Give me a few seconds."*
+Tell the user: *"I'm going to install your Obsidian plugins in the background. These power live queries, templates, and task tracking, and let Claude work with your vault directly. Give me a few seconds."*
 
 Then run this Python helper, substituting `[VAULT_PATH]` with the actual vault path saved in Phase 1 step 8:
 
@@ -18,11 +18,19 @@ PLUGINS_DIR.mkdir(parents=True, exist_ok=True)
 
 # Plugin id → GitHub repo (owner/repo). The release ZIP for each contains
 # main.js, manifest.json, and (sometimes) styles.css — Obsidian's plugin format.
+#
+# This is the DEFAULT set — light enough to enable on a vault of any size.
+# Smart Connections is deliberately NOT here: it is a heavy indexer (SQLite-
+# backed embeddings of every note) that can exhaust Obsidian's single renderer
+# process and crash it on open once a vault grows past a few thousand notes
+# (EXC_BREAKPOINT / renderer out-of-memory). It is offered as an explicit opt-in
+# instead — see "Optional: Smart Connections (opt-in)" below. graphify already
+# covers explicit relationships, and where the Mycelium runtime is in use that
+# runtime is the semantic retrieval layer, so Smart Connections is redundant.
 PLUGINS = {
     "dataview":  "blacksmithgu/obsidian-dataview",
     "templater-obsidian": "SilentVoid13/Templater",
     "obsidian-tasks-plugin": "obsidian-tasks-group/obsidian-tasks",
-    "smart-connections": "brianpetro/obsidian-smart-connections",
     "obsidian-local-rest-api": "coddingtonbear/obsidian-local-rest-api",
     "custom-sort": "SebastianMC/obsidian-custom-sort",
 }
@@ -162,10 +170,32 @@ Walk them through installing and enabling each one:
 1. **Dataview** — "Search 'Dataview' → Install → Enable. Powers live queries and dashboards."
 2. **Templater** — "Search 'Templater' → Install → Enable. Auto-applies templates when you create notes."
 3. **Tasks** — "Search 'Tasks' → Install → Enable. Tracks to-dos across your vault."
-4. **Smart Connections** — "Search 'Smart Connections' → Install → Enable. AI-powered note linking, finds connections you'd miss."
-5. **Local REST API** — "Search 'Local REST API' → Install → Enable. Lets Claude interact with your vault directly."
+4. **Local REST API** — "Search 'Local REST API' → Install → Enable. Lets Claude interact with your vault directly."
+
+(Smart Connections is intentionally omitted from the default set — it is an opt-in heavy indexer; see "Optional: Smart Connections" below.)
 
 "All installed and enabled? Let's keep going."
+
+### Optional: Smart Connections (opt-in, not enabled by default)
+
+Smart Connections adds semantic ("meaning-based") search over the vault. It is **deliberately not in the default install** because it is a heavy indexer: it builds SQLite-backed embeddings of every note and holds them in Obsidian's single renderer process. On a vault beyond ~5K notes, that — alongside other heavy indexers loading at once — can exhaust the renderer's memory and crash Obsidian on open (`EXC_BREAKPOINT (SIGTRAP)`, CPU pinned).
+
+Only offer it if the user explicitly asks for semantic search AND accepts the tradeoff. If they do:
+
+- **Scope it to a subset of folders, never the whole vault.** Point its inclusions at the few folders where semantic discovery actually helps (e.g. `📝 Notes/`, `📓 Journals/`), not everything.
+- graphify already covers explicit relationships; where the Mycelium runtime is in use, that runtime is the semantic retrieval layer and Smart Connections is redundant.
+- To install: add `"smart-connections": "brianpetro/obsidian-smart-connections"` back into the `PLUGINS` dict above and re-run, or manually do Community Plugins → search "Smart Connections" → Install → Enable, then immediately set its folder scope.
+
+Full settings and crash-recovery steps live in the obsidian-plugins rule ("Large-vault plugin posture").
+
+### Large-vault plugin posture
+
+Obsidian renders the whole vault in one Electron renderer with a bounded memory heap, and each "indexer" plugin holds an in-memory index. Past ~5K notes, several heavy ones loading at once can crash the renderer on open. As the user's vault grows, tell them:
+
+- **Keep Dataview** — it is the lightest indexer and the dashboards depend on it. Dataview alone opens fine even at 13K+ notes.
+- **Scope or disable the heavy indexers** — Smart Connections (embeddings of every note) is heaviest; Tasks (full-vault checkbox scan) compounds it.
+- Machine-generated folders are already excluded from Obsidian's index by the installer above (`userIgnoreFilters`); that bounds session/log/snapshot churn but not a plugin that indexes real notes.
+- If the renderer ever crashes on open, the recovery steps (restricted mode → re-add Dataview only → add others one at a time) are in the obsidian-plugins rule ("Large-vault plugin posture").
 
 ## Phase 3: Create Folder Structure
 

--- a/scripts/check-renderer-crashes.py
+++ b/scripts/check-renderer-crashes.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Guard: surface repeated Obsidian *renderer* crashes (the large-vault OOM class).
+
+On a large vault, heavy "indexer" plugins (Smart Connections embeddings, Tasks'
+full-vault scan) building their indexes on open can exhaust Obsidian's single
+Electron renderer heap and crash the app before you can disable anything: a hard
+EXC_BREAKPOINT (SIGTRAP) V8 fatal with the CPU pinned. macOS writes one crash
+report per crash to ~/Library/Logs/DiagnosticReports/ named like
+"Obsidian Helper (Renderer)-<timestamp>.ips". Repeated such reports are the
+signature of this footgun. This check counts the recent ones and points at the
+remedy (restricted mode -> Dataview only -> add others one at a time, scoped).
+
+This is a DIAGNOSTIC, not an install gate: the crashes already happened. diagnose
+treats a hit as a WARN with the remedy, never a hard FAIL.
+
+Crash reports are macOS-only (.ips DiagnosticReports). On other platforms this
+check skips unless an explicit --reports-dir is given (which is how the test
+exercises the detection logic on any CI OS).
+
+Usage:
+  check-renderer-crashes.py [--porcelain] [--days N] [--reports-dir DIR]
+
+Exit codes:
+  0  OK    - no repeated renderer crashes (or not applicable on this platform)
+  1  HIT   - repeated renderer-OOM crash reports found in the window
+  2  USAGE - bad arguments
+
+Porcelain first token: OK_NO_CRASHES | RENDERER_CRASHES:<count> | SKIP_NOT_MACOS
+"""
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+DEFAULT_DAYS = 14
+# "repeated": a single isolated crash can be anything; two or more in the window
+# is the chronic-misconfiguration signal this check exists to surface.
+REPEAT_THRESHOLD = 2
+DEFAULT_REPORTS_DIR = Path.home() / "Library" / "Logs" / "DiagnosticReports"
+CRASH_SIGNATURE = "EXC_BREAKPOINT"
+
+USAGE = "usage: check-renderer-crashes.py [--porcelain] [--days N] [--reports-dir DIR]"
+
+
+def _matches_obsidian_renderer(name: str) -> bool:
+    """True for a macOS crash report belonging to Obsidian's renderer process."""
+    low = name.lower()
+    return low.endswith(".ips") and "obsidian" in low and "renderer" in low
+
+
+def count_renderer_crashes(reports_dir: Path, days: int) -> int:
+    """Count recent Obsidian-renderer .ips reports carrying the OOM signature.
+
+    Best-effort and read-only. A single report we cannot stat or read (vanished
+    mid-scan, permission, transient I/O) is SKIPPED, not fatal, so one odd file
+    never crashes the whole diagnostic; worst case is undercounting by that file,
+    which for a >=2-in-14-days heuristic is acceptable. An unreadable directory
+    listing degrades to 0 (the caller reports that as "could not evaluate").
+    The broad `except OSError` is intentional for a filesystem scan, not a masked
+    correctness error: every OSError subtype here means "can't inspect this one
+    path", and the right response is to move on.
+    """
+    if not reports_dir.is_dir():
+        return 0
+    cutoff = time.time() - days * 86400
+    try:
+        entries = sorted(reports_dir.iterdir())
+    except OSError:
+        return 0
+    hits = 0
+    for entry in entries:
+        # Name match first (pure string, no I/O); only then touch the disk.
+        if not _matches_obsidian_renderer(entry.name):
+            continue
+        try:
+            if not entry.is_file():
+                continue
+            if entry.stat().st_mtime < cutoff:
+                continue
+            text = entry.read_text(errors="ignore")
+        except OSError:
+            continue
+        if CRASH_SIGNATURE in text:
+            hits += 1
+    return hits
+
+
+def main(argv):
+    porcelain = "--porcelain" in argv
+    args = [a for a in argv if a != "--porcelain"]
+
+    days = DEFAULT_DAYS
+    reports_dir = None
+    i = 0
+    while i < len(args):
+        a = args[i]
+        if a == "--days":
+            i += 1
+            if i >= len(args):
+                print(USAGE, file=sys.stderr)
+                return 2
+            try:
+                days = int(args[i])
+            except ValueError:
+                print("--days must be an integer", file=sys.stderr)
+                return 2
+        elif a == "--reports-dir":
+            i += 1
+            if i >= len(args):
+                print(USAGE, file=sys.stderr)
+                return 2
+            reports_dir = Path(args[i]).expanduser()
+        else:
+            print("unknown argument: {}".format(a), file=sys.stderr)
+            print(USAGE, file=sys.stderr)
+            return 2
+        i += 1
+
+    explicit_dir = reports_dir is not None
+    if reports_dir is None:
+        reports_dir = DEFAULT_REPORTS_DIR
+
+    # .ips DiagnosticReports are macOS-only. Off macOS, skip the default path. An
+    # explicit --reports-dir forces a scan so the test runs on any CI OS.
+    if not explicit_dir and sys.platform != "darwin":
+        if porcelain:
+            print("SKIP_NOT_MACOS")
+        else:
+            print("OK    Renderer-crash check is macOS-only; skipped on this platform.")
+        return 0
+
+    count = count_renderer_crashes(reports_dir, days)
+
+    if count >= REPEAT_THRESHOLD:
+        if porcelain:
+            print("RENDERER_CRASHES:{}".format(count))
+            return 1
+        print("WARN  {} Obsidian renderer crash report(s) in the last {} days "
+              "(EXC_BREAKPOINT / renderer OOM).".format(count, days))
+        print("      Likely a heavy indexer plugin exhausting the renderer on a large vault.")
+        print("      Remedy: quit Obsidian; set <vault>/.obsidian/community-plugins.json to []")
+        print("      (restricted mode); reopen; re-enable Dataview only; then add others one")
+        print("      at a time, watching Activity Monitor. Scope or drop Smart Connections / Tasks.")
+        print("      See templates/rules/obsidian-plugins.md -> 'Large-vault plugin posture'.")
+        return 1
+
+    if porcelain:
+        print("OK_NO_CRASHES")
+    else:
+        print("OK    No repeated Obsidian renderer crashes in the last {} days.".format(days))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -109,6 +109,7 @@ INTEGRATION_TESTS=(
   test_resource_aware_session_close
   test_cloud_sync_guard
   test_machinery_sidecar
+  test_renderer_crash_guard
 )
 echo "==> (b) Shell integration: ${#INTEGRATION_TESTS[@]} tests"
 for t in "${INTEGRATION_TESTS[@]}"; do

--- a/scripts/diagnose.ps1
+++ b/scripts/diagnose.ps1
@@ -354,6 +354,36 @@ if ($checkBackup) {
   Warn "check-vault-backup.py not found" "Cannot verify the vault has an off-machine backup."
 }
 
+# ----- 13. Obsidian renderer crashes (the large-vault OOM class) -----
+Section "13. Obsidian renderer crashes"
+$checkRenderer = $null
+$rendererCands = @(
+  (Join-Path $PSScriptRoot "check-renderer-crashes.py"),
+  (Join-Path $env:USERPROFILE ".claude\skills\ai-brain-starter\scripts\check-renderer-crashes.py")
+)
+foreach ($c in $rendererCands) { if (Test-Path -LiteralPath $c) { $checkRenderer = $c; break } }
+if ($checkRenderer) {
+  $py = Get-Command python -ErrorAction SilentlyContinue
+  if (-not $py) { $py = Get-Command python3 -ErrorAction SilentlyContinue }
+  if ($py) {
+    $rverdict = "$(& $py.Source $checkRenderer --porcelain 2>$null)".Trim()
+    if ($rverdict -eq "OK_NO_CRASHES") {
+      Ok "No repeated Obsidian renderer crashes"
+    } elseif ($rverdict -eq "SKIP_NOT_MACOS") {
+      Ok "Renderer-crash check skipped (macOS-only crash reports)"
+    } elseif ($rverdict -like "RENDERER_CRASHES:*") {
+      $cnt = ($rverdict -replace "^RENDERER_CRASHES:", "")
+      Warn "Repeated Obsidian renderer crashes ($cnt in ~14 days, EXC_BREAKPOINT / renderer OOM)" "A heavy indexer plugin is likely exhausting the renderer on a large vault. Quit Obsidian, set .obsidian/community-plugins.json to [] (restricted mode), reopen, enable Dataview only, then add others one at a time. Scope or drop Smart Connections / Tasks. See templates/rules/obsidian-plugins.md 'Large-vault plugin posture'."
+    } else {
+      Warn "Could not evaluate renderer-crash history" "check-renderer-crashes.py returned: $rverdict"
+    }
+  } else {
+    Warn "python not found" "Cannot check for repeated Obsidian renderer crashes."
+  }
+} else {
+  Warn "check-renderer-crashes.py not found" "Cannot check for repeated Obsidian renderer crashes."
+}
+
 # ----- summary -----
 Write-Host ""
 Write-Host "Summary" -ForegroundColor White

--- a/scripts/diagnose.sh
+++ b/scripts/diagnose.sh
@@ -338,6 +338,30 @@ else
   warn "check-vault-backup.py not found" "Cannot verify the vault has an off-machine backup."
 fi
 
+# ----- 13. Obsidian renderer crashes (the large-vault OOM class) -----
+section "13. Obsidian renderer crashes"
+CHECK_RENDERER=""
+for c in "$(cd "$(dirname "$0")" && pwd)/check-renderer-crashes.py" \
+         "$HOME/.claude/skills/ai-brain-starter/scripts/check-renderer-crashes.py"; do
+  [ -f "$c" ] && CHECK_RENDERER="$c" && break
+done
+if [ -n "$CHECK_RENDERER" ]; then
+  rverdict="$(python3 "$CHECK_RENDERER" --porcelain 2>/dev/null)"
+  case "$rverdict" in
+    OK_NO_CRASHES)
+      ok "No repeated Obsidian renderer crashes" ;;
+    SKIP_NOT_MACOS)
+      ok "Renderer-crash check skipped (macOS-only crash reports)" ;;
+    RENDERER_CRASHES:*)
+      warn "Repeated Obsidian renderer crashes (${rverdict#RENDERER_CRASHES:} in ~14 days, EXC_BREAKPOINT / renderer OOM)" \
+        "A heavy indexer plugin is likely exhausting the renderer on a large vault. Quit Obsidian, set .obsidian/community-plugins.json to [] (restricted mode), reopen, enable Dataview only, then add others one at a time. Scope or drop Smart Connections / Tasks. See templates/rules/obsidian-plugins.md 'Large-vault plugin posture'." ;;
+    *)
+      warn "Could not evaluate renderer-crash history" "check-renderer-crashes.py returned: ${rverdict:-<empty>}" ;;
+  esac
+else
+  warn "check-renderer-crashes.py not found" "Cannot check for repeated Obsidian renderer crashes."
+fi
+
 # ----- summary -----
 echo
 echo "${B}Summary${N}"

--- a/scripts/test-renderer-crash-guard.sh
+++ b/scripts/test-renderer-crash-guard.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Negative-control test for check-renderer-crashes.py (the large-vault renderer-OOM guard).
+# A guard earns trust only by failing on the thing it catches: this asserts a HIT
+# for a reports dir with repeated Obsidian-renderer EXC_BREAKPOINT crashes AND OK
+# for every negative control (no reports, wrong app, wrong signature, a single
+# isolated crash, and crashes outside the time window).
+# Run: bash scripts/test-renderer-crash-guard.sh
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+CHECK="$HERE/check-renderer-crashes.py"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+fails=0
+
+# mk DIR FILENAME EXCEPTION-LINE - write a synthetic .ips crash report. The
+# Obsidian/Renderer identity lives in the FILENAME (that is what the detector
+# matches); the EXCEPTION-LINE carries the crash signature.
+mk() { mkdir -p "$1"; printf '%s\n' "$3" > "$1/$2"; }
+
+assert_token() { # label  expected-prefix  dir
+  local label="$1" want="$2" d="$3" got
+  got="$(python3 "$CHECK" --porcelain --reports-dir "$d" 2>/dev/null)"
+  case "$got" in
+    "$want"*) echo "PASS  $label  ($got)";;
+    *)        echo "FAIL  $label  want=$want got=$got"; fails=$((fails+1));;
+  esac
+}
+
+assert_rc() { # label  want-rc  dir
+  local label="$1" want="$2" d="$3"
+  python3 "$CHECK" --porcelain --reports-dir "$d" >/dev/null 2>&1
+  local rc=$?
+  [ "$rc" = "$want" ] && echo "PASS  $label (rc=$rc)" || { echo "FAIL  $label want-rc=$want got-rc=$rc"; fails=$((fails+1)); }
+}
+
+EXC="Exception Type:  EXC_BREAKPOINT (SIGTRAP)"
+
+# POSITIVE: >=2 fresh Obsidian-renderer EXC_BREAKPOINT reports must be flagged HIT (exit 1)
+POS="$TMP/pos"
+mk "$POS" "Obsidian Helper (Renderer)-2026-06-06-100000.ips" "$EXC"
+mk "$POS" "Obsidian Helper (Renderer)-2026-06-06-110000.ips" "$EXC"
+mk "$POS" "Obsidian Helper (Renderer)-2026-06-06-120000.ips" "$EXC"
+assert_token "repeated renderer crashes" "RENDERER_CRASHES" "$POS"
+assert_rc    "HIT exits 1"               1                  "$POS"
+
+# NEGATIVE CONTROL 1: empty dir -> OK (proves it is not just always-HIT; a guard
+# that always fires is as useless as one that never does)
+assert_token "no reports"  "OK_NO_CRASHES" "$TMP/empty"
+assert_rc    "OK exits 0"  0               "$TMP/empty"
+
+# NEGATIVE CONTROL 2: wrong app / wrong process (filename lacks Obsidian or Renderer)
+WRONGAPP="$TMP/wrongapp"
+mk "$WRONGAPP" "SomeEditor Helper (Renderer)-1.ips" "$EXC"
+mk "$WRONGAPP" "Obsidian-main-1.ips"                 "$EXC"
+assert_token "wrong app/process" "OK_NO_CRASHES" "$WRONGAPP"
+
+# NEGATIVE CONTROL 3: right file, wrong signature (not an OOM EXC_BREAKPOINT)
+WRONGSIG="$TMP/wrongsig"
+mk "$WRONGSIG" "Obsidian Helper (Renderer)-a.ips" "Exception Type:  EXC_CRASH (SIGABRT)"
+mk "$WRONGSIG" "Obsidian Helper (Renderer)-b.ips" "Exception Type:  EXC_CRASH (SIGABRT)"
+assert_token "wrong signature" "OK_NO_CRASHES" "$WRONGSIG"
+
+# NEGATIVE CONTROL 4: a single isolated crash is below the "repeated" threshold
+SINGLE="$TMP/single"
+mk "$SINGLE" "Obsidian Helper (Renderer)-only.ips" "$EXC"
+assert_token "single crash (<threshold)" "OK_NO_CRASHES" "$SINGLE"
+
+# NEGATIVE CONTROL 5: crashes outside the time window do not count. Backdate via
+# Python os.utime so it is portable across BSD/GNU date (CI runs on ubuntu).
+OLD="$TMP/old"
+mk "$OLD" "Obsidian Helper (Renderer)-old1.ips" "$EXC"
+mk "$OLD" "Obsidian Helper (Renderer)-old2.ips" "$EXC"
+python3 - "$OLD" <<'PY'
+import os, sys, glob, time
+old = time.time() - 400 * 86400
+for f in glob.glob(os.path.join(sys.argv[1], "*.ips")):
+    os.utime(f, (old, old))
+PY
+assert_token "old crashes (outside window)" "OK_NO_CRASHES" "$OLD"
+
+echo
+if [ "$fails" -gt 0 ]; then echo "FAILED: $fails"; exit 1; fi
+echo "ALL TESTS PASSED"

--- a/templates/rules/obsidian-plugins.md
+++ b/templates/rules/obsidian-plugins.md
@@ -31,10 +31,12 @@ The API runs on `https://127.0.0.1:27124/` (localhost only, self-signed HTTPS). 
 
 ---
 
-## Smart Connections
+## Smart Connections (optional — not enabled by default)
 
 **Plugin**: Smart Connections by Brian Petro
-**What it gives Claude Code**: Semantic search (meaning-based, not just keyword/link-based) over the entire vault.
+**What it gives Claude Code**: Semantic search (meaning-based, not just keyword/link-based) over the vault.
+
+> ⚠️ **Large-vault warning.** Smart Connections is a heavy indexer — it builds SQLite-backed embeddings of every note and holds them in Obsidian's single renderer process. On a vault beyond ~5K notes, enabling it (alongside other heavy indexers) can exhaust the renderer's memory and crash Obsidian on open: a hard `EXC_BREAKPOINT (SIGTRAP)` V8 fatal, CPU pinned. For that reason it is **not in the default install**. If you enable it, **scope it to a subset of folders, not the whole vault.** graphify already covers explicit relationships; if you run the paid Mycelium runtime, that runtime is your semantic retrieval layer and Smart Connections is redundant. See "Large-vault plugin posture" below.
 
 ### How it complements graphify
 
@@ -46,9 +48,10 @@ The API runs on `https://127.0.0.1:27124/` (localhost only, self-signed HTTPS). 
 
 Use both: graphify for navigating explicit relationships, Smart Connections for discovering notes you forgot to link.
 
-### Recommended settings
+### Recommended settings (if you opt in)
 
-- **Excluded folders**: `⚙️ Meta/scripts/`, `Archive/`, `.obsidian/`, `graphify-out/`
+- **Scope it: include only a subset of folders, not the whole vault.** On a large vault this is the difference between stable and a renderer crash. Point it at the few folders where semantic discovery helps (e.g. `📝 Notes/`, `📓 Journals/`) rather than embedding everything.
+- **Excluded folders**: `⚙️ Meta/scripts/`, `⚙️ Meta/Sessions/`, `⚙️ Meta/logs/`, `⚙️ Meta/Worktree Snapshots/`, `Archive/`, `.obsidian/`, `graphify-out/`
 - **Minimum file length**: 50 characters (skip stubs)
 - **Embedding model**: Local model (default) to avoid API costs
 - **Re-embed interval**: "On file change" (switch to "On vault open" if you notice lag)
@@ -56,8 +59,32 @@ Use both: graphify for navigating explicit relationships, Smart Connections for 
 
 ### Watch out for
 
+- **Renderer crash on large vaults.** Past ~5K notes the embedding index can exhaust Obsidian's renderer heap and crash the app on open (`EXC_BREAKPOINT`). Scoping it to a few folders is the fix; full crash recovery is under "Large-vault plugin posture" below.
 - Initial embedding of a large vault (thousands of files) takes 30-60 minutes and spikes CPU. Run overnight.
 - Pause the plugin during bulk vault operations (auto-wikilink, graphify multi-stage) to avoid hundreds of queued re-embeddings.
+
+---
+
+## Large-vault plugin posture
+
+Obsidian renders your entire vault in a single Electron renderer process with a bounded JavaScript heap. Every "indexer" plugin you enable builds and holds an in-memory index of your notes. On a small vault that is invisible. Past roughly **5,000 notes**, several heavy indexers loading at once can exhaust the renderer heap and crash Obsidian on open — a hard `EXC_BREAKPOINT (SIGTRAP)` V8 fatal, CPU pinned while it builds the index.
+
+As your vault grows:
+
+- **Keep Dataview.** It is the lightest indexer and the dashboards/queries depend on it. A vault with Dataview alone opens fine at 13K+ notes.
+- **Scope or disable the heavy indexers.** Smart Connections (SQLite-backed embeddings of every note) is the heaviest; Tasks (full-vault scan for checkboxes) compounds it. Scope them to a subset of folders or turn them off.
+- **Machine-generated folders are already excluded** from Obsidian's index by the installer (`userIgnoreFilters` in `.obsidian/app.json` — session stubs, logs, worktree snapshots). That bounds machinery churn; it does not bound a plugin that indexes your real notes.
+- **graphify already covers explicit relationships**, and if you run the paid Mycelium runtime, that runtime is your semantic retrieval layer — so Smart Connections is redundant in that setup.
+
+### Recover from a renderer crash (Obsidian won't open)
+
+1. Fully quit Obsidian.
+2. Edit `<vault>/.obsidian/community-plugins.json` and set its contents to `[]`. This is "restricted mode" — no community plugins load.
+3. Reopen Obsidian. It should open cleanly with core features only.
+4. Re-add **Dataview only**, reopen, confirm it is stable.
+5. Add the other plugins back **one at a time**, reopening between each, watching CPU in Activity Monitor (macOS) or Task Manager (Windows). The plugin that pins "Obsidian Helper (Renderer)" at 100%+ and crashes on open is the culprit — leave it off or scope it to fewer folders.
+
+**Crash reports (macOS):** `~/Library/Logs/DiagnosticReports/*Obsidian*Renderer*.ips`. An `EXC_BREAKPOINT (SIGTRAP)` in a `*Renderer*` report is the renderer running out of memory — the signature of the heavy-indexer-on-a-large-vault crash. Run `bash scripts/diagnose.sh` (section 13) to flag repeated such crashes and reprint this remedy.
 
 ---
 
@@ -100,7 +127,7 @@ When to use which search tool:
 |------|------|-----|
 | Keyword/exact match | `obsidian search` or Grep | Fastest for known terms |
 | Structural neighbors ("what links to X?") | graphify graph.json query | Explicit relationships, communities |
-| Semantic similarity ("what else talks about themes like X?") | Smart Connections sidebar in Obsidian | Finds conceptually related notes even without shared links or keywords |
+| Semantic similarity ("what else talks about themes like X?") | Smart Connections sidebar in Obsidian *(optional, opt-in — see warning above)* | Finds conceptually related notes even without shared links or keywords |
 | Visual graph exploration | Neo4j Browser | Cypher queries, visual cluster browsing. Requires CSVs imported via `graph-to-neo4j.py` |
 
 ---
@@ -108,5 +135,5 @@ When to use which search tool:
 ## Installation checklist
 
 - [ ] Local REST API: install from Community Plugins, set API key in shell profile, test with `curl -sk -H "Authorization: Bearer $OBSIDIAN_REST_API_KEY" "https://127.0.0.1:27124/"`
-- [ ] Smart Connections: install from Community Plugins, configure exclusions, wait for initial embedding
+- [ ] Smart Connections *(optional, not in the default set — only on vaults under ~5K notes, or scoped to a few folders)*: install from Community Plugins, **scope it to a subset of folders**, configure exclusions, wait for initial embedding
 - [ ] Neo4j: install when you want Cypher query power (requires Neo4j Desktop or Docker)

--- a/templates/rules/tool-routing.md
+++ b/templates/rules/tool-routing.md
@@ -44,5 +44,5 @@ You likely have paid plans or free tiers on many tools. **Don't burn Claude toke
 |------|------|-----|
 | Keyword/exact match | `obsidian search` or Grep | Fastest for known terms |
 | Structural neighbors ("what links to X?") | graphify graph.json query | Explicit relationships, communities |
-| Semantic similarity ("what else talks about themes like X?") | Smart Connections sidebar in Obsidian | Finds conceptually related notes even without shared links or keywords |
+| Semantic similarity ("what else talks about themes like X?") | Smart Connections sidebar in Obsidian *(optional — heavy indexer; opt-in on large vaults, scope to a few folders)* | Finds conceptually related notes even without shared links or keywords |
 | Visual graph exploration | Neo4j Browser | Cypher queries, visual cluster browsing |

--- a/tests/integration/test_renderer_crash_guard.sh
+++ b/tests/integration/test_renderer_crash_guard.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# CI integration wrapper - runs the renderer-crash detection negative-control
+# suite (scripts/test-renderer-crash-guard.sh) as part of scripts/ci.sh. Thin:
+# logic lives next to the script it exercises.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+exec bash "$ROOT/scripts/test-renderer-crash-guard.sh"


### PR DESCRIPTION
## Why

On a large vault, opening Obsidian crashed the renderer repeatedly — a hard `EXC_BREAKPOINT (SIGTRAP)` V8 fatal with CPU pinned — because heavy **indexer** plugins build full indexes on open and exhaust Obsidian's single Electron renderer heap. The setup installed **and enabled** Smart Connections (SQLite-backed embeddings of every note) by default; it is the heaviest of the indexers. Core Obsidian and Dataview-alone were stable — the crash needed the heavy-plugin combination.

This reproduces on any machine as the vault grows, so it has to be a product default, not a per-machine patch.

## What changed

**Docs / install guide (the core of this PR):**
- Smart Connections removed from the default auto-install/enable set (`phases/phase-02-03-plugins-folders.md`). It is now documented as an explicit **opt-in**, with a large-vault warning and a "scope it to a subset of folders, not the whole vault" instruction.
- New **"Large-vault plugin posture"** section in `templates/rules/obsidian-plugins.md`: keep Dataview (lightest, dashboards depend on it), scope/disable Tasks + Smart Connections as the vault grows, plus step-by-step renderer-crash recovery (restricted mode → re-enable Dataview only → add others one at a time, watching Activity Monitor).
- Routing rows in `obsidian-plugins.md` + `tool-routing.md` mark Smart Connections optional. Checklist marks it optional.
- `CHANGELOG.md` entry.

Where the paid Mycelium runtime is in use, that runtime is the semantic retrieval layer, so Smart Connections is redundant; graphify already covers explicit relationships.

**Diagnose check (`Done =` completion):**
- `scripts/check-renderer-crashes.py` + section 13 in `diagnose.sh` / `diagnose.ps1`: flags repeated `Obsidian*Renderer*.ips` reports carrying `EXC_BREAKPOINT` (macOS; skips elsewhere) and prints the remedy. WARN, never a hard FAIL — the crashes already happened.
- Negative-control test `scripts/test-renderer-crash-guard.sh`, wired into `scripts/ci.sh`: positive flagged (exit 1); five negative controls stay silent (empty dir, wrong app, wrong crash signature, single isolated crash below the "repeated" threshold, crashes outside the time window).

Complements the machine-folder index exclusion (#157): that bounded session/log/snapshot churn; this bounds the plugins that index your real notes.

## Verification (local, full gate)

- `bash scripts/ci.sh`: **all gates passed** — py_compile (255 files) + 17 integration tests (incl. the new `test_renderer_crash_guard`) + shellcheck.
- `diagnose.ps1`: BOM intact, no em-dash, `ParseFile` clean.
- Detector validated against real crash reports on a live machine (7 `EXC_BREAKPOINT` renderer crashes correctly flagged) and the hermetic fixture suite.
- Personal-data scrub clean.

Linear: MYC-546