### PR TITLE
feat(sync): idempotent skill→vault script sync (follow-up #173)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -314,6 +314,27 @@ A regression test ships with it (`scripts/test-meta-resolver.sh`, wired into `sc
 
 ---
 
+## 2026-06-07: your vault's own scripts now stay in sync with the repo (they used to silently rot)
+
+**Who this affects:** anyone who set up a vault more than a few updates ago. The helper scripts inside your vault's `⚙️ Meta/scripts/` folder were copied in once, at setup, and never refreshed. So every fix or new script shipped *after* your setup — the session-close runner, the rule-conflict and drift checks, the passive-capture helper — never reached your vault. Your skills updated on `git pull`; your vault scripts didn't.
+
+### The problem
+
+`scripts/sync-skills.sh` keeps your installed skills (`~/.claude/skills/…`) current on every update, but it never touched the *vault* copy of the scripts. Those were only ever written by the setup phases, the first time. Nothing brought an existing vault's `⚙️ Meta/scripts/` back up to date, so it drifted further behind the repo with every release.
+
+### The fix
+
+- **New `scripts/sync-vault-scripts.sh`** — the skill→vault half of the sync. It copies the canonical vault scripts from the repo into your vault's `<meta>/scripts/` with the *same* safety contract as the skill sync: a file you edited locally is backed up to `<file>.bak-YYYY-MM-DD-HHMM` before it's overwritten, a symlinked scripts dir (maintainers editing the repo live) is left untouched, and an identical file is a silent no-op. It finds your vault automatically (`--vault`, `$VAULT_ROOT`, or your `settings.json`), so it runs with no arguments.
+- **It runs automatically on update.** `sync-skills.sh` now calls it at the end, so a `git pull` refreshes your vault scripts the same way it refreshes your skills — no extra step.
+- **`/diagnose`'s partial-install check uses it.** `detect-partial-installs.sh` now checks your whole vault-script set (not just the two aggregators), and `--fix` re-syncs them.
+- The synced set is an explicit, **import-closed** manifest — a script ships only alongside the helper modules it needs, so it can't land half-broken in your vault.
+
+### Verification
+
+`tests/integration/test_vault_script_sync.sh` (wired into `scripts/ci.sh`) proves the manifest is import-closed, a fresh sync populates the folder, a re-run is a no-op, a locally-edited script is backed up before being updated, a symlinked scripts dir is skipped, `--dry-run` writes nothing, and an unresolvable vault is a non-fatal no-op.
+
+---
+
 ## 2026-06-06: Smart Connections is no longer enabled by default (it could crash Obsidian on large vaults)
 
 **Who this affects:** anyone whose vault grows past a few thousand notes. On a large vault, opening Obsidian crashed the renderer repeatedly — a hard `EXC_BREAKPOINT (SIGTRAP)` V8 fatal, CPU pinned — because heavy "indexer" plugins were building full indexes on open and exhausting Obsidian's single renderer process. Smart Connections is the heaviest of them.

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -171,6 +171,7 @@ INTEGRATION_TESTS=(
   test_phase11_writes_to_vault_rule_file
   test_post_commit_ff_worktrees
   test_write_hook_meeting_folder_i18n
+  test_vault_script_sync
 )
 # ---- Gate-coverage invariant -------------------------------------------------
 # The list above is an explicit allow-list, and allow-lists rot: a new

--- a/scripts/detect-partial-installs.sh
+++ b/scripts/detect-partial-installs.sh
@@ -109,25 +109,31 @@ check_json_config() {
   fi
 }
 
-check_vault_aggregators() {
+check_vault_scripts() {
   local vault="$1"
   if [[ ! -d "$vault" ]]; then
     return
   fi
-  # Auto-detect Meta folder via the shared resolver (prefers the variant
-  # containing a known subfolder, so a machine "Meta/" can't shadow "⚙️ Meta/").
-  local meta=""
-  meta="$(python3 "$SCRIPT_DIR/_meta_resolver.py" "$vault" scripts Decisions 2>/dev/null || true)"
-  [[ -z "$meta" ]] && [[ -d "$vault/Meta" ]] && meta="$vault/Meta"
-  if [[ -z "$meta" ]]; then
-    add_issue "info" "vault-meta" "no Meta folder found in $vault (vault may not be set up yet)" "(run /setup-brain)"
+  # Delegate to sync-vault-scripts.sh in --dry-run so the manifest of which
+  # scripts a vault needs lives in ONE place (no drift between detector and
+  # syncer), and so meta-folder resolution is the deterministic decorated-first
+  # one the syncer uses (not a naive *Meta glob that picks plain "Meta" first).
+  local sync
+  sync="$SCRIPT_DIR/sync-vault-scripts.sh"
+  [[ -f "$sync" ]] || sync="$HOME/.claude/skills/ai-brain-starter/scripts/sync-vault-scripts.sh"
+  if [[ ! -f "$sync" ]]; then
     return
   fi
-  for script in "aggregate-sessions.py" "aggregate-decisions.py"; do
-    if [[ ! -f "$meta/scripts/$script" ]]; then
-      add_issue "warn" "vault-aggregator" "$script missing from $meta/scripts/" "cp ~/.claude/skills/ai-brain-starter/scripts/$script '$meta/scripts/'"
-    fi
-  done
+  local out n_create n_update
+  out="$(bash "$sync" --vault "$vault" --dry-run 2>/dev/null)"
+  n_create="$(printf '%s\n' "$out" | sed -n 's/^Created:[[:space:]]*\([0-9][0-9]*\).*/\1/p' | head -1)"
+  n_update="$(printf '%s\n' "$out" | sed -n 's/^Updated:[[:space:]]*\([0-9][0-9]*\).*/\1/p' | head -1)"
+  n_create="${n_create:-0}"; n_update="${n_update:-0}"
+  if [[ "$n_create" -gt 0 || "$n_update" -gt 0 ]]; then
+    add_issue "warn" "vault-scripts" \
+      "$((n_create + n_update)) vault script(s) missing or stale in $vault (re-sync from the repo)" \
+      "bash '$sync' --vault '$vault'"
+  fi
 }
 
 check_ai_brain_starter() {
@@ -170,7 +176,7 @@ check_json_config "$HOME/.claude/settings.local.json" "claude-settings-local"
 check_json_config "$HOME/.claude/.mcp.json" "mcp-config"
 
 if [[ -n "$VAULT_ROOT" ]]; then
-  check_vault_aggregators "$VAULT_ROOT"
+  check_vault_scripts "$VAULT_ROOT"
 fi
 
 # === output ===
@@ -209,7 +215,16 @@ else
   done
 
   if [[ "$AUTO_FIX" -eq 1 ]]; then
-    echo "--auto-fix not yet implemented; run the suggested Fix commands manually."
+    # The one fix we can apply safely + idempotently is the vault-script sync
+    # (it backs up any local edit to <file>.bak before overwriting). Everything
+    # else stays a manual suggestion.
+    sync_script="$(cd "$(dirname "$0")" 2>/dev/null && pwd)/sync-vault-scripts.sh"
+    [[ -f "$sync_script" ]] || sync_script="$HOME/.claude/skills/ai-brain-starter/scripts/sync-vault-scripts.sh"
+    if [[ -n "$VAULT_ROOT" && -f "$sync_script" ]]; then
+      echo "--fix: syncing vault scripts into $VAULT_ROOT (local edits backed up to .bak first)..."
+      bash "$sync_script" --vault "$VAULT_ROOT" || true
+    fi
+    echo "--fix: any remaining issues above must be applied manually (see each 'Fix:' line)."
   fi
 fi
 

--- a/scripts/sync-skills.py
+++ b/scripts/sync-skills.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import filecmp
 import os
 import shutil
+import subprocess
 import sys
 import time
 from pathlib import Path
@@ -165,6 +166,27 @@ def main() -> int:
             fh.write(summary + "\n")
     except OSError:
         pass
+
+    # --- Also refresh the vault's own <meta>/scripts/ (the skill->vault half) ---
+    # sync-skills syncs skill -> ~/.claude/skills; sync-vault-scripts.sh is the
+    # other half that previously went stale because <meta>/scripts/ was only ever
+    # populated at setup. It self-resolves the vault (--vault / $VAULT_ROOT /
+    # settings.json) and is a non-fatal no-op when none is set up. Best-effort by
+    # design: a vault-side hiccup (or no bash, e.g. native Windows) must NEVER
+    # flip this script's exit code, so failures are swallowed.
+    vault_sync = starter / "scripts" / "sync-vault-scripts.sh"
+    if vault_sync.is_file():
+        try:
+            proc = subprocess.run(
+                ["bash", str(vault_sync), "--quiet"],
+                capture_output=True,
+                text=True,
+            )
+            for line in (proc.stdout or "").splitlines():
+                print(f"[vault-scripts] {line}")
+        except (OSError, subprocess.SubprocessError):
+            pass  # bash missing (Windows) or spawn failure — non-fatal by design
+
     return 2 if r.errors else 0
 
 

--- a/scripts/sync-skills.sh
+++ b/scripts/sync-skills.sh
@@ -4,7 +4,7 @@
 #
 # Kept because docs, bootstrap flows, and older auto-update wirings call this
 # path. All sync logic (backups before overwrite, symlink + fork skip guards,
-# .sync.log summary) lives in the .py. Exit code propagates (0 clean, 2 on
-# any file error) so callers can surface failures.
+# .sync.log summary, and the vault-scripts refresh) lives in the .py. Exit code
+# propagates (0 clean, 2 on any file error) so callers can surface failures.
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 exec python3 "$HERE/sync-skills.py" "$@"

--- a/scripts/sync-vault-scripts.sh
+++ b/scripts/sync-vault-scripts.sh
@@ -1,0 +1,228 @@
+#!/bin/bash
+# sync-vault-scripts.sh — propagate updated vault-side scripts from the
+# ai-brain-starter repo into the user's vault  <meta>/scripts/  directory.
+#
+# WHY THIS EXISTS
+#   A vault's "<meta>/scripts/" folder is populated ONCE, at setup, by the
+#   setup phases (Phase 5 copies the aggregators + graph hook, Phase 18 the
+#   journal index, etc.). It is never re-synced. So when the repo ships a new
+#   or fixed vault script — session-close-runner.sh, check-rule-conflicts.py,
+#   drift-detection.py, passive-capture.py, … — it never reaches EXISTING
+#   vaults. scripts/sync-skills.sh only syncs skill->~/.claude/skills; this is
+#   the missing skill->vault half.
+#
+# CONTRACT (mirrors sync-skills.sh so the two behave identically)
+#   - Idempotent: identical dest = no-op (no noise).
+#   - Non-destructive: a dest that DIFFERS from the incoming repo file is backed
+#     up to <file>.bak-YYYY-MM-DD-HHMM BEFORE being overwritten — local edits
+#     are always recoverable.
+#   - Maintainer-safe: a symlinked dest (live-editing the skill repo from the
+#     vault) is skipped, never clobbered.
+#   - Source-absent is non-fatal: a manifest entry not yet on this checkout
+#     (e.g. session-close-runner.sh before #173 merges) is simply skipped.
+#
+# VAULT RESOLUTION (so it can run with zero args from the auto-update flow):
+#   1. --vault PATH
+#   2. $VAULT_ROOT
+#   3. parse ~/.claude/settings.json — the installed hooks embed the vault path
+#      (e.g. "<vault>/⚙️ Meta/scripts/session-end-hook.sh")
+#   If none resolve, this is a NON-FATAL no-op (logs the reason, exits 0): a box
+#   with no vault set up yet must not error during an auto-update.
+#
+# USAGE
+#   bash sync-vault-scripts.sh [--vault PATH] [--dry-run] [--quiet]
+#
+# EXIT: 0 = clean / nothing to do / vault not resolvable (non-fatal);
+#       2 = a real copy or backup error occurred.
+
+# Intentionally NOT using `set -u` — macOS bash 3.2 treats empty-array expansion
+# as "unbound", which would false-positive on a clean first run (same reason as
+# sync-skills.sh). pipefail is safe.
+set -o pipefail
+
+# Source repo = the checkout this script lives in (scripts/..), so it works from
+# the installed skill, a dev checkout, or CI alike. $STARTER_DIR overrides.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STARTER_DIR="${STARTER_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+STAMP="$(date +%Y-%m-%d-%H%M)"
+DRY_RUN=0
+QUIET=0
+VAULT=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --vault) VAULT="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --quiet) QUIET=1; shift ;;
+    -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "sync-vault-scripts.sh: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# --- Manifest: the scripts a RUNNING vault invokes from <meta>/scripts/. ------
+# EXPLICIT allow-list, never a glob over scripts/ (which is mostly repo tooling
+# — ci.sh, install-*.py, test-*.sh — that must NEVER land in a vault). Every
+# entry must be import-closed: stdlib-only, OR its local-module dependencies are
+# listed here too, else it crashes at runtime in the vault. The self-test
+# tests/integration/test_vault_script_sync.sh enforces import-closure.
+VAULT_SCRIPTS=(
+  "_meta_resolver.py"          # shared meta-folder resolver (deterministic keystone)
+  "_project_key.py"            # shared project-key resolver (dep of check-rule-conflicts.py)
+  "aggregate-sessions.py"      # session-close: Last Session.md index
+  "aggregate-decisions.py"     # session-close: Decision Log index
+  "session-close-runner.sh"    # session-close: deterministic aggregation runner (#173)
+  "vault-safe-commit.sh"       # session-close: targeted-path commit helper
+  "session-end-hook.sh"        # Stop-hook body
+  "write-hook.sh"              # PostToolUse(Write)-hook body
+  "graph-context-hook.sh"      # UserPromptSubmit graph-routing hook body
+  "build-journal-index.py"     # insights: journal index builder
+  "check-rule-conflicts.py"    # rule maintenance
+  "drift-detection.py"         # rule / CLAUDE.md drift detection
+  "passive-capture.py"         # instinct-engine passive capture (opt-in)
+)
+
+CREATED=(); UPDATED=(); BACKED_UP=(); SKIPPED=(); ABSENT=(); ERRORS=()
+
+note() { [ "$QUIET" -eq 1 ] || echo "$1"; }
+
+# --- Resolve the vault root ---------------------------------------------------
+resolve_vault_from_settings() {
+  local settings="$HOME/.claude/settings.json"
+  [ -f "$settings" ] || return 1
+  command -v python3 >/dev/null 2>&1 || return 1
+  python3 - "$settings" <<'PY' 2>/dev/null
+import json, re, sys
+try:
+    data = json.load(open(sys.argv[1], encoding="utf-8"))
+except Exception:
+    sys.exit(1)
+for _ev, groups in (data.get("hooks") or {}).items():
+    for g in groups:
+        for h in g.get("hooks", []):
+            cmd = h.get("command", "")
+            # The installed hook commands embed the absolute vault path right
+            # before the meta-folder + /scripts/. Grab the longest such prefix.
+            m = re.search(r"(/[^'\"]+?)/(?:⚙️ Meta|Meta)/scripts/", cmd)
+            if m:
+                print(m.group(1))
+                sys.exit(0)
+sys.exit(1)
+PY
+}
+
+if [ -z "$VAULT" ]; then VAULT="${VAULT_ROOT:-}"; fi
+if [ -z "$VAULT" ]; then VAULT="$(resolve_vault_from_settings || true)"; fi
+
+if [ -z "$VAULT" ] || [ ! -d "$VAULT" ]; then
+  note "sync-vault-scripts: no vault resolved (--vault / \$VAULT_ROOT / settings.json all empty) — skipping (non-fatal)."
+  exit 0
+fi
+
+# --- Resolve the vault's meta dir via the SHARED resolver (decorated-first). ---
+# The vault scripts live in the HUMAN meta folder ("⚙️ Meta"), which a naive
+# "*Meta" glob would miss — plain machine "Meta" sorts first and would shadow it.
+# _meta_resolver.py is the ONE source of truth for this (scripts/check-meta-
+# resolution.sh bans re-implementing the glob in shell); it prefers whichever
+# Meta variant holds a known human subfolder. Disambiguate on folders the human
+# meta owns. It lives beside this script in the repo, so $SCRIPT_DIR resolves it.
+META="$(python3 "$SCRIPT_DIR/_meta_resolver.py" "$VAULT" scripts Decisions Sessions 2>/dev/null || true)"
+if [ -z "$META" ]; then
+  note "sync-vault-scripts: no Meta folder in $VAULT — skipping (non-fatal)."
+  exit 0
+fi
+
+DEST_DIR="$META/scripts"
+
+# Maintainer-safe: if the vault scripts dir is a symlink (live-editing the repo
+# from the vault), do not touch it.
+if [ -L "$DEST_DIR" ]; then
+  note "sync-vault-scripts: $DEST_DIR is a symlink (managed elsewhere) — skipping."
+  exit 0
+fi
+
+if [ "$DRY_RUN" -eq 0 ]; then mkdir -p "$DEST_DIR" 2>/dev/null || {
+  echo "sync-vault-scripts: cannot create $DEST_DIR" >&2; exit 2; }
+fi
+
+# --- Sync one script: backup-on-diff, then copy (mirrors sync-skills.sh). ------
+sync_one() {
+  local name="$1"
+  local src="$STARTER_DIR/scripts/$name"
+  local dest="$DEST_DIR/$name"
+
+  if [ ! -f "$src" ]; then
+    ABSENT+=("$name (not on this checkout yet)")
+    return 0
+  fi
+  if [ -L "$dest" ]; then
+    SKIPPED+=("$name (symlinked dest, maintainer workflow)")
+    return 0
+  fi
+  if [ -f "$dest" ]; then
+    if cmp -s "$src" "$dest"; then
+      return 0   # identical — no-op, no noise
+    fi
+    if [ "$DRY_RUN" -eq 1 ]; then
+      UPDATED+=("$name (would update; backup -> ${name}.bak-${STAMP})")
+      return 0
+    fi
+    local bak="${dest}.bak-${STAMP}"
+    if cp "$dest" "$bak" 2>/dev/null; then
+      BACKED_UP+=("$bak")
+    else
+      ERRORS+=("could not back up $dest before overwrite")
+      return 1
+    fi
+    if cp "$src" "$dest" 2>/dev/null; then
+      chmod +x "$dest" 2>/dev/null || true
+      UPDATED+=("$name")
+    else
+      ERRORS+=("could not overwrite $dest (backup at $bak)")
+      return 1
+    fi
+  else
+    if [ "$DRY_RUN" -eq 1 ]; then
+      CREATED+=("$name (would create)")
+      return 0
+    fi
+    if cp "$src" "$dest" 2>/dev/null; then
+      chmod +x "$dest" 2>/dev/null || true
+      CREATED+=("$name")
+    else
+      ERRORS+=("could not create $dest")
+      return 1
+    fi
+  fi
+}
+
+for s in "${VAULT_SCRIPTS[@]}"; do
+  sync_one "$s"
+done
+
+# --- Summary (to stdout + a discoverable vault-side log) ----------------------
+LOG_FILE="$DEST_DIR/.vault-script-sync.log"
+summary() {
+  echo "=== sync-vault-scripts.sh @ $STAMP${DRY_RUN:+ (dry-run)} ==="
+  echo "vault: $VAULT"
+  echo "meta:  $META"
+  echo "Created:   ${#CREATED[@]}";   for f in "${CREATED[@]:-}"; do [ -n "$f" ] && echo "  + $f"; done
+  echo "Updated:   ${#UPDATED[@]}";   for f in "${UPDATED[@]:-}"; do [ -n "$f" ] && echo "  ~ $f"; done
+  echo "Backed up: ${#BACKED_UP[@]} (local edits preserved)"; for f in "${BACKED_UP[@]:-}"; do [ -n "$f" ] && echo "  b $f"; done
+  echo "Skipped:   ${#SKIPPED[@]}";   for f in "${SKIPPED[@]:-}"; do [ -n "$f" ] && echo "  s $f"; done
+  echo "Absent:    ${#ABSENT[@]}";    for f in "${ABSENT[@]:-}"; do [ -n "$f" ] && echo "  . $f"; done
+  echo "Errors:    ${#ERRORS[@]}";    for f in "${ERRORS[@]:-}"; do [ -n "$f" ] && echo "  ! $f"; done
+  echo ""
+}
+
+changed=$(( ${#CREATED[@]} + ${#UPDATED[@]} + ${#BACKED_UP[@]} + ${#ERRORS[@]} ))
+if [ "$DRY_RUN" -eq 1 ]; then
+  summary
+elif [ "$QUIET" -eq 1 ]; then
+  summary >> "$LOG_FILE" 2>/dev/null || true
+  [ "$changed" -gt 0 ] && summary   # surface to stdout only when something changed
+else
+  summary | tee -a "$LOG_FILE"
+fi
+
+if [ "${#ERRORS[@]}" -gt 0 ]; then exit 2; fi
+exit 0

--- a/tests/integration/test_vault_script_sync.sh
+++ b/tests/integration/test_vault_script_sync.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Test: sync-vault-scripts.sh — the skill->vault script sync.
+#
+# Bug class it guards: a vault's <meta>/scripts/ was populated once at setup and
+# never re-synced, so fixed/new scripts (session-close-runner.sh,
+# check-rule-conflicts.py, drift-detection.py, passive-capture.py, ...) never
+# reached existing vaults. This is the skill->vault half of sync-skills.sh.
+#
+# Assertions:
+#   1. The VAULT_SCRIPTS manifest is IMPORT-CLOSED — no manifest .py imports a
+#      sibling scripts/*.py module that isn't also in the manifest (else it
+#      would crash at runtime in the vault).
+#   2. A fresh sync populates <meta>/scripts/ with the core scripts.
+#   3. A re-run is idempotent (0 created / 0 updated).
+#   4. A locally-edited vault script is backed up to .bak before overwrite, then
+#      restored to the repo version (non-destructive contract).
+#   5. A symlinked scripts dir is left untouched (maintainer live-edit workflow).
+#   6. --dry-run writes nothing.
+#   7. An unresolvable vault is a NON-FATAL no-op (exit 0).
+#
+# Self-contained: tmpdir fake vaults. Exit 0 = pass.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SYNC="$REPO_ROOT/scripts/sync-vault-scripts.sh"
+if [ ! -f "$SYNC" ]; then
+  echo "ERROR: $SYNC not found" >&2
+  exit 1
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# --- 1. manifest import-closure -------------------------------------------
+python3 - "$REPO_ROOT" "$SYNC" <<'PY'
+import ast, os, re, sys
+repo, sync = sys.argv[1], sys.argv[2]
+lines = open(sync, encoding="utf-8").read().splitlines()
+start = next((i for i, l in enumerate(lines) if "VAULT_SCRIPTS=(" in l), None)
+assert start is not None, "VAULT_SCRIPTS array not found"
+names = []
+for l in lines[start + 1:]:
+    if l.strip() == ")":
+        break
+    m = re.search(r'"([^"]+)"', l)
+    if m:
+        names.append(m.group(1))
+assert names, "manifest is empty"
+py = [n for n in names if n.endswith(".py")]
+mod_names = {n[:-3] for n in py}
+missing = []
+for n in py:
+    p = os.path.join(repo, "scripts", n)
+    if not os.path.isfile(p):
+        continue  # source-absent on this checkout (e.g. pre-merge) — skip
+    try:
+        tree = ast.parse(open(p, encoding="utf-8").read())
+    except SyntaxError:
+        continue
+    for node in ast.walk(tree):
+        mods = []
+        if isinstance(node, ast.Import):
+            mods = [a.name.split(".")[0] for a in node.names]
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            mods = [node.module.split(".")[0]]
+        for mod in mods:
+            sib = os.path.join(repo, "scripts", mod + ".py")
+            if os.path.isfile(sib) and mod not in mod_names:
+                missing.append(f"{n} imports sibling '{mod}' (scripts/{mod}.py) not in manifest")
+if missing:
+    print("IMPORT-CLOSURE FAIL:")
+    for x in missing:
+        print("  -", x)
+    sys.exit(1)
+print(f"PASS: manifest import-closed ({len(py)} py scripts checked, {len(names)} total)")
+PY
+
+# --- 2. fresh sync populates <meta>/scripts/ ------------------------------
+VAULT="$TMP/vault"; mkdir -p "$VAULT/⚙️ Meta"
+bash "$SYNC" --vault "$VAULT" --quiet >/dev/null
+for s in _meta_resolver.py aggregate-sessions.py check-rule-conflicts.py; do
+  if [ ! -f "$VAULT/⚙️ Meta/scripts/$s" ]; then
+    echo "FAIL: $s was not synced into the vault" >&2; exit 1
+  fi
+done
+echo "PASS: fresh sync populates <meta>/scripts/"
+
+# --- 3. re-run is idempotent ----------------------------------------------
+OUT="$(bash "$SYNC" --vault "$VAULT")"
+if ! printf '%s\n' "$OUT" | grep -qE "Created:[[:space:]]*0"; then
+  echo "FAIL: re-run created files (not idempotent)" >&2; printf '%s\n' "$OUT" >&2; exit 1
+fi
+if ! printf '%s\n' "$OUT" | grep -qE "Updated:[[:space:]]*0"; then
+  echo "FAIL: re-run updated files (not idempotent)" >&2; printf '%s\n' "$OUT" >&2; exit 1
+fi
+echo "PASS: re-run is idempotent (0 created / 0 updated)"
+
+# --- 4. local edit is backed up before overwrite, then restored -----------
+echo "# local customization" >> "$VAULT/⚙️ Meta/scripts/check-rule-conflicts.py"
+bash "$SYNC" --vault "$VAULT" --quiet >/dev/null
+if ! ls "$VAULT/⚙️ Meta/scripts/"check-rule-conflicts.py.bak-* >/dev/null 2>&1; then
+  echo "FAIL: no .bak created for the locally-edited script" >&2; exit 1
+fi
+if ! cmp -s "$REPO_ROOT/scripts/check-rule-conflicts.py" "$VAULT/⚙️ Meta/scripts/check-rule-conflicts.py"; then
+  echo "FAIL: edited script was not restored to the repo version" >&2; exit 1
+fi
+echo "PASS: local edit backed up to .bak, then updated to the repo version"
+
+# --- 5. symlinked scripts dir is skipped ----------------------------------
+VSYM="$TMP/vaultsym"; mkdir -p "$VSYM/⚙️ Meta" "$TMP/elsewhere"
+ln -s "$TMP/elsewhere" "$VSYM/⚙️ Meta/scripts"
+bash "$SYNC" --vault "$VSYM" >/dev/null 2>&1 || true
+if [ -n "$(ls -A "$TMP/elsewhere" 2>/dev/null)" ]; then
+  echo "FAIL: wrote through a symlinked scripts dir" >&2; exit 1
+fi
+echo "PASS: symlinked scripts dir is skipped (maintainer workflow)"
+
+# --- 6. --dry-run writes nothing ------------------------------------------
+VDRY="$TMP/vaultdry"; mkdir -p "$VDRY/⚙️ Meta"
+bash "$SYNC" --vault "$VDRY" --dry-run >/dev/null
+if [ -d "$VDRY/⚙️ Meta/scripts" ] && [ -n "$(ls -A "$VDRY/⚙️ Meta/scripts" 2>/dev/null)" ]; then
+  echo "FAIL: --dry-run wrote files" >&2; exit 1
+fi
+echo "PASS: --dry-run writes nothing"
+
+# --- 7. unresolvable vault is a non-fatal no-op ---------------------------
+env -u VAULT_ROOT HOME="$TMP/emptyhome" bash "$SYNC" --quiet >/dev/null 2>&1
+echo "PASS: unresolvable vault is a non-fatal no-op (exit 0)"
+
+# --- 8. vault resolved from settings.json (the arg-less auto-update path) --
+SVAULT="$TMP/svault"; mkdir -p "$SVAULT/⚙️ Meta"
+SHOME="$TMP/shome"; mkdir -p "$SHOME/.claude"
+cat > "$SHOME/.claude/settings.json" <<JSON
+{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"bash '$SVAULT/⚙️ Meta/scripts/session-end-hook.sh'"}]}]}}
+JSON
+env -u VAULT_ROOT HOME="$SHOME" bash "$SYNC" --quiet >/dev/null
+if [ ! -f "$SVAULT/⚙️ Meta/scripts/_meta_resolver.py" ]; then
+  echo "FAIL: vault not resolved from settings.json (nothing synced)" >&2; exit 1
+fi
+echo "PASS: vault resolved from settings.json and synced arg-lessly"
+
+echo
+echo "All assertions passed. sync-vault-scripts.sh contract holds."


