### PR TITLE
fix(sync-guard): Drive Mirror detection in the SHARED detect_cloud_sync [MYC-1130]

### DIFF
--- a/hooks/_lib/worktree_safety.py
+++ b/hooks/_lib/worktree_safety.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import sqlite3
 import subprocess
 import time
 from pathlib import Path
@@ -468,13 +469,54 @@ def reclaim_orphan_dir(main_repo: Path, orphan: Path, idle_min: int = 60) -> tup
     return ("snapshot+removed" if snapped else "removed", snapped)
 
 
-def detect_cloud_sync(path: Path) -> str | None:
+DRIVEFS_ROOTS_DB = (
+    Path.home() / "Library/Application Support/Google/DriveFS/root_preference_sqlite.db"
+)
+
+
+def drive_mirror_root_paths(db_path: str | Path | None = None) -> list[str]:
+    """Native-path Google Drive "Mirror" roots (sync_type=1) from the DriveFS DB.
+
+    Mirror roots live at an arbitrary local path and never appear under
+    ~/Library/CloudStorage, so a path-marker check cannot see them. This is the
+    SINGLE source of that signal, shared by detect_cloud_sync (the install guard
+    + the SessionStart footprint signal) and the check-sync-folder-machinery
+    audit (MYC-1130) so they can never drift. Read FAIL-OPEN: a missing / locked
+    / malformed DB returns [] and never raises. `immutable=1` so a LIVE Drive
+    holding a write lock still reads (a plain `mode=ro` can return empty).
+    """
+    db = Path(db_path) if db_path is not None else DRIVEFS_ROOTS_DB
+    if not db.exists():
+        return []
+    roots: list[str] = []
+    try:
+        con = sqlite3.connect(db.as_uri() + "?immutable=1", uri=True, timeout=2.0)
+        try:
+            cur = con.execute(
+                "SELECT last_seen_absolute_path, root_path FROM roots "
+                "WHERE sync_type = 1"
+            )
+            for last_seen, root_path in cur.fetchall():
+                cand = (last_seen or "").strip() or (root_path or "").strip()
+                if cand:
+                    roots.append(cand)
+        finally:
+            con.close()
+    except Exception:
+        return []  # fail-open: a DB hiccup must never break the advisory guard
+    return roots
+
+
+def detect_cloud_sync(path: Path, *, _drivefs_db: str | Path | None = None) -> str | None:
     """Name of a consumer cloud-sync service whose scope contains `path`, else None.
 
     Cross-platform best-effort: a brain/vault under iCloud / OneDrive / Dropbox /
     Google Drive / Box is the exact combination that turns worktree churn into a
     machine-melting sync storm. The index belongs server-side; the local vault
     belongs on a real local disk, never in a consumer sync folder.
+
+    `_drivefs_db` overrides the DriveFS roots-DB path for hermetic tests; in
+    production it stays None and resolves to the real per-user location.
     """
     p = str(path.resolve())
     home = str(Path.home())
@@ -500,6 +542,17 @@ def detect_cloud_sync(path: Path) -> str | None:
             continue
         if (p == str(base) or p.startswith(str(base) + "/")) and (icloud / folder).exists():
             return f"iCloud Drive ({folder} sync)"
+    # Native-path Google Drive "Mirror" roots (sync_type=1) are invisible to the
+    # markers above; the DriveFS roots DB is the only signal (MYC-1130).
+    # WORKTREE_SAFETY_DRIVEFS_DB overrides the DB path for hermetic tests of the
+    # install-guard chain (check-cloud-sync.py has no _drivefs_db arg).
+    for root in drive_mirror_root_paths(_drivefs_db or os.environ.get("WORKTREE_SAFETY_DRIVEFS_DB")):
+        try:
+            rp = str(Path(root).resolve())
+        except OSError:
+            continue
+        if p == rp or p.startswith(rp + "/"):
+            return "Google Drive (Mirror)"
     return None
 
 

--- a/hooks/check-sync-folder-machinery.py
+++ b/hooks/check-sync-folder-machinery.py
@@ -40,7 +40,11 @@ import sqlite3
 import subprocess
 import sys
 import time
-from pathlib import Path
+
+# Single source for the DriveFS "Mirror" root read (MYC-1130) so this audit and
+# _lib.worktree_safety.detect_cloud_sync can never drift on the Mirror signal.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _lib.worktree_safety import drive_mirror_root_paths  # noqa: E402
 
 HOME = os.path.expanduser("~")
 
@@ -72,36 +76,13 @@ def _defaults_bool(domain, key):
 
 
 def drive_mirror_roots(db_path=DRIVEFS_DB):
-    """Native-path Google Drive 'Mirror' roots from the DriveFS roots DB.
+    """Native-path Google Drive 'Mirror' roots tagged for this scanner.
 
