### PR TITLE
fix(seo-substrate): reconcile marketing-skills refs to v2.x skill names

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Bootstrap touches your `~/.claude/` directory and registers third-party content.
 | `cloudflare/skills` | cloudflare (workers, durable-objects, agents-sdk, web-perf, wrangler, sandbox-sdk) | Apache 2.0 |
 | `AgriciDaniel/claude-seo` | claude-seo (25 sub-skills + 18 sub-agents) | MIT |
 | `obra/superpowers` | superpowers (engineering discipline as plugin) | MIT |
-| `coreyhaines31/marketingskills` | marketing-skills (41 marketing sub-skills) | MIT |
+| `coreyhaines31/marketingskills` | marketing-skills (44 marketing sub-skills) | MIT |
 | `kepano/obsidian-skills` | obsidian, context7, playwright | MIT |
 
 > **macOS vs Windows.** All eight marketplaces install via `bootstrap.sh` on macOS. On Windows, `bootstrap.ps1` installs only `obsidian-skills` plus the two MCP servers below; the seven vendor skill-packs are not ported yet. To add any of them manually after install, paste this into Claude Code (substituting names from the table above):

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1432,8 +1432,8 @@ if [[ "${SKIP_VENDOR_SKILLS:-0}" != "1" ]]; then
     ok "lean-ctx installed (top-level SKILL.md symlinked for auto-discovery)"
   fi
 
-  # coreyhaines31/marketingskills (MIT, 27.5k stars). Marketplace bundle with
-  # 41 marketing skills covering CRO, copywriting, SEO, paid ads, growth.
+  # coreyhaines31/marketingskills (MIT, 32.8k stars). Marketplace bundle with
+  # 44 marketing skills covering CRO, copywriting, SEO, paid ads, growth.
   # Direct fit for the Mycelium consulting funnel (myceliumai.co + diazroa.com),
   # Substack post launches, Apollo outreach sequences, pricing strategy.
   # Surfaced 2026-05-10 during proper WhatsApp-bar audit (missed in prior pass).

--- a/skills/seo-substrate/SKILL.md
+++ b/skills/seo-substrate/SKILL.md
@@ -350,10 +350,10 @@ This substrate covers the substrate primitives. Delegate to specialist skills fo
 - **AI SEO deep-dive (citation chasing, LLM-specific tactics)** → `marketing-skills:ai-seo` (coreyhaines)
 - **Programmatic SEO at >50 pages or with paid APIs** → `marketing-skills:programmatic-seo` (coreyhaines)
 - **Site architecture mapping for new sites** → `marketing-skills:site-architecture` (coreyhaines)
-- **Schema markup beyond the 11 types covered above** → `marketing-skills:schema-markup` (coreyhaines)
+- **Schema markup beyond the 11 types covered above** → `marketing-skills:schema` (coreyhaines)
 - **Full claude-seo (25 sub-skills + 18 sub-agents) for deep niches** → `claude-seo:*` (AgriciDaniel)
-- **Conversion rate optimization on the resulting traffic** → `marketing-skills:form-cro`, `marketing-skills:onboarding-cro`, `marketing-skills:page-cro` (coreyhaines)
-- **Pricing page work** → `marketing-skills:pricing-strategy` (coreyhaines)
+- **Conversion rate optimization on the resulting traffic** → `marketing-skills:cro`, `marketing-skills:onboarding`, `marketing-skills:cro` (coreyhaines)
+- **Pricing page work** → `marketing-skills:pricing` (coreyhaines)
 
 The substrate primitives stay opinionated and lean. The full SEO/marketing surface is plugin-installed and discoverable when the user's prompt drifts beyond substrate scope.
 


### PR DESCRIPTION
Upstream coreyhaines31/marketingskills v2.x renamed ~17 skills. seo-substrate cross-references used stale v1.x names (schema-markup, form-cro, onboarding-cro, page-cro, pricing-strategy) which now dangle for any installer. Renamed to current names; README/bootstrap counts updated 41→44 skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)