### PR TITLE
fix(graphify): use .graphify_python for serve step instead of bare python3

### DIFF
--- a/skills/graphify/SKILL.md
+++ b/skills/graphify/SKILL.md
@@ -715,7 +715,7 @@ print('graph.graphml written - open in Gephi, yEd, or any GraphML tool')
 ### Step 7d - MCP server (only if --mcp flag)
 
 ```bash
-python3 -m graphify.serve graphify-out/graph.json
+$(cat graphify-out/.graphify_python) -m graphify.serve graphify-out/graph.json
 ```
 
 This starts a stdio MCP server that exposes tools: `query_graph`, `get_node`, `get_neighbors`, `get_community`, `god_nodes`, `graph_stats`, `shortest_path`. Add to Claude Desktop or any MCP-compatible agent orchestrator so other agents can query the graph live.


### PR DESCRIPTION
The graphify serve step (Step 7d) was the only Python invocation in the
entire pipeline using bare `python3`, bypassing the `.graphify_python`
mechanism that every other step uses to find the correct interpreter.

When graphify is installed via pipx or a venv, system `python3` won't have
the graphify package — this produces `ModuleNotFoundError` when the user
tries to start the graph server. The fix is a one-line change matching the
same pattern already used in ~20 other blocks throughout the skill.