### PR TITLE
feat(agentic-os): client agentic-OS install primitive (MYC-254)

### DIFF
--- a/agentic-os/INSTALL.sh
+++ b/agentic-os/INSTALL.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# agentic-os/INSTALL.sh - drop the agentic-OS kernel + agents + contexts + rules +
+# data scaffold into a target repo. One command, idempotent, no network.
+#
+#   bash agentic-os/INSTALL.sh [TARGET_DIR]      (default: current directory)
+#
+# Lands:
+#   TARGET/CLAUDE.md                       the kernel (orchestrator)        [*]
+#   TARGET/.claude/agents/*.md             pinned specialist agents
+#   TARGET/.claude/contexts/*.md           posture modes
+#   TARGET/.claude/rules/<lang>/hooks.md   paths-scoped per-language rules
+#   TARGET/.claude/hooks/*.py              the validator + paths-scoped hook
+#   TARGET/data/                           durable project-memory scaffold
+#
+# [*] An existing TARGET/CLAUDE.md is NOT overwritten; the kernel is written to
+#     TARGET/CLAUDE.agentic-os.md for you to merge by hand.
+set -euo pipefail
+
+SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+TARGET="${1:-.}"
+mkdir -p "$TARGET"
+TARGET="$(cd "$TARGET" && pwd)"
+
+echo "agentic-os: installing into $TARGET"
+
+mkdir -p \
+  "$TARGET/.claude/agents" \
+  "$TARGET/.claude/contexts" \
+  "$TARGET/.claude/rules" \
+  "$TARGET/.claude/hooks" \
+  "$TARGET/data"
+
+# Kernel - never clobber an existing CLAUDE.md.
+if [ -e "$TARGET/CLAUDE.md" ]; then
+  cp "$SRC/kernel/CLAUDE.md" "$TARGET/CLAUDE.agentic-os.md"
+  echo "  note: TARGET/CLAUDE.md exists - kernel written to CLAUDE.agentic-os.md (merge by hand)"
+else
+  cp "$SRC/kernel/CLAUDE.md" "$TARGET/CLAUDE.md"
+  echo "  + CLAUDE.md (kernel)"
+fi
+
+# Agents (pinned model + tool surface).
+cp "$SRC"/agents/*.md "$TARGET/.claude/agents/"
+echo "  + .claude/agents/"
+
+# Contexts (posture modes).
+cp "$SRC"/contexts/*.md "$TARGET/.claude/contexts/"
+echo "  + .claude/contexts/"
+
+# Rules (one dir per language; copy each lang's hooks.md).
+for lang_dir in "$SRC"/rules/*/; do
+  [ -d "$lang_dir" ] || continue
+  lang="$(basename "$lang_dir")"
+  mkdir -p "$TARGET/.claude/rules/$lang"
+  cp "${lang_dir}hooks.md" "$TARGET/.claude/rules/$lang/hooks.md"
+done
+echo "  + .claude/rules/"
+
+# Hooks - the validator + the paths-scoped-rules auto-apply hook.
+cp "$SRC/bin/validate_agents.py" "$TARGET/.claude/hooks/validate_agents.py"
+cp "$SRC/bin/paths_scoped_rules.py" "$TARGET/.claude/hooks/paths_scoped_rules.py"
+chmod +x "$TARGET/.claude/hooks/validate_agents.py" "$TARGET/.claude/hooks/paths_scoped_rules.py"
+echo "  + .claude/hooks/"
+
+# Data scaffold (includes README.md + .gitkeep).
+cp -R "$SRC"/data/. "$TARGET/data/"
+echo "  + data/"
+
+# Settings snippet to wire the paths-scoped-rules hook (PostToolUse on Write|Edit).
+cat >"$TARGET/.claude/settings.agentic-os.json" <<'JSON'
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          { "type": "command", "command": "python3 .claude/hooks/paths_scoped_rules.py" }
+        ]
+      }
+    ]
+  }
+}
+JSON
+echo "  + .claude/settings.agentic-os.json"
+
+cat <<'EOF'
+
+agentic-os installed. Next:
+  1. Merge .claude/settings.agentic-os.json into .claude/settings.json
+     (wires paths_scoped_rules as a PostToolUse hook so rules auto-apply on edit).
+  2. Validate the agent tool-surface boundary:
+       python3 .claude/hooks/validate_agents.py .claude/agents
+  3. Replace the placeholder mission line at the bottom of CLAUDE.md with yours.
+EOF

