### PR TITLE
fix(meta): harden Meta resolution - guard recurrence + detect already-split vaults

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -62,6 +62,20 @@ jobs:
       - name: run the canonical shellcheck gate
         run: bash scripts/shellcheck.sh
 
+  meta-resolution:
+    name: no naive Meta glob (resolve via _meta_resolver)
+    runs-on: ubuntu-latest
+    # The vault Meta folder must be resolved through scripts/_meta_resolver.py,
+    # never a sort-order `for c in "$VAULT"/*Meta` glob - plain "Meta" (machine
+    # memory) sorts before the emoji "⚙️ Meta" (human memory), so the naive glob
+    # silently writes human session/traffic data into the machine folder
+    # (ai-brain-starter#176). This guard fails a PR that reintroduces it.
+    # No untrusted user input is referenced in any run: command.
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - name: run the meta-resolution guard
+        run: bash scripts/check-meta-resolution.sh
+
   powershell:
     name: PowerShell parse (.ps1)
     runs-on: ubuntu-latest

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,22 @@ description: What's new in AI Brain Starter — plain English, no jargon
 
 ---
 
+## 2026-06-07: a follow-up — guard the "Meta" leak from coming back, and detect vaults it already hit
+
+**Who this affects:** the same people as the entry below (emoji-`⚙️ Meta` vaults), plus anyone setting up a fresh vault. The earlier fix stopped *new* leaks; this makes the fix permanent and helps anyone already bitten find and repair the damage.
+
+### What's new
+
+- **A guard so the bug can't return.** A CI check (`scripts/check-meta-resolution.sh`) now fails the build if any shell script reintroduces the naive `*Meta` glob instead of using the shared resolver. The fix below was point-in-time; this makes it durable.
+- **`/diagnose` detects an already-split vault.** A new check (section 14, backed by `scripts/check-split-meta.py`) flags a vault whose session log, session archive, or traffic dashboard leaked into a plain `Meta/` beside your real `⚙️ Meta/`, and tells you how to move them back. If you were bitten before updating, this is how you find it.
+- **`/diagnose`'s Meta check no longer assumes the emoji name.** Section 2 used to look only for `⚙️ Meta/` and would false-fail a stock vault that uses a plain `Meta/`. It now resolves whichever variant you actually have.
+
+### Verification
+
+Both new checks ship with negative-control tests wired into `scripts/ci.sh`: the guard test proves a *reintroduced* glob is caught (not just that a clean tree passes), and the detector test proves a leaked `Sessions/` in a plain `Meta/` is flagged while a healthy machine/human partition stays quiet.
+
+---
+
 ## 2026-06-07: session logs + traffic dashboards could silently leak into the wrong "Meta" folder
 
 **Who this affects:** anyone whose vault uses an emoji-decorated meta folder like `⚙️ Meta` for their human notes (rules, decisions, the session log). If the closed-loop memory engine ever created a plain `Meta/` folder for machine memory, five shell scripts could quietly start writing your session log, session archive, repo-traffic dashboard, and daily-maintenance logs into that machine folder instead of your real one — no error, nothing visibly wrong, until you noticed your history split across two folders.

