### PR TITLE
fix(secret-scan): fail-closed auto-scrub partition + hex-256bit Workflow v2 cache-key carve-out

### DIFF
--- a/hooks/_lib/secret_patterns.py
+++ b/hooks/_lib/secret_patterns.py
@@ -235,14 +235,26 @@ _GENERIC = [
             # tuple per record type, not the full JSON payload."
             # Sibling carve-out to sha256: / sha512: above. Verified
             # precise: bumblebee shapes clean, bare-hex secrets still trip.
+            #
+            # Skip the Workflow runtime's content-addressed agent-call cache
+            # keys, serialized as `"key":"v2:<64-hex>"` in
+            # subagents/workflows/wf_*/journal.jsonl. Those are sha256 cache
+            # keys (a content address, not a secret). Critically the SAME
+            # redact() runs in the SessionEnd scrub layer — without this
+            # carve-out a scrub rewrites the cache key to [REDACTED-hex-256bit]
+            # and breaks Workflow resume. The lookbehind anchors on the JSON
+            # value structure `:"v<digit>:` so it survives a version bump
+            # (v2 -> v3) yet never masks a bare-hex secret, which is never
+            # preceded by that prefix. Fixed-width (\d = 1 char).
             r"(?<!sha256:)(?<!sha512:)(?<!sha384:)(?<!sha1:)(?<!md5:)"
             r"(?<!sha256\.)(?<!sha512\.)(?<!sha384\.)(?<!sha1\.)(?<!md5\.)"
             r"(?<!scan_summary:)(?<!package:)(?<!finding:)(?<!diagnostic:)"
+            r'(?<!:"v\d:)'
             r"(?<![A-Fa-f0-9])([A-Fa-f0-9]{64})(?![A-Fa-f0-9])",
             re.ASCII,
         ),
         redaction="[REDACTED-hex-256bit]",
-        description="64-char hex string (256-bit secret; HMAC, openssl rand -hex 32). Skips common content-digest prefixes (sha{1,256,384,512}:, md5:) and integrity-hash dot prefixes (sha{1,256,384,512}., md5.) used by pnpm/yarn.",
+        description="64-char hex string (256-bit secret; HMAC, openssl rand -hex 32). Skips common content-digest prefixes (sha{1,256,384,512}:, md5:), integrity-hash dot prefixes (sha{1,256,384,512}., md5.) used by pnpm/yarn, and the Workflow runtime's content-addressed cache key shape (\":\"v<digit>:<hex>\").",
     ),
 ]
 
@@ -321,6 +333,12 @@ if __name__ == "__main__":
         "sha512-hex": "sha512:" + "b" * 64,
         # pnpm packageManager integrity hash (dot separator, not colon)
         "pnpm-package-manager": '"packageManager": "pnpm@10.11.1+sha256.' + "c" * 64 + '"',
+        # Workflow runtime content-addressed cache key — `"key":"v2:<hex>"` in
+        # subagents/workflows/wf_*/journal.jsonl. The SAME redact() runs in the
+        # SessionEnd scrub, so this MUST be skipped or a scrub breaks Workflow resume.
+        "workflow-cache-key-v2": '{"type":"started","key":"v2:' + "e" * 64 + '","agentId":"x"}',
+        # Version-robustness: a future v3: prefix must also be skipped.
+        "workflow-cache-key-v3": '"key":"v3:' + "f" * 64 + '"',
         # Real 256-bit hex secret — MUST still match
         "real-hex-secret": "API_KEY=" + "d" * 64,
         # Resend literal placeholder (`re_x` * 30 in .env.example)
@@ -340,6 +358,8 @@ if __name__ == "__main__":
         "github-asset-digest": [],   # sha256: prefix → skipped
         "sha512-hex": [],            # sha512: prefix → skipped
         "pnpm-package-manager": [],  # sha256. prefix → skipped
+        "workflow-cache-key-v2": [],  # :"v2: prefix → skipped (Workflow cache key)
+        "workflow-cache-key-v3": [],  # :"v3: prefix → skipped (version-robust)
         "real-hex-secret": ["hex-256bit-secret"],
         "resend-placeholder-xs": [],
         "resend-placeholder-your": [],

--- a/hooks/scan-prior-sessions-for-secrets.py
+++ b/hooks/scan-prior-sessions-for-secrets.py
@@ -23,6 +23,14 @@ closed by FOUR guards, all in this file:
   * wall-clock budget + per-file size cap + os.nice(10) — a single pass can
     never run away or starve the foreground session.
 