--- a/agentic-os/README.md
+++ b/agentic-os/README.md
@@ -1,0 +1,67 @@
+# agentic-os — a clean agentic OS you can install into any repo
+
+A minimal, declarative "operating system" for a coding agent: a small kernel that
+orchestrates, specialist agents with **pinned models and tool surfaces**,
+user-selectable **posture modes**, and **per-language quality rules that
+auto-apply by file glob**. One command drops it into a fresh repo.
+
+It is built on one idea: **the safety and quality boundaries should be declarative**
+— readable in a markdown file, enforced by the harness, and checkable in CI — not
+buried in prose the model may or may not follow.
+
+## The four primitives
+
+| Primitive | Where | What it gives you |
+|---|---|---|
+| **Kernel** | `kernel/CLAUDE.md` | A small COO/orchestrator. Routes work to agents in a plain markdown table. Stays under 100 lines — detail lives in the files it points to. |
+| **Pinned agents** | `agents/*.md` | One specialist per file. `model:` pinned (heavy for planning, light for execution) and `tools:` pinned. A read-only `planner`/`reviewer` lists only `Read, Grep, Glob` and so **cannot** `Write` — a declarative safety boundary the harness enforces. |
+| **Posture modes** | `contexts/*.md` | `dev` / `review` / `research` / `security`. Switch how you operate mid-session ("switch to review") without a full skill invocation. |
+| **Paths-scoped rules** | `rules/<lang>/hooks.md` | Each rule declares a `paths:` glob (`**/*.ts`). When you edit a matching file, its checks auto-apply — zero per-file config. Add a language by dropping a folder. |
+
+## Install
+
+```sh
+bash agentic-os/INSTALL.sh /path/to/your/repo
+```
+
+Lands `CLAUDE.md` (kernel) + `.claude/agents/` + `.claude/contexts/` +
+`.claude/rules/<lang>/` + `.claude/hooks/` + a `data/` memory scaffold, plus a
+`settings.agentic-os.json` snippet that wires the auto-apply hook. An existing
+`CLAUDE.md` is never overwritten.
+
+## The two enforcement mechanisms (not just templates)
+
+Both load-bearing boundaries are **checkable**, each shipped with a negative
+control that proves it fails on a violation:
+
+- **`bin/validate_agents.py`** parses every agent spec and FAILS if a read-only
+  role declares a mutating tool (`Write`/`Edit`/`Bash`/…) or omits its `model`
+  pin. A `role: planner` that lists `Write` is rejected, so the lie never ships.
+
+  ```sh
+  python3 .claude/hooks/validate_agents.py .claude/agents
+  ```
+
+- **`bin/paths_scoped_rules.py`** is the auto-apply hook. Given an edited path it
+  surfaces the matching language rules; on a non-matching path it stays silent
+  (fail-open — it never blocks an edit). Wired as a `PostToolUse(Write|Edit)` hook.
+
+Run the whole invariant + negative-control suite:
+
+```sh
+bash scripts/test-agentic-os.sh
+```
+
+## Why declarative
+
+Prose rules degrade — the model follows them most of the time. A `tools:` list is
+different: the harness will not hand an agent a tool it did not declare, so
+"read-only" is a fact, not a hope. The kernel stays small so the agent's context
+stays lean. The rules ride a glob so they cannot be forgotten on a new file. Every
+boundary is one grep away from being audited.
+
+## What Mycelium adds
+
+This template is the free, public pattern. Mycelium's client install pack wraps it
+with per-client agents and rules, a security layer, CI wiring, and onboarding — the
+hardened, supported version for a team. The pattern here is yours to use either way.

--- a/agentic-os/agents/README.md
+++ b/agentic-os/agents/README.md
@@ -1,0 +1,35 @@
+# Agents
+
+Each agent is one specialist, one domain, under 100 lines. The frontmatter is a
+**declarative contract** the harness enforces:
+
+| Field | Meaning |
+|---|---|
+| `name` | how the kernel routes to it |
+| `description` | when to use it (the router reads this) |
+| `role` | `planner` / `reviewer` / `research` are **read-only** roles; `resolver` writes |
+| `tools` | the EXACT tool surface. Claude Code restricts the agent to this list — a tool not listed cannot be called |
+| `model` | pinned per agent: heavier model for planning, lighter for execution |
+
+## The safety boundary is the `tools:` list
+
+A read-only agent (`planner` / `reviewer`) lists only `Read, Grep, Glob`. It
+**cannot** `Write`, `Edit`, or run `Bash` — not by policy, by construction. The
+harness will not hand it a tool it did not declare.
+
+That invariant is checkable. `validate_agents.py` (shipped to `.claude/hooks/`)
+parses every spec and FAILS if a read-only role declares a mutating tool, or if an
+agent is missing its `model` pin. Run it in CI:
+
+```sh
+python3 .claude/hooks/validate_agents.py .claude/agents
+```
+
+A `role: planner` that lists `Write` is a contradiction — the validator rejects it
+so the lie never ships.
+
+## Adding an agent
+
+Drop a `<name>.md` with the five frontmatter fields, keep it under 100 lines, give
+it one job. Read-only by default; grant write tools only to a `resolver`-class
+agent that needs them.

--- a/agentic-os/agents/planner.md
+++ b/agentic-os/agents/planner.md
@@ -1,0 +1,36 @@
+---
+name: planner
+description: Decomposes a task into a concrete, ordered implementation plan. Use BEFORE any code is written for non-trivial work. Read-only by construction — it cannot edit files, so it can never "just fix it" and skip the plan.
+role: planner
+tools: [Read, Grep, Glob]
+model: opus
+---
+
+# Planner
+
+You produce the plan. You do not implement it. Your tool surface is read-only
+(`Read`, `Grep`, `Glob`) — you physically cannot Write, Edit, or run Bash, and
+that is the point: planning stays planning.
+
+## What you do
+
+1. **Understand** the request and the relevant code before proposing anything.
+   Read the files that matter; trace the seams; do not guess.
+2. **Surface assumptions** explicitly — list 2-5 you are making about scope,
+   constraints, and intent. Wrong assumptions are the top cause of rework.
+3. **Decompose** into the smallest ordered steps a `resolver` can execute, each
+   with a clear done-condition and the file(s) it touches.
+4. **Name the risks** — the one or two ways this plan could go wrong — in a single
+   line each. Do not gate the plan behind them; name them and move on.
+
+## What you return
+
+A numbered plan. For each step: what changes, which file(s), and how to verify it.
+End with the single highest-leverage step to do first. Hand off to `resolver` for
+execution and `reviewer` for the check.
+
+## What you never do
+
+- Edit a file or run a command (your tools do not allow it).
+- Pad the plan with steps that do not change behavior.
+- Decide it is "simple enough to skip planning" — if you were invoked, plan.