--- a/scripts/check-meta-resolution.sh
+++ b/scripts/check-meta-resolution.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# scripts/check-meta-resolution.sh - ban the naive "*Meta" glob in shell scripts.
+#
+# The vault Meta folder MUST be resolved through scripts/_meta_resolver.py, which
+# prefers the variant containing a known subfolder. It must NEVER be resolved with
+# a sort-order glob like `for c in "$VAULT"/*Meta; do ...; break`: plain "Meta"
+# (machine memory) sorts before the emoji "⚙️ Meta" (human memory), so the naive
+# glob silently writes human session/traffic data into the machine folder.
+# ai-brain-starter#176 fixed the five scripts that had it; this guard stops a
+# sixth from reintroducing the bug class.
+#
+# Usage:
+#   bash scripts/check-meta-resolution.sh         # scan tracked *.sh (CI + local)
+#   bash scripts/check-meta-resolution.sh <dir>   # scan *.sh under <dir> (tests)
+#
+# Exit: 0 = clean, 1 = a banned glob was found.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# The banned construct: iterating a "<var>"/*Meta glob.
+PATTERN='in[[:space:]]+"?\$[A-Za-z_][A-Za-z0-9_]*"?/\*Meta'
+
+# This guard + its test legitimately NAME the pattern as data; never flag them.
+SELF="$(basename "${BASH_SOURCE[0]}")"
+skip_basename() {
+  case "$1" in
+    "$SELF"|test-meta-resolution-guard.sh|test_meta_resolution_guard.sh) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+list_files() {
+  if [ -n "${1:-}" ]; then
+    find "$1" -name '*.sh' -type f 2>/dev/null
+  else
+    ( cd "$REPO_ROOT" && git ls-files '*.sh' ) \
+      | while IFS= read -r rel; do printf '%s/%s\n' "$REPO_ROOT" "$rel"; done
+  fi
+}
+
+offenders=0
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  skip_basename "$(basename "$f")" && continue
+  # Match executable uses only: drop pure-comment lines (a doc comment that
+  # NAMES the banned glob, e.g. in a test or a how-this-was-fixed note, is fine).
+  if hits="$(grep -nE "$PATTERN" "$f" 2>/dev/null | grep -vE '^[0-9]+:[[:space:]]*#')"; then
+    echo "::error file=$f::naive *Meta glob: resolve the Meta folder via scripts/_meta_resolver.py instead"
+    printf '%s\n' "$hits" | sed 's/^/    /'
+    offenders=$((offenders + 1))
+  fi
+done < <(list_files "${1:-}")
+
+if [ "$offenders" -gt 0 ]; then
+  echo "FAILED: $offenders shell file(s) use the banned naive *Meta glob."
+  echo 'Fix: META_DIR="$(python3 "$SCRIPT_DIR/_meta_resolver.py" "$VAULT" Sessions Decisions)" || META_DIR="$VAULT/Meta"'
+  exit 1
+fi
+echo "OK - no naive *Meta glob in shell scripts"

