### PR TITLE
fix(dev-repo-worktrees): make core.worktree heal idempotent

### DIFF
--- a/skills/dev-repo-worktrees/claude-dev-worktree
+++ b/skills/dev-repo-worktrees/claude-dev-worktree
@@ -83,7 +83,11 @@ heal_worktree_config() {
     # where linked worktrees no longer see it.
     local main_path="$1"
     local shared_wt
-    shared_wt="$(git -C "$main_path" config --get core.worktree 2>/dev/null || true)"
+    # --local scope ONLY: after migration the value lives in config.worktree,
+    # which the merged view (--get without scope) still returns — re-detecting
+    # it made this non-idempotent: the re-run's `--unset` on the shared config
+    # exited 5 (key absent) and killed the script. (Caught live 2026-06-09.)
+    shared_wt="$(git -C "$main_path" config --local --get core.worktree 2>/dev/null || true)"
     [[ -z "$shared_wt" ]] && return 0
 
     echo "note: shared core.worktree detected ($shared_wt) — migrating to" >&2

--- a/tests/integration/test_dev_worktree_detached_gitdir.sh
+++ b/tests/integration/test_dev_worktree_detached_gitdir.sh
@@ -98,4 +98,21 @@ if git -C "$main_repo" show-ref --verify --quiet "refs/heads/claude/probe-fix"; 
     fail "branch claude/probe-fix still present after cleanup"
 fi
 
+# ---- 7: heal must be IDEMPOTENT — a second start on the healed repo --------
+# After migration, core.worktree lives in config.worktree, which the merged
+# config view still returns. A heal that re-detects it re-runs `--unset` on
+# the shared config, which exits 5 (key absent) and kills the script — the
+# second-ever start against a healed repo fails. (Caught live 2026-06-09.)
+wt2_path=""
+if ! wt2_path="$(DEV_ROOT="$sandbox/dev" bash "$WRAPPER" start myrepo probe-again 2>"$sandbox/start2.log")"; then
+    sed 's/^/    wrapper: /' "$sandbox/start2.log" >&2 || true
+    fail "wrapper 'start' exited non-zero on an ALREADY-HEALED repo (heal not idempotent)"
+fi
+expected_wt2="$sandbox/dev/myrepo-probe-again"
+[ "$wt2_path" = "$expected_wt2" ] || fail "second start printed '$wt2_path', expected '$expected_wt2'"
+got2="$(git -C "$expected_wt2" rev-parse --show-toplevel 2>/dev/null || true)"
+[ "$got2" = "$(cd "$expected_wt2" && pwd -P)" ] || fail "second worktree resolves to '$got2'"
+DEV_ROOT="$sandbox/dev" bash "$WRAPPER" cleanup myrepo probe-again 2>/dev/null \
+    || fail "wrapper 'cleanup' exited non-zero on second worktree"
+
 echo "PASS: test_dev_worktree_detached_gitdir (wrapper: $WRAPPER)"


### PR DESCRIPTION
`heal_worktree_config` (shipped in #181) detected the shared `core.worktree` via the merged config view. After a successful migration the value lives in `config.worktree`, which the merged view still returns — so every subsequent `start` on the healed repo re-entered the migration, and its `--unset` on the shared config exited 5 (key absent), killing the wrapper. Caught live on the second-ever `start` against a healed detached-gitdir repo.

Fix: detect with `--local` scope only — present pre-migration, absent after.

Test: `test_dev_worktree_detached_gitdir` gains step 7 (a second `start` on an already-healed repo must succeed). Verified RED against the pre-fix wrapper (exact live failure reproduced), GREEN against the fix.

Disclosure: implemented by an AI agent (Claude Code) under operator direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)