### PR TITLE
fix(session-close): fail-safe verify-cascade hook + wire it (follow-up #173)

### DIFF
--- a/hooks.json
+++ b/hooks.json
@@ -86,6 +86,12 @@
             "type": "command",
             "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/coach-auto-prescribe-on-journal.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'",
             "statusMessage": "Coach auto-prescribe (post-journal, idempotent)..."
+          },
+          {
+            "_comment": "Hard-block gate, but FAIL-SAFE: enforcement is conditional on the session-close cascade being installed (<meta>/scripts/session-close-runner.sh). No runner -> advisory only, never blocks. Wired with an if/then/else (NOT '|| echo') so a real block (exit 2) propagates instead of being masked to 0; the [ -f ] guard passes cleanly if the script is missing on a divergent fork. Overrides: VERIFY_CASCADE_BYPASS=1 (skip), VERIFY_CASCADE_SOFT=1 (advisory).",
+            "type": "command",
+            "command": "if [ -f ~/.claude/skills/ai-brain-starter/hooks/verify-session-close-cascade.py ]; then python3 ~/.claude/skills/ai-brain-starter/hooks/verify-session-close-cascade.py; else echo '{\"continue\":true,\"suppressOutput\":true}'; fi",
+            "statusMessage": "Verifying session-close cascade (advisory unless the cascade is installed)..."
           }
         ]
       }

--- a/hooks/verify-session-close-cascade.py
+++ b/hooks/verify-session-close-cascade.py
@@ -13,7 +13,7 @@ Failure modes this prevents:
     permanent."
 
 Three-gate check when a closing claim is detected:
