### PR TITLE
chore(ci): pin actions to full commit SHA

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98  # v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Enable auto-merge on qualifying updates


### PR DESCRIPTION
Pins 1 unpinned GitHub Actions references to full commit SHAs (supply-chain hardening). Re-derived against current main. Auto: pin-github-actions-to-sha.