### PR TITLE
fix(hooks): de-noise SessionStart snapshot guard — diff script identity, not raw strings

### DIFF
--- a/hooks/sessionstart-hook-snapshot-guard.py
+++ b/hooks/sessionstart-hook-snapshot-guard.py
@@ -1,23 +1,36 @@
 #!/usr/bin/env python3
 """
-sessionstart-hook-snapshot-guard.py — warn if the SessionStart hook list shrank.
+sessionstart-hook-snapshot-guard.py - warn if a SessionStart hook DISAPPEARED.
 
-Fixed 2026-05-19 after my website-audit-freshness hook silently disappeared
-from settings.json (linter or parallel session pruned it). The strip was
-invisible until Mission Control v3 was rebuilt and I re-discovered it.
+A SessionStart hook can silently vanish from settings.json - a linter, a manual
+edit, or a parallel session can prune one, and the loss stays invisible until you
+happen to notice the missing behavior. This guard snapshots which SessionStart
+hooks are wired and warns inline when one disappears.
+
+De-noised: the original diffed exact command STRINGS, so any cosmetic reword by a
+concurrent session - `python3` <-> `/usr/bin/python3`, `~/` <-> absolute path,
+adding/removing a `2>/dev/null || echo {...}` wrapper or a `[ -f X ] &&` guard -
+false-flagged a hook as "missing" when the SAME SCRIPT was still wired. Cry-wolf
+is how the ONE real drop gets scrolled past, so the guard now diffs SCRIPT
+IDENTITY (script basename + normalized args) instead of raw command text.
 
 Behavior:
-  - Snapshot the SessionStart `hooks[].command` strings to
-    ~/.claude/state/sessionstart-hooks-snapshot.json
-  - On each fire, diff current hooks against snapshot
-  - If any prior hook is MISSING from current, surface inline warning
-  - If new hooks added, update snapshot silently (additions are fine)
-  - Idempotent: first run captures baseline silently
+  - Snapshot SessionStart hook IDENTITIES to
+    ~/.claude/state/sessionstart-hooks-snapshot.json (versioned: {"v":2,...}).
+  - On each fire, diff current identities against the snapshot.
+  - Any prior identity MISSING from current -> inline warning (snapshot NOT
+    updated, so the warning persists until reconciled).
+  - New identities only -> update snapshot silently (additions are fine).
+  - First run / corrupt / legacy snapshot -> (re)baseline silently.
+  - `--refresh` -> force-rewrite the snapshot to current and exit 0 (this is what
+    "if intentional, refresh" means; the old in-band rerun never refreshed
+    because the missing-branch skips the update).
 """
 
 from __future__ import annotations
 
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -25,54 +38,93 @@ SETTINGS = Path.home() / ".claude" / "settings.json"
 STATE = Path.home() / ".claude" / "state" / "sessionstart-hooks-snapshot.json"
 
 
-def extract_sessionstart_commands(settings_path: Path) -> set[str]:
+def _script_identity(cmd: str) -> str:
+    """Normalize a hook command to a stable identity: 'basename' or
+    'basename||args'. Collapses python-path / tilde-vs-absolute / [ -f X ] &&
+    guard / 2>redirect / || fallback variants of the same script."""
+    c = (cmd or "").strip()
+    c = re.sub(r"^\[\s*-[fe]\s+[^\]]*\]\s*&&\s*", "", c)   # leading [ -f X ] && guard
+    c = re.split(r"\s*\|\|\s*", c)[0]                       # trailing || true / || echo {...}
+    c = re.sub(r"\s*2>\S+", "", c).strip()                  # 2>/dev/null
+    m = re.search(r"([~/][^\s'\"]*\.(?:py|sh))", c)
+    if not m:
+        return c[:100]                                      # non-script command: trimmed text
+    p = m.group(1)
+    after = c[c.find(p) + len(p):].strip()
+    return f"{Path(p).name}||{after}" if after else Path(p).name
+
+
+def extract_sessionstart_commands(settings_path: Path) -> list[str]:
     try:
         data = json.loads(settings_path.read_text(encoding="utf-8"))
     except Exception:
-        return set()
-    out: set[str] = set()
+        return []
+    out: list[str] = []
     for block in (data.get("hooks", {}).get("SessionStart") or []):
         for hook in (block.get("hooks") or []):
-            cmd = hook.get("command", "").strip()
+            cmd = (hook.get("command") or "").strip()
             if cmd:
-                out.add(cmd)
+                out.append(cmd)
     return out
 
 
