### PR TITLE
fix(ci): test_install_api_canonical_base skips binary files (-I)

### DIFF
--- a/tests/integration/test_install_api_canonical_base.sh
+++ b/tests/integration/test_install_api_canonical_base.sh
@@ -46,7 +46,9 @@ done < <(grep -E 'curl .*\$INSTALL_API_BASE/api' bootstrap.sh)
 
 # 4. no non-canonical API calls in install-facing files
 #    (myceliumai.co — no hyphen — 308s; so does bare mycelium-ai.co without www)
-if matches=$(grep -rnE '(myceliumai\.co|[^.w]mycelium-ai\.co)/api' \
+#    -I skips binary files: a stray __pycache__/*.pyc (the URL compiled into a
+#    bytecode string constant) is an untracked local artifact, not source to audit.
+if matches=$(grep -rnEI '(myceliumai\.co|[^.w]mycelium-ai\.co)/api' \
     bootstrap.sh bootstrap.ps1 phases/ scripts/ hooks/ skills/ SECURITY.md 2>/dev/null); then
   fail "non-canonical install-API base found:"
   echo "$matches" | head -5 | sed 's|^|  |' >&2


### PR DESCRIPTION
The canonical-base check greps `scripts/` and `hooks/` recursively and matches the install-API URL compiled into an untracked `__pycache__/*.pyc` bytecode string constant. Any local session that runs a `scripts/*.py` hook and then runs the local gate (`bash scripts/ci.sh`) hits a false `non-canonical install-API base found` failure on a binary artifact — CI is unaffected (clean checkout), but the documented local pre-push gate is.

## Fix
`grep -rnEI` skips binary files, so only tracked source is audited (the test's intent). Surfaced while shipping #195.

## Verification
A synthetic binary decoy carrying the URL (plus a NUL byte) is now ignored, while a real source-file (`.sh`) violation is still caught — negative control confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)