### PR TITLE
feat(relocate): code-repo-aware residual sweep + symlink go/no-go

### DIFF
--- a/docs/CLOUD_SYNC.md
+++ b/docs/CLOUD_SYNC.md
@@ -62,6 +62,35 @@ bash scripts/relocate-vault.sh --migrate-claude-state ~/Desktop/MyVault ~/MyVaul
 Sync daemons follow the *symlink file* (a few bytes), not the target's
 contents — so the churn leaves the sync scope entirely.
 
+**Retiring the old-path symlink (optional, later).** That symlink is a safety net:
+while it is there, anything that still hardcodes the old path keeps working — which
+also *hides* which references you have actually migrated. The day the symlink dies,
+every un-migrated reference breaks (a scheduled job re-creates a phantom folder at
+the old path; a hook command points at nothing). When you want to retire the old
+path for good, sweep for what still resolves it first. The sweep reaches every
+surface a vault touches — code repos (including docstrings and comments), JSON
+config, MCP configs, docs, shell rc — greps each git repo at its **canonical**
+`origin/main` (a stale local branch can hide a reference the repo still ships), and
+classifies every hit:
+
+- **executed** — a real command or path (a code line, a fenced shell block, a JSON
+  string *value*). These break when the symlink dies. Repoint them first.
+- **doc-pointer** — a comment, a docstring, prose. Cosmetic; fix at leisure.
+- **keep** — intentional (a migration source, a dead JSON config *key*). Left alone.
+
+```bash
+# what still resolves the old path? (classified, with a go/no-go)
+bash scripts/relocate-vault.sh --sweep ~/Desktop/MyVault ~/MyVault
+# retire the symlink — refuses unless ZERO executed references remain
+bash scripts/relocate-vault.sh --drop-symlink ~/Desktop/MyVault
+```
+
+`--drop-symlink` runs the sweep and removes the symlink only when nothing
+executable still points at the old path; until then it tells you exactly what to
+repoint. It also reports the `~/.claude.json` blast radius separately (dead project
+*keys* are cosmetic; string *values* are load-bearing), and never edits anything
+itself — the repoint is yours.
+
 > **One failure, two shapes.** Whether a bare `.git/` sits inside a sync mirror
 > or a whole git-backed vault sits inside a sync root, the cause is identical:
 > high-churn git machinery + a real-time sync daemon. Shape A (above) moves the

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -112,6 +112,7 @@ INTEGRATION_TESTS=(
   test_cloud_sync_guard
   test_machinery_sidecar
   test_relocate_vault
+  test_relocate_sweep
   test_renderer_crash_guard
   test_agentic_os
 )