+Cross-platform note: this stays a SessionStart hook rather than a launchd /
+cron worker. ai-brain-starter installs on macOS, Linux, AND Windows, so a
+launchd-only worker would silently disable the historical sweep everywhere
+except macOS. The four in-session guards above bound the cost so the cold-start
+path is safe on every platform; a maintainer who wants the heavy walk fully off
+cold-start can schedule this script out-of-band (it is safe to run standalone —
+the single-instance flock + budget apply either way).
+
 Behavior:
   - Detect: scans every `~/.claude/projects/**/*.jsonl` against the
     registry (`_lib/secret_patterns.scan`). Rate-limited to one run per 6h
@@ -35,6 +43,11 @@ Behavior:
   - Mid-session safety: a JSONL whose worktree IS active is SKIPPED with
     "will retry next SessionStart after close" — scrubbing a mid-session
     JSONL corrupts Claude Code's resume state.
+  - Fail-closed scrub decision: if the active-worktree set cannot be
+    positively determined (git error) OR is empty, scrub NOTHING — an
+    empty/unknown set is never proof a JSONL is safe (the current session may
+    run from the main checkout, which has no `claude/*` worktree entry). See
+    `partition_for_scrub`.
   - Warn: surfaces residual findings (post-scrub) + threat-model reminder
     so the next response checks the leak vector before recommending
     rotation.
@@ -119,16 +132,23 @@ def _vault_root() -> Path | None:
     return p if p.exists() else None
 
 
-def _active_worktree_slugs(vault_root: Path) -> set[str]:
-    """Return slugs of currently active vault worktrees.
+def _active_worktree_slugs(vault_root: Path) -> set[str] | None:
+    """Slugs of currently active vault worktrees, or None when UNKNOWN.
 
     Slugs look like `silly-edison-565ec5` from branches named
     `claude/silly-edison-565ec5`. Used to skip scrubbing JSONLs whose
-    parent worktree is mid-session — mid-session scrub corrupts Claude
+    parent worktree is mid-session — a mid-session scrub corrupts Claude
     Code's resume state.
 
