### PR TITLE
feat(relocate-vault): migrate Claude Code session state when a vault leaves cloud sync (MYC-511)

### DIFF
--- a/docs/CLOUD_SYNC.md
+++ b/docs/CLOUD_SYNC.md
@@ -37,16 +37,36 @@ Windows, not inside `OneDrive\`. The index lives server-side; backups are a
 deliberate off-machine choice (below). Nothing to configure — this is the
 default.
 
-Already inside a sync folder and you don't need phone access? Move it out and
-leave a symlink so every tool that points at the old path keeps working:
+Already inside a sync folder and you don't need phone access? Move it out onto a
+local disk with the helper — **not** a raw `mv`. A bare move relocates the files
+but silently orphans your **Claude Code session history**: Claude keys
+per-project state on the vault's absolute path, so moving the vault makes every
+prior transcript read *"Session history unavailable"* and leaves the agent-memory
+symlink dangling. The helper does the move, leaves a symlink at the old path, AND
+re-homes that Claude state (copying it, so the old location stays a backup):
 
 ```bash
-mv ~/Desktop/MyVault ~/MyVault
-ln -s ~/MyVault ~/Desktop/MyVault   # old path still resolves; iCloud syncs only the tiny symlink
+# preview first (changes nothing)
+bash scripts/relocate-vault.sh ~/Desktop/MyVault ~/MyVault --dry-run
+# do it (quit Obsidian + close Claude sessions first; --force overrides the soft gates)
+bash scripts/relocate-vault.sh ~/Desktop/MyVault ~/MyVault
+```
+
+Already moved it with a plain `mv` and lost your session picker? Re-home just the
+Claude Code state, no second move:
+
+```bash
+bash scripts/relocate-vault.sh --migrate-claude-state ~/Desktop/MyVault ~/MyVault
 ```
 
 Sync daemons follow the *symlink file* (a few bytes), not the target's
 contents — so the churn leaves the sync scope entirely.
+
+> **One failure, two shapes.** Whether a bare `.git/` sits inside a sync mirror
+> or a whole git-backed vault sits inside a sync root, the cause is identical:
+> high-churn git machinery + a real-time sync daemon. Shape A (above) moves the
+> vault out; Shape B (below) keeps the vault synced and moves only the machinery.
+> Either removes the churn from the sync scope — that is the whole policy.
 
 ### Shape B — vault synced, machinery in a local sidecar (notes on every device)
 

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -110,6 +110,7 @@ INTEGRATION_TESTS=(
   test_resource_aware_session_close
   test_cloud_sync_guard
   test_machinery_sidecar
+  test_relocate_vault
   test_renderer_crash_guard
 )
 echo "==> (b) Shell integration: ${#INTEGRATION_TESTS[@]} tests"

--- a/scripts/relocate-vault.sh
+++ b/scripts/relocate-vault.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# relocate-vault.sh — move a vault OUT of a consumer cloud-sync folder onto a
+# local disk, leave a symlink so existing references keep resolving, AND migrate
+# Claude Code's path-keyed state (session transcripts + the agent-memory symlink)
+# so prior session history survives the move.
+#
+# WHY
+# ---
+# A git-backed Obsidian/AI-brain vault inside iCloud Drive / OneDrive / Dropbox /
+# Google Drive / Box melts the OS sync daemon — the high-churn .git/ + per-session
+# worktree checkouts generate millions of file events. The supported fix (Shape A
+# in docs/CLOUD_SYNC.md) is to move the vault onto a local disk and leave a
+# symlink. A RAW `mv` does the move but SILENTLY ORPHANS Claude Code history:
+# Claude stores per-project state under <config>/projects/<key>, where <key> is
+# the absolute cwd with every non-alphanumeric character replaced by '-'. Moving
+# the vault changes the key, so every prior transcript reads "Session history
+# unavailable ... no longer on disk" and the agent-memory symlink dangles. This
+# helper does the move AND re-homes that state (copy, never move — old keys stay
+# as a backup), so reopening Claude Code in the relocated vault shows the history.
+#
+# Pure bash + python3 (only for the key transform, to match Claude Code's
+# char-wise semantics exactly). No third-party deps.
+#
+# Usage:
+#   relocate-vault.sh <old-vault-path> <new-vault-path> [options]
+#   relocate-vault.sh --migrate-claude-state <old-abs-path> <new-abs-path>
+#     (state-only: the vault is already at the new path; just fix Claude history)
+#
+# Options:
+#   --dry-run            print intended actions, change nothing
+#   --no-symlink         do NOT leave a symlink at the old path (default leaves one)
+#   --force              skip the soft gates (Obsidian-running, active-session).
+#                        target-exists and source-already-a-symlink stay FATAL.
+#   --config-dir <dir>   Claude Code config dir (default: $CLAUDE_CONFIG_DIR or ~/.claude)
+#   -h, --help           this help
+#
+# Exit codes: 0 ok / no-op · 1 refused (gate) · 2 usage · 4 partial failure
+set -euo pipefail
+
+OLD="" ; NEW="" ; DRYRUN=0 ; FORCE=0 ; NOSYMLINK=0 ; MIGRATE_ONLY=0
+CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run|--dryrun) DRYRUN=1; shift;;
+    --no-symlink) NOSYMLINK=1; shift;;
+    --force) FORCE=1; shift;;
+    --config-dir) CONFIG_DIR="${2:?--config-dir needs a path}"; shift 2;;
+    --migrate-claude-state) MIGRATE_ONLY=1; shift;;
+    -h|--help) sed -n '2,38p' "$0" | sed 's/^# \{0,1\}//'; exit 0;;
+    -*) echo "unknown option: $1" >&2; exit 2;;
+    *) if [ -z "$OLD" ]; then OLD="$1"; elif [ -z "$NEW" ]; then NEW="$1"; else echo "unexpected arg: $1" >&2; exit 2; fi; shift;;
+  esac
+done
+
+say()  { printf '%s\n' "$*"; }
+warn() { printf 'WARN  %s\n' "$*" >&2; }
+die()  { printf 'relocate-vault: REFUSE — %s\n' "$1" >&2; exit "${2:-1}"; }
+
+# abspath/pathkey via python3 so the key transform matches Claude Code's JS
+# `cwd.replace(/[^a-zA-Z0-9]/g, "-")` for spaces, dots, slashes, and the ⚙️
+# variation-selector exactly. A byte-wise `sed` would mis-key multibyte paths.
+abspath() { python3 -c 'import os,sys; print(os.path.abspath(os.path.expanduser(sys.argv[1])))' "$1"; }
+# projkey: Claude Code's per-project dir name = the absolute cwd run through
+# `replace(/[^A-Za-z0-9]/g, "-")`. cwd is the PHYSICAL path (getcwd resolves
+# symlinks), so resolve the ANCESTRY — but NEVER follow a leaf symlink: post-move
+# the old leaf IS the symlink we leave behind, and following it would key the new
+# path. Resolve dirname, keep basename literal. Matches both before and after the
+# move, and the two modes (full relocate / state-only) compute the same key.
+projkey() { python3 -c 'import os,re,sys
+p = os.path.abspath(os.path.expanduser(sys.argv[1]))
+resolved = os.path.join(os.path.realpath(os.path.dirname(p)), os.path.basename(p))
+print(re.sub(r"[^a-zA-Z0-9]", "-", resolved))' "$1"; }
+
+# ---- migrate Claude Code path-keyed state (sessions + agent memory) -----------
+# Copies <config>/projects/<oldkey>* -> <newkey>* (prefix swap preserves every
+# sub-key suffix verbatim — worktree subdirs etc.) and re-homes the agent-memory
+# symlink under the new base key. Copy, never move: old keys remain a backup.
+# Fail LOUD when zero keys match (don't silently report "0 migrated").
+migrate_claude_state() {  # $1=old-abs  $2=new-abs
+  local old="$1" new="$2"
+  local projdir="$CONFIG_DIR/projects"
+  if [ ! -d "$projdir" ]; then
+    say "  · no Claude Code projects dir ($projdir) — nothing to migrate"
+    return 0
+  fi
+  local oldkey newkey
+  oldkey="$(projkey "$old")"
+  newkey="$(projkey "$new")"
+  if [ "$oldkey" = "$newkey" ]; then
+    say "  · old and new path keys are identical — nothing to migrate"
+    return 0
+  fi
+
+  local matched=0 keys=0 files=0
+  local d nb nd before after
+  while IFS= read -r d; do
+    [ -d "$d" ] || continue
+    matched=$((matched + 1))
+    nb="$(basename "$d" | sed "s#^${oldkey}#${newkey}#")"
+    nd="$projdir/$nb"
+    if [ "$DRYRUN" = 1 ]; then
+      say "  · would migrate $(basename "$d") -> $nb"
+      keys=$((keys + 1))
+      continue
+    fi
+    mkdir -p "$nd"
+    before="$(find "$nd" -maxdepth 1 -name '*.jsonl' 2>/dev/null | wc -l | tr -d ' ')"
+    find "$d" -maxdepth 1 -name '*.jsonl' -exec cp -np {} "$nd"/ \; 2>/dev/null || true
+    after="$(find "$nd" -maxdepth 1 -name '*.jsonl' 2>/dev/null | wc -l | tr -d ' ')"
+    keys=$((keys + 1))
+    files=$((files + after - before))
+  done < <(find "$projdir" -maxdepth 1 -type d -name "${oldkey}*" 2>/dev/null)
+
+  if [ "$matched" = 0 ]; then
+    warn "  · no Claude Code session history found under old key '${oldkey}*' in $projdir."
+    warn "    Nothing to migrate, OR the path-key encoding differs from what was expected —"
+    warn "    inspect $projdir if you expected prior sessions here."
+    return 0
+  fi
+  if [ "$DRYRUN" = 1 ]; then
+    say "  · would migrate transcripts across $keys project key(s) -> new path key"
+  else
+    say "  · migrated $files transcript(s) across $keys project key(s) -> new path key"
+  fi
+
+  # Re-home the agent-memory symlink under the new base key. Prefer repointing
+  # an existing old-key symlink (handles any memory layout); fall back to the
+  # ai-brain-starter convention "⚙️ Meta/Agent Memory".
+  local oldmem newmem target
+  oldmem="$projdir/$oldkey/memory"
+  newmem="$projdir/$newkey/memory"
+  if [ ! -e "$newmem" ]; then
+    if [ -L "$oldmem" ]; then
+      target="$(readlink "$oldmem")"
+      case "$target" in
+        "$old"/*) target="$new/${target#"$old"/}";;
+        "$old")   target="$new";;
+      esac
+    else
+      target="$new/⚙️ Meta/Agent Memory"
+    fi
+    if [ -d "$target" ]; then
+      if [ "$DRYRUN" = 1 ]; then
+        say "  · would re-link agent-memory -> $target"
+      else
+        mkdir -p "$projdir/$newkey"
+        ln -s "$target" "$newmem"
+        say "  · agent-memory re-linked -> $target"
+      fi
+    fi
+  fi
+}
+
+# =============================================================================
+# state-only mode: the vault is already at the new path; just fix Claude history
+# =============================================================================
+if [ "$MIGRATE_ONLY" = 1 ]; then
+  if [ -z "$OLD" ] || [ -z "$NEW" ]; then
+    echo "usage: $(basename "$0") --migrate-claude-state <old-abs-path> <new-abs-path>" >&2
+    exit 2
+  fi
+  OLD_ABS="$(abspath "$OLD")"
+  NEW_ABS="$(abspath "$NEW")"
+  say "relocate-vault: migrating Claude Code state only ($OLD_ABS -> $NEW_ABS)"
+  migrate_claude_state "$OLD_ABS" "$NEW_ABS"
+  exit 0
+fi
+
+# =============================================================================
+# full relocate
+# =============================================================================
+if [ -z "$OLD" ] || [ -z "$NEW" ]; then
+  echo "usage: $(basename "$0") <old-vault-path> <new-vault-path> [--dry-run] [--force] [--no-symlink]" >&2
+  exit 2
+fi
+[ -e "$OLD" ] || die "source '$OLD' not found (already moved?)"
+if [ -L "$OLD" ]; then die "source '$OLD' is already a symlink (already relocated?)"; fi
+[ -d "$OLD" ] || die "source '$OLD' is not a directory"
+
+OLD_ABS="$(cd "$OLD" && pwd -P)"   # physical path, BEFORE the move
+NEW_ABS="$(abspath "$NEW")"
+[ "$OLD_ABS" != "$NEW_ABS" ] || die "source and target are the same path"
+if [ -e "$NEW_ABS" ]; then die "target '$NEW_ABS' already exists (will not overwrite)"; fi
+
+# Soft gates — skippable with --force.
+if [ "$FORCE" != 1 ]; then
+  if command -v pgrep >/dev/null 2>&1 && pgrep -x Obsidian >/dev/null 2>&1; then
+    die "Obsidian is running — quit it first (moving an open vault is unsafe), or pass --force"
+  fi
+  if [ -d "$OLD_ABS/.claude/worktrees" ]; then
+    active="$(find "$OLD_ABS/.claude/worktrees" -type f -mmin -10 2>/dev/null | head -1 || true)"
+    if [ -n "$active" ]; then
+      die "an active Claude session is writing under .claude/worktrees (touched <10 min) — close it, or pass --force"
+    fi
+  fi
+fi
+
+say ""
+say "relocate-vault: BACK UP FIRST. A vault is often your one irreplaceable asset."
+say "  Stand up + VERIFY an off-machine backup before moving:"
+say "    bash scripts/vault-backup.sh setup && bash scripts/vault-backup.sh verify"
+say ""
+
+if [ "$DRYRUN" = 1 ]; then
+  say "DRY  would: mv '$OLD_ABS' -> '$NEW_ABS'"
+  [ "$NOSYMLINK" = 1 ] || say "DRY  would: ln -s '$NEW_ABS' '$OLD_ABS'"
+  migrate_claude_state "$OLD_ABS" "$NEW_ABS"
+  say "DRY-RUN complete — no changes made."
+  exit 0
+fi
+
+say "relocate-vault: moving '$OLD_ABS' -> '$NEW_ABS'"
+mkdir -p "$(dirname "$NEW_ABS")"
+mv "$OLD_ABS" "$NEW_ABS"
+[ -d "$NEW_ABS" ] || die "POST: '$NEW_ABS' missing after move" 4
+
+if [ "$NOSYMLINK" != 1 ]; then
+  ln -s "$NEW_ABS" "$OLD_ABS"
+  if [ -L "$OLD_ABS" ] && [ "$(readlink "$OLD_ABS")" = "$NEW_ABS" ]; then
+    say "relocate-vault: left symlink '$OLD_ABS' -> '$NEW_ABS' (old references keep resolving; the sync daemon follows the tiny symlink, not the churn)"
+  else
+    warn "POST: expected symlink not in place at $OLD_ABS"
+  fi
+fi
+
+say "relocate-vault: migrating Claude Code session history + agent memory ..."
+migrate_claude_state "$OLD_ABS" "$NEW_ABS"
+
+say ""
+say "relocate-vault: DONE."
+say "  - Vault now lives at:  $NEW_ABS   (outside the sync folder)"
+[ "$NOSYMLINK" = 1 ] || say "  - Old path is a symlink: $OLD_ABS -> $NEW_ABS   (scripts/hooks/CLAUDE.md keep working)"
+say "  - Reopen Obsidian; if it lost the vault, open $NEW_ABS"
+say "  - Reopen Claude Code in the vault — prior sessions appear in the picker"
+say "    (history was re-homed to the new path key; the old keys are kept as a backup)"
+say "  - Re-run a backup against the new path:  VAULT_ROOT=\"$NEW_ABS\" bash scripts/vault-backup.sh"

--- a/scripts/test-relocate-vault.sh
+++ b/scripts/test-relocate-vault.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Negative-control test for scripts/relocate-vault.sh — the vault relocation +
+# Claude Code path-keyed state migration helper (MYC-511 item 4).
+#
+# A guard earns trust only by failing on the thing it catches. This asserts:
+#   - POSITIVE: transcripts copy from the old path key to the new key (base +
+#     sub-keys), the agent-memory symlink re-homes, old keys are preserved.
+#   - NO-OP DETECTOR: 0 transcripts under the new key BEFORE migration, N after
+#     (a silently-broken key transform would leave it 0 -> this test goes red).
+#   - FAIL-LOUD: a zero-match key prints "no Claude Code session history" and
+#     exits 0 (nothing to do), never a silent success.
+#   - REFUSALS: full relocate refuses when the target exists and when the source
+#     is already a symlink (both fatal even under --force).
+#   - HAPPY PATH: a full move relocates the dir, leaves the symlink, migrates
+#     history; --no-symlink omits the symlink.
+# Hermetic: a temp HOME-like sandbox + an isolated --config-dir; the real
+# ~/.claude is never touched.
+# Run: bash scripts/test-relocate-vault.sh
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/relocate-vault.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+fails=0
+pass() { echo "PASS  $1"; }
+fail() { echo "FAIL  $1"; fails=$((fails + 1)); }
+
+# Mirror the script's projkey EXACTLY (resolve ancestry, keep leaf literal) so
+# fixtures land at the same key the script computes, even where $TMPDIR resolves
+# /var -> /private/var on macOS.
+pathkey() { python3 -c 'import os,re,sys
+p = os.path.abspath(os.path.expanduser(sys.argv[1]))
+resolved = os.path.join(os.path.realpath(os.path.dirname(p)), os.path.basename(p))
+print(re.sub(r"[^a-zA-Z0-9]", "-", resolved))' "$1"; }
+
+CFG="$TMP/.claude"
+PROJ="$CFG/projects"
+jsonl_count() { find "$1" -maxdepth 1 -name '*.jsonl' 2>/dev/null | wc -l | tr -d ' '; }
+
+# --- 1. POSITIVE + NO-OP DETECTOR: --migrate-claude-state copies old -> new ----
+# The old path has a SPACE -> exercises the non-alphanumeric key transform that
+# the reference [/ ]->- sed would also handle, but a dotted/emoji path needs the
+# full [^A-Za-z0-9]->- rule this helper uses.
+OLD="$TMP/Desktop/My Vault"
+NEW="$TMP/brain"
+mkdir -p "$OLD/⚙️ Meta/Agent Memory" "$NEW/⚙️ Meta/Agent Memory"
+OLDKEY="$(pathkey "$OLD")"
+NEWKEY="$(pathkey "$NEW")"
+mkdir -p "$PROJ/$OLDKEY" "$PROJ/${OLDKEY}--claude-worktrees-foo"
+echo '{"x":1}' > "$PROJ/$OLDKEY/sess1.jsonl"
+echo '{"x":2}' > "$PROJ/${OLDKEY}--claude-worktrees-foo/sess2.jsonl"
+
+before="$(jsonl_count "$PROJ/$NEWKEY")"
+[ "$before" = 0 ] && pass "no-op detector: 0 transcripts under new key before migration" \
+                  || fail "no-op detector: expected 0 before, got $before"
+
+CLAUDE_CONFIG_DIR="$CFG" bash "$SCRIPT" --migrate-claude-state "$OLD" "$NEW" >/dev/null 2>&1
+
+a1="$(jsonl_count "$PROJ/$NEWKEY")"
+[ "$a1" = 1 ] && pass "base-key transcript migrated (sess1)" || fail "base-key migrate: want 1 got $a1"
+a2="$(jsonl_count "$PROJ/${NEWKEY}--claude-worktrees-foo")"
+[ "$a2" = 1 ] && pass "sub-key transcript migrated (sess2)" || fail "sub-key migrate: want 1 got $a2"
+[ -L "$PROJ/$NEWKEY/memory" ] && pass "agent-memory symlink re-homed" || fail "agent-memory symlink missing"
+[ -f "$PROJ/$OLDKEY/sess1.jsonl" ] && pass "old key preserved (copy, not move)" || fail "old key was destroyed (should be a backup)"
+
+# --- 2. FAIL-LOUD: a zero-match key warns + exits 0 (never a silent success) ---
+out="$(CLAUDE_CONFIG_DIR="$CFG" bash "$SCRIPT" --migrate-claude-state "$TMP/nothing-here" "$TMP/elsewhere" 2>&1)"
+rc=$?
+echo "$out" | grep -qi 'no Claude Code session history' \
+  && pass "zero-match: fails loud (warns, not silent)" \
+  || fail "zero-match: expected a loud warning, got: $out"
+[ "$rc" = 0 ] && pass "zero-match: exits 0 (nothing to do, not a crash)" || fail "zero-match: want rc=0 got $rc"
+
+# --- 3. REFUSAL: full relocate refuses when the target already exists ----------
+src="$TMP/src-vault" ; dst="$TMP/dst-exists" ; mkdir -p "$src" "$dst"
+CLAUDE_CONFIG_DIR="$CFG" bash "$SCRIPT" "$src" "$dst" --force >/dev/null 2>&1
+rc=$?
+[ "$rc" = 1 ] && pass "refuses when target exists (rc=1, fatal even under --force)" \
+             || fail "target-exists: want rc=1 got $rc"
+
+# --- 4. REFUSAL: refuses when the source is already a symlink ------------------
+realdir="$TMP/realdir" ; linkdir="$TMP/linkdir" ; mkdir -p "$realdir" ; ln -s "$realdir" "$linkdir"
+CLAUDE_CONFIG_DIR="$CFG" bash "$SCRIPT" "$linkdir" "$TMP/new-from-link" --force >/dev/null 2>&1
+rc=$?
+[ "$rc" = 1 ] && pass "refuses when source already a symlink (rc=1)" || fail "source-symlink: want rc=1 got $rc"
+
+# --- 5. HAPPY PATH: move dir, leave symlink, migrate history -------------------
+hv="$TMP/Desktop/Happy Vault" ; nv="$TMP/local-brain"
+mkdir -p "$hv/⚙️ Meta/Agent Memory" ; echo "note" > "$hv/note.md"
+HK="$(pathkey "$hv")" ; NK="$(pathkey "$nv")"
+mkdir -p "$PROJ/$HK" ; echo '{"s":1}' > "$PROJ/$HK/h.jsonl"
+CLAUDE_CONFIG_DIR="$CFG" bash "$SCRIPT" "$hv" "$nv" --force >/dev/null 2>&1
+rc=$?
+[ "$rc" = 0 ] && pass "happy path exits 0" || fail "happy path rc=$rc"
+{ [ -d "$nv" ] && [ -f "$nv/note.md" ]; } && pass "vault moved to new local path" || fail "vault not at new path"
+{ [ -L "$hv" ] && [ "$(readlink "$hv")" = "$nv" ]; } && pass "symlink left at old path" || fail "symlink not left at old path"
+hh="$(jsonl_count "$PROJ/$NK")"
+[ "$hh" = 1 ] && pass "happy path migrated session history" || fail "happy path history not migrated (want 1 got $hh)"
+
+# --- 6. --no-symlink omits the symlink ----------------------------------------
+nsv="$TMP/Desktop/NoSym Vault" ; nsn="$TMP/nosym-brain" ; mkdir -p "$nsv"
+CLAUDE_CONFIG_DIR="$CFG" bash "$SCRIPT" "$nsv" "$nsn" --force --no-symlink >/dev/null 2>&1
+{ [ -d "$nsn" ] && [ ! -e "$nsv" ]; } && pass "--no-symlink leaves nothing at the old path" || fail "--no-symlink left something at old path"
+
+echo
+if [ "$fails" -gt 0 ]; then echo "FAILED: $fails"; exit 1; fi
+echo "ALL TESTS PASSED"

--- a/tests/integration/test_relocate_vault.sh
+++ b/tests/integration/test_relocate_vault.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# CI integration wrapper — runs the relocate-vault negative-control suite
+# (scripts/test-relocate-vault.sh) as part of scripts/ci.sh. Thin: the logic
+# lives next to the script it exercises.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+exec bash "$ROOT/scripts/test-relocate-vault.sh"


### PR DESCRIPTION
## Why

Finishes MYC-511. The install guard, diagnose check, and SessionStart footprint signal already shipped in #159; worktree orphan-reclaim in #158. The last gap was **item 4** — a relocate helper that also migrates Claude Code's path-keyed state — and **item 5**, the doc cross-ref.

A raw `mv` of a vault out of a sync folder silently orphans Claude Code session history. Claude keys per-project state on the vault's absolute path, so the move changes the `<config>/projects/<key>` dir: every prior transcript reads *"Session history unavailable"* and the agent-memory symlink dangles. The maintainer hit this (693 transcripts orphaned), and `docs/CLOUD_SYNC.md` Shape A previously told users to run exactly that raw `mv`.

## What

- **`relocate-vault.sh`** — moves the vault, leaves a symlink, AND re-homes Claude state (copy-not-move, so old keys remain a backup). `projkey()` reproduces Claude Code's real key transform `[^A-Za-z0-9]→-` over the *physical* path (resolving symlink ancestry, never the leaf), fixing the silent-no-op the reference `[/ ]→-` had on dotted/spaced/emoji paths. **Fails loud** when zero keys match (never a silent "0 migrated"). `--migrate-claude-state` repairs an already-moved vault with no second move. Hard-refuses when the target exists or the source is already a symlink; soft gates (Obsidian running, live session) are `--force`-skippable.
- **`test-relocate-vault.sh`** — negative-control suite (no-op detector, fail-loud, target-exists + source-symlink refusals, happy path, `--no-symlink`), wired into `ci.sh` via the integration allow-list so it actually runs.
- **`CLOUD_SYNC.md`** Shape A now steers to the helper instead of a raw `mv`, warns about the orphaned history, and frames the `.git`-in-mirror / vault-in-sync-root variants as one failure family.

Local `ci.sh` green: py_compile 256 files + 19 integration tests + shellcheck over 83 `.sh`.

MYC-511

🤖 Authored by Claude Code (Opus 4.8), reviewed by Adelaida.