### PR TITLE
docs(diagnose): sync check table with reality (10b/11/12/13) + crash trigger

### DIFF
--- a/skills/diagnose/SKILL.md
+++ b/skills/diagnose/SKILL.md
@@ -87,6 +87,10 @@ Most "Claude is broken" reports trace to one of:
 | 8 | All .ps1 have BOM, no em dashes, parse clean | Fix the parser error | Add BOM and strip em dashes (see SKILL.md notes) |
 | 9 | MCP config valid JSON | Fix the JSON | No MCPs registered (fine if intentional) |
 | 10 | ai-brain-starter up to date with origin/main | Re-clone | git pull in ~/.claude/skills/ai-brain-starter |
+| 10b | No scheduled-task name collides with a skill; cron-only tasks `_`-prefixed | - | Rename per docs/MAINTENANCE.md |
+| 11 | Vault on a local disk, not a consumer cloud-sync root | Move it local (docs/CLOUD_SYNC.md) | Could not evaluate the path |
+| 12 | Vault has an off-machine backup | Set one up: `bash scripts/vault-backup.sh setup` (docs/BACKUP.md) | Backup configured but no snapshot yet |
+| 13 | No repeated Obsidian renderer crashes (macOS; skips elsewhere) | - | Heavy indexer likely OOM-ing the renderer on a large vault: restricted mode -> Dataview only -> add others one at a time (see the obsidian-plugins rule, "Large-vault plugin posture") |
 
 ## When to suggest /diagnose proactively
 
@@ -94,6 +98,7 @@ Most "Claude is broken" reports trace to one of:
 - User says "the journal entries aren't showing up in /weekly"
 - User says "I just did a git pull and something feels off"
 - User says "my friend installed it but it's broken"
+- User says "Obsidian keeps crashing when I open it" / "Obsidian won't open" (likely a heavy-indexer renderer OOM on a large vault - check 13)
 - After every major upgrade prompt during /setup-brain
 
 Do NOT use /diagnose as an email-capture surface. If `~/.claude/.ai-brain-starter-email-on-file` is missing, that is fine and never a finding — the email is optional, and the only places it is ever asked are the setup interview (Phase 24.4) and the once-per-update post-pull nudge. Never tell the user to fetch or paste a token.


### PR DESCRIPTION
The diagnose skill's "What each check means" table stopped at row 10, but `diagnose.sh`/`diagnose.ps1` have since grown:
- **10b** scheduled-task naming hygiene
- **11** cloud-sync location (#159)
- **12** off-machine backup (#160)
- **13** Obsidian renderer crashes (#165)

Readers (and Claude reading the skill) couldn't discover those checks from the doc. This adds the four missing rows and an "Obsidian won't open / keeps crashing" proactive trigger that routes the renderer-OOM symptom to check 13.

Docs-only (single `.md`). Follow-up to #165; completes discoverability wiring for the renderer-crash check and fixes pre-existing table drift from #159/#160.

Linear: MYC-546