### PR TITLE
docs+test(hooks): lock the paid-install SessionStart freeze-class invariant (MYC-569)

### DIFF
--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -67,6 +67,8 @@ Howard Marks's dissent on the panel was load-bearing: name the cost. The cost is
 
 `hooks/health-auto-sync.py` ships in the repo and is fully tested but is NOT wired in the default `hooks.json` template. Users who want per-session sync (e.g., never journals but wants the data fresh) can manually add it to their `~/.claude/settings.json` SessionStart block. Documented at the bottom of this file.
 
+> Why it stays out by default is the general SessionStart resource-governance rule: a SessionStart hook fires once per session, so a machine running many concurrent sessions runs it many times at once. Heavy or network work (a corpus walk, a wearable sync) belongs on a scheduled job or once-daily Stop hook, never the cold-start path. The full invariant, the shipped-set audit, and the regression guards that enforce it are in [HOOK_FLEET_RESOURCE_GOVERNANCE.md](HOOK_FLEET_RESOURCE_GOVERNANCE.md).
+
 ## What auto-fires vs what stays manual
 
 **Auto:**

--- a/docs/HOOK_FLEET_RESOURCE_GOVERNANCE.md
+++ b/docs/HOOK_FLEET_RESOURCE_GOVERNANCE.md
@@ -1,0 +1,128 @@
+---
+name: hook-fleet-resource-governance
+description: The SessionStart hook fleet this repo ships is what EVERY install runs (free self-install and paid commercial installs alike). Its resource-governance invariant + provenance + how it's verified.
+---
+
+# Hook-fleet resource governance
+
+## Why this doc exists
+
+This repo's `hooks.json` is the source of truth for the Claude Code SessionStart
+hook fleet. That fleet is what runs on **every** install — a free self-install
+and a paid commercial install built on this substrate are the **same fleet**.
+There is no separate "paid" hook fleet.
+
+A SessionStart hook fires once per Claude Code session. A machine running many
+concurrent sessions runs every SessionStart hook many times at once. So a single
+SessionStart hook that does heavy or unbounded work is a per-session multiplier:
+under N concurrent sessions it becomes N concurrent heavy jobs.
+
+On 2026-06-05 that exact shape hard-froze a machine (load 36, total freeze): the
+corpus-walk secret scan ran on SessionStart, its cooldown was stamped *after* the
+slow scan, and four concurrent sessions each launched their own full-corpus walk.
+The fix was twofold and both halves live here: the scan moved **off** SessionStart
+(scheduled job + cached-findings surfacer), and a stuck-hook reaper now ships **on**
+SessionStart. This doc records the invariant so it can't silently regress.
+
+## Provenance — what an install actually wires
+
+```
+bootstrap.sh
+   └─ git clone (idempotent) ai-brain-starter@main → ~/.claude/skills/ai-brain-starter/
+        └─ scripts/install-hooks-user-level.py
+              └─ reads the canonical root hooks.json
+                    └─ merges its SessionStart block into ~/.claude/settings.json
+```
+
+- The clone tracks **`main`** (it refuses to pull over a locally diverged clone,
+  but it does not pin an old tag). A fresh install gets current `main`.
+- `install-hooks-user-level.py` is idempotent and additive: it never removes a
+  user's own hooks, only merges the ai-brain-starter set.
+- **Native desktop / commercial products that wrap this substrate do not vendor
+  or re-wire this fleet.** Where they spawn the Claude CLI for their own agent
+  loop they run it with SessionStart/SessionEnd hooks disabled, and where they
+  need vault-safety logic they re-implement it natively rather than shelling out
+  to these Python hooks. So the only thing that wires this SessionStart fleet onto
+  any machine — free or paid — is the path above.
+
+Net: "is the paid install's hook fleet hardened?" reduces to "is `ai-brain-starter@main`
+hardened?" — and the rest of this doc is the answer.
+
+## The invariant
+
+1. **No unbounded or corpus-scale work on SessionStart.** A SessionStart hook
+   reads small, bounded state (a marker file, one directory level, a bounded
+   subprocess with a timeout). Anything that walks a large corpus, syncs over the
+   network, or otherwise scales with the user's data belongs on a **scheduled job**
+   or a **cached-findings surfacer**, never the synchronous cold-start path.
+2. **The protective reaper ships on SessionStart.** `remediate-runaway-procs.py`
+   (CLASS-2 stuck-hook reaper) is the backstop that kills a wedged `~/.claude/hooks`
+   process; it must be present in every install.
+
+## Audit — the shipped SessionStart set
+
+Every hook in the canonical `hooks.json` SessionStart block, and why each is
+bounded (read against this repo at the time of writing — re-run the verification
+below to confirm on any later revision):
+
+| Hook | Work it does | Bound |
+|---|---|---|
+| `lint-claude-settings.py` (+ `--test`) | parse + lint one JSON file | single small file |
+| `check-claude-code-version.sh` | read one cached version string | cached, no walk |
+| `first-week-checkin.py` | read an install-date marker | marker read + budget guard |
+| `migrate-to-user-level.py` | one-shot settings migration check | idempotent, no walk |
+| `surface-orphan-claude-branches.py` | `git for-each-ref` + one `iterdir` | bounded git op + 1 dir level |
+| `surface-stranded-session-artifacts.py` | `iterdir` of `.claude/worktrees/` | 1 dir level + subprocess `timeout=15` |
+| `surface-orphan-worktree-snapshots.py` | `rglob` under the small snapshots dir | snapshot tree only, results capped |
+| `worktree-footprint-signal.py` | `iterdir` of the worktree dir | 1 dir level |
+| `surface-backup-status.py` | `iterdir` of repo root + `git` | 1 dir level + subprocess `timeout=30` |
+| `enforce-worktree-cap.py` | count worktrees vs cap | bounded count + budget guard |
+| `remediate-runaway-procs.py` | scan `~/.claude/hooks` procs, reap wedged ones | dual age/CPU gate, no FS walk |
+
+None walks the user's vault corpus or `~/.claude/projects` transcripts.
+
+**Deliberately NOT on SessionStart** (the two "heavy / concurrent" classes the
+freeze taught us to keep off the cold-start path):
+
+- `scan-prior-sessions-for-secrets.py` — corpus-walk secret scan. Runs as a
+  scheduled job; SessionStart only reads its cached findings. (Hardened anyway —
+  single-instance lock, stamp-at-start cooldown, incremental, `os.nice`, wall
+  budget, per-file cap — so even a manual re-add can't pile up.)
+- `health-auto-sync.py` — network wearable sync. Opt-in power-user file; the
+  default chain syncs once per day on `/journal` Stop, not per session.
+
+## How it's enforced (regression guards, all in `scripts/ci.sh`)
+
+- `tests/integration/test_sessionstart_freeze_class_excluded.sh` — asserts the
+  canonical `hooks.json` SessionStart set **excludes** the corpus-walk scan and
+  **includes** the reaper. Ships with negative controls that re-add the scan /
+  drop the reaper and confirm the guard trips.
+- `tests/integration/test_scan_prior_single_instance.sh` — a second concurrent
+  scan run backs off (no pile-up), even if the scan is invoked directly.
+- `tests/integration/test_remediate_runaway_procs.sh` — the reaper's pos/neg
+  controls (reaps a wedged hook proc; never reaps self or a non-python proc).
+- `services/health-mcp/tests/test_v05_hooks.py` — asserts `health-auto-sync.py`
+  stays out of the default SessionStart block.
+
+## Verify on a fresh install
+
+The repo being hardened is not the same as a fresh install landing the hardened
+wiring. To prove it on any revision, install into a throwaway `$HOME` and assert
+the SessionStart wiring:
+
+```bash
+FRESH="$(mktemp -d)"; mkdir -p "$FRESH/.claude"
+HOME="$FRESH" python3 scripts/install-hooks-user-level.py \
+  --hooks-source "$PWD/hooks.json" --quiet
+
+python3 - "$FRESH/.claude/settings.json" <<'PY'
+import json, sys
+ss = json.dumps(json.load(open(sys.argv[1])).get("hooks", {}).get("SessionStart", []))
+assert "remediate-runaway-procs.py" in ss,            "reaper must be wired"
+assert "scan-prior-sessions-for-secrets.py" not in ss, "corpus scan must stay off SessionStart"
+assert "health-auto-sync.py" not in ss,                "network sync must stay off SessionStart"
+print("fresh-install SessionStart wiring OK")
+PY
+```
+
+Expected: `fresh-install SessionStart wiring OK`.

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -113,6 +113,7 @@ INTEGRATION_TESTS=(
   test_remediate_runaway_procs
   test_scan_prior_single_instance
   test_scan_prior_failclosed_scrub
+  test_sessionstart_freeze_class_excluded
   test_vault_safety_guards
   test_resource_aware_session_close
   test_cloud_sync_guard

--- a/tests/integration/test_sessionstart_freeze_class_excluded.sh
+++ b/tests/integration/test_sessionstart_freeze_class_excluded.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Structural invariant on the shipped hooks.json SessionStart set — the hook
+# fleet that EVERY install wires, free AND paid.
+#
+# Why this exists (MYC-569, paid analog of MYC-514): a Mycelium Personal /
+# Team / Enterprise install does NOT vendor its own hook fleet. The paid
+# "Personal scope" Claude Code substrate IS this repo — bootstrap.sh clones
+# ai-brain-starter@main and install-hooks-user-level.py wires the canonical
+# root hooks.json into ~/.claude/settings.json. So whatever this hooks.json
+# wires on SessionStart is exactly what a paying Enterprise operator's machine
+# runs (99.9% SLA). See docs/HOOK_FLEET_RESOURCE_GOVERNANCE.md.
+#
+# The 2026-06-05 Mac-freeze (load 36, total freeze) was caused by the corpus-
+# walk secret scan (scan-prior-sessions-for-secrets.py) running on SessionStart:
+# under N concurrent sessions it piled up N synchronous full-corpus walks.
+# MYC-512 moved it OFF SessionStart (launchd job + cached-findings surfacer);
+# MYC-514 hardened the scan + shipped the CLASS-2 stuck-hook reaper. But until
+# now NOTHING asserted the wiring stays fixed: a future refactor could silently
+# re-add the corpus walk to SessionStart and re-expose every paid install to a
+# cold-start freeze. This test is that lock.
+#
+# Asserts (on the REAL canonical hooks.json):
+#   1. The corpus-walk freeze hook (scan-prior-sessions-for-secrets.py) is NOT
+#      wired in SessionStart. It belongs on a scheduled job / cached surfacer,
+#      never the synchronous cold-start path.
+#   2. The CLASS-2 stuck-hook reaper (remediate-runaway-procs.py) IS wired in
+#      SessionStart — the protective hook must ship in every install.
+#   3. NEGATIVE CONTROL: a mutated hooks.json that re-adds the freeze hook to
+#      SessionStart MUST trip assertion 1 (proves the guard bites, not just
+#      passes). And a mutated hooks.json that drops the reaper MUST trip
+#      assertion 2.
+#
+# Companion guard: services/health-mcp/tests/test_v05_hooks.py asserts the
+# network-syncing health-auto-sync.py also stays OUT of the default SessionStart
+# set. Together they pin the two "heavy/concurrent work on cold start" classes.
+#
+# Isolation: reads the repo's own hooks.json; mutations are built in a tmpdir
+# and removed on exit. Stdlib python3 + bash only; no network, no git.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HOOKS_JSON="$REPO_ROOT/hooks.json"
+
+FREEZE_HOOK="scan-prior-sessions-for-secrets.py"
+REAPER_HOOK="remediate-runaway-procs.py"
+
+PASS=0
+FAIL=0
+TMPDIRS=()
+cleanup() { for d in "${TMPDIRS[@]:-}"; do [ -n "$d" ] && rm -rf "$d"; done; }
+trap cleanup EXIT
+
+ok()  { PASS=$((PASS+1)); echo "PASS  $1"; }
+bad() { FAIL=$((FAIL+1)); echo "FAIL  $1 :: $2"; }
+
+# in_sessionstart <hooks.json path> <basename> -> rc 0 if wired in SessionStart,
+# rc 1 if absent. Pure structural read of the canonical template shape
+#   {"hooks": {"SessionStart": [ {"hooks": [ {"command": "..."} ]} ]}}.
+in_sessionstart() {
+  python3 - "$1" "$2" <<'PY'
+import json, sys
+path, needle = sys.argv[1], sys.argv[2]
+data = json.load(open(path))
+ss = data.get("hooks", {}).get("SessionStart", [])
+blob = json.dumps(ss)
+sys.exit(0 if needle in blob else 1)
+PY
+}
+
+echo "=== precondition ==="
+if [ -f "$HOOKS_JSON" ]; then ok "canonical hooks.json exists"; else bad "canonical hooks.json exists" "missing $HOOKS_JSON"; fi
+if python3 -c "import json;json.load(open('$HOOKS_JSON'))" 2>/dev/null; then
+  ok "hooks.json is valid JSON"
+else
+  bad "hooks.json is valid JSON" "parse error"
+fi
+
+echo "=== invariant 1: corpus-walk freeze hook is NOT on SessionStart ==="
+if in_sessionstart "$HOOKS_JSON" "$FREEZE_HOOK"; then
+  bad "freeze hook excluded from SessionStart" "$FREEZE_HOOK IS wired on SessionStart — re-exposes paid installs to cold-start corpus-walk pile-up (MYC-512/569)"
+else
+  ok "freeze hook ($FREEZE_HOOK) excluded from SessionStart"
+fi
+
+echo "=== invariant 2: CLASS-2 stuck-hook reaper IS on SessionStart ==="
+if in_sessionstart "$HOOKS_JSON" "$REAPER_HOOK"; then
+  ok "reaper ($REAPER_HOOK) wired on SessionStart"
+else
+  bad "reaper wired on SessionStart" "$REAPER_HOOK is NOT wired — the protective hook must ship in every install (MYC-514)"
+fi
+
+echo "=== negative control A: re-adding the freeze hook MUST trip invariant 1 ==="
+NCA="$(mktemp -d)"; TMPDIRS+=("$NCA")
+python3 - "$HOOKS_JSON" "$NCA/hooks.json" "$FREEZE_HOOK" <<'PY'
+import json, sys
+src, dst, needle = sys.argv[1], sys.argv[2], sys.argv[3]
+data = json.load(open(src))
+data.setdefault("hooks", {}).setdefault("SessionStart", []).append(
+    {"hooks": [{"type": "command",
+                "command": f"python3 ~/.claude/skills/ai-brain-starter/hooks/{needle}"}]}
+)
+json.dump(data, open(dst, "w"), indent=1)
+PY
+if in_sessionstart "$NCA/hooks.json" "$FREEZE_HOOK"; then
+  ok "negative control A: guard detects a re-added freeze hook (bites)"
+else
+  bad "negative control A bites" "mutation with $FREEZE_HOOK on SessionStart was NOT detected — guard is blind"
+fi
+
+echo "=== negative control B: dropping the reaper MUST trip invariant 2 ==="
+NCB="$(mktemp -d)"; TMPDIRS+=("$NCB")
+python3 - "$HOOKS_JSON" "$NCB/hooks.json" "$REAPER_HOOK" <<'PY'
+import json, sys
+src, dst, needle = sys.argv[1], sys.argv[2], sys.argv[3]
+data = json.load(open(src))
+ss = data.get("hooks", {}).get("SessionStart", [])
+for grp in ss:
+    grp["hooks"] = [h for h in grp.get("hooks", []) if needle not in h.get("command", "")]
+json.dump(data, open(dst, "w"), indent=1)
+PY
+if in_sessionstart "$NCB/hooks.json" "$REAPER_HOOK"; then
+  bad "negative control B bites" "reaper still detected after removal — mutation harness is broken"
+else
+  ok "negative control B: guard detects a dropped reaper (bites)"
+fi
+
+echo ""
+echo "=== SUMMARY: $PASS passed, $FAIL failed ==="
+[ "$FAIL" = 0 ]


### PR DESCRIPTION
## What + why

**MYC-569** (paid analog of MYC-514): verify the paid Personal/Team/Enterprise install ships the *hardened* SessionStart hook fleet, not the pre-freeze versions.

**Provenance finding (the gating unknown):** there is **no separate paid hook fleet**. The commercial "Personal scope" Claude Code substrate *is* this repo — `bootstrap.sh` clones `ai-brain-starter@main` and `install-hooks-user-level.py` wires the canonical `hooks.json`. Native desktop products that wrap the substrate don't vendor or re-wire it (they run their own `claude -p` loop with SessionStart hooks disabled and re-implement vault-safety natively). So "is the paid fleet hardened?" reduces to "is `ai-brain-starter@main` hardened?" — and it is (MYC-514 #154 + MYC-512 scrub fix). The gap was that **nothing asserted the wiring stays fixed**.

## Changes

- **`tests/integration/test_sessionstart_freeze_class_excluded.sh`** — structural invariant on the canonical `hooks.json` SessionStart set: the corpus-walk secret scan is **excluded**, the CLASS-2 reaper is **included**. Negative controls re-add the scan / drop the reaper and confirm the guard trips. Wired into `scripts/ci.sh` `INTEGRATION_TESTS`.
- **`docs/HOOK_FLEET_RESOURCE_GOVERNANCE.md`** — provenance, the shipped-set boundedness audit (12 hooks), and the fresh-`$HOME` install verification recipe (deployed ≠ committed ≠ working).
- **`docs/AUTOMATION.md`** — cross-link the general SessionStart resource-governance rule.

## Verification (evidence, not claim)

- Fresh-`$HOME` install sim: reaper **wired**, `scan-prior-sessions-for-secrets.py` + `health-auto-sync.py` **stay off** SessionStart. ✅
- Freeze regression tests green: `test_scan_prior_single_instance` (no pile-up), `test_remediate_runaway_procs` (pos+neg), `test_scan_prior_failclosed_scrub` (MYC-512 fix). ✅
- New guard: 6/6 pass, both negative controls bite. ✅
- Full `scripts/ci.sh`: 263 py_compile + 33 integration tests + shellcheck. ✅
- Personal-data scrub on diff: clean.

## Done-predicate mapping (MYC-569)

- [x] provenance documented (this PR + the new doc): paid = this substrate, no separate fleet
- [x] every bundled SessionStart hook bounded, verified on a fresh install (audit table + sim)
- [x] regression test: a fresh install can't pile up a corpus scan (`test_scan_prior_single_instance` + the new wiring lock)
- [x] CLASS-2 reaper ships in the (paid =) install — asserted in CI
- [x] carries the MYC-512 fail-closed scrub fix (same substrate, live on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)