--- a/scripts/check-split-meta.py
+++ b/scripts/check-split-meta.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""check-split-meta.py - detect a vault whose session/traffic data leaked into a
+plain "Meta/" folder instead of the human "⚙️ Meta/" (the ai-brain-starter#176
+bug). The resolver fix prevents NEW leaks; this finds vaults already split by the
+old naive glob so diagnose.sh can surface the one-time reconcile.
+
+Verdicts (--porcelain):
+  OK_NO_META        no Meta-suffixed folder
+  OK_SINGLE_META    exactly one Meta-suffixed folder
+  OK_PARTITIONED    plain "Meta/" holds only machine memory; human "⚙️ Meta/" is
+                    separate (the correct, healthy layout)
+  SPLIT_META:<n>    plain "Meta/" holds <n> human session/traffic item(s) that
+                    belong in "⚙️ Meta/" -- the leak happened
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Files/dirs the five buggy scripts wrote (session-end-hook, vault-daily-
+# maintenance, traffic-digest/snapshot). Their presence in a PLAIN "Meta/" while
+# a decorated "⚙️ Meta/" also exists means the human/machine split was breached.
+HUMAN_LEAK_MARKERS = (
+    "Sessions",
+    "Session Log.md",
+    "Last Session.md",
+    "Session Captures.md",
+    "Decision Log.md",
+    "Repo Traffic Dashboard.md",
+    "logs",
+)
+
+
+def verdict(vault_root: Path) -> str:
+    if not vault_root.is_dir():
+        return "OK_NO_META"
+    metas = sorted(
+        c for c in vault_root.iterdir()
+        if c.is_dir() and c.name.endswith("Meta")
+    )
+    if not metas:
+        return "OK_NO_META"
+    if len(metas) == 1:
+        return "OK_SINGLE_META"
+    # Two+ Meta dirs. A bare "Meta" is the machine folder; a decorated one (emoji
+    # prefix) is the human folder. Contamination = human markers inside bare Meta.
+    plain = next((m for m in metas if m.name == "Meta"), None)
+    decorated = [m for m in metas if m.name != "Meta"]
+    if plain is None or not decorated:
+        return "OK_PARTITIONED"
+    leaked = [m for m in HUMAN_LEAK_MARKERS if (plain / m).exists()]
+    if leaked:
+        return "SPLIT_META:%d" % len(leaked)
+    return "OK_PARTITIONED"
+
+
+def main(argv: list[str]) -> int:
+    porcelain = "--porcelain" in argv
+    args = [a for a in argv if a != "--porcelain"]
+    vault = Path(args[0]) if args else Path.cwd()
+    result = verdict(vault)
+    print(result if porcelain else "split-meta check: %s" % result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -99,6 +99,8 @@ INTEGRATION_TESTS=(
   test_reconcile_ff_invariant
   test_detect_closing_signal_worktree
   test_meta_resolver
+  test_meta_resolution_guard
+  test_split_meta
   test_stranded_session_artifacts_watchdog
   test_session_coordination_guards
   test_trust_prompt_preframing

--- a/scripts/diagnose.sh
+++ b/scripts/diagnose.sh
@@ -62,18 +62,27 @@ fi
 
 # ----- 2. Meta folder structure -----
 section "2. Meta folder"
-META="$VAULT/⚙️ Meta"
+# Resolve the Meta folder via the shared resolver so a plain "Meta/" and an
+# emoji "⚙️ Meta/" are both handled (and a machine "Meta/" can't shadow the
+# human one). Falls back to the decorated default when the resolver is absent.
+META_RESOLVER="$(cd "$(dirname "$0")" && pwd)/_meta_resolver.py"
+[ -f "$META_RESOLVER" ] || META_RESOLVER="$HOME/.claude/skills/ai-brain-starter/scripts/_meta_resolver.py"
+META=""
+if [ -f "$META_RESOLVER" ]; then
+  META="$(python3 "$META_RESOLVER" "$VAULT" scripts rules Decisions 2>/dev/null || true)"
+fi
+[ -z "$META" ] && META="$VAULT/⚙️ Meta"
 if [ -d "$META" ]; then
-  ok "⚙️ Meta/ folder present"
+  ok "Meta folder present ($(basename "$META")/)"
   for sub in scripts rules; do
     if [ -d "$META/$sub" ]; then
-      ok "⚙️ Meta/$sub/ present"
+      ok "$(basename "$META")/$sub/ present"
     else
-      warn "⚙️ Meta/$sub/ missing"
+      warn "$(basename "$META")/$sub/ missing"
     fi
   done
 else
-  bad "⚙️ Meta/ folder missing" "Run /setup-brain Phase 3."
+  bad "Meta folder missing (looked for ⚙️ Meta/ and Meta/)" "Run /setup-brain Phase 3."
 fi
 
 # ----- 3. Skills installed -----
@@ -360,6 +369,28 @@ if [ -n "$CHECK_RENDERER" ]; then
   esac
 else
   warn "check-renderer-crashes.py not found" "Cannot check for repeated Obsidian renderer crashes."
+fi
+
+# ----- 14. Split Meta folders (the leaked-session class) -----
+section "14. Split Meta folders"
+CHECK_SPLIT=""
+for c in "$(cd "$(dirname "$0")" && pwd)/check-split-meta.py" \
+         "$HOME/.claude/skills/ai-brain-starter/scripts/check-split-meta.py"; do
+  [ -f "$c" ] && CHECK_SPLIT="$c" && break
+done
+if [ -n "$CHECK_SPLIT" ]; then
+  sverdict="$(python3 "$CHECK_SPLIT" --porcelain "$VAULT" 2>/dev/null)"
+  case "$sverdict" in
+    OK_NO_META|OK_SINGLE_META|OK_PARTITIONED)
+      ok "Meta folders are not split (session + traffic data is where it belongs)" ;;
+    SPLIT_META:*)
+      bad "Session/traffic data leaked into a plain 'Meta/' (${sverdict#SPLIT_META:} item(s)), not '⚙️ Meta/'" \
+        "Update ai-brain-starter (the resolver fix stops new leaks), then move the leaked items from 'Meta/' into '⚙️ Meta/' and merge 'Session Log.md'. See docs/CHANGELOG.md (2026-06-07 Meta entries)." ;;
+    *)
+      warn "Could not evaluate Meta-folder split" "check-split-meta.py returned: ${sverdict:-<empty>}" ;;
+  esac
+else
+  warn "check-split-meta.py not found" "Cannot check for split Meta folders."
 fi
 
 # ----- summary -----

