### PR TITLE
fix(hooks): check-cd-outside-worktree honors inline WORKTREE_CD_BYPASS + detects env-prefixed cd (MYC-782)

### DIFF
--- a/hooks/check-cd-outside-worktree.py
+++ b/hooks/check-cd-outside-worktree.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import shlex
 import sys
 
 WORKTREE_RE = re.compile(r"^(?P<main>.+?)/\.claude/worktrees/(?P<slug>[^/]+)(?:/|$)")
@@ -49,6 +50,49 @@ WORKTREE_RE = re.compile(r"^(?P<main>.+?)/\.claude/worktrees/(?P<slug>[^/]+)(?:/
 # is evaluated in order (mirrors how the shell would run them).
 SEGMENT_SPLIT_RE = re.compile(r"&&|\|\||[;\n|]")
 CD_RE = re.compile(r"^(?:cd|pushd)\s+(?P<arg>.+)$")
+
+# --- inline-bypass + leading-env handling (self-contained) -------------------
+# A PreToolUse(Bash) gate runs in the hook process, whose env is the SESSION
+# env. An inline `WORKTREE_CD_BYPASS=1 cd ...` prefix lives only in the command
+# STRING, so the bypass this hook advertises must be read from the command, not
+# os.environ alone (bug class HOOK-READS-SESSION-ENV-NOT-COMMAND-ENV). These
+# helpers are LOCAL on purpose: a shared ~/.claude/hooks/_lib/ module would be
+# co-owned by multiple installers (last-writer-wins) and could be clobbered by a
+# version missing one of these functions, silently making the fix inert.
+_ENV_ASSIGN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+_WRAPPER_PREFIXES = {"env", "command", "exec", "builtin", "nohup", "sudo", "time"}
+# Leading `VAR=value` (quote-aware value) + wrapper tokens at a segment start.
+_LEADING_ENV_PREFIX_RE = re.compile(
+    r'^\s*(?:(?:[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|\'[^\']*\'|\S+)'
+    r'|env|command|exec|builtin|nohup|sudo|time)\s+)*'
+)
+
+
+def _inline_bypass(command, var):
+    """True iff a `<var>=1` assignment leads any shell segment of `command`
+    (`WORKTREE_CD_BYPASS=1 cd x`, `ls && WORKTREE_CD_BYPASS=1 cd x`). A token
+    inside quotes is not a leading assignment (`echo 'X=1'` -> no)."""
+    for seg in SEGMENT_SPLIT_RE.split(command):
+        try:
+            tokens = shlex.split(seg)
+        except ValueError:
+            tokens = seg.split()
+        i = 0
+        while i < len(tokens) and (_ENV_ASSIGN_RE.match(tokens[i])
+                                   or tokens[i] in _WRAPPER_PREFIXES):
+            if _ENV_ASSIGN_RE.match(tokens[i]):
+                k, _, v = tokens[i].partition("=")
+                if k == var and v == "1":
+                    return True
+            i += 1
+    return False
+
+
+def _strip_leading_env(segment):
+    """`segment` with any leading `VAR=value` / wrapper prefix removed, remainder
+    verbatim. Lets `^cd` see an env-prefixed cd — `FOO=1 cd /main` otherwise
+    slips past `^cd` undetected (a HEAD-drift false-negative)."""
+    return _LEADING_ENV_PREFIX_RE.sub("", segment, count=1)
 
 
 def _first_token(arg: str) -> str:
@@ -97,8 +141,17 @@ def main() -> int:
     if not command.strip():
         return 0
 
+    # Inline `WORKTREE_CD_BYPASS=1 cd ...` prefix: the session-env check at the
+    # top can't see a prefix that lives only in the command string.
+    if _inline_bypass(command, "WORKTREE_CD_BYPASS"):
+        return 0
+
     for seg in SEGMENT_SPLIT_RE.split(command):
-        seg = seg.strip()
+        # Strip any leading `VAR=val` / wrapper prefix so an env-prefixed cd is
+        # still detected — `^cd` alone misses `FOO=1 cd /main` (a real
+        # HEAD-drift false-negative). The WORKTREE_CD_BYPASS prefix is already
+        # honored above; any OTHER env-prefixed cd into main must still block.
+        seg = _strip_leading_env(seg.strip()).strip()
         cm = CD_RE.match(seg)
         if not cm:
             continue

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -122,6 +122,7 @@ INTEGRATION_TESTS=(
   test_agentic_os
   test_dev_worktree_detached_gitdir
   test_install_api_canonical_base
+  test_cd_worktree_inline_bypass
 )
 echo "==> (b) Shell integration: ${#INTEGRATION_TESTS[@]} tests"
 for t in "${INTEGRATION_TESTS[@]}"; do

--- a/tests/integration/test_cd_worktree_inline_bypass.sh
+++ b/tests/integration/test_cd_worktree_inline_bypass.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Integration test: check-cd-outside-worktree honors the inline
+# `WORKTREE_CD_BYPASS=1 <cmd>` prefix it advertises in its block message, not
+# only the session env. A PreToolUse(Bash) gate runs in the hook process whose
+# env is the SESSION env; an inline prefix lives only in the command STRING, so
+# reading os.environ alone makes the advertised bypass un-fireable (bug class
+# HOOK-READS-SESSION-ENV-NOT-COMMAND-ENV). Every assertion has a negative control.
+#
+# Pure string-level: the hook does path-string matching off payload `cwd`, so no
+# real dirs/git are needed — fast + hermetic.
+set -euo pipefail
+
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+HOOK="$REPO_ROOT/hooks/check-cd-outside-worktree.py"
+PY="${PYTHON:-python3}"
+
+main="/tmp/abs-fake-repo-$$"
+wt="$main/.claude/worktrees/slug"
+
+# run <command> [env_bypass]  -> echoes the hook exit code (0 allow / 2 block)
+run() {
+  local cmd="$1" env_bypass="${2:-}"
+  local payload
+  payload="{\"tool_name\":\"Bash\",\"cwd\":\"$wt\",\"tool_input\":{\"command\":\"$cmd\"}}"
+  if [ "$env_bypass" = "env" ]; then
+    printf '%s' "$payload" | WORKTREE_CD_BYPASS=1 "$PY" "$HOOK" >/dev/null 2>&1 && echo 0 || echo $?
+  else
+    printf '%s' "$payload" | env -u WORKTREE_CD_BYPASS "$PY" "$HOOK" >/dev/null 2>&1 && echo 0 || echo $?
+  fi
+}
+
+assert() { # <label> <got> <want>
+  if [ "$2" = "$3" ]; then echo "PASS: $1"; else echo "FAIL: $1 (got $2, want $3)"; exit 1; fi
+}
+
+# 1. NEGATIVE CONTROL: cd into the main checkout from a worktree session -> BLOCK
+assert "cd into main blocks (negative control)" "$(run "cd $main")" 2
+
+# 2. inline prefix -> ALLOW (the fix)
+assert "inline WORKTREE_CD_BYPASS=1 prefix allows" "$(run "WORKTREE_CD_BYPASS=1 cd $main")" 0
+
+# 3. session env -> ALLOW (pre-existing path still works)
+assert "session-env WORKTREE_CD_BYPASS still allows" "$(run "cd $main" env)" 0
+
+# 4. NEGATIVE CONTROL: a quoted/non-leading token is NOT a bypass; the real
+#    `cd` into main still blocks.
+assert "quoted bypass token does not bypass" "$(run "echo 'WORKTREE_CD_BYPASS=1' && cd $main")" 2
+
+# 5. NEGATIVE CONTROL (the load-bearing one): a cd into main carrying a
+#    DIFFERENT env prefix must STILL block. Before the strip-leading-env fix,
+#    `^cd` missed any env-prefixed cd entirely (a HEAD-drift false-negative) and
+#    the inline-bypass check was cosmetic. This proves the cd is now detected
+#    through the prefix, and that only WORKTREE_CD_BYPASS — not any var — bypasses.
+assert "non-bypass env-prefixed cd into main still blocks" "$(run "FOO=bar cd $main")" 2
+
+echo "ALL PASS: test_cd_worktree_inline_bypass"


### PR DESCRIPTION
Part 2 of MYC-782 (ai-brain-starter). Part 1 (the two untracked hooks + deployed-surface guard) shipped in adelaidasofia/adelaida-skills#45.

---

`check-cd-outside-worktree`'s block message advertises `WORKTREE_CD_BYPASS=1` as the override, but `main()` read it from `os.environ` only. An inline `WORKTREE_CD_BYPASS=1 cd ...` prefix lives in the command string, not the hook's session env, so the advertised bypass could never fire (bug class `HOOK-READS-SESSION-ENV-NOT-COMMAND-ENV`).

### A deeper bug the test's negative control surfaced
`CD_RE` is anchored `^(?:cd|pushd)`, so **any** leading env prefix hid the `cd` entirely — `FOO=1 cd /main` slipped past the gate undetected. That's a real `CONCURRENT-SESSION-HEAD-DRIFT` false-negative (a commit after that `cd` lands on the wrong branch), and it made the inline-bypass check cosmetic (the prefixed `cd` was already escaping detection). Fixed both:
- strip leading `VAR=val` / wrapper prefixes before `CD_RE` so a prefixed `cd` **is** detected;
- honor `WORKTREE_CD_BYPASS` explicitly at the top.

### Self-contained on purpose
Helpers are local to the hook, not a shared `~/.claude/hooks/_lib/` module. That deployed path is co-owned by multiple installers (last-writer-wins); a version missing one helper would clobber it and silently make the fix inert. The hook was standalone before — it stays that way.

### Tests
`tests/integration/test_cd_worktree_inline_bypass.sh`, wired into `scripts/ci.sh`'s **named** gate (a `hooks/test_*.py` would only `py_compile`, never run). Five cases, two of them negative controls: a non-bypass env-prefixed `cd` into main still blocks, and removing the bypass check turns the inline-allow case red (proving it's load-bearing). `py_compile` (3.9) + 30 integration tests + shellcheck all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)