--- a/agentic-os/agents/resolver.md
+++ b/agentic-os/agents/resolver.md
@@ -1,0 +1,35 @@
+---
+name: resolver
+description: Implements a planned change — edits files, runs commands, makes tests pass. The only agent with write authority. Use it to execute a planner's plan or apply a reviewer's confirmed fix, never to decide scope on its own.
+role: resolver
+tools: [Read, Write, Edit, Bash, Grep, Glob]
+model: sonnet
+---
+
+# Resolver
+
+You execute. You have write authority (`Write`, `Edit`, `Bash`) — the only agent
+that does — so you are the one place a mistake actually mutates the repo. Move
+carefully and verify.
+
+## What you do
+
+1. **Work from a plan.** Execute the `planner`'s steps or the `reviewer`'s
+   confirmed fix. If there is no plan and the task is non-trivial, ask for one.
+2. **Smallest change that satisfies the step.** Match the surrounding code's
+   style, naming, and idiom. Do not refactor adjacent code uninvited.
+3. **Run the per-language checks** the `paths_scoped_rules` hook surfaces for the
+   files you touched (typecheck, format, lint) before claiming done.
+4. **Verify behavior**, not just types. Run the test or the command and read the
+   output. Evidence before assertion.
+
+## What you return
+
+The change, plus the verification you ran and its result. If a check failed, say
+so with the output — never claim green you did not see.
+
+## What you never do
+
+- Expand scope past the plan without surfacing it first.
+- Commit or push unless explicitly asked, or your project rules say to.
+- Claim "done / verified" without a command output that proves it.

--- a/agentic-os/agents/reviewer.md
+++ b/agentic-os/agents/reviewer.md
@@ -1,0 +1,35 @@
+---
+name: reviewer
+description: Reviews a change for correctness, security, and convention adherence. Use AFTER a resolver edit and BEFORE merge. Read-only by construction — it reports findings, it does not "fix while reviewing" (which hides the bug behind a silent edit).
+role: reviewer
+tools: [Read, Grep, Glob]
+model: sonnet
+---
+
+# Reviewer
+
+You find what is wrong. You do not change it. Your tool surface is read-only
+(`Read`, `Grep`, `Glob`) — so a finding is a finding, never a silent fix that
+nobody sees in the diff.
+
+## What you do
+
+1. **Read the diff** and the code around it. Understand intent before judging.
+2. **Look for, in priority order:** correctness bugs, security issues
+   (injection, auth bypass, SSRF, secret leakage), then convention drift.
+3. **Trace the worst-case input** through the change. What does a hostile or
+   malformed input do here?
+4. **Check the seam**, not just the unit: does the producer match the consumer?
+
+## What you return
+
+A findings list, each as: `severity` (critical / high / medium / low), the
+`file:line`, what is wrong, and the smallest fix. If you find nothing real, say so
+plainly — do not invent findings to look thorough. Hand confirmed fixes to
+`resolver`.
+
+## What you never do
+
+- Edit a file (your tools do not allow it) — report, don't patch.
+- Approve on style while a correctness bug stands.
+- Pad with nitpicks that do not change behavior or risk.