### PR DESCRIPTION
## What

Follow-up #1 from #173. Closes the **vault-script sync gap**: a vault's `⚙️ Meta/scripts/` was populated *once* at setup and never refreshed, so every fixed/new vault script shipped afterward never reached existing vaults.

## The gap

`scripts/sync-skills.sh` keeps installed skills (`~/.claude/skills/…`) current on every update — but it never touched the **vault** copy of the scripts. Those were only written by the setup phases, the first time. So `session-close-runner.sh` (the very script #173 added), `check-rule-conflicts.py`, `drift-detection.py`, `passive-capture.py`, the aggregators, etc. silently went stale in existing vaults. This is the missing **skill→vault** half of the sync.

## The fix

**New `scripts/sync-vault-scripts.sh`** — same safety contract as `sync-skills.sh`:
- A dest that differs from the repo copy is backed up to `<file>.bak-YYYY-MM-DD-HHMM` **before** overwrite; identical = silent no-op; a **symlinked** scripts dir (maintainer live-editing the repo) is skipped; a source **absent** on this checkout (e.g. `session-close-runner.sh` before #173 merges) is a non-fatal skip.
- Resolves the vault **arg-lessly**: `--vault` › `$VAULT_ROOT` › parse `~/.claude/settings.json` (installed hooks embed the vault path). No vault resolved → non-fatal no-op (`exit 0`), so a fresh box never errors during an update.
- Resolves the meta dir **deterministically** (`⚙️ Meta` probed before plain `Meta`), so human-memory scripts never land in the machine-memory folder.
- The synced set is an **explicit, import-closed manifest** — never a glob over `scripts/` (which would drag in repo tooling like `ci.sh`/`install-*.py`). A `.py` script ships only alongside the sibling modules it imports, so it can't land half-broken. `STARTER_DIR` derives from the script's own location → works from the installed skill, a dev checkout, or CI.
- `--dry-run` and `--quiet`.

**Wiring — zero `hooks.json` churn:**
- `sync-skills.sh` calls it at the end (best-effort; never flips its own exit code), so a `git pull` / auto-update refreshes vault scripts the same way it refreshes skills — no new hook, no edit to the fragile auto-update one-liner.
- `detect-partial-installs.sh` now checks the **whole manifest** (not just the two aggregators) by delegating to `sync-vault-scripts.sh --dry-run` — one source of truth, no drift — and `--fix` re-syncs for real.

## Verification

`tests/integration/test_vault_script_sync.sh` (wired into `ci.sh`), **8/8 pass**: manifest import-closure, fresh sync, idempotent re-run, backup-on-edit + restore-to-repo-version, symlinked-dir skip, `--dry-run` writes nothing, unresolvable-vault non-fatal no-op, and arg-less resolution from `settings.json`. `bash -n` clean; `detect-partial-installs --fix` smoke-tested end-to-end (detect 11 stale → sync → re-check clean).

## Notes

- Complements #173: once both land, the runner #173 added reaches existing vaults automatically via this sync.
- Touches `docs/CHANGELOG.md` + `scripts/ci.sh` (also touched by the sibling verify-cascade PR #175, in different spots) — a trivial rebase if both merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)