+def _current_identities() -> set[str]:
+    return {_script_identity(c) for c in extract_sessionstart_commands(SETTINGS)}
+
+
+def _load_prior() -> set[str] | None:
+    """Prior identities, or None if missing/corrupt. Legacy snapshots (a bare
+    list of raw command strings) are normalized once on read; v2 snapshots
+    (already identities) are used verbatim - re-normalizing them would be lossy."""
+    try:
+        raw = json.loads(STATE.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    if isinstance(raw, dict) and raw.get("v") == 2:
+        return set(raw.get("identities", []))
+    if isinstance(raw, list):
+        return {_script_identity(c) for c in raw}
+    return None
+
+
+def _save(identities: set[str]) -> None:
+    STATE.parent.mkdir(parents=True, exist_ok=True)
+    STATE.write_text(json.dumps({"v": 2, "identities": sorted(identities)}, indent=2),
+                     encoding="utf-8")
+
+
+def _label(identity: str) -> str:
+    bn, _, args = identity.partition("||")
+    return f"{bn} {args}".strip()
+
+
 def main() -> int:
-    current = extract_sessionstart_commands(SETTINGS)
+    if "--refresh" in sys.argv:
+        _save(_current_identities())
+        print("[sessionstart-hook-guard] snapshot refreshed to current SessionStart hooks.")
+        return 0
+
+    current = _current_identities()
     if not current:
         return 0  # settings malformed or no hooks; don't false-alarm
 
-    STATE.parent.mkdir(parents=True, exist_ok=True)
-    if not STATE.exists():
-        STATE.write_text(json.dumps(sorted(current), indent=2), encoding="utf-8")
-        return 0
-
-    try:
-        prior = set(json.loads(STATE.read_text(encoding="utf-8")))
-    except Exception:
-        # Corrupted snapshot — rewrite from current, no warning
-        STATE.write_text(json.dumps(sorted(current), indent=2), encoding="utf-8")
+    prior = _load_prior()
+    if prior is None:
+        _save(current)                       # baseline / migrate / repair, silent
         return 0
 
     missing = prior - current
     if missing:
-        # WARN — print to stdout so SessionStart shows it inline
         print(f"[sessionstart-hook-guard] WARNING: {len(missing)} SessionStart hook(s) missing since last snapshot:")
-        for cmd in sorted(missing):
-            # Show only the script name, not the full path (more readable)
-            scripts = [p for p in cmd.split() if "/" in p and p.endswith((".py", ".sh"))]
-            label = scripts[0].split("/")[-1] if scripts else cmd[:80]
-            print(f"  - {label}")
-        print("[sessionstart-hook-guard] If intentional: rerun this script to refresh snapshot. If not: re-add the missing hook(s).")
-        # Do NOT update snapshot — leave it so the warning persists until reconciled
+        for ident in sorted(missing):
+            print(f"  - {_label(ident)}")
+        print("[sessionstart-hook-guard] If intentional: `python3 ~/.claude/hooks/sessionstart-hook-snapshot-guard.py --refresh`. If not: re-add the missing hook(s).")
+        # Do NOT update snapshot - leave it so the warning persists until reconciled.
+        return 0
 
-    # Update snapshot with any NEW additions (silent — additions are fine)
     additions = current - prior
-    if additions and not missing:
-        STATE.write_text(json.dumps(sorted(current), indent=2), encoding="utf-8")
-
+    if additions:
+        _save(current)                       # additions are fine - absorb silently
     return 0
 
 

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -124,6 +124,7 @@ INTEGRATION_TESTS=(
   test_dev_worktree_detached_gitdir
   test_install_api_canonical_base
   test_cd_worktree_inline_bypass
+  test_sessionstart_hook_snapshot_guard
 )
 echo "==> (b) Shell integration: ${#INTEGRATION_TESTS[@]} tests"
 for t in "${INTEGRATION_TESTS[@]}"; do

--- a/tests/integration/test_sessionstart_hook_snapshot_guard.sh
+++ b/tests/integration/test_sessionstart_hook_snapshot_guard.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Regression test for hooks/sessionstart-hook-snapshot-guard.py
+#
+# Guards the de-noise fix: the SessionStart snapshot guard diffs SCRIPT IDENTITY
+# (script basename + normalized args), NOT raw command strings. So a concurrent
+# session's cosmetic reword of a still-wired hook -- python3 vs /usr/bin/python3,
+# ~/ vs absolute path, an added `2>/dev/null || echo {...}` wrapper, or a
+# `[ -f X ] &&` guard -- must NOT false-flag the hook as "missing". A genuinely
+# removed script MUST still warn.
+#
+# Fails on revert: if identity normalization, the v2 snapshot format, legacy
+# raw-string migration, or the --refresh flag regresses, an assertion flips and
+# the script exits non-zero.
+#
+# Isolation: each scenario runs the guard under a throwaway $HOME so it reads a
+# fake settings.json and writes a fake state file -- the real ~/.claude is never
+# touched. Stdlib python3 + bash only; no network, no git, no ruff.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+GUARD="$REPO_ROOT/hooks/sessionstart-hook-snapshot-guard.py"
+
+PASS=0
+FAIL=0
+TMPDIRS=()
+cleanup() { for d in "${TMPDIRS[@]:-}"; do [ -n "$d" ] && rm -rf "$d"; done; }
+trap cleanup EXIT
+
+ok()  { PASS=$((PASS+1)); echo "PASS  $1"; }
+bad() { FAIL=$((FAIL+1)); echo "FAIL  $1 :: $2"; }
+assert_rc()     { [ "$RC" = "$2" ] && ok "$1" || bad "$1" "rc=$RC want $2 (err=${ERR:0:80})"; }
+assert_warns()  { case "$OUT" in *WARNING*) ok "$1" ;; *) bad "$1" "no WARNING (out=${OUT:0:90})" ;; esac; }
+assert_silent() { case "$OUT" in *WARNING*) bad "$1" "unexpected WARNING (out=${OUT:0:90})" ;; *) ok "$1" ;; esac; }
+assert_has()    { case "$OUT" in *"$2"*) ok "$1" ;; *) bad "$1" "missing '$2' (out=${OUT:0:90})" ;; esac; }
+
+newhome() { local d; d="$(mktemp -d)"; TMPDIRS+=("$d"); mkdir -p "$d/.claude"; echo "$d"; }
+state_file() { echo "$1/.claude/state/sessionstart-hooks-snapshot.json"; }
+
+# write_settings <home> <command...> -- one SessionStart hook per command arg.
+write_settings() {
+  local home="$1"; shift
+  python3 - "$home/.claude/settings.json" "$@" <<'PY'
+import json, sys
+path, cmds = sys.argv[1], sys.argv[2:]
+data = {"hooks": {"SessionStart": [{"hooks": [{"type": "command", "command": c} for c in cmds]}]}}
+with open(path, "w") as f:
+    f.write(json.dumps(data, indent=2))
+PY
+}
+
+# write_legacy_snapshot <home> <rawcommand...> -- the pre-fix format: a bare JSON
+# list of raw command strings (no {"v":2} wrapper). Must normalize on read.
+write_legacy_snapshot() {
+  local home="$1"; shift
+  mkdir -p "$home/.claude/state"
+  python3 - "$home/.claude/state/sessionstart-hooks-snapshot.json" "$@" <<'PY'
+import json, sys
+path, cmds = sys.argv[1], sys.argv[2:]
+with open(path, "w") as f:
+    f.write(json.dumps(sorted(cmds), indent=2))
+PY
+}
+
+# run_guard <home> [args...] ; sets RC + OUT + ERR
+run_guard() {
+  local home="$1"; shift
+  OUT="$(HOME="$home" python3 "$GUARD" "$@" 2>/tmp/_ss_err.$$)"
+  RC=$?
+  ERR="$(cat /tmp/_ss_err.$$ 2>/dev/null)"; rm -f /tmp/_ss_err.$$
+  return 0
+}
+
+echo "=== precondition ==="
+[ -f "$GUARD" ] && ok "guard exists" || bad "guard exists" "missing $GUARD"
+
+echo "=== scenario 1: first run baselines silently, writes v2 ==="
+H1="$(newhome)"
+# literal ~ is the raw settings.json command text under test, not a path to expand
+# shellcheck disable=SC2088
+write_settings "$H1" \
+  'python3 ~/.claude/hooks/foo.py' \
+  '~/.claude/hooks/bar.sh' \
+  'python3 ~/.claude/hooks/baz.py --flag'
+run_guard "$H1"
+assert_rc     "first run exits 0" 0
+assert_silent "first run is silent (baseline)"
+SF1="$(state_file "$H1")"
+[ -f "$SF1" ] && ok "baseline writes snapshot" || bad "baseline writes snapshot" "absent"
+grep -q '"v": 2' "$SF1" 2>/dev/null && ok "snapshot is v2 format" || bad "snapshot is v2 format" "$(head -1 "$SF1" 2>/dev/null)"
+python3 -c "import json;d=json.load(open('$SF1'));assert sorted(d['identities'])==['bar.sh','baz.py||--flag','foo.py'],d" 2>/dev/null \
+  && ok "baseline captured 3 script identities" || bad "baseline captured 3 script identities" "$(cat "$SF1" 2>/dev/null)"
+
+echo "=== scenario 2: reworded variants -> ZERO false missing ==="
+write_settings "$H1" \
+  '/usr/bin/python3 /home/u/.claude/hooks/foo.py' \
+  '[ -f ~/.claude/hooks/bar.sh ] && ~/.claude/hooks/bar.sh' \
+  "python3 ~/.claude/hooks/baz.py --flag 2>/dev/null || echo '{\"continue\":true}'"
+run_guard "$H1"
+assert_rc     "reworded run exits 0" 0
+assert_silent "reworded same-scripts -> no false missing"
+
+echo "=== scenario 3: genuine removal -> warns, persists until reconciled ==="
+write_settings "$H1" \
+  '/usr/bin/python3 /home/u/.claude/hooks/foo.py' \
+  '[ -f ~/.claude/hooks/bar.sh ] && ~/.claude/hooks/bar.sh'
+run_guard "$H1"
+assert_rc    "removal run exits 0" 0
+assert_warns "genuine removal warns"
+assert_has   "names the dropped script" "baz.py"
+run_guard "$H1"
+assert_warns "warning persists (snapshot not silently updated)"
+
+echo "=== scenario 4: --refresh force-rewrites + clears the warning ==="
+run_guard "$H1" --refresh
+assert_rc  "--refresh exits 0" 0
+assert_has "--refresh confirms" "refreshed"
+run_guard "$H1"
+assert_silent "after --refresh, no stale warning"
+
+echo "=== scenario 5: legacy raw-string snapshot normalizes on read ==="
+H2="$(newhome)"
+# literal ~ is the raw settings.json command text under test, not a path to expand
+# shellcheck disable=SC2088
+write_legacy_snapshot "$H2" \
+  'python3 ~/.claude/hooks/foo.py' \
+  '~/.claude/hooks/bar.sh' \
+  'python3 ~/.claude/hooks/baz.py --flag'
+write_settings "$H2" \
+  '/usr/bin/python3 /home/u/.claude/hooks/foo.py' \
+  '[ -f ~/.claude/hooks/bar.sh ] && ~/.claude/hooks/bar.sh' \
+  "python3 ~/.claude/hooks/baz.py --flag 2>/dev/null || echo '{}'"
+run_guard "$H2"
+assert_rc     "legacy migrate run exits 0" 0
+assert_silent "legacy list + reworded scripts -> no false missing (migration-free)"
+
+echo "=== scenario 6: legacy snapshot still catches a real drop ==="
+H3="$(newhome)"
+write_legacy_snapshot "$H3" \
+  'python3 ~/.claude/hooks/foo.py' \
+  'python3 ~/.claude/hooks/baz.py --flag'
+write_settings "$H3" 'python3 ~/.claude/hooks/foo.py'
+run_guard "$H3"
+assert_warns "legacy comparison catches a genuinely removed script"
+assert_has   "names dropped script (legacy path)" "baz.py"
+
+echo "=== scenario 7: additions absorbed silently ==="
+H4="$(newhome)"
+write_settings "$H4" 'python3 ~/.claude/hooks/foo.py'
+run_guard "$H4"                         # baseline
+write_settings "$H4" \
+  'python3 ~/.claude/hooks/foo.py' \
+  'python3 ~/.claude/hooks/new.py'
+run_guard "$H4"
+assert_rc     "additions run exits 0" 0
+assert_silent "new hook added -> absorbed silently"
+SF4="$(state_file "$H4")"
+python3 -c "import json;d=json.load(open('$SF4'));assert 'new.py' in d['identities'],d" 2>/dev/null \
+  && ok "addition recorded in snapshot" || bad "addition recorded in snapshot" "$(cat "$SF4" 2>/dev/null)"
+
+echo ""
+echo "=== SUMMARY: $PASS passed, $FAIL failed ==="
+[ "$FAIL" = 0 ]