--- a/agentic-os/bin/paths_scoped_rules.py
+++ b/agentic-os/bin/paths_scoped_rules.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""paths_scoped_rules.py - auto-apply per-language rules by path glob (MYC-254).
+
+Each rules/<lang>/hooks.md declares `paths:` globs in its frontmatter. Given an
+edited file path, this surfaces the matching rule block(s) - zero per-file config,
+the glob does the routing. Two entry points:
+
+  CLI:   paths_scoped_rules.py --path src/foo.ts
+         Prints the matching rule heading(s); used in CI and by a human.
+
+  Hook:  as a Claude Code PostToolUse(Write|Edit) hook, reads the hook JSON on
+         stdin, pulls tool_input.file_path, and prints the matching guidance so the
+         model sees which language rules govern the file it just touched.
+
+The rules dir resolves to <script_dir>/../rules, correct both in the template
+(agentic-os/bin -> agentic-os/rules) and after install (.claude/hooks ->
+.claude/rules). Override with AGENTIC_OS_RULES_DIR.
+
+Fail-open: any unexpected condition returns 0 with no output, so a PostToolUse
+hook can never block the client's edit.
+"""
+from __future__ import annotations
+
+import fnmatch
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def rules_dir():
+    env = os.environ.get("AGENTIC_OS_RULES_DIR")
+    if env:
+        return Path(env)
+    return Path(__file__).resolve().parent.parent / "rules"
+
+
+def split_frontmatter(text):
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return None
+    body = []
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            return body
+        body.append(lines[i])
+    return None
+
+
+def parse_paths(fm_lines):
+    """Pull the `paths:` globs (inline list or block list) from frontmatter lines."""
+    i = 0
+    n = len(fm_lines)
+    while i < n:
+        line = fm_lines[i].strip()
+        if line.startswith("paths:"):
+            val = line.partition(":")[2].strip()
+            if val.startswith("[") and val.endswith("]"):
+                return [g.strip().strip("\"'") for g in val[1:-1].split(",") if g.strip()]
+            if val == "":
+                globs = []
+                j = i + 1
+                while j < n and fm_lines[j].lstrip().startswith("- "):
+                    globs.append(fm_lines[j].lstrip()[2:].strip().strip("\"'"))
+                    j += 1
+                return globs
+            return [val.strip("\"'")]
+        i += 1
+    return []
+
+
+def name_of(fm_lines, fallback):
+    for line in fm_lines:
+        s = line.strip()
+        if s.startswith("name:"):
+            return s.partition(":")[2].strip().strip("\"'") or fallback
+    return fallback
+
+
+def match_path(path, glob):
+    # fnmatch's `*` already spans `/`, so `*.ts` matches src/a/b.ts. We also add the
+    # `**/`-stripped variant so a root-level file (no slash) matches `**/*.ts` too.
+    candidates = {glob}
+    if glob.startswith("**/"):
+        candidates.add(glob[3:])
+    return any(fnmatch.fnmatch(path, g) for g in candidates)
+
+
+def matching_rules(path):
+    """Return [(name, hooks_md_path)] for every rule whose globs match `path`."""
+    out = []
+    rd = rules_dir()
+    if not rd.is_dir():
+        return out
+    for hooks_md in sorted(rd.glob("*/hooks.md")):
+        fm = split_frontmatter(hooks_md.read_text(encoding="utf-8"))
+        if fm is None:
+            continue
+        globs = parse_paths(fm)
+        if any(match_path(path, g) for g in globs):
+            out.append((name_of(fm, hooks_md.parent.name), hooks_md))
+    return out
+
+
+def render(path, rules):
+    lines = []
+    for name, hooks_md in rules:
+        lines.append(f"[paths-scoped rule: {name}] matched {path}")
+        lines.append(f"  rules: {hooks_md}")
+    return "\n".join(lines)
+
+
+def file_path_from_stdin():
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:  # noqa: BLE001 - hook must fail open on any malformed stdin
+        return None
+    tool_input = payload.get("tool_input") or {}
+    return tool_input.get("file_path") or tool_input.get("path")
+
+
+def main(argv):
+    path = None
+    if "--path" in argv:
+        idx = argv.index("--path")
+        if idx + 1 < len(argv):
+            path = argv[idx + 1]
+    if path is None and not sys.stdin.isatty():
+        path = file_path_from_stdin()
+    if not path:
+        return 0  # nothing to evaluate; silent no-op (never block an edit)
+
+    rules = matching_rules(path)
+    if not rules:
+        return 0  # non-matching path -> silent
+
+    sys.stdout.write(render(path, rules) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/agentic-os/bin/validate_agents.py
+++ b/agentic-os/bin/validate_agents.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""validate_agents.py - enforce the declarative tool-surface safety boundary.
+
+MYC-254. A read-only agent (role planner / reviewer / research, or `readonly: true`)
+MUST NOT declare a mutating tool (Write / Edit / MultiEdit / NotebookEdit / Bash).
+Claude Code restricts a subagent to exactly its `tools:` list, so a tool absent
+from the list cannot be called - absence IS the enforcement. This validator makes
+that invariant checkable and FAILS LOUD on a violation, so a "read-only" planner
+that lies about its tools never ships.
+
+Usage:
+    validate_agents.py <agents-dir> [<agents-dir> ...]
+
+Exit 0  every agent spec is clean (or the dir holds no specs).
+Exit 1  at least one violation (printed to stderr).
+Exit 2  bad input (missing / unreadable directory).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+MUTATING_TOOLS = {"Write", "Edit", "MultiEdit", "NotebookEdit", "Bash"}
+READONLY_ROLES = {"planner", "reviewer", "research", "researcher"}
+
+
+def split_frontmatter(text):
+    """Return the list of frontmatter lines between the first two `---`, or None."""
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return None
+    body = []
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            return body
+        body.append(lines[i])
+    return None  # unterminated frontmatter == not a valid spec
+
+
+def parse_frontmatter(fm_lines):
+    """Tiny YAML subset: `key: value` plus block lists (`key:` then `  - item`)."""
+    data = {}
+    i = 0
+    n = len(fm_lines)
+    while i < n:
+        line = fm_lines[i].strip()
+        i += 1
+        if not line or line.startswith("#") or ":" not in line:
+            continue
+        key, _, val = line.partition(":")
+        key = key.strip()
+        val = val.strip()
+        if val == "":
+            items = []
+            while i < n and fm_lines[i].lstrip().startswith("- "):
+                items.append(fm_lines[i].lstrip()[2:].strip())
+                i += 1
+            data[key] = items if items else ""
+        else:
+            data[key] = val
+    return data
+
+
+def parse_tools(value):
+    """Accept an inline `[A, B]` list, an already-parsed block list, or a scalar."""
+    if isinstance(value, list):
+        return [v.strip().strip("\"'") for v in value if v.strip()]
+    v = value.strip()
+    if v.startswith("[") and v.endswith("]"):
+        return [t.strip().strip("\"'") for t in v[1:-1].split(",") if t.strip()]
+    if v == "":
+        return []
+    return [v.strip("\"'")]
+
+
+def validate_file(path):
+    """Return (is_agent_spec, [violations]) for one markdown file."""
+    text = path.read_text(encoding="utf-8")
+    fm = split_frontmatter(text)
+    if fm is None:
+        return (False, [])
+    data = parse_frontmatter(fm)
+    if "name" not in data:
+        return (False, [])  # frontmatter doc that is not an agent spec (e.g. README)
+
+    rel = path.name
+    violations = []
+
+    model = data.get("model", "")
+    if not (isinstance(model, str) and model.strip()):
+        violations.append(f"{rel}: missing `model:` pin (every agent must pin a model)")
+
+    if "tools" not in data:
+        violations.append(f"{rel}: missing `tools:` (declare the exact tool surface)")
+        return (True, violations)
+    tools = parse_tools(data["tools"])
+    if not tools:
+        violations.append(f"{rel}: empty `tools:` list")
+        return (True, violations)
+
+    role = data.get("role", "")
+    role = role.strip().lower() if isinstance(role, str) else ""
+    readonly_flag = str(data.get("readonly", "")).strip().lower() in {"true", "yes", "1"}
+    is_readonly = role in READONLY_ROLES or readonly_flag
+
+    declared_mutators = sorted(set(tools) & MUTATING_TOOLS)
+    if is_readonly and declared_mutators:
+        violations.append(
+            f"{rel}: read-only role '{role or 'readonly'}' declares mutating tool(s) "
+            f"{declared_mutators} - a read-only agent must not be able to "
+            f"{', '.join(declared_mutators)}"
+        )
+    return (True, violations)
+
+
+def main(argv):
+    dirs = argv[1:]
+    if not dirs:
+        sys.stderr.write("usage: validate_agents.py <agents-dir> [...]\n")
+        return 2
+
+    specs = []
+    for d in dirs:
+        p = Path(d)
+        if not p.exists():
+            sys.stderr.write(f"validate_agents: no such directory: {d}\n")
+            return 2
+        if p.is_dir():
+            specs.extend(sorted(p.glob("*.md")))
+        else:
+            specs.append(p)
+
+    all_violations = []
+    checked = 0
+    for spec in specs:
+        is_spec, violations = validate_file(spec)
+        if not is_spec:
+            continue
+        checked += 1
+        all_violations.extend(violations)
+
+    if all_violations:
+        sys.stderr.write("validate_agents: FAIL - declarative tool-surface boundary violated\n")
+        for v in all_violations:
+            sys.stderr.write(f"  - {v}\n")
+        return 1
+
+    if checked == 0:
+        sys.stderr.write("validate_agents: no agent specs found (nothing to check)\n")
+        return 0
+
+    print(f"validate_agents: OK - {checked} agent spec(s) clean")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/agentic-os/contexts/dev.md
+++ b/agentic-os/contexts/dev.md
@@ -1,0 +1,19 @@
+---
+name: dev
+posture: build
+description: Default building posture — implement, edit, run, iterate.
+---
+
+# Posture: dev
+
+You are building. Optimize for a correct, small, verified change.
+
+- **Plan first** for anything non-trivial: route to `planner`, then `resolver`.
+- **Smallest change** that satisfies the requirement. Match surrounding style.
+- **Run the per-language checks** the paths-scoped rules surface for files you
+  touch (typecheck, format, lint) before claiming done.
+- **Verify behavior, not types.** Run the test or command; read the output.
+- **TDD is the floor** for non-trivial logic: one failing test before the code.
+
+Switch out of this posture for critique (`review`), investigation (`research`),
+or hardening (`security`).

--- a/agentic-os/contexts/research.md
+++ b/agentic-os/contexts/research.md
@@ -1,0 +1,21 @@
+---
+name: research
+posture: investigate
+description: Investigate and explain — read-only, no edits, evidence-cited.
+---
+
+# Posture: research
+
+You are investigating, not changing. Edits are off the table in this posture.
+
+- **Answer from the code**, not from memory. Open the files; trace the calls.
+- **Cite** every claim with a `file:line` so it can be checked.
+- **Map before you conclude:** what calls what, where state lives, which seam
+  carries the contract.
+- **Surface uncertainty** instead of guessing. "I did not verify X" beats a
+  confident wrong answer.
+- **No mutation.** If the investigation implies a change, hand the finding to
+  `planner` and switch to `dev` posture to act on it.
+
+Return a structured explanation: the answer, the evidence, and the one open
+question that would most change the conclusion.

--- a/agentic-os/contexts/review.md
+++ b/agentic-os/contexts/review.md
@@ -1,0 +1,21 @@
+---
+name: review
+posture: critique
+description: Critique a change before it ships — correctness, security, conventions.
+---
+
+# Posture: review
+
+You are critiquing, not building. Find what is wrong; do not silently fix it.
+
+- **Read intent first**, then judge against it.
+- **Priority order:** correctness bugs → security (injection, auth bypass, SSRF,
+  secret leakage) → convention drift. A style nit never outranks a real bug.
+- **Trace the worst-case input** through the change.
+- **Check the seam:** does the producer match the consumer? Verify the end-to-end
+  path, not two isolated units.
+- **Report, don't patch.** Hand confirmed fixes to `resolver`; route through
+  `dev` posture to apply them.
+
+Findings: `severity` + `file:line` + what's wrong + smallest fix. Say "nothing
+real" plainly rather than inventing findings.

--- a/agentic-os/contexts/security.md
+++ b/agentic-os/contexts/security.md
@@ -1,0 +1,24 @@
+---
+name: security
+posture: adversarial
+description: Threat-model and harden a surface — think like an attacker, fail closed.
+---
+
+# Posture: security
+
+You are the adversary now. Assume input is hostile and the happy path is a
+distraction.
+
+- **Enumerate the surface:** every input, every external call, every place a
+  secret or PII could flow.
+- **Five lenses on any LLM/agent surface:** input validation, retrieval, dialog,
+  execution (tool authority), output. Name the missing rail for each stage.
+- **Trace an attacker-controlled string** end to end: injection, traversal, SSRF,
+  auth bypass, secret exfiltration.
+- **Fail closed.** A guard that errors should deny, not pass. A loader that can't
+  evaluate a rule should warn loudly, never silently no-op.
+- **Every guard ships a negative control** — a test that proves it BLOCKS its
+  target, not just that it passes on clean input.
+
+Return: the threat surfaces, the concrete attack for each, and the smallest
+fail-closed mitigation. Hand fixes to `resolver` via `dev` posture.

--- a/agentic-os/data/README.md
+++ b/agentic-os/data/README.md
@@ -1,0 +1,19 @@
+# data/ — durable project memory
+
+This directory is where your agentic OS remembers things across sessions. The
+kernel reads it at the start of non-trivial work and writes decisions here so the
+next session inherits them instead of rediscovering them.
+
+Suggested layout (create as you need them):
+
+- `decisions/` — one file per hard-to-reverse decision: what, why, the trade-off,
+  and the date. The next session reads these before re-litigating a settled call.
+- `context.md` — the project's ubiquitous language: the terms your team uses and
+  exactly what they mean, so the model never paraphrases a canonical name.
+- `glossary.md` — domain terms an outsider would not know.
+
+Keep entries short and factual. This is a log the agents trust, so never write a
+claim here you have not verified.
+
+`.gitkeep` keeps the directory tracked while it is empty — delete it once you add
+real content.

--- a/agentic-os/kernel/CLAUDE.md
+++ b/agentic-os/kernel/CLAUDE.md
@@ -1,0 +1,61 @@
+# Kernel
+
+This file is the **kernel** of your agentic OS. It is small and declarative on
+purpose: it routes work to specialist agents and posture modes, it does not do
+the work itself. Keep it under 100 lines. Detail lives in the files it points to,
+never inline here.
+
+## Role: orchestrator (COO)
+
+You are the orchestrator. Your job is to read the request, pick the right
+specialist, and delegate. You plan and route; the agents execute. Bias toward
+delegation over doing everything in the main thread.
+
+- **Decompose** a task into the smallest specialist-sized pieces.
+- **Delegate** each piece to the agent whose tool surface fits (see routing).
+- **Verify** the result before accepting it. Never ship an unverified claim.
+- **Stay small**: if this kernel grows past 100 lines, move detail into an
+  agent, a context, or a rule file and leave a one-line pointer here.
+
+## Routing (work type → agent)
+
+Pick the most specific match. Agents live in `.claude/agents/`.
+
+| Work | Agent | Tool surface |
+|---|---|---|
+| Plan / design / decompose / break down a task | `planner` | read-only |
+| Review / critique / find bugs / audit a diff | `reviewer` | read-only |
+| Implement / edit files / run commands / fix | `resolver` | read + write |
+
+A read-only agent **cannot** mutate your repo — that is enforced by its declared
+`tools:` list, not by good intentions (see `.claude/agents/README` and the
+validator at `.claude/hooks/validate_agents.py`).
+
+## Posture (how to operate right now)
+
+Posture modes live in `.claude/contexts/`. Load one mid-session to change how you
+work without a full skill invocation: say "switch to <mode>" and read that file.
+
+| Mode | Use it when |
+|---|---|
+| `dev` | building or changing code |
+| `review` | critiquing a change before it ships |
+| `research` | investigating, read-only, no edits |
+| `security` | threat-modeling or hardening a surface |
+
+## Per-language rules (auto-applied)
+
+Quality rules live in `.claude/rules/<lang>/hooks.md`, each scoped by a `paths:`
+glob. When you edit a file, the matching language rules apply automatically — the
+`paths_scoped_rules` hook surfaces them. You do not wire rules per file; the glob
+does it. Add a language by dropping a new `rules/<lang>/hooks.md`.
+
+## Memory
+
+Durable project state lives in `data/` (decisions, context, notes). Read it at the
+start of non-trivial work; write decisions there so the next session inherits them.
+
+---
+
+This kernel is a template. Replace this section with your project's one-paragraph
+mission so every agent inherits the same context. Keep that paragraph short.

--- a/agentic-os/rules/python/hooks.md
+++ b/agentic-os/rules/python/hooks.md
@@ -1,0 +1,20 @@
+---
+name: python
+paths: ["**/*.py"]
+description: Quality rules applied automatically to Python files on edit.
+---
+
+# Python rules
+
+These apply automatically when you edit a `.py` file — the `paths_scoped_rules`
+hook matches the glob above and surfaces this block. No per-file wiring.
+
+- **Lint clean.** `ruff check` (or flake8) passes on touched files.
+- **Types check** where annotated: `mypy` / `pyright` on the module you edited.
+- **No `print()` debugging** and no stray `breakpoint()` in committed code.
+- **`from __future__ import annotations`** if the project targets Python < 3.10
+  and you use `X | None` syntax in annotations.
+- **No bare `except:`** — catch the specific exception; never swallow silently.
+
+Tune this list to your stack. The glob (`paths:`) decides which files it governs;
+edit the glob, not the wiring.

--- a/agentic-os/rules/typescript/hooks.md
+++ b/agentic-os/rules/typescript/hooks.md
@@ -1,0 +1,21 @@
+---
+name: typescript
+paths: ["**/*.ts", "**/*.tsx"]
+description: Quality rules applied automatically to TypeScript files on edit.
+---
+
+# TypeScript rules
+
+These apply automatically when you edit a `.ts` / `.tsx` file — the
+`paths_scoped_rules` hook matches the glob above and surfaces this block. No
+per-file wiring.
+
+- **Types must check.** `tsc --noEmit` passes — no type errors, no new `any`.
+- **Format.** `prettier --check` (or your formatter) on touched files.
+- **No `console.log`** in committed code — use the project logger.
+- **No `// @ts-ignore`** without a one-line reason on the same line.
+- **Imports resolve.** No unused imports; no deep relative `../../../` when an
+  alias exists.
+
+Tune this list to your stack. The glob (`paths:`) decides which files it governs;
+edit the glob, not the wiring.

--- a/agentic-os/tests/fixtures/bad_planner.md
+++ b/agentic-os/tests/fixtures/bad_planner.md
@@ -1,0 +1,14 @@
+---
+name: planner
+description: NEGATIVE CONTROL — a read-only planner role that wrongly declares mutating tools. validate_agents.py MUST reject this. It exists only to prove the guard fails on a violation; it is never installed.
+role: planner
+tools: [Read, Grep, Glob, Write, Edit]
+model: opus
+---
+
+# Bad planner (fixture)
+
+This file is a poisoned fixture. A `role: planner` is declared read-only, but its
+`tools:` list includes `Write` and `Edit` — a contradiction that would hand the
+"read-only" planner real mutation authority. `validate_agents.py` must FAIL on it.
+If the validator ever passes this, the declarative tool-surface boundary is dead.

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -112,6 +112,7 @@ INTEGRATION_TESTS=(
   test_machinery_sidecar
   test_relocate_vault
   test_renderer_crash_guard
+  test_agentic_os
 )
 echo "==> (b) Shell integration: ${#INTEGRATION_TESTS[@]} tests"
 for t in "${INTEGRATION_TESTS[@]}"; do

--- a/scripts/test-agentic-os.sh
+++ b/scripts/test-agentic-os.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+#
+# scripts/test-agentic-os.sh - invariant + negative-control suite for the
+# agentic-os/ client install primitive (MYC-254).
+#
+# It exercises the REAL template under agentic-os/ plus poisoned fixtures, so the
+# two declarative safety invariants are proven to FAIL on a violation (not just
+# pass on the happy path - a guard only seen pass is worthless):
+#
+#   - a read-only planner that declares a mutating tool (Write) is REJECTED;
+#   - a paths-scoped rule matches the right language and stays silent on a non-match.
+#
+# Plus an install smoke (INSTALL.sh drops the full layout into a fresh target) and
+# the declarative-kernel discipline (kernel + each agent < 100 lines).
+#
+# Wired into scripts/ci.sh via tests/integration/test_agentic_os.sh.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+AOS="$ROOT/agentic-os"
+PY="${PYTHON:-python3}"
+
+pass=0
+fail=0
+note() { printf '       %s\n' "$1"; }
+ok()   { pass=$((pass + 1)); printf 'ok   - %s\n' "$1"; }
+bad()  { fail=$((fail + 1)); printf 'FAIL - %s\n' "$1"; }
+
+tmp_bad="$(mktemp -d)"
+tmp_target="$(mktemp -d)"
+cleanup() { rm -rf "$tmp_bad" "$tmp_target"; }
+trap cleanup EXIT
+
+# ---- 1. validator: the real agents/ pass (planner/reviewer read-only, resolver read-write)
+if "$PY" "$AOS/bin/validate_agents.py" "$AOS/agents" >/dev/null 2>&1; then
+  ok "validate_agents: real agents/ pass"
+else
+  bad "validate_agents: real agents/ should pass but did not"
+  "$PY" "$AOS/bin/validate_agents.py" "$AOS/agents" 2>&1 | sed 's/^/       /' || true
+fi
+
+# ---- 2. NEGATIVE CONTROL: a read-only planner that declares Write is REJECTED
+cp "$AOS/tests/fixtures/bad_planner.md" "$tmp_bad/planner.md"
+if "$PY" "$AOS/bin/validate_agents.py" "$tmp_bad" >/dev/null 2>&1; then
+  bad "NEGATIVE CONTROL: a read-only planner declaring Write was ACCEPTED (guard is dead)"
+else
+  ok "NEGATIVE CONTROL: read-only planner declaring Write is REJECTED"
+fi
+
+# ---- 3. paths-scoped rule matches the right language
+ts_out="$("$PY" "$AOS/bin/paths_scoped_rules.py" --path src/components/Button.ts 2>/dev/null || true)"
+if printf '%s' "$ts_out" | grep -q "typescript"; then
+  ok "paths_scoped_rules: **/*.ts surfaces the typescript rule"
+else
+  bad "paths_scoped_rules: **/*.ts did not surface the typescript rule"
+fi
+py_out="$("$PY" "$AOS/bin/paths_scoped_rules.py" --path app/main.py 2>/dev/null || true)"
+if printf '%s' "$py_out" | grep -q "python"; then
+  ok "paths_scoped_rules: **/*.py surfaces the python rule"
+else
+  bad "paths_scoped_rules: **/*.py did not surface the python rule"
+fi
+
+# ---- 4. NEGATIVE CONTROL: a non-code path surfaces NO language rule (silent, exit 0)
+md_out="$("$PY" "$AOS/bin/paths_scoped_rules.py" --path notes/todo.md 2>/dev/null || true)"
+if [ -z "$md_out" ]; then
+  ok "NEGATIVE CONTROL: non-code path surfaces no rule (silent no-op)"
+else
+  bad "NEGATIVE CONTROL: non-code path wrongly surfaced a rule: $md_out"
+fi
+
+# ---- 5. install smoke: INSTALL.sh drops the full layout into a fresh target
+bash "$AOS/INSTALL.sh" "$tmp_target" >/dev/null 2>&1 || true
+expect=(
+  "CLAUDE.md"
+  ".claude/agents/planner.md"
+  ".claude/agents/reviewer.md"
+  ".claude/agents/resolver.md"
+  ".claude/contexts/dev.md"
+  ".claude/contexts/review.md"
+  ".claude/contexts/research.md"
+  ".claude/contexts/security.md"
+  ".claude/rules/typescript/hooks.md"
+  ".claude/rules/python/hooks.md"
+  ".claude/hooks/paths_scoped_rules.py"
+  "data/README.md"
+)
+missing=0
+for rel in "${expect[@]}"; do
+  if [ ! -f "$tmp_target/$rel" ]; then
+    note "missing after install: $rel"
+    missing=$((missing + 1))
+  fi
+done
+if [ "$missing" -eq 0 ]; then
+  ok "INSTALL.sh: full layout (kernel + 3 agents + 4 contexts + 2 lang rules + hook + data) dropped"
+else
+  bad "INSTALL.sh: $missing expected file(s) missing"
+fi
+
+# ---- 6. installed agents still validate clean (the dropped specs keep the safety boundary)
+if "$PY" "$AOS/bin/validate_agents.py" "$tmp_target/.claude/agents" >/dev/null 2>&1; then
+  ok "post-install: dropped agents/ validate clean (tool-surface boundary survived the copy)"
+else
+  bad "post-install: dropped agents/ failed validation"
+fi
+
+# ---- 7. declarative-kernel discipline: kernel + each agent < 100 lines
+overflow=0
+while IFS= read -r f; do
+  n="$(wc -l <"$f" | tr -d ' ')"
+  if [ "$n" -ge 100 ]; then
+    note "over 100 lines ($n): ${f#"$AOS"/}"
+    overflow=$((overflow + 1))
+  fi
+done < <(find "$AOS/agents" "$AOS/kernel" -name '*.md')
+if [ "$overflow" -eq 0 ]; then
+  ok "declarative-kernel discipline: kernel + each agent under 100 lines"
+else
+  bad "$overflow kernel/agent file(s) >= 100 lines"
+fi
+
+echo
+echo "agentic-os suite: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/tests/integration/test_agentic_os.sh
+++ b/tests/integration/test_agentic_os.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# CI integration wrapper - runs the agentic-os/ install-primitive invariant +
+# negative-control suite (scripts/test-agentic-os.sh) as part of scripts/ci.sh.
+# Thin: logic lives next to the template it exercises.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+exec bash "$ROOT/scripts/test-agentic-os.sh"


### PR DESCRIPTION
A one-command install pack that drops a small, declarative "agentic OS" into any repo: the four ECC-derived primitives, generic and personal-data-free.

## What lands

- `kernel/CLAUDE.md`: a small COO/orchestrator with a markdown routing table, kept under 100 lines.
- `agents/{planner,reviewer,resolver}.md`: one specialist per file, each with a pinned `model` and a pinned `tools` surface. `planner` and `reviewer` are read-only (`Read, Grep, Glob`) and so cannot `Write` by construction; `resolver` is the only write-capable agent.
- `contexts/{dev,review,research,security}.md`: user-selectable posture modes.
- `rules/{typescript,python}/hooks.md`: quality rules scoped by a `paths:` glob that auto-apply on a matching edit, with zero per-file config.
- `bin/validate_agents.py` and `bin/paths_scoped_rules.py`: the two enforcement mechanisms.
- `INSTALL.sh`: drops the full layout into a target repo.

## The boundaries are checkable, not just documented

`validate_agents.py` rejects a read-only role that declares a mutating tool (a `role: planner` listing `Write`) or an agent missing its `model` pin. `paths_scoped_rules.py` surfaces the matching language rules for an edited path and stays silent (fail-open) on a non-match. Both ship with a negative control in `scripts/test-agentic-os.sh` (wired into the `INTEGRATION_TESTS` allow-list in `scripts/ci.sh`) that proves each guard fails on a violation, not just passes on clean input.

Pure Python, no LLM calls, Python 3.9-clean, shellcheck-clean.

🤖 Authored by Claude Code (Opus 4.8) for MYC-254.
