### PR TITLE
ci(security): SHA-pin dependabot/fetch-metadata (MYC-929)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Enable auto-merge on qualifying updates


### PR DESCRIPTION
Pins the only remaining tag-pinned action in mycelium-hq (`dependabot/fetch-metadata@v2` -> `21025c7`) so org-wide SHA-pinning enforcement can be turned on without breaking this workflow.

Part of MYC-929 (org security hardening). No behavior change: SHA is the current `v2`.