-  1. Session file exists at ⚙️ Meta/Sessions/YYYY-MM-DD*<worktree>*.md
+  1. Session file exists at <meta>/Sessions/YYYY-MM-DD*<worktree>*.md
   2. session-close-runner.sh ran in the last 30 min — verified via
      /tmp/abs-session-close-runner.report ending in `RUNNER COMPLETE @ <ts>`.
   3. No uncommitted session-close artifacts (today's Sessions/Decisions/
@@ -27,9 +27,23 @@ warnings; block at the model layer.
 
 Spanish closing patterns added 2026-05-13 — the same session's goodbye
 ("Que descanses, Ade") slipped past the English-only regex, so the
-two-gate check never even fired.
+three-gate check never even fired.
 
-Bypass: VERIFY_CASCADE_BYPASS=1.
+FAIL-SAFE / conditional enforcement (so this hook is safe to wire by
+default for every vault):
+  - The hard-block (exit 2) is gated on the session-close cascade actually
+    being INSTALLED in this vault — i.e. <meta>/scripts/session-close-runner.sh
+    exists. If it does NOT, the vault never opted into the cascade and the
+    hook NEVER blocks; it degrades to a non-blocking advisory. This prevents
+    the "missing runner blocks every close forever" failure: gate 2 can only
+    fire against a runner that is actually present to run.
+  - When the runner IS installed, the user has opted into the close
+    machinery, so all three gates get teeth.
+
+Bypass / overrides:
+  - VERIFY_CASCADE_BYPASS=1  — skip the check entirely (no block, no advisory).
+  - VERIFY_CASCADE_SOFT=1    — force advisory mode even when the runner is
+                               installed (warn, never block).
 """
 
 import json
@@ -40,9 +54,52 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 VAULT_ROOT = Path(os.environ.get("VAULT_ROOT", str(Path.home() / "vault")))
-SESSIONS_DIR = VAULT_ROOT / "⚙️ Meta" / "Sessions"
-RUNNER_REPORT = Path("/tmp/abs-session-close-runner.report")
+
+
+def _find_meta_dir(vault_root: Path) -> Path:
+    """Deterministically resolve THIS vault's human-memory Meta folder.
+
+    Mirrors hooks/detect-closing-signal.py — decorated "⚙️ Meta" is probed
+    BEFORE plain "Meta". Vaults intentionally run two meta folders: "⚙️ Meta"
+    (human memory: Sessions/, Decisions/) and plain "Meta" (instinct-engine
+    machine memory). A naive `sorted(iterdir())[0]` picks plain "Meta" first
+    (the letter M sorts before the emoji codepoint), which would point this
+    hook's session-file + runner checks at the wrong folder. The explicit
+    decorated-first probe avoids that.
+    """
+    for candidate_name in ("⚙️ Meta", "Meta"):
+        candidate = vault_root / candidate_name
+        if candidate.is_dir():
+            return candidate
+    try:
+        for child in sorted(vault_root.iterdir()):
+            if child.is_dir() and child.name.endswith("Meta"):
+                return child
+    except OSError:
+        pass
+    return vault_root / "Meta"
+
+
+META_DIR = _find_meta_dir(VAULT_ROOT)
+META_NAME = META_DIR.name
+SESSIONS_DIR = META_DIR / "Sessions"
+RUNNER_SCRIPT = META_DIR / "scripts" / "session-close-runner.sh"
+# Default is the exact path session-close-runner.sh writes; the env override is
+# for hermetic tests (and any setup where both sides agree to relocate it).
+RUNNER_REPORT = Path(os.environ.get("ABS_RUNNER_REPORT", "/tmp/abs-session-close-runner.report"))
 RUNNER_FRESH_SECONDS = 1800  # 30 minutes
+
+
+def runner_installed() -> bool:
+    """True iff session-close-runner.sh is installed in THIS vault's meta dir.
+
+    This is the fail-safe signal. When the runner is NOT installed, the vault
+    never opted into the session-close cascade, so the hook must NOT hard-block
+    — a missing runner would otherwise block EVERY close forever (the exact
+    failure this fail-safe prevents). Enforcement (hard-block) is gated on this
+    returning True; otherwise the hook degrades to a non-blocking advisory.
+    """
+    return RUNNER_SCRIPT.is_file()
 
 # High-confidence closing-claim patterns. Conservative — only matches when the
 # model is CLAIMING closure, not discussing the rule meta.
@@ -221,7 +278,8 @@ def uncommitted_session_artifacts(worktree_slug: str) -> list[str]:
     try:
         result = subprocess.run(
             ["git", "-C", str(VAULT_ROOT), "status", "--short",
-             "--", "⚙️ Meta/Sessions/", "⚙️ Meta/Decisions/", "⚙️ Meta/Session Captures.md"],
+             "--", f"{META_NAME}/Sessions/", f"{META_NAME}/Decisions/",
+             f"{META_NAME}/Session Captures.md"],
             capture_output=True, text=True, timeout=10,
         )
     except Exception:
@@ -240,11 +298,11 @@ def uncommitted_session_artifacts(worktree_slug: str) -> list[str]:
         if "Session Captures.md" in path:
             captures_unc.append(path)
             continue
-        if "/Sessions/" in path or path.startswith("⚙️ Meta/Sessions/"):
+        if "/Sessions/" in path or path.startswith(f"{META_NAME}/Sessions/"):
             if (today in path or yesterday in path) and worktree_slug and worktree_slug in path:
                 sessions_unc.append(path)
             continue
-        if "/Decisions/" in path or path.startswith("⚙️ Meta/Decisions/"):
+        if "/Decisions/" in path or path.startswith(f"{META_NAME}/Decisions/"):
             if today in path or yesterday in path:
                 if _decision_belongs_to_worktree(path, worktree_slug):
                     decisions_unc.append(path)
@@ -278,6 +336,11 @@ def runner_ran_recently() -> bool:
     # Accept either trailing Z (zulu) or +00:00 offset
     if ts_raw.endswith("Z"):
         ts_raw = ts_raw[:-1] + "+00:00"
+    # Normalize a no-colon UTC offset (e.g. -0500 / +0530) to +05:00 form.
+    # session-close-runner.sh stamps the report with `date '+%z'`, which emits
+    # the no-colon form, but datetime.fromisoformat() rejects it before Python
+    # 3.11 — without this a fresh report parses as stale and spuriously blocks.
+    ts_raw = re.sub(r"([+-]\d{2})(\d{2})$", r"\1:\2", ts_raw)
     try:
         ts = datetime.fromisoformat(ts_raw)
     except Exception:
@@ -308,15 +371,40 @@ def main() -> int:
     if not is_closing_claim(last_text):
         return 0  # no closing claim — skip
 
-    # Two-gate check: BOTH must be true. Single-gate (file-only) was the
-    # 2026-05-11 gallant-kalam miss — session file existed but runner never
-    # ran, so aggregators / Phase 0c-e / worktree settle all silently skipped.
+    # Enforcement (hard-block) is conditional on the session-close cascade
+    # being INSTALLED in this vault — see runner_installed(). This is what
+    # makes the hook safe to wire by default: a vault that never set up the
+    # cascade can always close (the "missing runner blocks every close
+    # forever" failure is structurally impossible). VERIFY_CASCADE_SOFT=1
+    # forces advisory mode even when the runner IS installed.
+    enforce = runner_installed() and os.environ.get("VERIFY_CASCADE_SOFT") != "1"
+
     today = datetime.now().strftime("%Y-%m-%d")
     file_ok = session_file_exists_for_today(worktree_slug)
-    runner_ok = runner_ran_recently()
     uncommitted = uncommitted_session_artifacts(worktree_slug)
     commit_ok = not uncommitted
 
+    if not enforce:
+        # Advisory mode: NEVER block. The only signal worth surfacing without
+        # the cascade is genuinely-uncommitted session artifacts (lost-work
+        # risk). Don't nag about the runner (absent by design here) or the
+        # session file (a non-cascade vault legitimately may not author one).
+        if uncommitted:
+            sample = "\n".join(f"      {p}" for p in uncommitted[:8])
+            more = f"\n      ... and {len(uncommitted) - 8} more" if len(uncommitted) > 8 else ""
+            print(
+                "verify-session-close-cascade (advisory — session-close cascade\n"
+                "not installed in this vault, so NOT blocking):\n"
+                f"  • {len(uncommitted)} uncommitted session artifact(s) at risk:\n"
+                f"{sample}{more}\n"
+                f"    Commit them before closing (e.g. vault-safe-commit.sh), or\n"
+                f"    install the cascade for automatic handling.",
+                file=sys.stderr,
+            )
+        return 0
+
+    # Enforce mode: all three gates must pass; hard-block on any failure.
+    runner_ok = runner_ran_recently()
     if file_ok and runner_ok and commit_ok:
         return 0  # all three gates clear — cascade ran fully
 
@@ -324,7 +412,7 @@ def main() -> int:
     failures = []
     if not file_ok:
         failures.append(
-            f"  • Session file missing at ⚙️ Meta/Sessions/{today}T*-{worktree_slug}.md\n"
+            f"  • Session file missing at {META_NAME}/Sessions/{today}T*-{worktree_slug}.md\n"
             f"    Author it manually (Phase 2 of session-close.md) before retry."
         )
     if not runner_ok:
@@ -332,7 +420,7 @@ def main() -> int:
         failures.append(
             f"  • session-close-runner.sh report is {runner_state}\n"
             f"    Path: {RUNNER_REPORT}\n"
-            f"    Run: bash \"⚙️ Meta/scripts/session-close-runner.sh\"\n"
+            f"    Run: bash \"{META_NAME}/scripts/session-close-runner.sh\"\n"
             f"    The runner handles Phase 0c-0e + Phase 2 aggregators +\n"
             f"    Phase 2c worktree settle deterministically."
         )
@@ -343,7 +431,7 @@ def main() -> int:
             f"  • Session-close artifacts uncommitted ({len(uncommitted)} files):\n"
             f"{sample}{more}\n"
             f"    Run vault-safe-commit.sh BEFORE the goodbye:\n"
-            f"      bash \"⚙️ Meta/scripts/vault-safe-commit.sh\" \\\n"
+            f"      bash \"{META_NAME}/scripts/vault-safe-commit.sh\" \\\n"
             f"        \"session-close: <worktree> — <one-line summary>\" \\\n"
             f"        \"<path1>\" \"<path2>\" ..."
         )
@@ -351,13 +439,14 @@ def main() -> int:
     msg = (
         f"BLOCKED by verify-session-close-cascade hook.\n\n"
         f"Your last response claims to close the session, but the cascade\n"
-        f"did not fully run. Two-gate check (BOTH required):\n\n"
+        f"did not fully run. Three-gate check (ALL required):\n\n"
         + "\n".join(failures) + "\n\n"
         f"Manual phases (not in runner — still your job): Phase 0b\n"
         f"(incomplete-work gate), Phase 1 (conversation scan + Pending\n"
         f"Signals), Phase 2 (session file authorship), Phase 2b\n"
         f"(vault-safe-commit), Phase 3 (functional audit on public ships).\n\n"
-        f"Bypass (use sparingly): VERIFY_CASCADE_BYPASS=1\n"
+        f"Bypass (use sparingly): VERIFY_CASCADE_BYPASS=1 (skip) or\n"
+        f"VERIFY_CASCADE_SOFT=1 (advisory, never block).\n"
     )
     print(msg, file=sys.stderr)
     return 2  # block

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -102,6 +102,7 @@ INTEGRATION_TESTS=(
   test_meta_resolution_guard
   test_split_meta
   test_context_load_selftest
+  test_verify_cascade_failsafe
   test_stranded_session_artifacts_watchdog
   test_session_coordination_guards
   test_trust_prompt_preframing

--- a/scripts/install-hooks-user-level.py
+++ b/scripts/install-hooks-user-level.py
@@ -59,6 +59,7 @@ from pathlib import Path
 # that no third-party hook would accidentally include it.
 ABS_FINGERPRINTS = [
     "ai-brain-starter/hooks/detect-closing-signal.py",
+    "ai-brain-starter/hooks/verify-session-close-cascade.py",
     "ai-brain-starter/hooks/lint-vault-frontmatter.py",
     "ai-brain-starter/hooks/log-skill-usage.py",
     "ai-brain-starter/hooks/first-week-checkin.py",
@@ -94,7 +95,8 @@ ABS_FINGERPRINTS = [
 # SCRIPT BASENAME, else a re-run duplicates every hook a hand-maintained config
 # wired at the user-hooks path. Only OUR script basenames are matched this way.
 ABS_OWNED_BASENAMES = {
-    "detect-closing-signal.py", "lint-vault-frontmatter.py", "log-skill-usage.py",
+    "detect-closing-signal.py", "verify-session-close-cascade.py",
+    "lint-vault-frontmatter.py", "log-skill-usage.py",
     "first-week-checkin.py", "migrate-to-user-level.py",
     "inject-love-language-context.py", "inject-meeting-workflow-on-trigger.py",
     "session-end-hook.sh", "email-gate-hook.py", "graph-context-hook.sh",

--- a/tests/integration/test_verify_cascade_failsafe.sh
+++ b/tests/integration/test_verify_cascade_failsafe.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Test: verify-session-close-cascade.py is FAIL-SAFE and only hard-blocks when
+# the session-close cascade is actually installed in the vault.
+#
+# Bug class: the hook is a hard-block Stop hook whose gate 2 requires a fresh
+# /tmp/abs-session-close-runner.report. If session-close-runner.sh is NOT
+# installed in the vault, that report can never exist, so gate 2 is permanently
+# failed — the hook would block EVERY session close forever. The fix makes
+# enforcement CONDITIONAL on the runner being installed: no runner -> never
+# block (advisory at most); runner present -> full three-gate hard-block.
+#
+# Assertions (the matrix the follow-up brief asked for + the override knobs):
+#   1. fresh vault (no Meta)                  -> never blocks            (exit 0)
+#   2. runner absent (Meta but no runner)     -> never blocks            (exit 0)
+#   3. runner present + incomplete cascade    -> BLOCKS                  (exit 2)
+#   4. runner present + all three gates pass  -> allows close           (exit 0)
+#   5. runner present + VERIFY_CASCADE_SOFT=1 -> advisory, never blocks  (exit 0)
+#   6. runner present + VERIFY_CASCADE_BYPASS -> skipped entirely        (exit 0)
+#   7. not a closing claim                    -> skipped                 (exit 0)
+#   8. closing claim outside a worktree       -> skipped                 (exit 0)
+#   9. runner absent + uncommitted artifacts  -> advisory WARNING        (exit 0)
+#      (also exercises a PLAIN "Meta" vault, proving META_NAME parametrization)
+#
+# Self-contained: tmpdir fake vaults, ABS_RUNNER_REPORT redirected into the
+# tmpdir so the shared /tmp report is never touched. Exit 0 = pass.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOK="$REPO_ROOT/hooks/verify-session-close-cascade.py"
+if [ ! -f "$HOOK" ]; then
+  echo "ERROR: $HOOK not found" >&2
+  exit 1
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+REPORT="$TMP/runner.report"
+TODAY="$(date +%Y-%m-%d)"
+
+# run_hook VAULT CWD TEXT [EXTRA_ENV=val ...] -> echoes the hook's exit code.
+# stdout/stderr land in $TMP/out.txt / $TMP/err.txt for inspection.
+run_hook() {
+  local vault="$1" cwd="$2" text="$3"; shift 3
+  local tpath="$TMP/transcript.jsonl"
+  python3 -c "import json,sys; open(sys.argv[1],'w',encoding='utf-8').write(json.dumps({'type':'assistant','message':{'content':[{'type':'text','text':sys.argv[2]}]}})+'\n')" "$tpath" "$text"
+  local stdin_json
+  stdin_json=$(python3 -c "import json,sys; print(json.dumps({'cwd':sys.argv[1],'transcript_path':sys.argv[2]}))" "$cwd" "$tpath")
+  set +e
+  printf '%s' "$stdin_json" | env -u VERIFY_CASCADE_BYPASS -u VERIFY_CASCADE_SOFT \
+    VAULT_ROOT="$vault" ABS_RUNNER_REPORT="$REPORT" "$@" \
+    python3 "$HOOK" >"$TMP/out.txt" 2>"$TMP/err.txt"
+  local rc=$?
+  set -e
+  echo "$rc"
+}
+
+assert_rc() {  # label expected actual
+  if [ "$2" != "$3" ]; then
+    echo "FAIL: $1 — expected exit $2, got $3" >&2
+    echo "  --- stderr ---" >&2; sed 's/^/  /' "$TMP/err.txt" >&2
+    exit 1
+  fi
+  echo "PASS: $1 (exit $3)"
+}
+
+CLOSING="Closing the session now — that's all for today."
+WORKTREE_CWD() { echo "$1/.claude/worktrees/$2"; }
+
+# --- Fixtures -------------------------------------------------------------
+# Fresh vault: nothing.
+VFRESH="$TMP/fresh"; mkdir -p "$VFRESH"
+# Runner-absent: decorated Meta exists, but no session-close-runner.sh.
+VNORUN="$TMP/norunner"; mkdir -p "$VNORUN/⚙️ Meta/Sessions"
+# Runner-present: the cascade is installed.
+VRUN="$TMP/runner"; mkdir -p "$VRUN/⚙️ Meta/scripts" "$VRUN/⚙️ Meta/Sessions"
+: > "$VRUN/⚙️ Meta/scripts/session-close-runner.sh"
+# Runner-present + all gates satisfied (git-clean, session file, fresh report).
+VPASS="$TMP/pass"; mkdir -p "$VPASS/⚙️ Meta/scripts" "$VPASS/⚙️ Meta/Sessions"
+: > "$VPASS/⚙️ Meta/scripts/session-close-runner.sh"
+echo "session" > "$VPASS/⚙️ Meta/Sessions/${TODAY}T120000-slugpass.md"
+git -C "$VPASS" init -q
+git -C "$VPASS" -c user.email=t@t -c user.name=t add -A
+git -C "$VPASS" -c user.email=t@t -c user.name=t commit -qm init
+# Advisory: PLAIN "Meta" vault (ASCII), git repo, no runner, uncommitted session
+# artifact -> proves the advisory warning path + plain-Meta parametrization.
+# Commit a skeleton FIRST so the repo has tracked history; otherwise an
+# entirely-untracked tree collapses to "?? Meta/" under `git status --short`
+# (real vaults always have history, so a new session file shows individually).
+VADV="$TMP/advisory"; mkdir -p "$VADV/Meta/Sessions"
+git -C "$VADV" init -q
+: > "$VADV/Meta/Sessions/.gitkeep"
+git -C "$VADV" -c user.email=t@t -c user.name=t add -A
+git -C "$VADV" -c user.email=t@t -c user.name=t commit -qm init
+echo "session" > "$VADV/Meta/Sessions/${TODAY}T120000-slugadv.md"   # left untracked
+
+# --- 1. fresh vault: never blocks ----------------------------------------
+rm -f "$REPORT"
+rc=$(run_hook "$VFRESH" "$(WORKTREE_CWD "$VFRESH" slug1)" "$CLOSING")
+assert_rc "fresh vault never blocks" 0 "$rc"
+
+# --- 2. runner absent: never blocks (even with no session file) -----------
+rc=$(run_hook "$VNORUN" "$(WORKTREE_CWD "$VNORUN" slug1)" "$CLOSING")
+assert_rc "runner absent never blocks" 0 "$rc"
+
+# --- 3. runner present + incomplete cascade: BLOCKS -----------------------
+rm -f "$REPORT"   # gate 2: no fresh report
+rc=$(run_hook "$VRUN" "$(WORKTREE_CWD "$VRUN" slug1)" "$CLOSING")
+assert_rc "runner present + incomplete cascade blocks" 2 "$rc"
+if ! grep -q "BLOCKED by verify-session-close-cascade" "$TMP/err.txt"; then
+  echo "FAIL: block message missing from stderr" >&2; exit 1
+fi
+echo "PASS: block emits the diagnostic message"
+
+# --- 4. runner present + all three gates pass: allows close ---------------
+# Fresh report with a no-colon %z offset — also exercises the offset-normalize fix.
+printf 'RUNNER COMPLETE @ %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" > "$REPORT"
+rc=$(run_hook "$VPASS" "$(WORKTREE_CWD "$VPASS" slugpass)" "$CLOSING")
+assert_rc "runner present + all gates pass allows close" 0 "$rc"
+
+# --- 5. runner present + SOFT: advisory, never blocks ---------------------
+rm -f "$REPORT"
+rc=$(run_hook "$VRUN" "$(WORKTREE_CWD "$VRUN" slug1)" "$CLOSING" VERIFY_CASCADE_SOFT=1)
+assert_rc "VERIFY_CASCADE_SOFT never blocks" 0 "$rc"
+
+# --- 6. runner present + BYPASS: skipped entirely -------------------------
+rc=$(run_hook "$VRUN" "$(WORKTREE_CWD "$VRUN" slug1)" "$CLOSING" VERIFY_CASCADE_BYPASS=1)
+assert_rc "VERIFY_CASCADE_BYPASS skips" 0 "$rc"
+
+# --- 7. not a closing claim: skipped --------------------------------------
+rc=$(run_hook "$VRUN" "$(WORKTREE_CWD "$VRUN" slug1)" "Here is the analysis you requested.")
+assert_rc "non-closing claim skipped" 0 "$rc"
+
+# --- 8. closing claim outside a worktree: skipped -------------------------
+rc=$(run_hook "$VRUN" "$VRUN" "$CLOSING")
+assert_rc "closing claim outside worktree skipped" 0 "$rc"
+
+# --- 9. runner absent + uncommitted artifacts: advisory WARNING -----------
+rc=$(run_hook "$VADV" "$(WORKTREE_CWD "$VADV" slugadv)" "$CLOSING")
+assert_rc "advisory mode never blocks on uncommitted artifacts" 0 "$rc"
+if ! grep -qi "advisory" "$TMP/err.txt"; then
+  echo "FAIL: expected an advisory warning about uncommitted artifacts" >&2
+  echo "  --- stderr ---" >&2; sed 's/^/  /' "$TMP/err.txt" >&2
+  exit 1
+fi
+echo "PASS: advisory mode surfaces uncommitted artifacts without blocking"
+
+echo
+echo "All assertions passed. verify-session-close-cascade.py fail-safe holds."


### PR DESCRIPTION
## What

Follow-up #2 from #173. Makes `hooks/verify-session-close-cascade.py` **fail-safe** and wires it into the installer — but as an *advisory unless the cascade is installed*, not a default-on hard block.

## The bug it closes

`verify-session-close-cascade.py` is a hard-block `Stop` hook. Gate 2 requires a fresh `/tmp/abs-session-close-runner.report`. **If `session-close-runner.sh` isn't installed in a vault, that report can never exist → the hook would block every session close, forever.** That's why #173 explicitly deferred wiring it.

## The fix — conditional enforcement (fail-safe by construction)

Enforcement (`exit 2`) is gated on the session-close cascade actually being installed (`<meta>/scripts/session-close-runner.sh`):

- **Runner absent** → the hook **never blocks**. It degrades to a non-blocking advisory that surfaces only *genuinely-uncommitted session artifacts* (lost-work risk). A vault that never opted into the cascade can always close.
- **Runner present** → the user opted into the close machinery, so all three gates get teeth (the intended behavior).
- `VERIFY_CASCADE_SOFT=1` forces advisory mode even with the runner present; `VERIFY_CASCADE_BYPASS=1` (existing) still skips entirely.

This is the "safe for everyone who forks this" default: a missing runner is now *structurally unable* to block a close, and gates 1/3 can't hard-block someone who never set up the cascade.

## Two robustness fixes surfaced by the test

- **Timestamp parse:** `runner_ran_recently()` now normalizes a no-colon UTC offset (`date +%z` emits `-0500`); `datetime.fromisoformat()` rejects that before Python 3.11, so a *fresh* report was parsing as stale and spuriously blocking.
- **Meta resolution:** resolved deterministically (decorated-first, mirroring `detect-closing-signal.py`) instead of hardcoding `⚙️ Meta`, so plain-`Meta` vaults work too. Report path is env-overridable (`ABS_RUNNER_REPORT`) for hermetic tests; defaults to the exact path the runner writes.

## Wiring

- Added to `hooks.json` `Stop` group via an `if [ -f … ]; then python3 …; else echo …; fi` form — **not** `… 2>/dev/null || echo …`, which would mask the blocking `exit 2` to `0`. The `[ -f ]` guard passes cleanly if the script is missing on a divergent fork.
- Registered fingerprint + basename in `install-hooks-user-level.py` so a re-run wires it and `--uninstall` removes it cleanly.

## Verification

- `tests/integration/test_verify_cascade_failsafe.sh` (registered in `ci.sh`) covers the full matrix: fresh-vault / runner-absent / runner-present-block / runner-present-pass / soft / bypass / non-claim / no-worktree / advisory-with-warning (the last on a plain-`Meta` vault). **11/11 pass.**
- `bash -n` + `py_compile` clean. Install / idempotent re-run / uninstall verified against a throwaway temp `settings.json` (never the real one).

## Design note

The brief said "wire it ON." Asked which default was best for everyone, the advisory panel converged on *wire-it-but-gate-enforcement-on-cascade-installed* (above) rather than a default-on hard block — a false positive on gate 1/3 would otherwise leave a stranger unable to end their session with no idea the bypass env var exists. The hook is still fully wired/fingerprinted/uninstallable; it just can't hard-block a vault that didn't opt into the cascade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)