--- a/scripts/relocate-sweep.py
+++ b/scripts/relocate-sweep.py
@@ -1,0 +1,754 @@
+#!/usr/bin/env python3
+"""relocate-sweep.py — after a vault relocation, find every place that still
+resolves the OLD path, classify each by whether it actually EXECUTES, and decide
+whether it is safe to drop the symlink the move left behind.
+
+WHY
+---
+`relocate-vault.sh` moves a vault out of a cloud-sync folder and leaves a symlink
+at the old path so existing references keep resolving. That symlink is a crutch:
+while it is there, any tool that still hardcodes the old path "works" — so you
+cannot tell which references are migrated and which are silently riding the
+symlink. The day the symlink dies, every un-migrated reference breaks (a cron job
+mkdir's a phantom folder at the old path; a hook command points at nothing). This
+sweep removes the guesswork: it hunts the old path across every surface a vault
+touches, classifies each hit, and gives a go/no-go on dropping the symlink.
+
+WHAT IT CHECKS (the lesson from one real, hard relocation tail)
+---------------------------------------------------------------
+1. ALL surfaces, not just automation: code-repo source (incl. docstrings +
+   comments), JSON config, MCP configs, markdown docs, shell rc — auto-discovered
+   (resolve the vault's symlinked-in dirs + walk the code-repo root), because a
+   hand-kept root list always lags the surface area (SCAN-SCOPE-BLIND-SPOT).
+2. CLASSIFY every hit three ways — blind find/replace is banned:
+     - EXECUTED   : a load-bearing position — a code line, a markdown code-span /
+                    fenced block, a JSON string VALUE under a live key, a shell
+                    command. These RECREATE/BREAK and BLOCK the symlink drop.
+     - DOC-POINTER: a human-readable mention — a comment, a docstring, markdown
+                    prose. Cosmetic; repoint at leisure; never blocks.
+     - KEEP       : intentional — the relocate tooling's own OLD= source, a JSON
+                    dict KEY (a dead project key, never looked up), an inert
+                    permissions matcher, a `relocate-keep`-marked line.
+3. Grep the CANONICAL ref (origin/main) per git repo, NOT only the working tree —
+   a stale checked-out branch can HIDE a reference that origin/main still ships
+   (WRONG-ARTIFACT-VERIFIED). Working-tree-only (uncommitted) hits are reported
+   too, labelled by provenance.
+4. A residual REPORT grouped by class + a go/no-go: GO only when zero EXECUTED
+   references remain.
+5. Characterize the ~/.claude.json blast radius before anyone touches it: dict
+   KEYS that hold the old path are cosmetic (dead project keys); string VALUES are
+   load-bearing. Report the split and confirm the file parses.
+
+This script NEVER edits anything. It classifies and reports. The repoint is yours;
+the symlink drop is `relocate-vault.sh --drop-symlink`, which runs this sweep and
+obeys its verdict.
+
+Usage:
+  relocate-sweep.py --old <old-vault-path> [--new <new-vault-path>] [options]
+
+Options:
+  --root <dir>          add a scan root (repeatable). Combined with auto-discovery
+                        unless --no-auto-discover.
+  --dev-root <dir>      parent dir of code repos to auto-scan (default: ~/dev)
+  --config-dir <dir>    Claude Code config dir (default: $CLAUDE_CONFIG_DIR or ~/.claude)
+  --claude-json <file>  the big per-host config to characterize (default: ~/.claude.json)
+  --no-auto-discover    scan only the explicit --root paths (+ --claude-json if given)
+  --json                emit a machine-readable report on stdout
+  -h, --help            this help
+
+Exit codes: 0 GO (no executed residuals) · 1 NO-GO (executed residuals remain) · 2 usage
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import io
+import json
+import os
+import re
+import subprocess
+import sys
+import tokenize
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+HOME = Path.home()
+
+# File suffixes worth scanning on a filesystem walk. Everything else is skipped.
+SCAN_EXTS = {".py", ".sh", ".bash", ".zsh", ".md", ".compressed", ".txt",
+             ".json", ".plist", ".yaml", ".yml", ".toml", ""}
+# Path fragments that are never executable config (caches, vcs internals, logs).
+SKIP_SUB = ("/.git/", "/.venv/", "/node_modules/", "/.claude/worktrees/",
+            ".jsonl", ".log", ".bak", ".pyc", "/.smart-env/", "/graphify-out/")
+# Directory names pruned from any filesystem walk — vcs internals + regenerable
+# caches. A walk root is only ever a non-git dir (a git repo is grepped instead),
+# so this bounds the cost of scanning e.g. a Claude config subtree.
+WALK_PRUNE = {".git", ".venv", "node_modules", "worktrees", "__pycache__",
+              ".smart-env", "graphify-out", ".codegraph"}
+# Cloud-sync containers — reading a placeholder file inside one BLOCKS while the OS
+# downloads it (the demand-paging hazard). Never deep-walk these; they hold docs,
+# not code path-recreators anyway.
+CLOUD_MARKERS = ("/Library/CloudStorage/", "/Library/Mobile Documents/",
+                 "/Dropbox/", "/OneDrive", "/.Trash/")
+
+
+def _under_cloud_sync(path):
+    return any(m in (os.path.realpath(path) + "/") for m in CLOUD_MARKERS)
+# Files whose OLD-path references are intentional — the relocate tooling itself
+# (migration sources, fixtures) and personal-data scrub token lists.
+KEEP_BASENAMES = {"relocate-vault.sh", "relocate-sweep.py", "relocate-machinery-sidecar.sh",
+                  "test-relocate-vault.sh", "test-relocate-sweep.py",
+                  "check-desktop-path-recreators.py"}
+KEEP_PATH_TOKENS = ("scrub-or-die", "gh-harden-repos", "personal-pii-scrub", "/docs/superpowers/")
+# A line carrying one of these is an intentional KEEP regardless of file type:
+#   relocate-keep  → explicit marker;  OLD=/NEW= → a migration source assignment;
+#   .exists()/-e   → a guarded ref that no-ops once the path is gone.
+KEEP_LINE_RE = re.compile(r"relocate-keep|^\s*(OLD|NEW)=|\.exists\(\)|os\.path\.exists|\[\s+-[ed]\s")
+# JSON keys whose subtree is an inert string-MATCHER list, not executable config.
+INERT_JSON_KEYS = {"permissions"}
+
+# Markdown executable-context extraction (CommonMark fences + inline code spans).
+_FENCE_RE = re.compile(r"^\s{0,3}(`{3,}|~{3,})(.*)$")
+_INLINE_CODE_RE = re.compile(r"`+([^`\n]+?)`+")
+
+WARNINGS = []
+
+
+# --------------------------------------------------------------------------- #
+# patterns                                                                     #
+# --------------------------------------------------------------------------- #
+def derive_patterns(old_abs):
+    """The literal + piecewise forms a hardcoded old path takes in real tooling.
+
+    A literal grep for the full path MISSES the piecewise pathlib form
+    `Path.home() / "Desktop" / "Vault"`, which is exactly how an in-script default
+    is written — so we search the full path, its ~-relative form, the trailing
+    `parent/leaf` slash form, and the quoted piecewise form.
+    """
+    p = Path(old_abs)
+    base, parent = p.name, p.parent.name
+    pats = [old_abs]
+    try:
+        pats.append("~/" + str(p.relative_to(HOME)))
+    except ValueError:
+        pass
+    if parent and base:
+        pats.append(parent + "/" + base)
+        pats.append('"' + parent + '" / "' + base + '"')
+    out, seen = [], set()
+    for x in pats:
+        if x not in seen:
+            seen.add(x)
+            out.append(x)
+    return out
+
+
+def line_hits(line, patterns):
+    return any(pat in line for pat in patterns)
+
+
+def abbrev(path_str):
+    h = str(HOME)
+    return path_str.replace(h, "~") if path_str.startswith(h) else path_str
+
+
+# --------------------------------------------------------------------------- #
+# per-file-type classifiers → list of (lineno, klass, reason)                  #
+# --------------------------------------------------------------------------- #
+def _file_keep_reason(abspath):
+    base = os.path.basename(abspath)
+    if base in KEEP_BASENAMES:
+        return "relocate tooling / fixture (intentional)"
+    for tok in KEEP_PATH_TOKENS:
+        if tok in abspath:
+            return "scrub-token / example list (intentional)"
+    return None
+
+
+def _classify_python(text, patterns):
+    """Column- and AST-aware: a hit inside a `#` comment or a docstring is a
+    DOC-POINTER; a hit in a code string (assignment, piecewise expression) is
+    EXECUTED. Falls back to a line heuristic if the file won't tokenize/parse on
+    this interpreter (conservatively EXECUTED, so go/no-go stays safe)."""
+    comment_spans = {}   # lineno -> [(startcol, endcol)]
+    tok_ok = True
+    try:
+        for tok in tokenize.generate_tokens(io.StringIO(text).readline):
+            if tok.type == tokenize.COMMENT:
+                comment_spans.setdefault(tok.start[0], []).append((tok.start[1], tok.end[1]))
+    except (tokenize.TokenError, IndentationError, SyntaxError, ValueError):
+        tok_ok = False
+    docstring_lines = set()
+    ast_ok = True
+    try:
+        tree = ast.parse(text)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Expr) and isinstance(getattr(node, "value", None), ast.Constant) \
+                    and isinstance(node.value.value, str):
+                end = getattr(node, "end_lineno", node.lineno) or node.lineno
+                for ln in range(node.lineno, end + 1):
+                    docstring_lines.add(ln)
+    except (SyntaxError, ValueError):
+        ast_ok = False
+
+    out = []
+    lines = text.splitlines()
+    for i, line in enumerate(lines, 1):
+        if not line_hits(line, patterns):
+            continue
+        if KEEP_LINE_RE.search(line):
+            out.append((i, "keep", "relocate-keep / migration source / guarded"))
+            continue
+        if not tok_ok and not ast_ok:
+            klass = "doc-pointer" if line.lstrip().startswith("#") else "executed"
+            out.append((i, klass, "python (heuristic fallback)"))
+            continue
+        # Is every hit on this line inside a comment or a docstring?
+        in_code = False
+        for pat in patterns:
+            col = line.find(pat)
+            while col != -1:
+                in_comment = any(col >= cs for (cs, ce) in comment_spans.get(i, []))
+                in_doc = i in docstring_lines
+                if not in_comment and not in_doc:
+                    in_code = True
+                col = line.find(pat, col + 1)
+        if in_code:
+            out.append((i, "executed", "python code (load-bearing)"))
+        elif i in docstring_lines:
+            out.append((i, "doc-pointer", "python docstring"))
+        else:
+            out.append((i, "doc-pointer", "python comment"))
+    return out
+
+
+def _classify_shell(text, patterns):
+    out = []
+    for i, line in enumerate(text.splitlines(), 1):
+        if not line_hits(line, patterns):
+            continue
+        if KEEP_LINE_RE.search(line):
+            out.append((i, "keep", "relocate-keep / migration source / guarded"))
+        elif line.lstrip().startswith("#"):
+            out.append((i, "doc-pointer", "shell comment"))
+        else:
+            out.append((i, "executed", "shell command (load-bearing)"))
+    return out
+
+
+def _classify_markdown(text, patterns):
+    """A hit inside a fenced block or an inline code span is EXECUTED (it is a
+    command/path); a hit in prose is a DOC-POINTER (a descriptive mention)."""
+    out = []
+    in_fence = False
+    fence_char = ""
+    fence_len = 0
+    for i, line in enumerate(text.splitlines(), 1):
+        is_exec_ctx = False
+        if in_fence:
+            m = _FENCE_RE.match(line)
+            if m and m.group(1)[0] == fence_char and len(m.group(1)) >= fence_len \
+                    and m.group(2).strip() == "":
+                in_fence = False
+                continue
+            is_exec_ctx = True
+        else:
+            m = _FENCE_RE.match(line)
+            if m:
+                in_fence = True
+                fence_char = m.group(1)[0]
+                fence_len = len(m.group(1))
+                continue
+            for span in _INLINE_CODE_RE.findall(line):
+                if line_hits(span, patterns):
+                    is_exec_ctx = True
+                    break
+        if not line_hits(line, patterns):
+            continue
+        if KEEP_LINE_RE.search(line):
+            out.append((i, "keep", "relocate-keep marker"))
+        elif is_exec_ctx:
+            out.append((i, "executed", "markdown code-span / fenced block"))
+        else:
+            out.append((i, "doc-pointer", "markdown prose"))
+    return out
+
+
+def _classify_other(text, patterns):
+    """plist / yaml / toml / txt / dotfiles: conservative — a comment-prefixed line
+    is a DOC-POINTER, anything else with the path is EXECUTED."""
+    out = []
+    for i, line in enumerate(text.splitlines(), 1):
+        if not line_hits(line, patterns):
+            continue
+        s = line.lstrip()
+        if KEEP_LINE_RE.search(line):
+            out.append((i, "keep", "relocate-keep / migration source / guarded"))
+        elif s.startswith("#") or s.startswith(";") or s.startswith("//") or s.startswith("<!--"):
+            out.append((i, "doc-pointer", "config comment"))
+        else:
+            out.append((i, "executed", "config value (load-bearing)"))
+    return out
+
+
+def _line_of(raw, needle):
+    idx = raw.find(needle)
+    return raw[:idx].count("\n") + 1 if idx != -1 else None
+
+
+def classify_json(text, patterns):
+    """Parse JSON and split hits: a dict KEY holding the old path is cosmetic
+    (KEEP — e.g. a dead project key); a string VALUE under a live key is
+    load-bearing (EXECUTED); a value under an inert matcher subtree (permissions)
+    is KEEP. Returns (findings, dict_keys, string_values, valid)."""
+    try:
+        data = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        return [], 0, 0, False
+
+    findings = []
+    counts = {"keys": 0, "values": 0}
+
+    def walk(node, inert):
+        if isinstance(node, dict):
+            for k, v in node.items():
+                if isinstance(k, str) and line_hits(k, patterns):
+                    counts["keys"] += 1
+                    findings.append((_line_of(text, k), "keep",
+                                     "json dict key (cosmetic — dead key, never looked up)"))
+                walk(v, inert or (k in INERT_JSON_KEYS))
+        elif isinstance(node, list):
+            for v in node:
+                walk(v, inert)
+        elif isinstance(node, str) and line_hits(node, patterns):
+            if inert:
+                findings.append((_line_of(text, node), "keep",
+                                 "json inert permissions matcher"))
+            else:
+                counts["values"] += 1
+                findings.append((_line_of(text, node), "executed",
+                                 "json string value (load-bearing)"))
+
+    walk(data, False)
+    return findings, counts["keys"], counts["values"], True
+
+
+def classify_text(abspath, text, patterns):
+    """Dispatch by file type. Returns (findings, file_type) where each finding is
+    (lineno, klass, reason)."""
+    keep_reason = _file_keep_reason(abspath)
+    suffix = Path(abspath).suffix.lower()
+    base = os.path.basename(abspath)
+    if suffix == ".py":
+        ftype = "py"
+        found = _classify_python(text, patterns)
+    elif suffix in (".sh", ".bash", ".zsh") or base.startswith(".z") or base in (".bashrc", ".bash_profile", ".profile"):
+        ftype = "sh"
+        found = _classify_shell(text, patterns)
+    elif suffix in (".md", ".compressed"):
+        ftype = "md"
+        found = _classify_markdown(text, patterns)
+    elif suffix == ".json":
+        ftype = "json"
+        f, _dk, _sv, _ok = classify_json(text, patterns)
+        found = f
+    else:
+        ftype = "other"
+        found = _classify_other(text, patterns)
+    if keep_reason:
+        found = [(ln, "keep", keep_reason) for (ln, _k, _r) in found]
+    return found, ftype
+
+
+# --------------------------------------------------------------------------- #
+# git helpers                                                                  #
+# --------------------------------------------------------------------------- #
+def _git(args, cwd=None, timeout=None):
+    return subprocess.run(["git"] + args, cwd=cwd, capture_output=True, text=True, timeout=timeout)
+
+
+# Vendored / build / cache trees never hold a path-recreator and can be enormous;
+# excluding them keeps an --untracked grep from walking e.g. node_modules or a
+# Rust target/ dir and hanging the whole sweep on one repo.
+_GREP_EXCLUDES = [
+    ":(exclude,glob)**/node_modules/**", ":(exclude,glob)**/.venv/**",
+    ":(exclude,glob)**/venv/**", ":(exclude,glob)**/target/**",
+    ":(exclude,glob)**/dist/**", ":(exclude,glob)**/build/**",
+    ":(exclude,glob)**/.next/**", ":(exclude,glob)**/__pycache__/**",
+    ":(exclude,glob)**/worktrees/**",
+]
+
+
+def git_toplevel(path):
+    if not os.path.isdir(path):
+        return None
+    r = _git(["-C", path, "rev-parse", "--show-toplevel"])
+    return r.stdout.strip() if r.returncode == 0 and r.stdout.strip() else None
+
+
+def resolve_canonical_ref(top):
+    """First of origin/main, origin/master, main, master, HEAD that resolves.
+    origin/* → authoritative ('canonical'); a local branch/HEAD → 'committed-HEAD'."""
+    for ref in ("origin/main", "origin/master", "main", "master", "HEAD"):
+        if _git(["-C", top, "rev-parse", "--verify", "--quiet", ref + "^{commit}"]).returncode == 0:
+            label = "canonical" if ref.startswith("origin/") else "committed-HEAD"
+            return ref, label
+    return None, None
+
+
+def git_grep_files(top, patterns, ref):
+    """Files in the repo matching any pattern. ref=None → working tree (tracked +
+    untracked); ref set → that committed tree. Returns a set of repo-relative paths."""
+    cmd = ["-C", top, "grep", "-l", "-I", "--no-color", "-F"]
+    if ref is None:
+        cmd.append("--untracked")
+    for p in patterns:
+        cmd += ["-e", p]
+    if ref is not None:
+        cmd.append(ref)
+    cmd += ["--", "."] + _GREP_EXCLUDES
+    try:
+        r = _git(cmd, timeout=25)
+    except subprocess.TimeoutExpired:
+        WARNINGS.append("git grep timed out (>25s) in " + abbrev(top) + " — skipped (large untracked tree?)")
+        return set()
+    if r.returncode not in (0, 1):  # 1 = no matches; >1 = real error
+        WARNINGS.append("git grep failed in " + abbrev(top) + (" @" + ref if ref else " (worktree)"))
+        return set()
+    files = set()
+    prefix = (ref + ":") if ref else ""
+    for line in r.stdout.splitlines():
+        rel = line[len(prefix):] if prefix and line.startswith(prefix) else line
+        files.add(rel)
+    return files
+
+
+def git_show(top, ref, relpath):
+    r = _git(["-C", top, "show", ref + ":" + relpath])
+    return r.stdout if r.returncode == 0 else None
+
+
+# --------------------------------------------------------------------------- #
+# discovery                                                                    #
+# --------------------------------------------------------------------------- #
+def discover_roots(old_abs, new_abs, explicit_roots, dev_root, config_dir, auto):
+    roots = list(explicit_roots)
+    if not auto:
+        return _dedupe_existing(roots)
+    if new_abs and os.path.isdir(new_abs):
+        roots.append(new_abs)
+        # The vault's symlinked-in dirs (a separate repo mounted under the vault is
+        # a classic blind spot — os.walk won't follow the symlink, so add the target).
+        # BUT only follow a target that is itself a git repo (a real code surface).
+        # A symlink to a cloud-sync DOC mirror (Google Drive / iCloud) is not a code
+        # surface, and deep-walking it BLOCKS on placeholder downloads — the very
+        # demand-paging hazard this tool exists to help users escape.
+        try:
+            for entry in os.listdir(new_abs):
+                full = os.path.join(new_abs, entry)
+                if os.path.islink(full):
+                    target = os.path.realpath(full)
+                    if (os.path.isdir(target) and not target.startswith(new_abs + os.sep)
+                            and not _under_cloud_sync(target) and git_toplevel(target)):
+                        roots.append(target)
+        except OSError:
+            pass
+    if os.path.islink(old_abs):
+        roots.append(os.path.realpath(old_abs))
+    if dev_root and os.path.isdir(dev_root):
+        for entry in sorted(os.listdir(dev_root)):
+            full = os.path.join(dev_root, entry)
+            if os.path.isdir(full):
+                roots.append(full)
+    # Scope the Claude config dir to where DEPLOYED tooling lives — never the whole
+    # tree: it holds large plugin caches, session transcripts, and snapshots that
+    # would balloon the walk to 100k+ files for zero executable-config value.
+    if config_dir:
+        for sub in ("hooks", "scripts"):
+            d = os.path.join(config_dir, sub)
+            if os.path.isdir(d):
+                roots.append(d)
+    return _dedupe_existing(roots)
+
+
+def discover_explicit_files(config_dir, auto):
+    """Top-level config + shell-rc files that sit OUTSIDE any walked dir but can
+    hold a load-bearing old-path ref (a hook command, an `export VAULT=`, a `cd`)."""
+    if not auto:
+        return []
+    cands = [os.path.join(config_dir, "settings.json"),
+             os.path.join(config_dir, "settings.local.json")]
+    for rc in (".zshrc", ".zshenv", ".zprofile", ".zlogin",
+               ".bashrc", ".bash_profile", ".profile"):
+        cands.append(str(HOME / rc))
+    return [c for c in cands if os.path.isfile(c)]
+
+
+def _dedupe_existing(roots):
+    out, seen = [], set()
+    for r in roots:
+        rp = os.path.realpath(r)
+        if rp in seen or not os.path.exists(r):
+            continue
+        seen.add(rp)
+        out.append(r)
+    return out
+
+
+def _skip(path):
+    return (any(tok in path for tok in SKIP_SUB)
+            or any(m in path for m in CLOUD_MARKERS)
+            or os.path.basename(path) == ".claude.json")
+
+
+# --------------------------------------------------------------------------- #
+# scanning                                                                     #
+# --------------------------------------------------------------------------- #
+def add_findings(findings, abspath, text, patterns, provenance, repo_label):
+    cl, ftype = classify_text(abspath, text, patterns)
+    for (ln, klass, reason) in cl:
+        snippet = ""
+        if ln and 0 < ln <= len(text.splitlines()):
+            snippet = text.splitlines()[ln - 1].strip()[:160]
+        findings.append({
+            "path": abbrev(abspath),
+            "line": ln,
+            "snippet": abbrev(snippet),
+            "file_type": ftype,
+            "klass": klass,
+            "provenance": provenance,
+            "reason": reason,
+            "repo": repo_label,
+        })
+
+
+def scan_git_repo(top, patterns):
+    """Grep one repo at its canonical ref + working tree; classify each hit.
+    Returns (root_summary, findings) so callers can run repos in parallel without
+    sharing a mutable findings list across threads."""
+    findings = []
+    ref, ref_label = resolve_canonical_ref(top)
+    canon = git_grep_files(top, patterns, ref) if ref else set()
+    work = git_grep_files(top, patterns, None)
+    for rel in sorted(canon | work):
+        if _skip(rel):
+            continue
+        abspath = os.path.join(top, rel)
+        in_canon, in_work = rel in canon, rel in work
+        if in_canon:
+            text = git_show(top, ref, rel)
+            prov = "both" if in_work else ref_label
+        else:
+            try:
+                text = Path(abspath).read_text()
+            except (OSError, UnicodeDecodeError):
+                text = None
+            prov = "working-tree"
+        if text is None:
+            continue
+        add_findings(findings, abspath, text, patterns, prov, abbrev(top))
+    return {"path": abbrev(top), "kind": "git", "ref": ref}, findings
+
+
+def scan_fs_root(root, patterns):
+    findings = []
+    if _under_cloud_sync(root):
+        return {"path": abbrev(root), "kind": "fs(skipped: cloud-sync)", "ref": None}, findings
+    for dirpath, dirs, files in os.walk(root):
+        dirs[:] = [d for d in dirs if d not in WALK_PRUNE]
+        for fn in files:
+            full = os.path.join(dirpath, fn)
+            if _skip(full) or Path(fn).suffix.lower() not in SCAN_EXTS:
+                continue
+            try:
+                text = Path(full).read_text()
+            except (OSError, UnicodeDecodeError):
+                continue
+            if not line_hits(text, patterns):
+                continue
+            add_findings(findings, full, text, patterns, "filesystem", None)
+    return {"path": abbrev(root), "kind": "fs", "ref": None}, findings
+
+
+# --------------------------------------------------------------------------- #
+# main                                                                         #
+# --------------------------------------------------------------------------- #
+def build_report(args):
+    old_abs = os.path.abspath(os.path.expanduser(args.old))
+    new_abs = os.path.abspath(os.path.expanduser(args.new)) if args.new else None
+    patterns = derive_patterns(old_abs)
+
+    roots = discover_roots(old_abs, new_abs, args.root, args.dev_root, args.config_dir,
+                           not args.no_auto_discover)
+
+    # Group roots into git repos (deduped by toplevel) vs plain filesystem roots.
+    repo_tops, fs_roots = {}, []
+    for r in roots:
+        top = git_toplevel(r)
+        if top:
+            repo_tops.setdefault(top, True)
+        else:
+            fs_roots.append(r)
+
+    findings, scanned = [], []
+    # Per-repo git work is I/O-bound (subprocess git grep) — run repos in parallel.
+    # A power user's ~/dev can hold 100+ repos; serial would take minutes.
+    tops = sorted(repo_tops)
+    if tops:
+        workers = min(16, (os.cpu_count() or 4) + 4)
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            for sc, loc in pool.map(lambda t: scan_git_repo(t, patterns), tops):
+                scanned.append(sc)
+                findings.extend(loc)
+    for r in fs_roots:
+        sc, loc = scan_fs_root(r, patterns)
+        scanned.append(sc)
+        findings.extend(loc)
+
+    # Top-level config + shell-rc files (outside any walked dir).
+    for f in discover_explicit_files(args.config_dir, not args.no_auto_discover):
+        if _skip(f):
+            continue
+        try:
+            text = Path(f).read_text()
+        except (OSError, UnicodeDecodeError):
+            continue
+        if line_hits(text, patterns):
+            add_findings(findings, f, text, patterns, "filesystem", None)
+
+    # Dedupe identical findings reachable via two roots.
+    uniq, seen = [], set()
+    for f in findings:
+        key = (f["path"], f["line"], f["klass"])
+        if key not in seen:
+            seen.add(key)
+            uniq.append(f)
+    findings = uniq
+
+    # ~/.claude.json blast radius — characterized separately, always.
+    claude_summary = {"path": None, "present": False, "valid": None,
+                      "dict_keys": 0, "string_values": 0}
+    cj_path = None
+    if args.claude_json:
+        cj_path = os.path.abspath(os.path.expanduser(args.claude_json))
+    elif not args.no_auto_discover:
+        cj_path = str(HOME / ".claude.json")
+    if cj_path and os.path.isfile(cj_path):
+        claude_summary["path"] = abbrev(cj_path)
+        claude_summary["present"] = True
+        try:
+            text = Path(cj_path).read_text()
+        except (OSError, UnicodeDecodeError):
+            text = None
+        if text is None:
+            claude_summary["valid"] = False
+        else:
+            cj_findings, dk, sv, valid = classify_json(text, patterns)
+            claude_summary["valid"] = valid
+            claude_summary["dict_keys"] = dk
+            claude_summary["string_values"] = sv
+            if not valid:
+                WARNINGS.append("~/.claude.json did not parse — characterize it by hand before editing")
+            for (ln, klass, reason) in cj_findings:
+                snippet = ""
+                if ln and 0 < ln <= len(text.splitlines()):
+                    snippet = text.splitlines()[ln - 1].strip()[:160]
+                findings.append({
+                    "path": abbrev(cj_path), "line": ln, "snippet": abbrev(snippet),
+                    "file_type": "json", "klass": klass, "provenance": "filesystem",
+                    "reason": reason, "repo": None,
+                })
+
+    counts = {"executed": 0, "doc-pointer": 0, "keep": 0}
+    for f in findings:
+        counts[f["klass"]] = counts.get(f["klass"], 0) + 1
+    verdict = "NO-GO" if counts["executed"] > 0 else "GO"
+
+    return {
+        "old": old_abs,
+        "new": new_abs,
+        "patterns": patterns,
+        "roots": scanned,
+        "findings": findings,
+        "claude_json": claude_summary,
+        "counts": {"executed": counts["executed"],
+                   "doc_pointer": counts["doc-pointer"],
+                   "keep": counts["keep"]},
+        "warnings": list(WARNINGS),
+        "verdict": verdict,
+    }
+
+
+def print_human(rep):
+    print("relocate-sweep")
+    print("  old path: " + abbrev(rep["old"]))
+    if rep["new"]:
+        print("  new path: " + abbrev(rep["new"]))
+    gitn = sum(1 for r in rep["roots"] if r["kind"] == "git")
+    print("  scanned %d root(s) (%d git repo(s) at canonical ref where present, else HEAD; + working tree)"
+          % (len(rep["roots"]), gitn))
+    for w in rep["warnings"]:
+        print("  WARN: " + w)
+
+    def group(klass):
+        return [f for f in rep["findings"] if f["klass"] == klass]
+
+    ex = group("executed")
+    print("\nEXECUTED — blocks symlink drop (%d):" % len(ex))
+    if not ex:
+        print("  (none)")
+    for f in sorted(ex, key=lambda x: (x["path"], x["line"] or 0)):
+        loc = f["path"] + (":" + str(f["line"]) if f["line"] else "")
+        print("  - [%s] %s  %s" % (f["provenance"], loc, f["snippet"]))
+
+    dp = group("doc-pointer")
+    print("\nDOC-POINTER — cosmetic, repoint at leisure (%d):" % len(dp))
+    for f in sorted(dp, key=lambda x: (x["path"], x["line"] or 0)):
+        loc = f["path"] + (":" + str(f["line"]) if f["line"] else "")
+        print("  - %s  (%s)" % (loc, f["reason"]))
+
+    kp = group("keep")
+    print("\nKEEP — intentional, left as-is (%d):" % len(kp))
+    for f in sorted(kp, key=lambda x: (x["path"], x["line"] or 0)):
+        loc = f["path"] + (":" + str(f["line"]) if f["line"] else "")
+        print("  - %s  (%s)" % (loc, f["reason"]))
+
+    cj = rep["claude_json"]
+    if cj["present"]:
+        valid = "valid" if cj["valid"] else "DID NOT PARSE"
+        print("\n~/.claude.json blast radius: %d dead dict-key(s) (cosmetic) / %d string-value(s) (load-bearing)  [%s]"
+              % (cj["dict_keys"], cj["string_values"], valid))
+        print("  (this sweep does not edit it — repoint the string VALUES by hand, then re-validate the JSON)")
+
+    print("\nVERDICT: " + rep["verdict"])
+    if rep["verdict"] == "NO-GO":
+        print("  %d executed reference(s) still resolve the old path. Repoint them, then re-run." % rep["counts"]["executed"])
+        print("  The symlink at the old path is doing real work — do NOT drop it yet.")
+    else:
+        print("  Zero executed references. Safe to drop the symlink:")
+        print("    relocate-vault.sh --drop-symlink " + abbrev(rep["old"]))
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(add_help=True, description="code-repo-aware vault-relocation residual sweep")
+    ap.add_argument("--old", required=True)
+    ap.add_argument("--new", default=None)
+    ap.add_argument("--root", action="append", default=[])
+    ap.add_argument("--dev-root", default=str(HOME / "dev"))
+    ap.add_argument("--config-dir", default=os.environ.get("CLAUDE_CONFIG_DIR", str(HOME / ".claude")))
+    ap.add_argument("--claude-json", default=None)
+    ap.add_argument("--no-auto-discover", action="store_true")
+    ap.add_argument("--json", action="store_true")
+    # argparse exits 2 on a missing required arg / bad usage, which is our usage code.
+    args = ap.parse_args(argv)
+
+    rep = build_report(args)
+    if args.json:
+        print(json.dumps(rep, indent=2))
+    else:
+        print_human(rep)
+    return 1 if rep["verdict"] == "NO-GO" else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/relocate-vault.sh
+++ b/scripts/relocate-vault.sh
@@ -25,6 +25,12 @@
 #   relocate-vault.sh <old-vault-path> <new-vault-path> [options]
 #   relocate-vault.sh --migrate-claude-state <old-abs-path> <new-abs-path>
 #     (state-only: the vault is already at the new path; just fix Claude history)
+#   relocate-vault.sh --sweep <old-path> [<new-path>]
+#     (report residual references to the old path — classified executed /
+#      doc-pointer / keep — with a go/no-go on retiring the symlink)
+#   relocate-vault.sh --drop-symlink <old-path> [<new-path>]
+#     (retire the old-path symlink, but ONLY when the sweep finds zero executed
+#      references; otherwise it refuses and lists what still points at the old path)
 #
 # Options:
 #   --dry-run            print intended actions, change nothing
@@ -34,10 +40,14 @@
 #   --config-dir <dir>   Claude Code config dir (default: $CLAUDE_CONFIG_DIR or ~/.claude)
 #   -h, --help           this help
 #
-# Exit codes: 0 ok / no-op · 1 refused (gate) · 2 usage · 4 partial failure
+# --sweep / --drop-symlink shell out to scripts/relocate-sweep.py (same dir).
+#
+# Exit codes: 0 ok / no-op / GO · 1 refused (gate) / NO-GO · 2 usage · 4 partial failure
 set -euo pipefail
 
-OLD="" ; NEW="" ; DRYRUN=0 ; FORCE=0 ; NOSYMLINK=0 ; MIGRATE_ONLY=0
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OLD="" ; NEW="" ; DRYRUN=0 ; FORCE=0 ; NOSYMLINK=0 ; MIGRATE_ONLY=0 ; SWEEP=0 ; DROP=0
+SWEEP_EXTRA=()
 CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
 
 while [ $# -gt 0 ]; do
@@ -47,7 +57,10 @@ while [ $# -gt 0 ]; do
     --force) FORCE=1; shift;;
     --config-dir) CONFIG_DIR="${2:?--config-dir needs a path}"; shift 2;;
     --migrate-claude-state) MIGRATE_ONLY=1; shift;;
-    -h|--help) sed -n '2,38p' "$0" | sed 's/^# \{0,1\}//'; exit 0;;
+    --sweep) SWEEP=1; shift;;
+    --drop-symlink) DROP=1; shift;;
+    --) shift; SWEEP_EXTRA=("$@"); break;;
+    -h|--help) sed -n '2,/^set -euo/p' "$0" | sed '/^set -euo/d; s/^# \{0,1\}//'; exit 0;;
     -*) echo "unknown option: $1" >&2; exit 2;;
     *) if [ -z "$OLD" ]; then OLD="$1"; elif [ -z "$NEW" ]; then NEW="$1"; else echo "unexpected arg: $1" >&2; exit 2; fi; shift;;
   esac
@@ -164,6 +177,49 @@ if [ "$MIGRATE_ONLY" = 1 ]; then
   NEW_ABS="$(abspath "$NEW")"
   say "relocate-vault: migrating Claude Code state only ($OLD_ABS -> $NEW_ABS)"
   migrate_claude_state "$OLD_ABS" "$NEW_ABS"
+  exit 0
+fi
+
+# Run the code-repo-aware residual sweep. Returns the sweep's exit code:
+# 0 = GO (zero executed references) · 1 = NO-GO (executed references remain).
+sweep_old_refs() {  # $1=old  [$2=new];  forwards any args given after `--`
+  local sweep_py="$SCRIPT_DIR/relocate-sweep.py"
+  [ -f "$sweep_py" ] || die "relocate-sweep.py not found next to this script ($sweep_py)"
+  local args=( --old "$1" )
+  [ -n "${2:-}" ] && args+=( --new "$2" )
+  if [ "${#SWEEP_EXTRA[@]}" -gt 0 ]; then args+=( "${SWEEP_EXTRA[@]}" ); fi
+  python3 "$sweep_py" "${args[@]}"
+}
+
+# =============================================================================
+# sweep mode: report residual references to the old path, classified, + go/no-go
+# =============================================================================
+if [ "$SWEEP" = 1 ]; then
+  [ -n "$OLD" ] || { echo "usage: $(basename "$0") --sweep <old-path> [<new-path>]" >&2; exit 2; }
+  set +e; sweep_old_refs "$OLD" "$NEW"; rc=$?; set -e
+  exit "$rc"
+fi
+
+# =============================================================================
+# drop-symlink mode: retire the old-path symlink ONLY when the sweep says GO
+# =============================================================================
+if [ "$DROP" = 1 ]; then
+  [ -n "$OLD" ] || { echo "usage: $(basename "$0") --drop-symlink <old-path> [<new-path>]" >&2; exit 2; }
+  [ -L "$OLD" ] || die "old path '$OLD' is not a symlink — nothing to drop (relocate first, or it is already gone)"
+  # If the caller did not pass the new path, read it from the symlink target so the
+  # sweep can name the repoint destination in its report.
+  [ -n "$NEW" ] || NEW="$(readlink "$OLD")"
+  say "relocate-vault: sweeping for residual references before retiring the symlink at '$OLD' ..."
+  set +e; sweep_old_refs "$OLD" "$NEW"; rc=$?; set -e
+  if [ "$rc" != 0 ]; then
+    die "NO-GO — executed references still resolve the old path (see report above). Repoint them, then re-run --drop-symlink." 1
+  fi
+  if [ "$DRYRUN" = 1 ]; then
+    say "DRY  would: rm '$OLD' (symlink) — sweep returned GO (zero executed references)."
+    exit 0
+  fi
+  rm "$OLD"
+  say "relocate-vault: retired the symlink '$OLD' — sweep returned GO (zero executed references)."
   exit 0
 fi
 

--- a/scripts/test-relocate-sweep.py
+++ b/scripts/test-relocate-sweep.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Negative-control test for scripts/relocate-sweep.py — the code-repo-aware
+residual-reference sweep that decides whether it is safe to drop the symlink a
+relocation left behind.
+
+A guard earns trust only by failing on the thing it catches
+(docs/CLOUD_SYNC.md + the deployed-not-committed-not-working discipline). This
+asserts every classification + provenance + verdict behaviour the sweep promises:
+
+  CLASSIFY (3-way): a reference to the old path is one of
+    - EXECUTED   : a load-bearing position (a code line, a markdown code-span /
+                   fenced block, a JSON string VALUE under a live key). BLOCKS the
+                   symlink drop. (positive control — MUST be caught)
+    - DOC-POINTER: a human-readable position (a comment, a docstring, markdown
+                   prose). Cosmetic; never blocks. (negative control — must NOT
+                   land in EXECUTED, or it would create false NO-GO churn)
+    - KEEP       : intentional (the relocate tooling's own OLD= source, a JSON
+                   dict KEY = a dead project key, an inert permissions matcher,
+                   a relocate-keep-marked line). Excluded from the verdict.
+
+  PROVENANCE: a git repo is grepped at its CANONICAL ref (origin/main), NOT only
+    the working tree — a stale checked-out branch can HIDE a ref that origin/main
+    still carries (the WRONG-ARTIFACT-VERIFIED class). The sweep must find a ref
+    that exists on origin/main even when the working tree (a different branch)
+    lacks it, AND find an uncommitted working-tree-only ref.
+
+  .claude.json BLAST RADIUS: dict KEYS that hold the old path are cosmetic (dead
+    keys, never looked up); string VALUES are load-bearing. The sweep reports the
+    split and validates the JSON parses (a malformed file warns, never crashes).
+
+  VERDICT + EXIT: any EXECUTED ref -> NO-GO + exit 1; none -> GO + exit 0; a
+    clean tree -> GO with zero executed (the NO-OP/GO detector); usage error -> 2.
+
+Hermetic: a temp sandbox with its own roots, --config-dir, and --claude-json;
+--no-auto-discover keeps the real machine untouched. Run:
+    python3 scripts/test-relocate-sweep.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SWEEP = HERE / "relocate-sweep.py"
+
+fails = 0
+
+
+def pass_(msg: str) -> None:
+    print(f"PASS  {msg}")
+
+
+def fail(msg: str) -> None:
+    global fails
+    print(f"FAIL  {msg}")
+    fails += 1
+
+
+def run_sweep(*args: str):
+    """Run the sweep in --json mode; return (exit_code, parsed_obj_or_None, raw)."""
+    proc = subprocess.run(
+        [sys.executable, str(SWEEP), "--json", *args],
+        capture_output=True,
+        text=True,
+    )
+    obj = None
+    try:
+        obj = json.loads(proc.stdout)
+    except (json.JSONDecodeError, ValueError):
+        pass
+    return proc.returncode, obj, proc.stdout + proc.stderr
+
+
+def klass_of(obj, needle: str):
+    """Return the classification of the first finding whose path contains needle."""
+    for f in obj.get("findings", []):
+        if needle in f.get("path", ""):
+            return f.get("klass")
+    return None
+
+
+def findings_with(obj, needle: str):
+    return [f for f in obj.get("findings", []) if needle in f.get("path", "")]
+
+
+def classes_of(obj, needle: str):
+    """Set of classifications across ALL findings for a path (a file may carry a
+    code ref AND prose mentions; the sweep emits one finding per occurrence)."""
+    return {f.get("klass") for f in findings_with(obj, needle)}
+
+
+def git(*args: str, cwd: str) -> None:
+    env = dict(os.environ)
+    env.update(
+        GIT_AUTHOR_NAME="t",
+        GIT_AUTHOR_EMAIL="t@example.com",
+        GIT_COMMITTER_NAME="t",
+        GIT_COMMITTER_EMAIL="t@example.com",
+    )
+    subprocess.run(["git", *args], cwd=cwd, env=env, check=True,
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def main() -> int:
+    if not SWEEP.exists():
+        fail(f"relocate-sweep.py not found at {SWEEP} (build it first)")
+        return 1
+
+    tmp = tempfile.mkdtemp()
+    # A generic old path — NEVER a real personal path (public-repo scrub).
+    OLD = f"{tmp}/Desktop/Old Vault"
+    NEW = f"{tmp}/Brain"
+    base, leaf = "Desktop", "Old Vault"
+
+    # ---------------------------------------------------------------------
+    # Root 1: a plain (non-git) filesystem tree with one ref per file type.
+    # ---------------------------------------------------------------------
+    fsroot = Path(tmp) / "fsroot"
+    (fsroot).mkdir(parents=True)
+
+    # .py — a load-bearing assignment (EXECUTED) + a docstring + a comment (DOC).
+    (fsroot / "recreator.py").write_text(
+        '"""Writes to ' + OLD + ' historically (docstring mention)."""\n'
+        "import os\n"
+        "# old default was " + OLD + " (comment mention)\n"
+        'VAULT_ROOT = "' + OLD + '/sub"\n'
+        "os.makedirs(VAULT_ROOT, exist_ok=True)\n"
+    )
+    # .py — the piecewise pathlib form is a load-bearing expression (EXECUTED).
+    (fsroot / "piecewise.py").write_text(
+        "from pathlib import Path\n"
+        'ROOT = Path.home() / "' + base + '" / "' + leaf + '"\n'
+    )
+    # .py — a docstring-only mention with NO code ref: must be DOC-POINTER only.
+    (fsroot / "doconly.py").write_text(
+        '"""Legacy note: this module used to default to ' + OLD + '."""\n'
+        "X = 1\n"
+    )
+    # .sh — a cd into the old path is EXECUTED; a leading-# comment is DOC.
+    (fsroot / "run.sh").write_text(
+        "#!/usr/bin/env bash\n"
+        "# once cd " + OLD + " (comment)\n"
+        'cd "' + OLD + '" || exit 1\n'
+    )
+    # .md — old path inside a fenced block is EXECUTED; in prose it is DOC.
+    (fsroot / "prose.md").write_text(
+        "The vault used to live at " + OLD + " before the move (prose only).\n"
+    )
+    (fsroot / "fenced.md").write_text(
+        "Deploy:\n\n```bash\ncd \"" + OLD + "\"\nmake\n```\n"
+    )
+    # KEEP: a relocate-keep-marked line is intentional.
+    (fsroot / "keepme.sh").write_text(
+        "#!/usr/bin/env bash\n"
+        'OLD="' + OLD + '"  # relocate-keep: migration source\n'
+    )
+
+    # ---------------------------------------------------------------------
+    # Root 2: a git repo where origin/main CARRIES the ref but the checked-out
+    # branch does NOT (provenance: canonical must still find it), PLUS an
+    # uncommitted working-tree-only ref.
+    # ---------------------------------------------------------------------
+    origin = Path(tmp) / "origin.git"
+    repo = Path(tmp) / "coderepo"
+    git("init", "--bare", str(origin), cwd=tmp)
+    git("clone", str(origin), str(repo), cwd=tmp)
+    (repo / "config.py").write_text('CWD = "' + OLD + '"  # load-bearing\n')
+    git("add", "config.py", cwd=str(repo))
+    git("commit", "-m", "add config", cwd=str(repo))
+    # default branch may be 'main' or 'master'; force a 'main' on origin.
+    git("branch", "-M", "main", cwd=str(repo))
+    git("push", "-u", "origin", "main", cwd=str(repo))
+    # Move to a different branch and DELETE the ref from the working tree.
+    git("checkout", "-b", "feature", cwd=str(repo))
+    (repo / "config.py").write_text("CWD = 'repointed'  # fixed on this branch\n")
+    git("commit", "-am", "repoint on feature", cwd=str(repo))
+    # An uncommitted working-tree-only recreator (never pushed).
+    (repo / "uncommitted.sh").write_text('cd "' + OLD + '"\n')
+
+    # ---------------------------------------------------------------------
+    # A sandbox ~/.claude.json: a dead project KEY (cosmetic) + a live string
+    # VALUE (load-bearing) both referencing the old path.
+    # ---------------------------------------------------------------------
+    claude_json = Path(tmp) / "claude.json"
+    claude_json.write_text(json.dumps({
+        "projects": {OLD: {"history": []}},          # dict KEY = cosmetic
+        "statusLine": {"command": OLD + "/bin/x"},   # string VALUE = load-bearing
+        "permissions": {"allow": ["Read(" + OLD + "/**)"]},  # inert matcher = KEEP
+    }))
+
+    # =====================================================================
+    # RUN 1: full sweep over both roots + the .claude.json.
+    # =====================================================================
+    rc, obj, raw = run_sweep(
+        "--old", OLD, "--new", NEW,
+        "--no-auto-discover",
+        "--root", str(fsroot),
+        "--root", str(repo),
+        "--claude-json", str(claude_json),
+        "--config-dir", str(Path(tmp) / "noexist-claude"),
+    )
+    if obj is None:
+        fail(f"sweep did not emit parseable JSON (rc={rc}). Output:\n{raw}")
+        print(f"\nFAILED: {fails}")
+        return 1
+
+    # ---- CLASSIFY: EXECUTED positive controls ----------------------------
+    # Membership, not first-finding: recreator.py carries prose AND a code ref;
+    # the code ref must be EXECUTED even though earlier lines are prose.
+    for name, label in [
+        ("recreator.py", "py assignment (load-bearing)"),
+        ("piecewise.py", "py piecewise pathlib expression"),
+        ("run.sh", "sh cd command"),
+        ("fenced.md", "md fenced block"),
+    ]:
+        cs = classes_of(obj, name)
+        (pass_ if "executed" in cs else fail)(f"EXECUTED: {label} ({name}) -> {cs}")
+
+    # the .claude.json string VALUE must be EXECUTED
+    sv = [f for f in obj.get("findings", []) if f.get("file_type") == "json"
+          and f.get("klass") == "executed"]
+    (pass_ if sv else fail)("EXECUTED: .claude.json statusLine.command string value")
+
+    # ---- CLASSIFY: DOC-POINTER (must NOT block) --------------------------
+    k = klass_of(obj, "prose.md")
+    (pass_ if k == "doc-pointer" else fail)(f"DOC-POINTER: md prose (prose.md) -> {k}")
+    k = klass_of(obj, "doconly.py")
+    (pass_ if k == "doc-pointer" else fail)(f"DOC-POINTER: py docstring-only (doconly.py) -> {k}")
+    # doconly.py must NOT appear as executed anywhere (the core false-NO-GO guard)
+    bad = [f for f in findings_with(obj, "doconly.py") if f.get("klass") == "executed"]
+    (pass_ if not bad else fail)("DOC-POINTER: docstring-only never classified EXECUTED")
+
+    # recreator.py has BOTH a docstring/comment mention AND a code ref; the file's
+    # finding set must include an EXECUTED one (the code line) — not silently
+    # downgraded to doc just because prose mentions exist.
+    rk = {f.get("klass") for f in findings_with(obj, "recreator.py")}
+    (pass_ if "executed" in rk else fail)("MIXED: recreator.py code line stays EXECUTED amid prose")
+
+    # ---- CLASSIFY: KEEP --------------------------------------------------
+    k = klass_of(obj, "keepme.sh")
+    (pass_ if k == "keep" else fail)(f"KEEP: relocate-keep-marked line (keepme.sh) -> {k}")
+    # the inert permissions matcher in .claude.json must be KEEP, not EXECUTED
+    perm_exec = [f for f in obj.get("findings", [])
+                 if "permissions" in (f.get("reason", "") + f.get("snippet", ""))
+                 and f.get("klass") == "executed"]
+    (pass_ if not perm_exec else fail)("KEEP: inert permissions matcher not EXECUTED")
+
+    # ---- PROVENANCE ------------------------------------------------------
+    canon = [f for f in findings_with(obj, "config.py")
+             if "canonical" in f.get("provenance", "")]
+    (pass_ if canon else fail)("PROVENANCE: origin/main ref found though working tree lacks it")
+    wt = [f for f in findings_with(obj, "uncommitted.sh")
+          if "working" in f.get("provenance", "")]
+    (pass_ if wt else fail)("PROVENANCE: uncommitted working-tree-only ref found + labelled")
+
+    # ---- .claude.json blast radius --------------------------------------
+    cj = obj.get("claude_json", {})
+    (pass_ if cj.get("dict_keys", 0) >= 1 else fail)(".claude.json: dead dict KEY counted (cosmetic)")
+    (pass_ if cj.get("string_values", 0) >= 1 else fail)(".claude.json: live string VALUE counted (load-bearing)")
+    (pass_ if cj.get("valid") is True else fail)(".claude.json: validated as parseable JSON")
+
+    # ---- VERDICT + exit --------------------------------------------------
+    (pass_ if obj.get("verdict") == "NO-GO" else fail)(f"VERDICT: NO-GO with executed refs (got {obj.get('verdict')})")
+    (pass_ if rc == 1 else fail)(f"EXIT: 1 on NO-GO (got {rc})")
+
+    # =====================================================================
+    # RUN 2: GO path — a clean root with only a DOC-POINTER + a KEEP, no
+    # executed refs anywhere -> GO + exit 0 (the NO-OP/GO detector).
+    # =====================================================================
+    goroot = Path(tmp) / "goroot"
+    goroot.mkdir()
+    (goroot / "history.md").write_text("We moved from " + OLD + " long ago (prose).\n")
+    (goroot / "keep.sh").write_text('OLD="' + OLD + '"  # relocate-keep\n')
+    rc2, obj2, raw2 = run_sweep(
+        "--old", OLD, "--new", NEW,
+        "--no-auto-discover", "--root", str(goroot),
+        "--config-dir", str(Path(tmp) / "noexist-claude"),
+    )
+    if obj2 is None:
+        fail(f"GO-run did not emit JSON (rc={rc2}): {raw2}")
+    else:
+        (pass_ if obj2.get("counts", {}).get("executed", -1) == 0 else fail)(
+            "GO detector: zero executed refs over a doc+keep-only tree")
+        (pass_ if obj2.get("verdict") == "GO" else fail)(f"VERDICT: GO (got {obj2.get('verdict')})")
+        (pass_ if rc2 == 0 else fail)(f"EXIT: 0 on GO (got {rc2})")
+
+    # =====================================================================
+    # RUN 3: malformed .claude.json warns, never crashes (fail-loud, not fatal).
+    # =====================================================================
+    bad_json = Path(tmp) / "bad.json"
+    bad_json.write_text("{ not valid json ,,, ")
+    rc3, obj3, raw3 = run_sweep(
+        "--old", OLD, "--no-auto-discover", "--root", str(goroot),
+        "--claude-json", str(bad_json),
+        "--config-dir", str(Path(tmp) / "noexist-claude"),
+    )
+    if obj3 is None:
+        fail(f"malformed-claude-json run did not emit JSON (rc={rc3}): {raw3}")
+    else:
+        cj3 = obj3.get("claude_json", {})
+        (pass_ if cj3.get("valid") is False else fail)("malformed .claude.json reported valid=false (not a crash)")
+        (pass_ if rc3 in (0, 1) else fail)(f"malformed .claude.json did not crash the sweep (rc={rc3})")
+
+    # =====================================================================
+    # RUN 4: usage error (no --old) -> exit 2.
+    # =====================================================================
+    rc4, _, _ = run_sweep("--no-auto-discover", "--root", str(goroot))
+    (pass_ if rc4 == 2 else fail)(f"EXIT: 2 on usage error / missing --old (got {rc4})")
+
+    print()
+    if fails:
+        print(f"FAILED: {fails}")
+        return 1
+    print("ALL TESTS PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test-relocate-sweep.py
+++ b/scripts/test-relocate-sweep.py
@@ -186,11 +186,13 @@ def main() -> int:
     # VALUE (load-bearing) both referencing the old path.
     # ---------------------------------------------------------------------
     claude_json = Path(tmp) / "claude.json"
+    # indent=2 so each value is on its own line (a real ~/.claude.json is indented)
+    # — keeps per-finding snippets meaningful instead of the whole one-line blob.
     claude_json.write_text(json.dumps({
         "projects": {OLD: {"history": []}},          # dict KEY = cosmetic
         "statusLine": {"command": OLD + "/bin/x"},   # string VALUE = load-bearing
         "permissions": {"allow": ["Read(" + OLD + "/**)"]},  # inert matcher = KEEP
-    }))
+    }, indent=2))
 
     # =====================================================================
     # RUN 1: full sweep over both roots + the .claude.json.
@@ -243,11 +245,15 @@ def main() -> int:
     # ---- CLASSIFY: KEEP --------------------------------------------------
     k = klass_of(obj, "keepme.sh")
     (pass_ if k == "keep" else fail)(f"KEEP: relocate-keep-marked line (keepme.sh) -> {k}")
-    # the inert permissions matcher in .claude.json must be KEEP, not EXECUTED
-    perm_exec = [f for f in obj.get("findings", [])
-                 if "permissions" in (f.get("reason", "") + f.get("snippet", ""))
-                 and f.get("klass") == "executed"]
-    (pass_ if not perm_exec else fail)("KEEP: inert permissions matcher not EXECUTED")
+    # The inert permissions matcher in .claude.json must be KEEP, not EXECUTED.
+    # Match on the semantic `reason` field, NOT the snippet: a finding's snippet is
+    # path-length-fragile (a compact one-line JSON or a long tmp path can push an
+    # unrelated key into/out of the 160-char window). `reason` is precise per-finding.
+    perm = [f for f in obj.get("findings", []) if "permission" in f.get("reason", "").lower()]
+    perm_exec = [f for f in perm if f.get("klass") == "executed"]
+    perm_keep = [f for f in perm if f.get("klass") == "keep"]
+    (pass_ if perm_keep and not perm_exec else fail)(
+        f"KEEP: inert permissions matcher kept, not executed (keep={len(perm_keep)} exec={len(perm_exec)})")
 
     # ---- PROVENANCE ------------------------------------------------------
     canon = [f for f in findings_with(obj, "config.py")

--- a/tests/integration/test_relocate_sweep.sh
+++ b/tests/integration/test_relocate_sweep.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# CI integration wrapper — runs the relocate-sweep negative-control suite
+# (scripts/test-relocate-sweep.py) as part of scripts/ci.sh. Thin: the logic
+# lives next to the script it exercises. python3 (not bash) because the sweep and
+# its test are Python — JSON parsing, AST/tokenize-aware classification, and
+# git-ref grepping are not shell work.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+exec python3 "$ROOT/scripts/test-relocate-sweep.py"


### PR DESCRIPTION
## What

After a vault relocation, `relocate-vault.sh` leaves a symlink at the old path so existing references keep resolving. That symlink is also a blindfold: while it is there, anything still hardcoding the old path "works", so you cannot tell which references are migrated. The new `relocate-sweep.py` removes the guesswork.

It hunts the old path across **every surface a vault touches** — code repos (including docstrings and comments), JSON config, MCP configs, docs, shell rc — auto-discovering roots (it resolves the vault's symlinked-in git repos and walks the dev tree, since a hand-kept root list always lags). For each git repo it greps the **canonical** `origin/main`, not just the working tree, because a stale local branch can hide a committed reference.

Every hit is classified three ways:

- **executed** — load-bearing: a code line, a markdown fenced block, a JSON string *value*. Blocks the symlink drop.
- **doc-pointer** — a comment, a docstring, prose. Cosmetic.
- **keep** — intentional: a migration source, a dead JSON dict *key*, an inert matcher.

`relocate-vault.sh --sweep <old> [<new>]` prints the classified report plus a go/no-go. `relocate-vault.sh --drop-symlink <old>` runs the sweep and retires the symlink **only on a GO** (zero executed references); otherwise it refuses and lists what to repoint. The `.claude.json` blast radius is reported separately (dead project *keys* are cosmetic; string *values* are load-bearing) and the JSON is validated. The sweep never edits anything.

## Performance

Per-repo greps run in parallel with vendored-tree pathspec excludes (`node_modules`, `target`, ...) and a cloud-sync skip, so a 100+-repo dev tree sweeps in seconds instead of blocking on a synced doc mirror's placeholder downloads.

## Tests

`test-relocate-sweep.py` (a negative-control suite wired into `ci.sh`) asserts the three-way classification, canonical-vs-working-tree provenance, the `.claude.json` key/value split, and the GO/NO-GO exit codes -- including that a docstring mention never produces a false NO-GO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)