### PR TITLE
fix(dev-repo-worktrees): support detached-gitdir repos + self-heal core.worktree poison

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -117,6 +117,7 @@ INTEGRATION_TESTS=(
   test_relocate_sweep
   test_renderer_crash_guard
   test_agentic_os
+  test_dev_worktree_detached_gitdir
 )
 echo "==> (b) Shell integration: ${#INTEGRATION_TESTS[@]} tests"
 for t in "${INTEGRATION_TESTS[@]}"; do

--- a/skills/dev-repo-worktrees/claude-dev-worktree
+++ b/skills/dev-repo-worktrees/claude-dev-worktree
@@ -24,11 +24,22 @@
 #   DEV_ROOT      Where your code repos live. Defaults to ~/dev.
 #                 Override per-call: DEV_ROOT=~/projects claude-dev-worktree ...
 #
+# Detached-gitdir repos are SUPPORTED: a repo whose `.git` is a pointer FILE
+# (`gitdir: /path/to/gitdir`, the cloud-sync-safe layout where git's database
+# lives outside a synced folder) works the same as a normal `.git` directory.
+# Historically those repos carried `core.worktree` in the SHARED config; linked
+# worktrees inherit it and silently resolve their work tree to the MAIN
+# checkout — files created in the new worktree are invisible to git, and
+# commits land on the wrong tree. `start` auto-heals that: it migrates
+# `core.worktree` to per-worktree config (extensions.worktreeConfig) and then
+# verifies the new worktree resolves to itself before handing it over.
+# Bug class: WRAPPER-FAILS-ON-DETACHED-GITDIR.
+#
 # Exit codes:
 #   0  success
 #   1  invalid args / missing repo
 #   2  worktree already exists (start) or doesn't exist (cleanup)
-#   3  git operation failed
+#   3  git operation failed (including post-create resolution check)
 #
 # Pattern source: this skill (dev-repo-worktrees). License: MIT.
 
@@ -50,6 +61,38 @@ EOF
     exit 1
 }
 