-    Empty set on any error (fail-closed: if we can't tell which worktrees
-    are active, we DON'T auto-scrub anything — the warn path still fires).
+    Returns None — the UNKNOWN sentinel — when the set cannot be determined
+    (git error / timeout / non-zero exit). The OLD code returned an EMPTY set
+    on these errors, which the consumer could NOT tell apart from "git ran,
+    genuinely zero active worktrees" — so on any git error it scrubbed
+    EVERYTHING, including active-session JSONLs (fail-OPEN; the exact
+    corruption the skip exists to prevent). Callers MUST treat None (and an
+    empty set) as "do not scrub". See partition_for_scrub().
+
+    output_mapping: error / cannot-determine -> None ; ran-ok -> set (maybe empty).
     """
     try:
         proc = subprocess.run(
@@ -139,9 +159,9 @@ def _active_worktree_slugs(vault_root: Path) -> set[str]:
             timeout=5,
         )
     except (OSError, subprocess.TimeoutExpired):
-        return set()
+        return None
     if proc.returncode != 0:
-        return set()
+        return None
     slugs: set[str] = set()
     for line in proc.stdout.splitlines():
         if line.startswith("branch refs/heads/claude/"):
@@ -160,6 +180,39 @@ def _jsonl_is_in_active_worktree(jsonl: Path, active_slugs: set[str]) -> bool:
         project_dir = project_dir.parent.parent
     name = project_dir.name
     return any(slug in name for slug in active_slugs)
+
+
+def partition_for_scrub(
+    finding_paths: list[Path], active_slugs: set[str] | None
+) -> tuple[list[Path], list[Path], list[Path]]:
+    """Decide which findings are safe to auto-scrub. PURE + the fail-closed core.
+
+    Returns (to_scrub, skipped_active, skipped_unknown).
+
+    FAIL-CLOSED: when `active_slugs` is None (could not determine) OR an EMPTY
+    set (no worktree positively identified as active), we cannot confirm any
+    JSONL is safe to scrub — the current session may be running from the main
+    checkout, which leaves no `claude/*` worktree entry. So scrub NOTHING; every
+    finding goes to `skipped_unknown`. The warn surface still reports them for
+    manual review.
+
+    With a NON-EMPTY active set we have a positive boundary: scrub everything
+    that is NOT inside an active worktree (`to_scrub`), skip the ones that are
+    (`skipped_active`).
+
+    output_mapping: `not active_slugs` (None or empty) -> to_scrub is ALWAYS []
+    (the safe side). Only a non-empty set ever yields scrub targets.
+    """
+    if not active_slugs:  # None or empty set -> fail closed, scrub nothing
+        return [], [], list(finding_paths)
+    to_scrub: list[Path] = []
+    skipped_active: list[Path] = []
+    for p in finding_paths:
+        if _jsonl_is_in_active_worktree(p, active_slugs):
+            skipped_active.append(p)
+        else:
+            to_scrub.append(p)
+    return to_scrub, skipped_active, []
 
 
 def _log_scrub(record: dict) -> None:
@@ -297,16 +350,25 @@ def main() -> int:
     bypass_auto_scrub = os.environ.get(BYPASS_ENV, "").strip() not in ("", "0", "false")
     vault_root = _vault_root()
     auto_scrub_enabled = (vault_root is not None) and (not bypass_auto_scrub)
-    active_slugs = _active_worktree_slugs(vault_root) if auto_scrub_enabled else set()
+
+    # FAIL-CLOSED partition. `_active_worktree_slugs` returns None on a git
+    # error and a (possibly empty) set when it ran cleanly. partition_for_scrub
+    # treats BOTH None and empty as "cannot confirm safe -> scrub nothing", so a
+    # git hiccup (or a session running from the main checkout, which has no
+    # `claude/*` worktree entry) can never scrub an active session's JSONL — the
+    # corruption the active-worktree skip exists to prevent.
+    finding_paths = [path for path, _hits in findings]
+    if auto_scrub_enabled:
+        active_slugs = _active_worktree_slugs(vault_root)  # set | None
+        to_scrub, skipped_active, skipped_unknown = partition_for_scrub(
+            finding_paths, active_slugs
+        )
+    else:
+        active_slugs = None
+        to_scrub, skipped_active, skipped_unknown = [], [], []
 
     auto_scrubbed: list[tuple[Path, str]] = []
-    skipped_active: list[Path] = []
-    for path, _hits in list(findings):
-        if not auto_scrub_enabled:
-            continue
-        if _jsonl_is_in_active_worktree(path, active_slugs):
-            skipped_active.append(path)
-            continue
+    for path in to_scrub:
         ok, msg = _auto_scrub(path)
         if ok:
             auto_scrubbed.append((path, msg))
@@ -333,6 +395,14 @@ def main() -> int:
         lines.append(f"Skipped {len(skipped_active)} active-worktree JSONL(s) (mid-session safety):")
         for path in skipped_active:
             lines.append(f"  ⏸  {path.name}: will retry next SessionStart after close")
+    if skipped_unknown and auto_scrub_enabled:
+        lines.append(
+            f"Skipped {len(skipped_unknown)} JSONL(s) — could not confirm which "
+            f"worktrees are active (git error, or none detected). FAIL-CLOSED: "
+            f"scrubbed nothing (a mid-session scrub corrupts resume state):"
+        )
+        for path in skipped_unknown:
+            lines.append(f"  ⏸  {path.name}: left intact; retries once active worktrees are detectable")
     if residual_findings:
         lines.append("Residual findings (re-scan post-scrub):")
         for path, hits in residual_findings:

--- a/hooks/test_scan_prior_sessions.py
+++ b/hooks/test_scan_prior_sessions.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Regression tests for the two secret-scan residuals.
+
+These cover the failures that the in-session freeze fix (single-instance lock +
+incremental + budget) did NOT close:
+
+  1. partition_for_scrub() is FAIL-CLOSED. When the active-worktree set is None
+     (git error / cannot determine) OR an empty set, scrub NOTHING.
+     NEGATIVE CONTROL: the pre-fix code returned an empty set on a git error and
+     then scrubbed EVERYTHING (fail-OPEN — it corrupted active-session JSONLs).
+     test_partition_fail_closed_{none,empty} assert the OPPOSITE and FAIL loudly
+     if the code ever regresses to fail-open.
+
+  2. hex-256bit no longer fires on the Workflow runtime's `"key":"v2:<hex>"`
+     content-addressed cache keys, BUT still fires on a bare 64-hex secret
+     (both directions). The SAME redact() runs in the SessionEnd scrub, so a
+     missing carve-out would rewrite the cache key and break Workflow resume.
+
+Run: python3 hooks/test_scan_prior_sessions.py
+(Also wired into CI via tests/integration/test_scan_prior_failclosed_scrub.sh.)
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+HOOKS = Path(__file__).resolve().parent
+sys.path.insert(0, str(HOOKS))
+
+
+def _load(name: str, filename: str):
+    """Load a hyphenated-filename hook module by path (not import-able normally)."""
+    spec = importlib.util.spec_from_file_location(name, HOOKS / filename)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+worker = _load("secret_scan_worker", "scan-prior-sessions-for-secrets.py")
+from _lib.secret_patterns import scan  # noqa: E402
+
+# A synthetic 64-hex value (all hex chars, obviously not a real secret). Used as
+# BOTH a bare secret and a Workflow cache key so one assertion proves the split.
+HEXV = "d" * 64
+
+
+# -- 1. fail-closed scrub decision (the bug fix + its negative controls) -------
+
+def test_partition_fail_closed_none():
+    """None (git error / unknown) -> 0 scrubs, all -> skipped_unknown."""
+    paths = [Path("/x/a.jsonl"), Path("/x/b.jsonl")]
+    to_scrub, skipped_active, skipped_unknown = worker.partition_for_scrub(paths, None)
+    assert to_scrub == [], f"FAIL-OPEN REGRESSION: scrubbed {to_scrub} on UNKNOWN set"
+    assert skipped_active == []
+    assert skipped_unknown == paths
+
+
+def test_partition_fail_closed_empty():
+    """Empty set -> 0 scrubs (the Done predicate: 'empty slug set -> 0 scrubs')."""
+    paths = [Path("/x/a.jsonl")]
+    to_scrub, _skip_active, skipped_unknown = worker.partition_for_scrub(paths, set())
+    assert to_scrub == [], f"FAIL-OPEN REGRESSION: scrubbed {to_scrub} on EMPTY set"
+    assert skipped_unknown == paths
+
+
+def test_partition_nonempty_scrubs_inactive_skips_active():
+    """Non-empty set: scrub files NOT in an active worktree, skip those that are.
+    Proves the fail-closed fix did NOT disable the feature."""
+    active = Path("/p/-Users-x--claude-worktrees-active-slug-abc123/sess.jsonl")
+    closed = Path("/p/-Users-x--claude-worktrees-closed-slug-def456/sess.jsonl")
+    to_scrub, skipped_active, skipped_unknown = worker.partition_for_scrub(
+        [active, closed], {"active-slug-abc123"}
+    )
+    assert active in skipped_active, "active-worktree JSONL was NOT skipped"
+    assert closed in to_scrub, "closed-worktree JSONL was NOT scrub-eligible"
+    assert skipped_unknown == []
+
+
+def test_auto_scrub_redacts_secret_backs_up_preserves_v2_key():
+    """_auto_scrub on a real file: backs up, redacts the bare secret, and leaves
+    the Workflow v2: cache key UNTOUCHED (the scrub-corrupts-resume guard)."""
+    d = Path(tempfile.mkdtemp(prefix="secret-scan-scrub-"))
+    try:
+        j = d / "sess.jsonl"
+        j.write_text(f'{{"secret":"API_KEY={HEXV}","key":"v2:{HEXV}"}}\n')
+        ok, msg = worker._auto_scrub(j)
+        assert ok, f"_auto_scrub did not scrub: {msg}"
+        backups = list(d.glob("sess.jsonl.bak.*-secret-scrub"))
+        assert backups, "no backup written before scrub"
+        scrubbed = j.read_text()
+        assert "[REDACTED-hex-256bit]" in scrubbed, "real secret not redacted"
+        assert f"v2:{HEXV}" in scrubbed, "v2 cache key was corrupted by the scrub"
+        assert f"API_KEY={HEXV}" not in scrubbed, "bare secret survived the scrub"
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
+# -- 2. hex-256bit narrowing (both directions) ---------------------------------
+
+def test_hex_v2_cache_key_skipped_real_secret_caught():
+    wf_key = f'{{"type":"started","key":"v2:{HEXV}","agentId":"x"}}'
+    assert dict(scan(wf_key)).get("hex-256bit-secret") is None, "v2 cache key WAS flagged"
+    bare = f"API_KEY={HEXV}"
+    assert dict(scan(bare)).get("hex-256bit-secret") == 1, "real bare-hex secret MISSED"
+
+
+def main() -> None:
+    tests = [v for k, v in sorted(globals().items())
+             if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  [OK] {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"  [FAIL] {t.__name__}: {e}")
+        except Exception as e:  # noqa: BLE001 — surface any error as a failure
+            failed += 1
+            print(f"  [ERROR] {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    if failed:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -105,6 +105,7 @@ INTEGRATION_TESTS=(
   test_installer_retires_email_gate
   test_remediate_runaway_procs
   test_scan_prior_single_instance
+  test_scan_prior_failclosed_scrub
   test_vault_safety_guards
   test_resource_aware_session_close
   test_cloud_sync_guard

--- a/tests/integration/test_scan_prior_failclosed_scrub.sh
+++ b/tests/integration/test_scan_prior_failclosed_scrub.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Test: scan-prior-sessions-for-secrets.py — fail-CLOSED auto-scrub partition
+# + hex-256bit Workflow-cache-key carve-out (the two secret-scan residuals the
+# in-session freeze fix did not close).
+#
+# Runs the Python regression suite hooks/test_scan_prior_sessions.py, which
+# carries the NEGATIVE CONTROLS that make the fix detectable:
+#   - partition_for_scrub(None)  -> scrub nothing   (fail-OPEN regression = red)
+#   - partition_for_scrub(set()) -> scrub nothing   (fail-OPEN regression = red)
+#   - a non-empty active set still scrubs closed + skips active (feature intact)
+#   - _auto_scrub redacts a bare 64-hex secret but PRESERVES a `"key":"v2:<hex>"`
+#     Workflow cache key (the scrub-corrupts-resume guard)
+#   - scan() skips the v2 cache key but still catches a bare 64-hex secret
+#
+# Hermetic: HOME is pointed at a temp dir so nothing touches the real
+# ~/.claude. The Python suite is otherwise self-contained (pure functions +
+# its own tempdirs), so it never mutates the repo or the real corpus.
+#
+# Exit 0 = pass, exit 1 = fail.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SUITE="$REPO_ROOT/hooks/test_scan_prior_sessions.py"
+if [ ! -f "$SUITE" ]; then
+  echo "FAIL: regression suite not found at $SUITE" >&2
+  exit 1
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+echo "--- hooks/test_scan_prior_sessions.py (fail-closed partition + hex v2 carve-out)"
+HOME="$TMP" python3 "$SUITE"
+
+echo
+echo "PASS: secret-scan residual regressions hold (fail-closed scrub + hex v2 carve-out)."


### PR DESCRIPTION
## What

Two secret-scan residuals in the historical-sweep layer (`scan-prior-sessions-for-secrets.py` + `_lib/secret_patterns.py`), ported from the maintainer's private toolchain. Both are bugs the earlier in-session freeze fix did not close.

### 1. Fail-closed auto-scrub (data-corruption fix)

`_active_worktree_slugs` returned an empty set on a git error, which is indistinguishable from "git ran and found zero active worktrees". The consumer then treated every finding as safe and scrubbed all of them, **including the active session's JSONL**, corrupting Claude Code's resume state. That is the exact failure the active-worktree skip exists to prevent.

- `_active_worktree_slugs` now returns `None` on any git error / timeout / non-zero exit (the UNKNOWN sentinel).
- New pure function `partition_for_scrub` fail-**closes**: when the active set is `None` OR empty, it scrubs nothing and routes every finding to `skipped_unknown`.
- `main` scrubs only `to_scrub` and surfaces `skipped_unknown`, so a fail-closed skip is visible, never silent.

### 2. hex-256bit false positive on Workflow cache keys

The `hex-256bit-secret` pattern carried every content-digest carve-out except the Workflow runtime's content-addressed `"key":"v2:<64-hex>"` cache keys. Because the same `redact` runs in the SessionEnd scrub, a scrub rewrote those keys to `[REDACTED-hex-256bit]` and broke Workflow resume. Added the fixed-width `(?<!:"v\d:)` lookbehind. It survives a version bump (`v2` to `v3`) and still matches a bare 64-hex secret.

## Not included (by design)

The launchd-worker split from the private toolchain is **not** ported. `ai-brain-starter` installs on macOS, Linux, and Windows; a launchd-only worker would silently disable the scan on every non-macOS platform. This stays a `SessionStart` hook, and the existing in-session guards (single-instance flock, stamp-at-start, incremental baseline, wall-clock budget, `os.nice`) already bound its cost. The rationale is documented in the hook docstring.

## Verification

- New `hooks/test_scan_prior_sessions.py` carries both **negative controls**: a fail-open partition and a removed `v2` carve-out each turn the suite red.
- Wired into CI via `tests/integration/test_scan_prior_failclosed_scrub.sh` in the `scripts/ci.sh` allow-list (17 to 18 integration tests).
- `bash scripts/ci.sh` green: py_compile (256 files) + 18 integration tests + shellcheck.
- Suite verified on Python 3.9.6 (CI's pinned interpreter); both negative controls confirmed red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)