### PR TITLE
feat(install): automated first-run context-load self-test (MYC-630)

### DIFF
--- a/phases/phase-19-23-finish.md
+++ b/phases/phase-19-23-finish.md
@@ -1,8 +1,22 @@
 ## Phase 19: First Test Drive
 
-"Everything is set up. Let's test it."
+"Everything is set up. Let's prove it actually loads — automatically — before you test it by hand."
 
-1. "Close this Claude session and open a new one in your vault folder."
+**Automated context-load self-test (run this — do NOT skip).** The manual "ask me what you know about you" check below only works if the user happens to relaunch from the right folder with a filled-in CLAUDE.md. Wrong folder or unfilled template = generic answer = "this doesn't work" = churn. So PROVE the personalized context will load FIRST, while we can still fix it. Run (substitute the real vault path):
+
+```bash
+python3 ~/.claude/skills/ai-brain-starter/scripts/check-context-load.py "[VAULT_PATH]"
+```
+
+It simulates how Claude Code discovers CLAUDE.md (walking up from the launch folder) and reports one of:
+
+- **Exit 0 (`OK_WILL_LOAD`)** — the vault is set up so context loads. The script prints the EXACT launch command; use THAT in step 1 below, not a vague "your vault folder."
+- **Exit 1 (`FAIL_*`)** — context will NOT load on first run (no CLAUDE.md, or the template was never filled in). **Do not declare the install done.** Re-run Phase 4 to build/fill CLAUDE.md, then re-run the self-test until it passes.
+- **Exit 2 (`WARN_MISSING_CONTEXT`)** — loads, but a session-start file CLAUDE.md references is missing. Create it or fix the reference.
+
+Then hand off the manual confirmation, using the exact command the self-test printed:
+
+1. "Close this Claude session and reopen with `cd \"[VAULT_PATH]\" && claude` — launching anywhere else loads a generic answer, not you."
 2. "Ask me: 'What do you know about me?'"
 3. "I should answer from your CLAUDE.md without you explaining anything."
 
@@ -516,6 +530,7 @@ After the cascade completes, run a self-verification check before saying goodbye
 - Hooks installed (session-start-context, post-tool-use-learnings, etc.)
 - session-end-hook.sh present and executable
 - No .ps1 BOM issues (Windows only)
+- First-run context load will succeed (CLAUDE.md is filled in, not the bare template, and loads on launch from the vault) — the diagnose "First-run context load" section, the same check Phase 19's self-test runs. A red here means the install's headline test ("what do you know about me") would answer generically; do NOT declare the install done until it is green.
 
 Read the diagnose output. If everything is green, proceed to the goodbye. If anything is yellow (warning) or red (failure), surface a one-paragraph summary in the user's PRIMARY_LANGUAGE BEFORE the goodbye:
 