### PR DESCRIPTION
The `sessionstart-hook-snapshot-guard` SessionStart hook diffed exact command STRINGS, so a concurrent session rewording a still-wired hook — `python3` vs `/usr/bin/python3`, `~/` vs an absolute path, an added `2>/dev/null || echo {...}` wrapper, or a `[ -f X ] &&` guard — false-flagged it as "missing" even though the same script was still wired. Cry-wolf trains users to ignore the warning, so the one real drop slips past.

## What changed
- `_script_identity` normalizes each command to a stable identity (script basename + normalized args), stripping a leading `[ -f X ] &&` guard, a trailing `|| ...` fallback, and a `2>redirect`. The guard now diffs identities, not raw text.
- Snapshot is versioned (`{"v":2,"identities":[...]}`); a legacy bare-list snapshot is normalized on read, so the upgrade is migration-free.
- New `--refresh` flag force-rewrites the snapshot. The old "rerun to refresh" instruction never worked because the missing-branch returns before updating the snapshot.
- Behavior preserved: warn only on truly-missing identities, absorb additions silently, baseline silently on first run / corrupt / legacy snapshot.

## Verification
`test_sessionstart_hook_snapshot_guard.sh` (wired into the `scripts/ci.sh` integration gate) runs the real hook under a throwaway `$HOME`: 22 assertions covering reworded variants (zero false missing), genuine removal (still warns + persists), legacy migration, and `--refresh`. The test was confirmed to fail 7/22 against the pre-fix version, so it fails on revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)