### PR TITLE
fix(agentic-os): auto-apply hook must surface via additionalContext + validate model alias (MYC-254)

### DIFF
--- a/agentic-os/bin/paths_scoped_rules.py
+++ b/agentic-os/bin/paths_scoped_rules.py
@@ -120,21 +120,38 @@ def file_path_from_stdin():
 
 
 def main(argv):
-    path = None
+    # CLI mode (--path) prints plain text for a human / CI. Hook mode (stdin tool
+    # JSON) MUST emit the PostToolUse additionalContext envelope: plain stdout from
+    # a hook is NOT surfaced to the model, so a bare print would make the rule
+    # auto-apply cosmetic. The arriving input decides the mode.
+    cli_path = None
     if "--path" in argv:
         idx = argv.index("--path")
         if idx + 1 < len(argv):
-            path = argv[idx + 1]
-    if path is None and not sys.stdin.isatty():
-        path = file_path_from_stdin()
-    if not path:
-        return 0  # nothing to evaluate; silent no-op (never block an edit)
+            cli_path = argv[idx + 1]
 
+    if cli_path is not None:
+        rules = matching_rules(cli_path)
+        if rules:
+            sys.stdout.write(render(cli_path, rules) + "\n")
+        return 0
+
+    # Hook mode: read the edited path from the PostToolUse tool JSON on stdin.
+    if sys.stdin.isatty():
+        return 0  # no --path and no piped input: nothing to evaluate
+    path = file_path_from_stdin()
+    if not path:
+        return 0  # malformed / missing file_path -> fail open, never block the edit
     rules = matching_rules(path)
     if not rules:
-        return 0  # non-matching path -> silent
+        return 0  # non-matching path -> emit nothing (no context added)
 
-    sys.stdout.write(render(path, rules) + "\n")
+    sys.stdout.write(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PostToolUse",
+            "additionalContext": render(path, rules),
+        }
+    }) + "\n")
     return 0
 
 

--- a/agentic-os/bin/validate_agents.py
+++ b/agentic-os/bin/validate_agents.py
@@ -22,6 +22,14 @@ from pathlib import Path
 
 MUTATING_TOOLS = {"Write", "Edit", "MultiEdit", "NotebookEdit", "Bash"}
 READONLY_ROLES = {"planner", "reviewer", "research", "researcher"}
+# Claude Code accepts the bare aliases or a full model id; an invalid value has no
+# documented safe fallback, so a typo would silently mis-pin. `_model_ok` rejects it.
+MODEL_ALIASES = {"opus", "sonnet", "haiku", "inherit"}
+
+
+def _model_ok(model):
+    m = model.strip().lower()
+    return m in MODEL_ALIASES or m.startswith("claude-")
 
 
 def split_frontmatter(text):
@@ -89,6 +97,11 @@ def validate_file(path):
     model = data.get("model", "")
     if not (isinstance(model, str) and model.strip()):
         violations.append(f"{rel}: missing `model:` pin (every agent must pin a model)")
+    elif not _model_ok(model):
+        violations.append(
+            f"{rel}: invalid `model:` value '{model.strip()}' - use opus/sonnet/haiku/inherit "
+            f"or a full claude-* id (an invalid alias has no documented fallback)"
+        )
 
     if "tools" not in data:
         violations.append(f"{rel}: missing `tools:` (declare the exact tool surface)")

--- a/agentic-os/tests/fixtures/bad_model/agent.md
+++ b/agentic-os/tests/fixtures/bad_model/agent.md
@@ -1,0 +1,13 @@
+---
+name: typo-model
+description: NEGATIVE CONTROL — an agent whose model: is not a valid Claude Code alias. validate_agents.py MUST reject it; Claude Code does not document a safe fallback for an invalid model value, so a typo would silently mis-pin. Never installed.
+role: reviewer
+tools: [Read, Grep, Glob]
+model: gpt4o
+---
+
+# Bad model (fixture)
+
+`model: gpt4o` is not a valid Claude Code model alias (`opus` / `sonnet` / `haiku`
+/ `inherit`, or a full `claude-*` id). The validator must FAIL on it so a typo
+never ships a silently mis-pinned agent.

--- a/scripts/test-agentic-os.sh
+++ b/scripts/test-agentic-os.sh
@@ -121,6 +121,32 @@ else
   bad "$overflow kernel/agent file(s) >= 100 lines"
 fi
 
+# ---- 8. HOOK MODE surfaces to the model: stdin tool JSON -> hookSpecificOutput.additionalContext
+# A PostToolUse hook only reaches the model via the additionalContext envelope; plain
+# stdout is NOT read. This asserts the matched rule is delivered in the real envelope.
+hook_out="$(printf '%s' '{"tool_input":{"file_path":"src/x.ts"}}' | "$PY" "$AOS/bin/paths_scoped_rules.py" 2>/dev/null || true)"
+if printf '%s' "$hook_out" | "$PY" -c 'import sys,json; d=json.load(sys.stdin); ac=d.get("hookSpecificOutput",{}).get("additionalContext",""); sys.exit(0 if "typescript" in ac else 1)' 2>/dev/null; then
+  ok "hook mode: tool JSON -> hookSpecificOutput.additionalContext carries the matched rule (reaches the model)"
+else
+  bad "hook mode: matched rule NOT delivered via hookSpecificOutput.additionalContext (auto-apply would be cosmetic)"
+  printf '       got: %s\n' "$hook_out"
+fi
+
+# ---- 9. NEGATIVE CONTROL: hook mode on a non-code edit emits nothing (no envelope, exit 0)
+hook_md="$(printf '%s' '{"tool_input":{"file_path":"notes/todo.md"}}' | "$PY" "$AOS/bin/paths_scoped_rules.py" 2>/dev/null || true)"
+if [ -z "$hook_md" ]; then
+  ok "hook mode NEGATIVE CONTROL: non-code edit emits no envelope (silent, never blocks the edit)"
+else
+  bad "hook mode NEGATIVE CONTROL: non-code edit wrongly emitted: $hook_md"
+fi
+
+# ---- 10. NEGATIVE CONTROL: validate_agents rejects an invalid model alias (would silently misfire)
+if "$PY" "$AOS/bin/validate_agents.py" "$AOS/tests/fixtures/bad_model" >/dev/null 2>&1; then
+  bad "NEGATIVE CONTROL: an agent with an invalid model: value was ACCEPTED (typo would silently mis-pin)"
+else
+  ok "NEGATIVE CONTROL: invalid model: alias is REJECTED (no silent fallback on a typo)"
+fi
+
 echo
 echo "agentic-os suite: $pass passed, $fail failed"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
Follow-up correctness fix after verifying actual Claude Code harness behavior.

**Bug:** `paths_scoped_rules.py` wrote plain stdout in hook mode. A `PostToolUse` hook's plain stdout is NOT surfaced to the model, so 'rules auto-apply on edit' was cosmetic in a live install. Now emits the documented `{"hookSpecificOutput": {"hookEventName": "PostToolUse", "additionalContext": …}}` envelope; `--path` CLI mode still prints plain text.

**Hardening:** `validate_agents.py` now rejects an invalid `model:` value (only `opus`/`sonnet`/`haiku`/`inherit` or a full `claude-*` id) — Claude Code documents no safe fallback for a typo, so a mis-pinned model would fail silently.

Adds 3 assertions to `scripts/test-agentic-os.sh` (now 11), including 2 negative controls: the envelope carries the matched rule, a non-code edit stays silent, and an invalid model alias is rejected. Pure Python, 3.9-clean, shellcheck-clean.

🤖 Authored by Claude Code (Opus 4.8) for MYC-254.