--- a/scripts/check-context-load.py
+++ b/scripts/check-context-load.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""check-context-load.py — MYC-630: automated first-run context-load self-test.
+
+Phase 19's "ask me what you know about me" test relies on the user launching
+Claude from the *right* working directory. Claude Code loads a vault's CLAUDE.md
+by walking UP from the launch cwd to the filesystem root — so a vault launched
+from the wrong folder loads only the global ~/.claude/CLAUDE.md, answers
+generically, and the user concludes "this doesn't work" and churns. Nothing
+in the install actually proved the personalized context would load.
+
+This script is that proof. It does NOT just re-check that context files exist
+(diagnose.sh and context-audit.py already do existence). It simulates Claude
+Code's CLAUDE.md ancestor-walk and answers one deterministic question:
+
+    "If Claude is launched from <launch-dir>, will the vault's personalized
+     context load on the first run?"
+
+It also emits the exact `cd "<vault>" && claude` command, so the install can
+tell the user precisely where to launch instead of a vague "your vault folder."
+
+Verdicts (--porcelain prints the single most-severe token):
+  OK_WILL_LOAD               personalized CLAUDE.md will load from launch-dir
+  FAIL_NO_CLAUDE_MD          no CLAUDE.md at the vault root
+  FAIL_TEMPLATE_UNFILLED:<d> CLAUDE.md is the unfilled template or a stub
+                             (d = "stub" or the placeholder count)
+  FAIL_WRONG_CWD:<dir>       launch-dir is not inside the vault, so the vault
+                             CLAUDE.md is NOT on the cwd->root path (won't load)
+  WARN_MISSING_CONTEXT:<n>   CLAUDE.md references session-start files that are
+                             absent (loads, but the first answer will be thin)
+
+Exit codes (match diagnose.sh): 0 = will load, 1 = will NOT load (a FAIL_*
+verdict — the install gate should not declare "done"), 2 = loads with warnings.
+
+Usage:
+  python3 check-context-load.py [VAULT] [--launch-dir DIR] [--porcelain|--json]
+
+VAULT defaults to $VAULT_PATH or the current directory. --launch-dir defaults to
+VAULT (the recommended launch dir); pass the live session cwd to catch a vault
+that is being run from the wrong folder right now.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+# Minimum size below which a CLAUDE.md is treated as a stub, not a real
+# personalized memory file. Matches diagnose.sh's "tiny" threshold.
+MIN_PERSONALIZED_BYTES = 200
+
+# Substrings that only ever appear in the UNFILLED claude-md template
+# (templates/generated/claude-md-template.md) — a real personalized CLAUDE.md
+# substitutes every one of them. Any survivor means the install wrote the
+# template but never filled it in. Curated to be zero-false-positive against a
+# genuinely filled file.
+TEMPLATE_PLACEHOLDERS = (
+    "[Name]. [What they do]",
+    "[What they do]",
+    "[Key context from their answers",
+    "[Priority 1",
+    "[Priority 2]",
+    "[Priority 3]",
+    "[from their answer]",
+    "[who they are]",
+    "[FILL THIS IN",
+    "[VAULT_PATH]",
+    "[TEAM_VAULT_PATH]",
+    "{{CUSTOMIZE}}",
+    "{{VAULT_ROOT}}",
+    "<your name>",
+    "PRIMARY_LANGUAGE",
+)
+
+# Canonical session-start context files the substrate's CLAUDE.md tells Claude
+# to read on every session. Checked by BASENAME and only when CLAUDE.md actually
+# references them — so a vault whose CLAUDE.md never mentions a file is never
+# faulted for it (portable across vault layouts).
+CANONICAL_CONTEXT_FILES = (
+    "Last Session.md",
+    "Current Priorities.md",
+    "About Me.md",
+)
+
+
+def _resolve(p: Path) -> Path:
+    try:
+        return p.resolve()
+    except OSError:
+        return p.absolute()
+
+
+def _is_within(child: Path, parent: Path) -> bool:
+    """True if `child` is `parent` or a descendant — i.e. `parent` lies on the
+    cwd->root walk from `child`, which is exactly when Claude Code loads
+    parent/CLAUDE.md."""
+    child, parent = _resolve(child), _resolve(parent)
+    return child == parent or parent in child.parents
+
+
+def _find_basename(vault: Path, basename: str) -> bool:
+    """True if a file with this basename exists in the vault. Layout-agnostic
+    (works whether About Me lives in '🏠 Home/' or elsewhere) but shallow-first:
+    the canonical context files live at depth 1-2 ('⚙️ Meta/…', '🏠 Home/…'),
+    so check those before falling back to a full walk — a mature vault can hold
+    10k+ files and the repo's own rule forbids gratuitous full-tree walks."""
+    # Depth 1 (vault root) then depth 2 (one level down) — covers every real
+    # layout in O(top-level entries) without descending into .git.
+    if (vault / basename).is_file():
+        return True
+    if any(p.is_file() for p in vault.glob("*/" + basename)):
+        return True
+    # Fallback: deeper nesting. Prune .git so the walk can't blow up on it.
+    for f in vault.rglob(basename):
+        if ".git" in f.parts:
+            continue
+        if f.is_file():
+            return True
+    return False
+
+
+def _ancestor_claude_mds(vault: Path) -> list[Path]:
+    """CLAUDE.md files in STRICT ancestors of the vault. If the user launches
+    from one of these, that file loads instead of (or merged ahead of) the
+    vault's. Informational only — it never flips the verdict, because launching
+    from the vault itself still loads the vault CLAUDE.md."""
+    found: list[Path] = []
+    for anc in _resolve(vault).parents:
+        cm = anc / "CLAUDE.md"
+        if cm.is_file():
+            found.append(cm)
+    return found
+
+
+def evaluate(vault: Path, launch_dir: Path) -> dict:
+    """Run every check and return a structured result. The porcelain verdict is
+    the single most-severe finding; `checks` carries the full picture."""
+    vault = _resolve(vault)
+    launch_dir = _resolve(launch_dir)
+    checks: list[dict] = []
+    claude_md = vault / "CLAUDE.md"
+    launch_command = 'cd "%s" && claude' % vault
+
+    # --- Check 1: CLAUDE.md exists at the vault root -------------------------
+    if not claude_md.is_file():
+        checks.append({"name": "CLAUDE.md present", "status": "fail",
+                       "detail": "no CLAUDE.md at vault root %s" % vault})
+        return {"verdict": "FAIL_NO_CLAUDE_MD", "exit": 1,
+                "vault": str(vault), "launch_dir": str(launch_dir),
+                "launch_command": launch_command, "checks": checks}
+    text = claude_md.read_text(encoding="utf-8", errors="replace")
+    size = len(text.encode("utf-8"))
+    checks.append({"name": "CLAUDE.md present", "status": "pass",
+                   "detail": "%d bytes" % size})
+
+    # --- Check 2: it is personalized, not the unfilled template / a stub -----
+    placeholders = [p for p in TEMPLATE_PLACEHOLDERS if p in text]
+    if size < MIN_PERSONALIZED_BYTES:
+        checks.append({"name": "CLAUDE.md personalized", "status": "fail",
+                       "detail": "stub: %d bytes (< %d)" % (size, MIN_PERSONALIZED_BYTES)})
+        return {"verdict": "FAIL_TEMPLATE_UNFILLED:stub", "exit": 1,
+                "vault": str(vault), "launch_dir": str(launch_dir),
+                "launch_command": launch_command, "checks": checks}
+    if placeholders:
+        checks.append({"name": "CLAUDE.md personalized", "status": "fail",
+                       "detail": "%d template placeholder(s) left unfilled: %s"
+                       % (len(placeholders), ", ".join(placeholders[:4]))})
+        return {"verdict": "FAIL_TEMPLATE_UNFILLED:%d" % len(placeholders),
+                "exit": 1, "vault": str(vault), "launch_dir": str(launch_dir),
+                "launch_command": launch_command, "checks": checks}
+    checks.append({"name": "CLAUDE.md personalized", "status": "pass",
+                   "detail": "no template placeholders"})
+
+    # --- Check 3: the load path — is the vault on the launch cwd's walk? -----
+    if not _is_within(launch_dir, vault):
+        checks.append({"name": "Launch cwd loads the vault", "status": "fail",
+                       "detail": "launch dir %s is outside the vault; the vault "
+                       "CLAUDE.md is not on its cwd->root path and will not load"
+                       % launch_dir})
+        return {"verdict": "FAIL_WRONG_CWD:%s" % launch_dir.name, "exit": 1,
+                "vault": str(vault), "launch_dir": str(launch_dir),
+                "launch_command": launch_command, "checks": checks}
+    checks.append({"name": "Launch cwd loads the vault", "status": "pass",
+                   "detail": "launch dir is the vault or a descendant"})
+
+    # --- Soft: a CLAUDE.md in an ancestor could shadow on a wrong-cwd launch -
+    shadows = _ancestor_claude_mds(vault)
+    if shadows:
+        checks.append({"name": "Ancestor CLAUDE.md", "status": "info",
+                       "detail": "non-vault CLAUDE.md above the vault: %s "
+                       "(loads if launched from there)"
+                       % ", ".join(str(s) for s in shadows)})
+
+    # --- Check 4 (soft): referenced session-start context files resolve ------
+    referenced = [c for c in CANONICAL_CONTEXT_FILES if c in text]
+    missing = [c for c in referenced if not _find_basename(vault, c)]
+    if missing:
+        checks.append({"name": "Context layer resolves", "status": "warn",
+                       "detail": "CLAUDE.md references but the vault is missing: "
+                       + ", ".join(missing)})
+        return {"verdict": "WARN_MISSING_CONTEXT:%d" % len(missing), "exit": 2,
+                "vault": str(vault), "launch_dir": str(launch_dir),
+                "launch_command": launch_command, "checks": checks,
+                "missing_context": missing}
+    checks.append({"name": "Context layer resolves", "status": "pass",
+                   "detail": "%d referenced session-start file(s) present"
+                   % len(referenced)})
+
+    return {"verdict": "OK_WILL_LOAD", "exit": 0, "vault": str(vault),
+            "launch_dir": str(launch_dir), "launch_command": launch_command,
+            "checks": checks}
+
+
+def _print_human(result: dict) -> None:
+    icons = {"pass": "✅", "fail": "❌", "warn": "⚠️", "info": "ℹ️"}
+    print("\n=== First-run context-load self-test ===\n")
+    print("Vault:      %s" % result["vault"])
+    print("Launch dir: %s\n" % result["launch_dir"])
+    for c in result["checks"]:
+        line = "  %s %s" % (icons.get(c["status"], "•"), c["name"])
+        if c.get("detail"):
+            line += "  —  %s" % c["detail"]
+        print(line)
+    verdict = result["verdict"]
+    print()
+    if result["exit"] == 0:
+        print("Context WILL load. Launch the vault with:")
+        print("    %s" % result["launch_command"])
+    elif result["exit"] == 2:
+        print("Context will load, with warnings (%s)." % verdict)
+        print("Launch the vault with:")
+        print("    %s" % result["launch_command"])
+    else:
+        print("Context will NOT load on first run (%s)." % verdict)
+        print("Fix the failure above, then launch the vault with:")
+        print("    %s" % result["launch_command"])
+    print()
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Prove the vault's personalized context will load on first run")
+    parser.add_argument("vault", nargs="?",
+                        default=os.environ.get("VAULT_PATH", os.getcwd()),
+                        help="vault root (default: $VAULT_PATH or cwd)")
+    parser.add_argument("--launch-dir", default=None,
+                        help="directory Claude would launch from "
+                             "(default: the vault; pass the live cwd to catch a "
+                             "wrong-folder launch)")
+    parser.add_argument("--porcelain", action="store_true",
+                        help="print only the single most-severe verdict token")
+    parser.add_argument("--json", action="store_true",
+                        help="print the full structured result as JSON")
+    args = parser.parse_args(argv)
+
+    vault = Path(args.vault)
+    launch_dir = Path(args.launch_dir) if args.launch_dir else vault
+    result = evaluate(vault, launch_dir)
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    elif args.porcelain:
+        print(result["verdict"])
+    else:
+        _print_human(result)
+    return result["exit"]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -101,6 +101,7 @@ INTEGRATION_TESTS=(
   test_meta_resolver
   test_meta_resolution_guard
   test_split_meta
+  test_context_load_selftest
   test_stranded_session_artifacts_watchdog
   test_session_coordination_guards
   test_trust_prompt_preframing

--- a/scripts/diagnose.sh
+++ b/scripts/diagnose.sh
@@ -393,6 +393,39 @@ else
   warn "check-split-meta.py not found" "Cannot check for split Meta folders."
 fi
 
+# ----- 15. First-run context load (the wrong-cwd / generic-answer class) -----
+# The install's "ask me what you know about you" test only works if the vault's
+# personalized CLAUDE.md actually loads — which depends on launching from the
+# right folder and on CLAUDE.md being filled in, not the bare template. This
+# simulates Claude Code's CLAUDE.md ancestor-walk and proves the load instead of
+# only checking that files exist (sections 1-2 check existence; this checks LOAD).
+section "15. First-run context load"
+CHECK_CTX=""
+for c in "$(cd "$(dirname "$0")" && pwd)/check-context-load.py" \
+         "$HOME/.claude/skills/ai-brain-starter/scripts/check-context-load.py"; do
+  [ -f "$c" ] && CHECK_CTX="$c" && break
+done
+if [ -n "$CHECK_CTX" ]; then
+  cverdict="$(python3 "$CHECK_CTX" "$VAULT" --porcelain 2>/dev/null)"
+  case "$cverdict" in
+    OK_WILL_LOAD)
+      ok "Personalized context will load — launch with: cd \"$VAULT\" && claude" ;;
+    FAIL_NO_CLAUDE_MD)
+      bad "No CLAUDE.md at the vault root — first run answers generically" \
+        "Re-run /setup-brain Phase 4 to build it." ;;
+    FAIL_TEMPLATE_UNFILLED:*)
+      bad "CLAUDE.md is the unfilled template or a stub (${cverdict#FAIL_TEMPLATE_UNFILLED:})" \
+        "The first-run 'what do you know about me' answer will be generic. Re-run /setup-brain Phase 4 to fill it in." ;;
+    WARN_MISSING_CONTEXT:*)
+      warn "CLAUDE.md references session-start files the vault is missing (${cverdict#WARN_MISSING_CONTEXT:})" \
+        "Run: python3 \"$CHECK_CTX\" \"$VAULT\" to see which. Create them or fix the references." ;;
+    *)
+      warn "Could not evaluate first-run context load" "check-context-load.py returned: ${cverdict:-<empty>}" ;;
+  esac
+else
+  warn "check-context-load.py not found" "Cannot verify the vault's context will load on first run."
+fi
+
 # ----- summary -----
 echo
 echo "${B}Summary${N}"