--- a/scripts/test-meta-resolution-guard.sh
+++ b/scripts/test-meta-resolution-guard.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# scripts/test-meta-resolution-guard.sh - negative-control test for
+# scripts/check-meta-resolution.sh. Proves the guard FAILS on a reintroduced
+# naive "*Meta" glob and PASSES on a script that uses the resolver. A guard that
+# is only ever seen pass is worthless (deployed-not-committed-not-working.md).
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUARD="$HERE/check-meta-resolution.sh"
+
+fail=0
+check() {  # check <description> <expected-rc> <actual-rc>
+  if [ "$2" = "$3" ]; then
+    echo "  ok: $1"
+  else
+    echo "  FAIL: $1 (expected rc=$2, got rc=$3)"
+    fail=1
+  fi
+}
+
+base="$(mktemp -d)"
+trap 'rm -rf "$base"' EXIT
+
+# --- a clean script (uses the resolver) -> guard PASSES (rc 0) ---------------
+mkdir -p "$base/clean"
+cat > "$base/clean/good.sh" <<'SH'
+#!/usr/bin/env bash
+META_DIR="$(python3 "$SCRIPT_DIR/_meta_resolver.py" "$VAULT" Sessions Decisions 2>/dev/null || true)"
+[ -z "$META_DIR" ] && META_DIR="$VAULT/Meta"
+SH
+rc=0
+bash "$GUARD" "$base/clean" >/dev/null 2>&1 || rc=$?
+check "resolver-based script passes the guard" 0 "$rc"
+
+# --- a script with the banned glob -> guard FAILS (rc 1) --------------------
+mkdir -p "$base/bad"
+cat > "$base/bad/regression.sh" <<'SH'
+#!/usr/bin/env bash
+for candidate in "$VAULT"/*Meta; do
+  [ -d "$candidate" ] && { META_DIR="$candidate"; break; }
+done
+SH
+rc=0
+bash "$GUARD" "$base/bad" >/dev/null 2>&1 || rc=$?
+check "reintroduced *Meta glob is caught" 1 "$rc"
+
+if [ "$fail" != 0 ]; then
+  echo "FAILED: meta-resolution guard test"
+  exit 1
+fi
+echo "PASSED: meta-resolution guard test (2 assertions)"

--- a/scripts/test-split-meta.sh
+++ b/scripts/test-split-meta.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# scripts/test-split-meta.sh - regression test for scripts/check-split-meta.py.
+# Proves the detector flags a vault whose session data leaked into a plain
+# "Meta/" beside the human "⚙️ Meta/", and stays quiet on healthy layouts.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DETECT="$HERE/check-split-meta.py"
+
+fail=0
+check() {  # check <description> <expected> <actual>
+  if [ "$2" = "$3" ]; then
+    echo "  ok: $1"
+  else
+    echo "  FAIL: $1"
+    echo "        expected: [$2]"
+    echo "        actual:   [$3]"
+    fail=1
+  fi
+}
+
+base="$(mktemp -d)"
+trap 'rm -rf "$base"' EXIT
+
+# --- split-brain: human session data leaked into plain Meta (the bug) -------
+mkdir -p "$base/split/Meta/Sessions"
+mkdir -p "$base/split/Meta/Learnings"
+mkdir -p "$base/split/⚙️ Meta/Decisions"
+check "leaked Sessions/ in plain Meta -> SPLIT_META" "SPLIT_META:1" \
+  "$(python3 "$DETECT" --porcelain "$base/split")"
+
+# --- healthy partition: machine in Meta, human in ⚙️ Meta -------------------
+mkdir -p "$base/clean/Meta/Learnings"
+mkdir -p "$base/clean/⚙️ Meta/Sessions"
+mkdir -p "$base/clean/⚙️ Meta/Decisions"
+check "machine-only plain Meta -> OK_PARTITIONED" "OK_PARTITIONED" \
+  "$(python3 "$DETECT" --porcelain "$base/clean")"
+
+# --- single Meta vault (stock) ----------------------------------------------
+mkdir -p "$base/single/⚙️ Meta/Decisions"
+check "single Meta -> OK_SINGLE_META" "OK_SINGLE_META" \
+  "$(python3 "$DETECT" --porcelain "$base/single")"
+
+# --- no Meta at all ---------------------------------------------------------
+mkdir -p "$base/empty"
+check "no Meta -> OK_NO_META" "OK_NO_META" \
+  "$(python3 "$DETECT" --porcelain "$base/empty")"
+
+if [ "$fail" != 0 ]; then
+  echo "FAILED: split-meta detector test"
+  exit 1
+fi
+echo "PASSED: split-meta detector test (4 assertions)"

--- a/tests/integration/test_meta_resolution_guard.sh
+++ b/tests/integration/test_meta_resolution_guard.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# CI wrapper - runs the meta-resolution guard negative-control suite
+# (scripts/test-meta-resolution-guard.sh) as part of scripts/ci.sh.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+exec bash "$ROOT/scripts/test-meta-resolution-guard.sh"

--- a/tests/integration/test_split_meta.sh
+++ b/tests/integration/test_split_meta.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# CI wrapper - runs the split-meta detector regression suite
+# (scripts/test-split-meta.sh) as part of scripts/ci.sh.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+exec bash "$ROOT/scripts/test-split-meta.sh"


### PR DESCRIPTION
## What

Follow-up to #176. That PR routed the five shell scripts through `_meta_resolver`, but left three durability gaps this closes:

1. **A guard so the bug can't return.** `check-meta-resolution.sh` fails CI if any shell script reintroduces the naive `for c in "$VAULT"/*Meta` glob instead of the resolver. Wired as a `lint.yml` job (`meta-resolution`). The #176 fix was point-in-time; this makes it permanent.
2. **A detector for vaults already hit.** `check-split-meta.py` plus a new `/diagnose` section 14 flag a vault whose session log, session archive, or traffic dashboard leaked into a plain `Meta/` beside the human `⚙️ Meta/`, and print the reconcile remedy. The resolver fix stops new leaks; this finds old damage.
3. **`diagnose.sh` section 2 parity.** It hardcoded `⚙️ Meta` and false-failed a stock plain-`Meta` vault. It now resolves whichever variant exists via the shared resolver.

## Why forks need it

`_meta_resolver` and `diagnose` ship in the public template, so the guard protects every fork from reintroducing the bug, and the detector lets anyone already bitten find and repair the split. A per-vault patch can do neither.

## Verification

Both new checks ship negative-control tests wired into `ci.sh`: `test-meta-resolution-guard` proves a reintroduced glob is caught (rc 1), not just that a clean tree passes; `test-split-meta` proves a leaked `Sessions/` in a plain `Meta/` is flagged while a healthy machine/human partition stays quiet. Local `ci.sh` green: `py_compile` 261, 24 integration tests, `shellcheck` 97.

Doubt-pass on the `lint.yml` surface: the `meta-resolution` job runs a static `bash scripts/check-meta-resolution.sh` with no `github.event` interpolation; the guard's grep pattern is a fixed internal string scanning repo-tracked `.sh`, so no attacker input reaches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