+require_repo() {
+    # Accept BOTH layouts: `.git` as a directory (normal) and `.git` as a
+    # pointer file (detached gitdir — the cloud-sync-safe layout). A bare
+    # `[[ -d .git ]]` check wrongly rejects the second.
+    local main_path="$1"
+    if ! git -C "$main_path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        echo "error: $main_path is not a git repo (no .git dir or gitdir pointer)" >&2
+        exit 1
+    fi
+}
+
+heal_worktree_config() {
+    # A detached-gitdir repo often carries `core.worktree` in the SHARED
+    # config (it makes bare `git --git-dir=...` invocations resolve the main
+    # work tree). But linked worktrees read the same shared config, inherit
+    # that path, and resolve their work tree to the MAIN checkout — the
+    # worktree looks created yet every git command inside it operates on the
+    # wrong tree. The git-documented fix: enable extensions.worktreeConfig
+    # and move core.worktree into the MAIN worktree's own config.worktree,
+    # where linked worktrees no longer see it.
+    local main_path="$1"
+    local shared_wt
+    shared_wt="$(git -C "$main_path" config --get core.worktree 2>/dev/null || true)"
+    [[ -z "$shared_wt" ]] && return 0
+
+    echo "note: shared core.worktree detected ($shared_wt) — migrating to" >&2
+    echo "      per-worktree config so linked worktrees resolve correctly." >&2
+    git -C "$main_path" config extensions.worktreeConfig true
+    git -C "$main_path" config --worktree core.worktree "$shared_wt"
+    git -C "$main_path" config --unset core.worktree
+}
+
 cmd_start() {
     local repo="$1"
     local slug="$2"
@@ -57,15 +100,73 @@ cmd_start() {
     local worktree_path="${DEV_ROOT}/${repo}-${slug}"
     local branch="claude/${slug}"
 
-    if [[ ! -d "$main_path/.git" ]]; then
-        echo "error: $main_path is not a git repo" >&2
+    require_repo "$main_path"
+
+    # Slug validation — reject bare issue-ID slugs (e.g. "abc-83") AND warn
+    # on issue-prefixed slugs (e.g. "abc-83-anything"): issue trackers with
+    # GitHub auto-link (Linear et al.) close any issue whose ID appears as a
+    # substring in the branch name on PR merge — a work-slug suffix does not
+    # change that. If the PR will actually ship that issue's work, the
+    # auto-close is CORRECT; if the branch ships something else, the wrong
+    # issue gets closed.
+    #
+    # Real prevention: the branch's issue-ID prefix MUST equal the issue the
+    # PR actually closes. Shipping a different issue, multiple issues, or no
+    # issue → use a slug with NO issue prefix at all.
+    #
+    # Bypass: DEV_WORKTREE_BARE_SLUG_BYPASS=1 for bare-slug rejection
+    #         DEV_WORKTREE_ISSUE_PREFIX_BYPASS=1 to silence the warn
+
+    if [[ -z "${DEV_WORKTREE_BARE_SLUG_BYPASS:-}" ]] \
+       && [[ "$slug" =~ ^[a-z]{2,5}-[0-9]+$ ]]; then
+        cat <<EOF >&2
+error: bare issue-ID slug "${slug}" rejected.
+
+Why: branch claude/${slug} triggers issue-tracker auto-close on ANY PR
+merge from this branch, whether or not the PR ships that issue's work.
+
+Fix — pick the right pattern for what this branch will ship:
+
+  IF the PR will ship work for issue ${slug}:
+    $0 start ${repo} ${slug}-<describes-the-work>
+    # auto-close fires for ${slug} on merge — CORRECT for this case
+
+  IF the PR will ship work for a DIFFERENT issue or no single issue:
+    $0 start ${repo} <work-slug-no-issue-prefix>
+    # Example: $0 start ${repo} verifier-reconcile-$(date +%Y-%m-%d)
+    # No auto-link fires; close the actual issue manually
+
+Bypass:
+  DEV_WORKTREE_BARE_SLUG_BYPASS=1 $0 start ${repo} ${slug}
+EOF
         exit 1
+    fi
+
+    if [[ -z "${DEV_WORKTREE_ISSUE_PREFIX_BYPASS:-}" ]] \
+       && [[ "$slug" =~ ^([a-z]{2,5}-[0-9]+)- ]]; then
+        local issue_id="${BASH_REMATCH[1]}"
+        cat <<EOF >&2
+notice: branch claude/${slug} will auto-close issue ${issue_id} on PR merge.
+
+If this branch will actually ship work for ${issue_id} → fine, proceed.
+
+If this branch ships work for a DIFFERENT issue or multi-issue / no-issue
+scope → STOP and use a slug WITHOUT an issue prefix instead:
+  $0 cleanup ${repo} ${slug}    # discard this worktree
+  $0 start ${repo} <work-slug-only>    # e.g. verifier-reconcile-$(date +%Y-%m-%d)
+
+Continuing in 3 seconds. Ctrl-C to abort.
+Silence this notice: DEV_WORKTREE_ISSUE_PREFIX_BYPASS=1
+EOF
+        sleep 3
     fi
 
     if [[ -e "$worktree_path" ]]; then
         echo "error: $worktree_path already exists" >&2
         exit 2
     fi
+
+    heal_worktree_config "$main_path"
 
     cd "$main_path"
     git fetch origin --quiet
@@ -78,6 +179,24 @@ cmd_start() {
         git worktree add "$worktree_path" -b "$branch" origin/main >&2
     fi
 
+    # Post-create resolution self-check: the new worktree MUST resolve its
+    # work tree to ITSELF. If it resolves anywhere else (e.g. the main
+    # checkout, via a stray core.worktree), every git command inside it
+    # would silently operate on the wrong tree — fail loud, never hand over
+    # a poisoned worktree.
+    local want got
+    want="$(cd "$worktree_path" && pwd -P)"
+    got="$(git -C "$worktree_path" rev-parse --show-toplevel 2>/dev/null || true)"
+    if [[ "$got" != "$want" ]]; then
+        echo "error: worktree resolution check FAILED" >&2
+        echo "       expected work tree: $want" >&2
+        echo "       git resolved:       ${got:-<none>}" >&2
+        echo "       removing the broken worktree; check 'git -C $main_path config --list' for core.worktree" >&2
+        git -C "$main_path" worktree remove --force "$worktree_path" >&2 || true
+        git -C "$main_path" branch -D "$branch" >&2 || true
+        exit 3
+    fi
+
     echo "$worktree_path"
 }
 
@@ -88,10 +207,7 @@ cmd_cleanup() {
     local worktree_path="${DEV_ROOT}/${repo}-${slug}"
     local branch="claude/${slug}"
 
-    if [[ ! -d "$main_path/.git" ]]; then
-        echo "error: $main_path is not a git repo" >&2
-        exit 1
-    fi
+    require_repo "$main_path"
 
     cd "$main_path"
 
@@ -113,6 +229,7 @@ cmd_cleanup() {
 cmd_list() {
     # Walk every git repo under DEV_ROOT, dump its worktree list. The first
     # entry per repo is the main checkout; the rest are session worktrees.
+    # `.git` may be a directory OR a pointer file — accept both.
     for dir in "$DEV_ROOT"/*/.git; do
         [[ -d "$dir" || -f "$dir" ]] || continue
         local repo_dir

--- a/tests/integration/test_dev_worktree_detached_gitdir.sh
+++ b/tests/integration/test_dev_worktree_detached_gitdir.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# test_dev_worktree_detached_gitdir.sh — negative-control test for the
+# claude-dev-worktree wrapper against a DETACHED-GITDIR repo.
+#
+# The hazard (bug class WRAPPER-FAILS-ON-DETACHED-GITDIR): a repo whose
+# `.git` is a pointer FILE (`gitdir: /path`, the cloud-sync-safe layout)
+# (a) fails a naive `[[ -d .git ]]` repo check, and (b) carries
+# `core.worktree` in the SHARED config, which every linked worktree
+# inherits — so a new worktree silently resolves its work tree to the MAIN
+# checkout and files created inside it are invisible to git.
+#
+# This test builds that exact layout in a sandbox and asserts the wrapper:
+#   1. accepts the repo (rev-parse check, not -d .git),
+#   2. auto-heals the shared core.worktree (per-worktree config migration),
+#   3. hands over a worktree that resolves to ITSELF,
+#   4. sees files created inside the worktree,
+#   5. leaves the main checkout resolving correctly,
+#   6. cleans up (worktree + branch gone).
+#
+# Run the OLD wrapper through this test to see it fail (the negative
+# control): bash tests/integration/test_dev_worktree_detached_gitdir.sh /path/to/old/wrapper
+#
+# No network: origin is a local bare repo; `git fetch origin` stays on disk.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WRAPPER="${1:-$repo_root/skills/dev-repo-worktrees/claude-dev-worktree}"
+
+sandbox="$(mktemp -d)"
+cleanup() { rm -rf "$sandbox"; }
+trap cleanup EXIT
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+[ -f "$WRAPPER" ] || fail "wrapper not found at $WRAPPER"
+
+# ---- fixture: detached-gitdir repo with the core.worktree poison ----------
+mkdir -p "$sandbox/dev"
+main_repo="$sandbox/dev/myrepo"
+
+git init -q -b main --separate-git-dir "$sandbox/gitdb" "$main_repo"
+git -C "$main_repo" config user.email "test@example.invalid"
+git -C "$main_repo" config user.name "Test"
+# Set the poison explicitly (some git versions set it via --separate-git-dir,
+# some don't — the fixture must be deterministic about reproducing the hazard).
+git -C "$main_repo" config core.worktree "$main_repo"
+
+echo "hello" > "$main_repo/README.md"
+git -C "$main_repo" add README.md
+git -C "$main_repo" commit -qm "init"
+
+git init -q -b main --bare "$sandbox/origin.git"
+git -C "$main_repo" remote add origin "$sandbox/origin.git"
+git -C "$main_repo" push -q origin main
+
+# Preconditions: the fixture really is the hazardous layout.
+[ -f "$main_repo/.git" ] || fail "fixture: .git should be a pointer FILE"
+[ -n "$(git -C "$main_repo" config --get core.worktree)" ] \
+    || fail "fixture: shared core.worktree should be set"
+
+# ---- 1+2+3: start must accept the repo, heal, and hand over a clean tree ---
+wt_path=""
+if ! wt_path="$(DEV_ROOT="$sandbox/dev" bash "$WRAPPER" start myrepo probe-fix 2>"$sandbox/start.log")"; then
+    sed 's/^/    wrapper: /' "$sandbox/start.log" >&2 || true
+    fail "wrapper 'start' exited non-zero on a detached-gitdir repo"
+fi
+
+expected_wt="$sandbox/dev/myrepo-probe-fix"
+[ "$wt_path" = "$expected_wt" ] || fail "wrapper printed '$wt_path', expected '$expected_wt'"
+[ -d "$expected_wt" ] || fail "worktree dir not created at $expected_wt"
+
+want="$(cd "$expected_wt" && pwd -P)"
+got="$(git -C "$expected_wt" rev-parse --show-toplevel 2>/dev/null || true)"
+[ "$got" = "$want" ] || fail "worktree resolves to '$got', expected '$want' (core.worktree poison not healed)"
+
+# ---- 4: files created in the worktree must be visible to git ---------------
+touch "$expected_wt/probe.txt"
+status_out="$(git -C "$expected_wt" status --porcelain)"
+case "$status_out" in
+    *"?? probe.txt"*) : ;;
+    *) fail "probe.txt invisible to git in the worktree (status: '$status_out')" ;;
+esac
+
+# ---- 5: the main checkout must still resolve to itself ---------------------
+main_want="$(cd "$main_repo" && pwd -P)"
+main_got="$(git -C "$main_repo" rev-parse --show-toplevel)"
+[ "$main_got" = "$main_want" ] || fail "main checkout resolves to '$main_got' after heal, expected '$main_want'"
+
+# ---- 6: cleanup removes worktree + branch ----------------------------------
+DEV_ROOT="$sandbox/dev" bash "$WRAPPER" cleanup myrepo probe-fix 2>/dev/null \
+    || fail "wrapper 'cleanup' exited non-zero"
+[ ! -e "$expected_wt" ] || fail "worktree dir still present after cleanup"
+if git -C "$main_repo" show-ref --verify --quiet "refs/heads/claude/probe-fix"; then
+    fail "branch claude/probe-fix still present after cleanup"
+fi
+
+echo "PASS: test_dev_worktree_detached_gitdir (wrapper: $WRAPPER)"


### PR DESCRIPTION
Three failure modes closed in the `claude-dev-worktree` wrapper:

1. **`require_repo`** — a repo whose `.git` is a pointer FILE (`gitdir: /path`, the cloud-sync-safe layout) failed the naive `-d .git` check. Now `rev-parse` based.
2. **`heal_worktree_config`** — those repos carry `core.worktree` in the SHARED config; linked worktrees inherit it and silently resolve their work tree to the MAIN checkout (files invisible to git, commits land on the wrong tree). `start` now migrates it to per-worktree config (`extensions.worktreeConfig`) — the git-documented fix.
3. **Post-create resolution self-check** — never hand over a worktree that doesn't resolve to itself; remove it and fail loud (exit 3).

Also reconciles the slug-validation block (bare issue-ID reject + issue-prefix auto-close notice) that previously lived only in a deployed copy — ending a two-way canonical-vs-deployed fork.

`test_dev_worktree_detached_gitdir` builds the poisoned layout in a sandbox (negative control: the pre-fix wrapper FAILS it) and is wired into the `ci.sh` allow-list. Full local gate green: py_compile (261) + 25 integration tests + shellcheck.

Bug class: WRAPPER-FAILS-ON-DETACHED-GITDIR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)