-    Mirror roots (sync_type=1) live at an arbitrary local path and are invisible
-    to a ~/Library/CloudStorage walk, so they are the structural blind spot this
-    closes (MYC-705): a Mirror-synced git repo melts the sync daemon undetected.
-    Read FAIL-OPEN: a missing / locked / malformed DB returns [] and never
-    raises, keeping the guard advisory. `immutable=1` so a LIVE Drive holding a
-    write lock still reads (a plain `mode=ro` can return empty under the lock).
+    Thin wrapper over the shared `_lib.worktree_safety.drive_mirror_root_paths`
+    (the single source of the DriveFS sync_type=1 read; MYC-1130) so this audit
+    and detect_cloud_sync can never drift on the Mirror-root signal.
     """
-    if not os.path.exists(db_path):
-        return []
-    roots = []
-    try:
-        uri = Path(db_path).as_uri() + "?immutable=1"
-        con = sqlite3.connect(uri, uri=True, timeout=2.0)
-        try:
-            cur = con.execute(
-                "SELECT last_seen_absolute_path, root_path FROM roots "
-                "WHERE sync_type = ?",
-                (DRIVE_MIRROR_SYNC_TYPE,),
-            )
-            for last_seen, root_path in cur.fetchall():
-                path = (last_seen or "").strip() or (root_path or "").strip()
-                if path:
-                    roots.append((path, "GoogleDrive-Mirror"))
-        finally:
-            con.close()
-    except Exception:
-        return []  # fail-open: a DB hiccup must never crash the advisory guard
-    return roots
+    return [(p, "GoogleDrive-Mirror") for p in drive_mirror_root_paths(db_path)]
 
 
 def synced_roots():

--- a/scripts/test-detect-cloud-sync-mirror.sh
+++ b/scripts/test-detect-cloud-sync-mirror.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Negative-control test for Drive "Mirror" root detection in the SHARED
+# detect_cloud_sync (MYC-1130). A guard earns trust only by failing on the thing
+# it catches: a Google Drive for Desktop Mirror root (sync_type=1) sits at a
+# NATIVE path invisible to the path markers, so the DriveFS roots DB is the only
+# signal. This asserts (1) detect_cloud_sync flags a vault under a Mirror root,
+# (2) a sync_type=2 (stream) root is NOT Mirror-flagged, (3) a missing DB
+# fail-opens to None, and (4) the REAL SINK -- the INSTALL GUARD
+# (scripts/check-cloud-sync.py) -- inherits it end-to-end via the
+# WORKTREE_SAFETY_DRIVEFS_DB test seam. Pure stdlib (sqlite3 module, no CLI dep).
+# Run: bash scripts/test-detect-cloud-sync-mirror.sh
+set -u
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+exec python3 - "$REPO_ROOT" <<'PY'
+import os, sys, subprocess, sqlite3, tempfile
+from pathlib import Path
+
+repo = Path(sys.argv[1])
+sys.path.insert(0, str(repo / "hooks"))
+from _lib.worktree_safety import detect_cloud_sync
+
+SCHEMA = (
+    "CREATE TABLE roots (root_id INTEGER PRIMARY KEY, metadata BLOB, "
+    "media_id TEXT NOT NULL, title TEXT NOT NULL, root_path TEXT NOT NULL, "
+    "account_token TEXT NOT NULL, sync_type INTEGER NOT NULL, "
+    "destination INTEGER NOT NULL, medium INTEGER NOT NULL, state INTEGER NOT NULL, "
+    "one_shot BOOL NOT NULL, is_my_drive BOOL NOT NULL, doc_id TEXT NOT NULL, "
+    "last_seen_absolute_path TEXT NOT NULL)"
+)
+INS = ("INSERT INTO roots (media_id,title,root_path,account_token,sync_type,"
+       "destination,medium,state,one_shot,is_my_drive,doc_id,last_seen_absolute_path) "
+       "VALUES (?,?,?,?,?,?,?,?,?,?,?,?)")
+
+fails = 0
+def check(label, cond):
+    global fails
+    print(f"[mirror-test] {'PASS' if cond else 'FAIL'}  {label}")
+    if not cond:
+        fails += 1
+
+with tempfile.TemporaryDirectory() as tmp:
+    tmp = Path(tmp)
+    mirror_root = tmp / "MirrorDrive"
+    vault = mirror_root / "Brain"
+    vault.mkdir(parents=True)
+    stream_root = tmp / "StreamDrive"
+    stream_vault = stream_root / "Brain"
+    stream_vault.mkdir(parents=True)
+    db = tmp / "drivefs_roots.db"
+    con = sqlite3.connect(db)
+    con.execute(SCHEMA)
+    con.execute(INS, ("m", "t", str(mirror_root), "a", 1, 0, 0, 0, 0, 1, "d", str(mirror_root)))
+    con.execute(INS, ("m2", "t2", str(stream_root), "a", 2, 0, 0, 0, 0, 1, "d2", str(stream_root)))
+    con.commit()
+    con.close()
+
+    # 1. function: a vault under a sync_type=1 Mirror root -> flagged
+    check("detect_cloud_sync flags Mirror vault",
+          detect_cloud_sync(vault, _drivefs_db=db) == "Google Drive (Mirror)")
+    # 2. sync_type=2 (stream) root -> NOT a Mirror finding
+    check("sync_type=2 stream not Mirror-flagged",
+          detect_cloud_sync(stream_vault, _drivefs_db=db) is None)
+    # 3. fail-open: a missing DB -> None
+    check("missing DB -> fail-open None",
+          detect_cloud_sync(vault, _drivefs_db=tmp / "nope.db") is None)
+
+    # 4. REAL SINK: the install guard (check-cloud-sync.py) inherits it via env
+    guard = repo / "scripts" / "check-cloud-sync.py"
+    env = dict(os.environ, WORKTREE_SAFETY_DRIVEFS_DB=str(db))
+    out = subprocess.run([sys.executable, str(guard), "--porcelain", str(vault)],
+                         capture_output=True, text=True, env=env).stdout.strip()
+    check(f"install guard flags Mirror vault (got {out!r})", out.startswith("CLOUD_SYNC_RISK"))
+    out2 = subprocess.run([sys.executable, str(guard), "--porcelain", str(stream_vault)],
+                          capture_output=True, text=True, env=env).stdout.strip()
+    check(f"install guard OK for stream root (got {out2!r})", out2.startswith("OK_LOCAL"))
+
+print("[mirror-test] PASS" if fails == 0 else f"[mirror-test] FAIL ({fails})")
+sys.exit(0 if fails == 0 else 1)
+PY

--- a/tests/integration/test_vault_safety_guards.sh
+++ b/tests/integration/test_vault_safety_guards.sh
@@ -9,6 +9,7 @@
 #
 # Covers:
 #   - scripts/test-cloud-sync-guard.sh           (vault-in-cloud-sync detector, #159)
+#   - scripts/test-detect-cloud-sync-mirror.sh   (shared detect_cloud_sync + install guard: Drive Mirror roots, MYC-1130)
 #   - scripts/test-sync-folder-machinery-guard.sh (machinery-in-synced-folder + Drive Mirror roots, MYC-705)
 #   - scripts/test-vault-backup-guard.sh         (no-off-machine-backup detector)
 #   - scripts/test-vault-backup-roundtrip.sh     (one-command backup: real restore loop)
@@ -34,6 +35,7 @@ run_guard() { # <relative-script-path>
 }
 
 run_guard "scripts/test-cloud-sync-guard.sh"
+run_guard "scripts/test-detect-cloud-sync-mirror.sh"
 run_guard "scripts/test-sync-folder-machinery-guard.sh"
 run_guard "scripts/test-vault-backup-guard.sh"
 run_guard "scripts/test-vault-backup-roundtrip.sh"


### PR DESCRIPTION
## What
MYC-705 added Drive **Mirror**-root detection to the *weekly* `check-sync-folder-machinery` audit. But the **automatic + install-time** surfaces share a different, still-blind detector: `_lib/worktree_safety.py::detect_cloud_sync`, used by the **install guard** (`scripts/check-cloud-sync.py`, via `bootstrap.sh`) and the **SessionStart footprint signal** (`hooks/worktree-footprint-signal.py`). So a user installing into, or running with, a native-path Google Drive "Mirror" vault was silently accepted / never warned. This closes the hole at the single source.

## Change
- **`_lib/worktree_safety.py`**: new shared `drive_mirror_root_paths()` (reads the DriveFS roots DB, `sync_type=1`, read-only + `immutable=1`, fail-open) is the SINGLE source of the Mirror signal. `detect_cloud_sync` returns `"Google Drive (Mirror)"` when the path is at/under a Mirror root. Keyword-only `_drivefs_db` + `WORKTREE_SAFETY_DRIVEFS_DB` env seam for hermetic tests.
- **`check-sync-folder-machinery.py`**: dedup, its `drive_mirror_roots` now delegates to the shared helper (no drift between the audit and the install guard).
- **`scripts/test-detect-cloud-sync-mirror.sh`**: negative control proving `detect_cloud_sync` AND the **real sink** (`check-cloud-sync.py` install guard) flag a `sync_type=1` Mirror vault, ignore `sync_type=2` (stream), fail-open on a missing DB. Wired into `tests/integration/test_vault_safety_guards.sh`.

## Verification
- New test: 5/5 pass, incl. `install guard flags Mirror vault (got 'CLOUD_SYNC_RISK:Google Drive (Mirror)')`.
- `check-sync-folder-machinery.py --self-test`: 8/8 (now through the shared helper).
- `bash scripts/ci.sh`: green (py_compile 265 + 35 integration tests + shellcheck 111).

Closes MYC-1130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)