### PR TITLE
fix(install): canonical API host + follow redirects — un-kill the install funnel reporters (MYC-419)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -67,7 +67,7 @@ If Claude asks for permission to do something and you are not sure what it does,
 
 Local-first by default. Your vault, journals, notes, and files never leave your machine. The install does not require an email and does not phone home about your content.
 
-There is exactly one opt-in. At the end of setup you may choose to give an email (for occasional update notes and a free workflow audit). If you do, an install token is minted: `myceliumai.co/api/install/quick-mint` receives the email, name, and language you gave, plus a short OS label (e.g. `mac-arm`). That is the email submission you chose to make.
+There is exactly one opt-in. At the end of setup you may choose to give an email (for occasional update notes and a free workflow audit). If you do, an install token is minted: `www.mycelium-ai.co/api/install/quick-mint` receives the email, name, and language you gave, plus a short OS label (e.g. `mac-arm`). That is the email submission you chose to make.
 
 While that token exists on your machine, three best-effort, fail-open events may be sent. Each carries only the token and a coarse signal — never any content:
 

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -74,7 +74,9 @@ function T([string]$en, [string]$es) {
 
 # ─── Optional signup (the install never blocks on it) ──────────────────────
 $emailMarker = "$env:USERPROFILE\.claude\.ai-brain-starter-email-on-file"
-$installApiBase = if ($env:MYCELIUM_INSTALL_API) { $env:MYCELIUM_INSTALL_API } else { "https://myceliumai.co" }
+# Canonical host: alternate domains 308-redirect and POST bodies are not
+# reliably re-sent on redirect by older PowerShell. Always call canonical.
+$installApiBase = if ($env:MYCELIUM_INSTALL_API) { $env:MYCELIUM_INSTALL_API } else { "https://www.mycelium-ai.co" }
 
 # Optional signup. This block only runs when the user already provided an
 # email - a web-form token or EMAIL/NAME env vars. With nothing provided it

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -502,7 +502,12 @@ fi
 # Bypass entirely for development: EMAIL_GATE_BYPASS=1 bash bootstrap.sh
 # ───────────────────────────────────────────────────────────────────────────────
 EMAIL_MARKER="$HOME/.claude/.ai-brain-starter-email-on-file"
-INSTALL_API_BASE="${MYCELIUM_INSTALL_API:-https://myceliumai.co}"
+# Canonical host. The bare/alternate domains 308-redirect here, and curl
+# does not follow redirects without -L: every install-API call against a
+# non-canonical base silently died for weeks (consumed/completed stayed 0
+# in the funnel while real installs ran). Keep the canonical host AND -L
+# on every call below — defense in depth against the next domain change.
+INSTALL_API_BASE="${MYCELIUM_INSTALL_API:-https://www.mycelium-ai.co}"
 
 # Optional signup. This block only runs when the user already provided an
 # email -- a web-form token (TOKEN=) or EMAIL=/NAME= env vars. With nothing
@@ -539,7 +544,7 @@ print(json.dumps({
 PY
 )"
     set +e
-    QM_RESP="$(curl -sS -m 12 -X POST "$INSTALL_API_BASE/api/install/quick-mint" \
+    QM_RESP="$(curl -sSL -m 12 -X POST "$INSTALL_API_BASE/api/install/quick-mint" \
       -H "content-type: application/json" \
       -d "$QM_PAYLOAD" 2>/dev/null)"
     set -e
@@ -576,7 +581,7 @@ except Exception:
     log "$(t "Validating token against $INSTALL_API_BASE..." \
             "Validando token contra $INSTALL_API_BASE...")"
     set +e
-    VERIFY_RESP="$(curl -sS -m 10 "$INSTALL_API_BASE/api/install/verify?token=$TOKEN" 2>/dev/null)"
+    VERIFY_RESP="$(curl -sSL -m 10 "$INSTALL_API_BASE/api/install/verify?token=$TOKEN" 2>/dev/null)"
     set -e
     if [[ -z "$VERIFY_RESP" ]] || ! echo "$VERIFY_RESP" | grep -q '"valid":true'; then
       warn "$(t "Token did not validate - continuing without it." \
@@ -595,7 +600,7 @@ except Exception:
     # the user's name, role, intent, language, voice link, etc.
     RECAP_FILE="$HOME/.claude/.ai-brain-starter-recap.json"
     set +e
-    RECAP_RESP="$(curl -sS -m 8 "$INSTALL_API_BASE/api/install/recap?token=$TOKEN" 2>/dev/null)"
+    RECAP_RESP="$(curl -sSL -m 8 "$INSTALL_API_BASE/api/install/recap?token=$TOKEN" 2>/dev/null)"
     set -e
     if [[ -n "$RECAP_RESP" ]] && echo "$RECAP_RESP" | grep -q '"ok":true'; then
       printf '%s\n' "$RECAP_RESP" > "$RECAP_FILE"
@@ -606,7 +611,7 @@ except Exception:
 
     # Fire install_bootstrap_started event (best-effort, fail-open).
     set +e
-    curl -sS -m 6 -X POST "$INSTALL_API_BASE/api/install/started" \
+    curl -sSL -m 6 -X POST "$INSTALL_API_BASE/api/install/started" \
       -H "content-type: application/json" \
       -d "{\"token\":\"$TOKEN\",\"os\":\"$(uname -srm 2>/dev/null || echo unknown)\"}" \
       >/dev/null 2>&1 || true
@@ -1756,7 +1761,7 @@ if [[ -f "$EMAIL_MARKER" && $DRY_RUN -eq 0 ]]; then
       PAYLOAD="{\"token\":\"$RECORDED_TOKEN\",\"os\":\"$OS_INFO\",\"completed\":true}"
     fi
     set +e
-    curl -sS -m 8 -X POST "$INSTALL_API_BASE/api/install/complete" \
+    curl -sSL -m 8 -X POST "$INSTALL_API_BASE/api/install/complete" \
       -H "content-type: application/json" \
       -d "$PAYLOAD" \
       >/dev/null 2>&1 || true

--- a/hooks/install-ping.py
+++ b/hooks/install-ping.py
@@ -33,7 +33,7 @@ def main():
     try:
         data = json.dumps({"plugin": PLUGIN_NAME, "version": VERSION}).encode()
         req = urllib.request.Request(
-            "https://myceliumai.co/api/install",
+            "https://www.mycelium-ai.co/api/install",
             data=data,
             headers={"Content-Type": "application/json"},
         )

--- a/phases/phase-19-23-finish.md
+++ b/phases/phase-19-23-finish.md
@@ -422,7 +422,7 @@ payload = json.dumps({
     "stage": "post_install",
 }).encode()
 req = urllib.request.Request(
-    "https://myceliumai.co/api/install/quick-mint",
+    "https://www.mycelium-ai.co/api/install/quick-mint",
     data=payload, headers={"content-type": "application/json"}, method="POST")
 try:
     with urllib.request.urlopen(req, timeout=12) as r:

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -121,6 +121,7 @@ INTEGRATION_TESTS=(
   test_renderer_crash_guard
   test_agentic_os
   test_dev_worktree_detached_gitdir
+  test_install_api_canonical_base
 )
 echo "==> (b) Shell integration: ${#INTEGRATION_TESTS[@]} tests"
 for t in "${INTEGRATION_TESTS[@]}"; do

--- a/scripts/post-update-email-ask.py
+++ b/scripts/post-update-email-ask.py
@@ -185,7 +185,7 @@ payload = json.dumps({
     "stage": "post_install",
 }).encode()
 req = urllib.request.Request(
-    "https://myceliumai.co/api/install/quick-mint",
+    "https://www.mycelium-ai.co/api/install/quick-mint",
     data=payload, headers={"content-type": "application/json"}, method="POST")
 mp = os.path.expanduser("~/.claude/.ai-brain-starter-email-on-file")
 try:
@@ -230,7 +230,7 @@ payload = json.dumps({
     "stage": "post_install",
 }).encode()
 req = urllib.request.Request(
-    "https://myceliumai.co/api/install/quick-mint",
+    "https://www.mycelium-ai.co/api/install/quick-mint",
     data=payload, headers={"content-type": "application/json"}, method="POST")
 mp = os.path.expanduser("~/.claude/.ai-brain-starter-email-on-file")
 try:

--- a/skills/daily-journal/SKILL.md
+++ b/skills/daily-journal/SKILL.md
@@ -738,7 +738,7 @@ if [ -f "$TOKEN_FILE" ] && [ ! -f "$SENTINEL" ]; then
   # server returned no token). In those cases send nothing.
   if printf '%s' "$TOKEN" | grep -Eq '^[a-f0-9]{32}$'; then
     TODAY="$(date -u +%Y-%m-%d)"
-    curl -sS -m 6 -X POST "https://myceliumai.co/api/install/first-journal" \
+    curl -sSL -m 6 -X POST "https://www.mycelium-ai.co/api/install/first-journal" \
       -H "content-type: application/json" \
       -d "{\"token\":\"$TOKEN\",\"journalDate\":\"$TODAY\"}" \
       >/dev/null 2>&1 \

--- a/tests/integration/test_install_api_canonical_base.sh
+++ b/tests/integration/test_install_api_canonical_base.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Regression test: every install-API call targets the CANONICAL host and
+# shell callers follow redirects.
+#
+# Bug class (caught 2026-06-10, MYC-419): alternate domains 308-redirect to
+# the canonical host. curl does NOT follow redirects without -L, and
+# Python 3.9's urllib does not follow 308 at all — so every install-API
+# call against a non-canonical base died silently (the reporters are
+# deliberately fail-open). The funnel showed signups but consumed=0 /
+# completed=0 for weeks while real installs ran: the mid-funnel zeros were
+# measurement failure, not user drop-off.
+#
+# Asserts:
+#   1. bootstrap.sh INSTALL_API_BASE default is the canonical host.
+#   2. bootstrap.ps1 $installApiBase default is the canonical host.
+#   3. Every bootstrap.sh curl against $INSTALL_API_BASE carries -L
+#      (defense in depth for the NEXT domain change).
+#   4. No install-facing file calls the API on a non-canonical base.
+#
+# Self-contained. Exit 0 = pass. Exit 1 = fail with details.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+CANON="https://www.mycelium-ai.co"
+FAILED=0
+
+fail() { echo "FAIL: $1" >&2; FAILED=$((FAILED + 1)); }
+
+# 1. bootstrap.sh default base
+grep -qF "INSTALL_API_BASE=\"\${MYCELIUM_INSTALL_API:-$CANON}\"" bootstrap.sh \
+  || fail "bootstrap.sh INSTALL_API_BASE default is not $CANON"
+
+# 2. bootstrap.ps1 default base
+grep -qF "else { \"$CANON\" }" bootstrap.ps1 \
+  || fail "bootstrap.ps1 installApiBase default is not $CANON"
+
+# 3. every INSTALL_API_BASE curl in bootstrap.sh follows redirects
+while IFS= read -r line; do
+  if ! echo "$line" | grep -qE 'curl[^|]*-[a-zA-Z]*L'; then
+    fail "bootstrap.sh curl without -L: $line"
+  fi
+done < <(grep -E 'curl .*\$INSTALL_API_BASE/api' bootstrap.sh)
+
+# 4. no non-canonical API calls in install-facing files
+#    (myceliumai.co — no hyphen — 308s; so does bare mycelium-ai.co without www)
+if matches=$(grep -rnE '(myceliumai\.co|[^.w]mycelium-ai\.co)/api' \
+    bootstrap.sh bootstrap.ps1 phases/ scripts/ hooks/ skills/ SECURITY.md 2>/dev/null); then
+  fail "non-canonical install-API base found:"
+  echo "$matches" | head -5 | sed 's|^|  |' >&2
+fi
+
+if [ "$FAILED" -gt 0 ]; then
+  echo "test_install_api_canonical_base: $FAILED failure(s)" >&2
+  exit 1
+fi
+echo "PASS: install-API calls all target $CANON and follow redirects"


### PR DESCRIPTION
Part of MYC-419. Root cause found while building the funnel snapshot.

---

Alternate domains 308-redirect to the canonical `www.mycelium-ai.co` host. `curl` does not follow redirects without `-L`, and Python 3.9's `urllib` does not follow 308 at all — so **every install-API call on the non-canonical base died silently** (the reporters are fail-open by design): `quick-mint`, `verify`, `recap`, `started`, `complete`, `first-journal`, `install-ping`, and the post-update opt-in. The funnel's `consumed=0 / completed=0` over the last weeks was measurement failure, not user drop-off.

Sweep: canonical host at every call site (`bootstrap.sh` / `bootstrap.ps1` defaults, phase 19-23 opt-in snippet, `post-update-email-ask`, `install-ping`, daily-journal first-journal ping, SECURITY.md reference) plus `-L` on every shell curl as defense in depth for the next domain change.

Guard: `test_install_api_canonical_base.sh` joins the `ci.sh` gate — asserts canonical defaults, `-L` on every `INSTALL_API_BASE` curl, and zero non-canonical API bases across install-facing files. Verified red on a planted violation, green after the sweep.

Disclosure: authored end-to-end by an AI agent (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)