--- a/scripts/test-context-load-selftest.sh
+++ b/scripts/test-context-load-selftest.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# test-context-load-selftest.sh — fixture suite for scripts/check-context-load.py
+#
+# check-context-load.py is MYC-630: the automated first-run context-load
+# self-test. It simulates Claude Code's CLAUDE.md ancestor-walk so the install
+# can PROVE the vault's personalized context will load on first launch — instead
+# of relying on the user happening to launch from the right cwd (wrong folder =
+# generic answer = "this doesn't work" = churn).
+#
+# This suite builds throwaway fixture vaults and asserts the porcelain verdict +
+# exit code for each first-run failure mode. Logic lives next to the script it
+# exercises; tests/integration/test_context_load_selftest.sh is a thin CI wrapper.
+#
+# Exit 0 = all fixtures pass.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECK="$HERE/check-context-load.py"
+
+PASS=0
+FAIL=0
+
+# A filled, personalized CLAUDE.md (no template placeholders). References the
+# canonical session-start files so the missing-context check has something to
+# resolve.
+write_filled_claude() {
+  cat > "$1/CLAUDE.md" <<'EOF'
+# Memory
+
+## Me
+Jane Doe. Founder of Acme. Building a longevity platform.
+
+## Current Focus
+- Ship the PRD this week
+- Close the seed round
+
+## People
+- **Sam** — cofounder and CTO
+
+## Vault Map
+- 📓 Journals/
+- 🏠 Home/
+- ⚙️ Meta/
+
+## Session Protocol
+1. Start: read this file + ⚙️ Meta/Last Session.md + ⚙️ Meta/Current Priorities.md
+   and 🏠 Home/About Me.md. Don't ask what we were doing.
+EOF
+}
+
+# Create the canonical session-start context files the filled CLAUDE.md points at.
+write_context_layer() {
+  mkdir -p "$1/⚙️ Meta" "$1/🏠 Home"
+  printf 'Last session: wrote tests.\n' > "$1/⚙️ Meta/Last Session.md"
+  printf 'Top priority: ship.\n'        > "$1/⚙️ Meta/Current Priorities.md"
+  printf 'Jane Doe. Founder.\n'         > "$1/🏠 Home/About Me.md"
+}
+
+# run_case <label> <expected-verdict-prefix> <expected-exit> -- <check args...>
+run_case() {
+  local label="$1" expect_verdict="$2" expect_exit="$3"; shift 3
+  [ "$1" = "--" ] && shift
+  local out rc
+  out="$(python3 "$CHECK" "$@" --porcelain 2>/dev/null)"
+  rc=$?
+  if [[ "$out" == "$expect_verdict"* ]] && [ "$rc" -eq "$expect_exit" ]; then
+    printf '  \033[32mPASS\033[0m %-22s -> %s (exit %d)\n' "$label" "$out" "$rc"
+    PASS=$((PASS+1))
+  else
+    printf '  \033[31mFAIL\033[0m %-22s\n        got:    %s (exit %d)\n        expect: %s* (exit %d)\n' \
+      "$label" "$out" "$rc" "$expect_verdict" "$expect_exit"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+ROOT="$(mktemp -d)"
+trap 'rm -rf "$ROOT"' EXIT
+
+# --- Fixture 1: healthy vault, launched from the vault root ------------------
+V1="$ROOT/good"; mkdir -p "$V1"; write_filled_claude "$V1"; write_context_layer "$V1"
+run_case "healthy"        OK_WILL_LOAD        0 -- "$V1" --launch-dir "$V1"
+
+# --- Fixture 2: healthy vault, launched from a subfolder (descendant is OK) --
+run_case "healthy-subdir" OK_WILL_LOAD        0 -- "$V1" --launch-dir "$V1/🏠 Home"
+
+# --- Fixture 3: no launch-dir given => defaults to vault, still loads --------
+run_case "default-launch" OK_WILL_LOAD        0 -- "$V1"
+
+# --- Fixture 4: no CLAUDE.md at vault root ----------------------------------
+V4="$ROOT/no-claude"; mkdir -p "$V4"; write_context_layer "$V4"
+run_case "no-claude-md"   FAIL_NO_CLAUDE_MD   1 -- "$V4" --launch-dir "$V4"
+
+# --- Fixture 5: unfilled template (placeholders survived) -------------------
+V5="$ROOT/template"; mkdir -p "$V5"; write_context_layer "$V5"
+cat > "$V5/CLAUDE.md" <<'EOF'
+# Memory
+
+## Me
+[Name]. [What they do]. [Key context from their answers.]
+
+## Current Focus
+- [Priority 1 — with specifics from their answer]
+
+## Vault Map
+[FILL THIS IN — list the actual folders created in Phase 3]
+EOF
+run_case "unfilled-template" FAIL_TEMPLATE_UNFILLED 1 -- "$V5" --launch-dir "$V5"
+
+# --- Fixture 6: stub CLAUDE.md (too small to be real personalization) -------
+V6="$ROOT/stub"; mkdir -p "$V6"; write_context_layer "$V6"
+printf '# Memory\n' > "$V6/CLAUDE.md"
+run_case "stub-claude-md"  FAIL_TEMPLATE_UNFILLED 1 -- "$V6" --launch-dir "$V6"
+
+# --- Fixture 7: healthy vault, launched from the WRONG folder (the cwd bug) --
+WRONG="$ROOT/somewhere-else"; mkdir -p "$WRONG"
+run_case "wrong-cwd"       FAIL_WRONG_CWD     1 -- "$V1" --launch-dir "$WRONG"
+
+# --- Fixture 8: filled CLAUDE.md but the context layer it references is gone -
+V8="$ROOT/missing-context"; mkdir -p "$V8"; write_filled_claude "$V8"
+run_case "missing-context" WARN_MISSING_CONTEXT 2 -- "$V8" --launch-dir "$V8"
+
+# --- Fixture 9: human (non-porcelain) output prints the exact launch command -
+human_out="$(python3 "$CHECK" "$V1" 2>/dev/null)"
+if printf '%s' "$human_out" | grep -q "cd .*good.* && claude"; then
+  printf '  \033[32mPASS\033[0m %-22s -> prints launch command\n' "launch-command"
+  PASS=$((PASS+1))
+else
+  printf '  \033[31mFAIL\033[0m %-22s -> no exact launch command in human output\n' "launch-command"
+  FAIL=$((FAIL+1))
+fi
+
+# --- Fixture 10: --json emits parseable, structured output ------------------
+if python3 "$CHECK" "$V1" --json 2>/dev/null \
+    | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['verdict']=='OK_WILL_LOAD'; assert 'launch_command' in d" 2>/dev/null; then
+  printf '  \033[32mPASS\033[0m %-22s -> valid JSON with verdict+launch_command\n' "json-output"
+  PASS=$((PASS+1))
+else
+  printf '  \033[31mFAIL\033[0m %-22s -> --json output not parseable/complete\n' "json-output"
+  FAIL=$((FAIL+1))
+fi
+
+echo
+echo "context-load self-test fixtures: $PASS pass, $FAIL fail"
+[ "$FAIL" -eq 0 ]

--- a/tests/integration/test_context_load_selftest.sh
+++ b/tests/integration/test_context_load_selftest.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# CI integration wrapper — runs the first-run context-load self-test fixture
+# suite (scripts/test-context-load-selftest.sh) as part of `scripts/ci.sh`.
+# Thin: the fixtures live next to the script they exercise (check-context-load.py).
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+exec bash "$ROOT/scripts/test-context-load-selftest.sh"


### PR DESCRIPTION
## What

Closes **MYC-630**. Phase 19's "ask me what you know about you" test silently depends on the user relaunching Claude from the *right* folder with a *filled-in* CLAUDE.md. Claude Code loads a vault's CLAUDE.md by walking **up** from the launch cwd — so a wrong-folder launch loads only the global `~/.claude/CLAUDE.md`, answers generically, and reads as *"this doesn't work" → churn*. Nothing in the install actually proved the personalized context would load.

## How

New `scripts/check-context-load.py` **simulates that ancestor-walk and proves the load** — it does not just re-check that files exist (`diagnose.sh` §1–2 and `context-audit.py` already cover existence). Porcelain verdicts:

| Verdict | Meaning | Exit |
|---|---|---|
| `OK_WILL_LOAD` | personalized CLAUDE.md will load from the launch dir | 0 |
| `FAIL_NO_CLAUDE_MD` | no CLAUDE.md at vault root | 1 |
| `FAIL_TEMPLATE_UNFILLED:<d>` | CLAUDE.md is the unfilled template or a stub | 1 |
| `FAIL_WRONG_CWD:<dir>` | launch dir is outside the vault → won't load | 1 |
| `WARN_MISSING_CONTEXT:<n>` | referenced session-start files are absent | 2 |

It also prints the exact `cd "<vault>" && claude` command, so the install stops saying a vague "your vault folder."

## Wiring (the gate, per the "gate vs exists" principle)

- **`diagnose.sh`** — new section 15 *"First-run context load"* (runs at Phase 24.7, *before* the install declares itself done).
- **`phase-19-23-finish.md`** — Phase 19 runs the self-test before the manual confirmation and hands off the exact launch command; Phase 24.7 documents the gate (red here = do **not** declare install done).
- **`ci.sh` + `tests/integration/`** — `test_context_load_selftest` registered in the gate; `scripts/test-context-load-selftest.sh` is a 10-fixture suite covering every first-run failure mode.

## Verification

- 10/10 fixtures pass.
- `py_compile` clean on all 263 tracked `*.py` under **Python 3.9.6** (CI's pinned target; `from __future__ import annotations` keeps it 3.9-safe).
- `bash -n` clean on all touched shell scripts.
- `diagnose.sh` §15 green against a real vault; `FAIL_WRONG_CWD` when launched from `\$HOME`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)