### PR TITLE
feat(hooks): vault-in-worktree melt tripwire (3-channel detection + tool-time wiring)

### DIFF
--- a/hooks.json
+++ b/hooks.json
@@ -14,6 +14,11 @@
           },
           {
             "type": "command",
+            "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/warn-vault-session-in-worktree.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'",
+            "statusMessage": "Vault-in-worktree tripwire (per-turn catch)..."
+          },
+          {
+            "type": "command",
             "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/log-skill-usage.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'",
             "statusMessage": "Logging skill usage (opt-in)..."
           },
@@ -105,6 +110,10 @@
           {
             "type": "command",
             "command": "[ -f ~/.claude/hooks/retry-budget.py ] && python3 ~/.claude/hooks/retry-budget.py || true"
+          },
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/warn-vault-session-in-worktree.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'"
           }
         ]
       },
@@ -202,6 +211,11 @@
             "type": "command",
             "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/worktree-footprint-signal.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'",
             "statusMessage": "Checking worktree + disk footprint..."
+          },
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/warn-vault-session-in-worktree.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'",
+            "statusMessage": "Vault-in-worktree tripwire (loud abort-and-relaunch)..."
           },
           {
             "type": "command",

--- a/hooks/warn-vault-session-in-worktree.py
+++ b/hooks/warn-vault-session-in-worktree.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""LOUD tripwire: this session is running inside an Obsidian-vault git worktree.
+
+The Claude Desktop app's per-session "worktree" checkbox creates a
+`.claude/worktrees/<slug>/` checkout. On a CODE repo that is cheap and correct.
+On an OBSIDIAN VAULT (repo-root == vault-root, thousands of files) that checkout
+lands INSIDE Obsidian's watched file tree -> runaway CPU / RAM / crash, AND the
+worktree can be silently archived/deleted mid-session, taking any worktree-only
+files with it. A vault must run PLAIN (no worktree); code isolation belongs in a
+sibling worktree on a CODE repo, never inside the vault.
+
+There is no documented config switch to stop the Desktop app creating the
+worktree, and a hook cannot un-create the worktree the session already started
+in. But it CAN make the bad state LOUD on the first turn so you abort and
+relaunch plain BEFORE the melt compounds and BEFORE anything is silently lost.
+A plain (non-worktree) vault session never trips this.
+
+Detection reads THREE independent channels; first hit wins. The `.obsidian/`
+gate distinguishes a vault from a code repo in ALL THREE, so a code-repo worktree
+(Desktop `.claude/worktrees/` on a code repo, or a sibling-dir `<repo>-<slug>/`
+worktree) never fires.
+  - Channel A (payload cwd): cwd is under a `.claude/worktrees/` segment. This is
+    the terminal/CLI shape and the tool-time payloads (where the worktree cwd is
+    reliably present).
+  - Channel B (transcript marker): cwd is the main root; the worktree id is in
+    transcript_path as `--claude-worktrees-<slug>` (Desktop SessionStart, when the
+    marker is present).
+  - Channel C (git ground truth, payload-INDEPENDENT): ask git -- from the hook's
+    OWN process cwd AND the payload cwd -- for the working-tree root
+    (`rev-parse --show-toplevel`). A linked worktree's toplevel carries the
+    `/.claude/worktrees/` segment regardless of what the harness reported in the
+    payload. This is the channel that catches the Desktop-SessionStart case where
+    the harness delivers cwd=main AND a transcript_path with no marker, so A and B
+    both go silent while git knows the truth.
+
+Wiring (scripts/install-hooks-user-level.py + hooks.json): SessionStart (early)
+PLUS UserPromptSubmit + PreToolUse(Bash) -- the tool-time events where the
+worktree cwd is reliably present, so Channel A/C catch the Desktop-SessionStart
+miss. A once-per-worktree-slug dedup sentinel means it warns ONCE per session,
+not on every prompt/tool. Slugs are unique per Desktop worktree, so once-per-slug
+== once-per-session.
+
+Fail-open: any error -> silent continue (a nudge must never block a session).
+Bypass: VAULT_WORKTREE_WARN_BYPASS=1.
+Test knobs: VAULT_WORKTREE_WARN_NODEDUP=1 (skip dedup), VAULT_WORKTREE_WARN_STATE_DIR
+(redirect the sentinel dir).
+
+Canonical: ai-brain-starter/hooks/ (installed to ~/.claude/skills/ai-brain-starter/
+hooks/ and wired into ~/.claude/settings.json by scripts/install-hooks-user-level.py).
+Negative-control test: warn-vault-session-in-worktree.test.sh.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+WORKTREE_SEGMENT = "/.claude/worktrees/"
+# Claude Code encodes the session cwd into the ~/.claude/projects/<dir> name by
+# replacing path separators (and the leading dot of `.claude`) with dashes, so a
+# worktree session's transcript path carries this literal marker -- WHEN the
+# harness passes a worktree-rooted transcript_path (not guaranteed at SessionStart).
+PROJECTS_WORKTREE_MARKER = "--claude-worktrees-"
+
+
+def _silent() -> int:
+    print(json.dumps({"continue": True, "suppressOutput": True}))
+    return 0
+
+
+def _read_payload() -> tuple[str, str]:
+    """Hook stdin provides `cwd` + `transcript_path`. Returns ("", "") on anything odd."""
+    cwd = ""
+    transcript = ""
+    try:
+        raw = sys.stdin.read()
+        if raw.strip():
+            data = json.loads(raw)
+            if isinstance(data, dict):
+                cwd = data.get("cwd") or data.get("workingDirectory") or ""
+                transcript = data.get("transcript_path") or data.get("transcriptPath") or ""
+    except Exception:
+        pass
+    return cwd, transcript
+
+
+def _git_toplevel(cwd: str) -> str:
+    """`git rev-parse --show-toplevel` from `cwd`; "" on any failure. Bounded (2s)."""
+    if not cwd:
+        return ""
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        if out.returncode == 0:
+            return out.stdout.strip()
+    except Exception:
+        pass
+    return ""
+
+
+def _detect(payload_cwd: str, transcript: str) -> tuple[str, Path] | tuple[None, None]:
+    """(worktree_path, main_root) if a worktree session on any channel, else (None, None).
+
+    The `.obsidian/` vault gate is applied by the caller, not here.
+    """
+    # Channel A -- any payload cwd that contains the worktree segment.
+    if payload_cwd and WORKTREE_SEGMENT in payload_cwd:
+        return payload_cwd, Path(payload_cwd[: payload_cwd.index(WORKTREE_SEGMENT)])
+
+    # Channel B -- transcript marker (Desktop mode, when the marker is present).
+    if payload_cwd and transcript and PROJECTS_WORKTREE_MARKER in transcript:
+        slug = transcript.split(PROJECTS_WORKTREE_MARKER, 1)[1].split("/", 1)[0]
+        if slug:
+            return str(Path(payload_cwd) / ".claude" / "worktrees" / slug), Path(payload_cwd)
+
+    # Channel C -- git ground truth, payload-INDEPENDENT. Ask git from the hook's
+    # own process cwd AND the payload cwd (either may be the worktree even when the
+    # other is reported as main). Catches the Desktop-SessionStart miss.
+    try:
+        proc_cwd = os.getcwd()
+    except OSError:
+        proc_cwd = ""
+    for gcwd in dict.fromkeys([proc_cwd, payload_cwd]):  # de-dup, preserve order
+        toplevel = _git_toplevel(gcwd)
+        if toplevel and WORKTREE_SEGMENT in toplevel:
+            return toplevel, Path(toplevel[: toplevel.index(WORKTREE_SEGMENT)])
+
+    return None, None
+
+
+def _already_warned(slug: str) -> bool:
+    """Once-per-worktree-slug dedup so the re-firing events (UserPromptSubmit each
+    turn / every Bash) warn ONCE. Slugs are unique per Desktop worktree, so
+    once-per-slug == once-per-session. Stale sentinels for archived worktrees are
+    harmless (a slug never recurs)."""
+    if os.environ.get("VAULT_WORKTREE_WARN_NODEDUP") == "1":
+        return False
+    state_dir = os.environ.get("VAULT_WORKTREE_WARN_STATE_DIR") or tempfile.gettempdir()
+    sentinel = Path(state_dir) / f".vault-worktree-warned-{slug}"
+    try:
+        if sentinel.exists():
+            return True
+        sentinel.parent.mkdir(parents=True, exist_ok=True)
+        sentinel.touch()
+    except OSError:
+        pass  # fail-open: if we cannot record, warn (better loud than silent)
+    return False
+
+
+def main() -> int:
+    if os.environ.get("VAULT_WORKTREE_WARN_BYPASS") == "1":
+        return _silent()
+
+    payload_cwd, transcript = _read_payload()
+    worktree_path, main_root = _detect(payload_cwd, transcript)
+    if worktree_path is None:
+        return _silent()  # not a worktree session on any channel
+
+    try:
+        is_vault = (main_root / ".obsidian").is_dir()
+    except OSError:
+        return _silent()
+    if not is_vault:
+        return _silent()  # a code-repo worktree -- cheap + correct, not the melt
+
+    slug = Path(worktree_path).name
+    if _already_warned(slug):
+        return _silent()  # already warned this worktree -- do not nag every turn
+
+    body = (
+        "SURFACE THIS TO THE USER IMMEDIATELY, before any other work:\n\n"
+        "🛑 [vault-worktree] This vault session is running INSIDE a git worktree:\n"
+        f"    {worktree_path}\n\n"
+        "An Obsidian vault must NEVER run in worktree mode. The Desktop app's\n"
+        "per-session worktree checkbox created a multi-thousand-file checkout inside\n"
+        "Obsidian's watched tree → runaway CPU / RAM / crash, AND this worktree can\n"
+        "be SILENTLY DELETED mid-session, taking any worktree-only files with it.\n\n"
+        "DO THIS NOW:\n"
+        "  1. Close this session.\n"
+        f"  2. Relaunch the vault PLAIN: `cd {main_root} && claude`\n"
+        "     (or, in the Desktop app, open the vault with the worktree box UNCHECKED).\n\n"
+        "UNTIL YOU DO: any file created that lives ONLY in this worktree is discarded\n"
+        f"when the worktree is archived. Edit shared/canonical files at the MAIN vault\n"
+        f"path ({main_root}/...) and commit them there — never the worktree path. The\n"
+        "Stop-hook snapshot net backstops divergent files, but the only safe state is a\n"
+        "plain (non-worktree) vault session.\n\n"
+        "Bypass this warning: VAULT_WORKTREE_WARN_BYPASS=1"
+    )
+    print(json.dumps({"continue": True, "additionalContext": body}))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        # Fail-open: never let a nudge crash a session start / tool call.
+        try:
+            print(json.dumps({"continue": True, "suppressOutput": True}))
+        except Exception:
+            pass
+        sys.exit(0)

--- a/hooks/warn-vault-session-in-worktree.test.sh
+++ b/hooks/warn-vault-session-in-worktree.test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Negative-control test for warn-vault-session-in-worktree.py.
+#
+# A guard earns trust only by failing on the thing it catches. This proves:
+#   Channel A (payload cwd inside the worktree — terminal launch + tool-time payloads):
+#     1. FIRES   on a VAULT worktree cwd (main root has .obsidian/)        <- the catch
+#     2. SILENT  on a plain vault cwd (no worktree segment)
+#     3. SILENT  on a CODE-repo worktree cwd (no .obsidian/ at main root)  <- no over-fire
+#     4. SILENT  under VAULT_WORKTREE_WARN_BYPASS=1
+#   Channel B (Desktop mode — cwd is the MAIN ROOT, worktree id in transcript_path):
+#     5. FIRES   cwd=vault main root + transcript_path carries the marker  <- the catch
+#     6. SILENT  cwd=code-repo main root + marker present (no .obsidian/)   <- no over-fire
+#     7. SILENT  plain vault session (transcript_path has NO marker)
+#   Channel C (git ground truth — payload-INDEPENDENT; the Desktop-SessionStart miss):
+#     8. FIRES   payload cwd=MAIN + NO marker, but the PROCESS runs in a real git
+#                worktree -> git reveals the truth A+B both missed   <- THE FIX
+#     9. SILENT  same shape but a CODE repo (no .obsidian/ at main root) <- no over-fire
+#    10. SILENT  process in the real MAIN vault checkout (not a worktree) <- no over-fire
+#   Dedup (warn once per worktree slug, not every turn/tool):
+#    11. FIRES   first call for a slug
+#    12. SILENT  second call for the same slug (sentinel written)
+#
+# Exit 0 = all pass. Non-zero = regression (or git fixture setup failed — loud, never skipped).
+set -u
+HOOK="$(cd "$(dirname "$0")" && pwd)/warn-vault-session-in-worktree.py"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+fail=0
+
+# --- path fixtures (Channels A/B: no real git needed) ---
+mkdir -p "$TMP/vaultmain/.obsidian" "$TMP/vaultmain/.claude/worktrees/slug"
+mkdir -p "$TMP/devrepo/.claude/worktrees/slug"   # NO .obsidian -> code repo
+mkdir -p "$TMP/neutral"                          # non-git proc-cwd so Channel C stays quiet
+WT_TRANSCRIPT="/Users/x/.claude/projects/-Users-x-vaultmain--claude-worktrees-slug/abc.jsonl"
+PLAIN_TRANSCRIPT="/Users/x/.claude/projects/-Users-x-vaultmain/abc.jsonl"
+
+# --- real git fixtures (Channel C: needs an actual linked worktree) ---
+mkgitwt() { # $1=root  ($2=obsidian => create .obsidian)  -> creates <root>/.claude/worktrees/wt
+  git init -q "$1"
+  [ "${2:-}" = "obsidian" ] && mkdir -p "$1/.obsidian"
+  git -C "$1" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+  git -C "$1" worktree add -q "$1/.claude/worktrees/wt" HEAD 2>/dev/null
+  [ -e "$1/.claude/worktrees/wt/.git" ] || { echo "SETUP-FAIL: could not create git worktree at $1/.claude/worktrees/wt"; fail=1; }
+}
+mkgitwt "$TMP/gitvault" obsidian
+mkgitwt "$TMP/gitcode"  ""
+
+run() { # $1=payload-cwd  $2=extra-env  $3=transcript(opt)  $4=process-cwd(opt, default neutral)
+  local payload pcwd
+  pcwd="${4:-$TMP/neutral}"
+  if [ -n "${3:-}" ]; then payload="{\"cwd\":\"$1\",\"transcript_path\":\"$3\"}"
+  else payload="{\"cwd\":\"$1\"}"; fi
+  # NODEDUP on so detection asserts are not silenced by a prior fire of the same slug;
+  # STATE_DIR isolated. cd sets os.getcwd() for Channel C.
+  ( cd "$pcwd" && printf '%s' "$payload" \
+      | env VAULT_WORKTREE_WARN_NODEDUP=1 VAULT_WORKTREE_WARN_STATE_DIR="$TMP/state" $2 python3 "$HOOK" )
+}
+
+assert_fires() { # $1=label $2=stdout
+  if printf '%s' "$2" | grep -q "vault-worktree"; then echo "PASS: $1 (fired)"
+  else echo "FAIL: $1 — expected FIRE, got: $2"; fail=1; fi
+}
+assert_silent() { # $1=label $2=stdout
+  if printf '%s' "$2" | grep -q "suppressOutput"; then echo "PASS: $1 (silent)"
+  else echo "FAIL: $1 — expected SILENT, got: $2"; fail=1; fi
+}
+
+# --- Channel A ---
+assert_fires  "A1 vault worktree cwd"      "$(run "$TMP/vaultmain/.claude/worktrees/slug" "")"
+assert_silent "A2 plain vault cwd"         "$(run "$TMP/vaultmain" "")"
+assert_silent "A3 code-repo worktree cwd"  "$(run "$TMP/devrepo/.claude/worktrees/slug" "")"
+assert_silent "A4 bypass set"              "$(run "$TMP/vaultmain/.claude/worktrees/slug" "VAULT_WORKTREE_WARN_BYPASS=1")"
+
+# --- Channel B ---
+assert_fires  "B5 vault main + marker"     "$(run "$TMP/vaultmain" "" "$WT_TRANSCRIPT")"
+assert_silent "B6 code main + marker"      "$(run "$TMP/devrepo" "" "$WT_TRANSCRIPT")"
+assert_silent "B7 plain vault, no marker"  "$(run "$TMP/vaultmain" "" "$PLAIN_TRANSCRIPT")"
+
+# --- Channel C: git ground truth (payload=main, NO marker, process in a real worktree) ---
+assert_fires  "C8 vault: payload=main+no-marker, PROCESS in real git worktree" \
+              "$(run "$TMP/gitvault" "" "" "$TMP/gitvault/.claude/worktrees/wt")"
+assert_silent "C9 code-repo: same shape, no .obsidian"   \
+              "$(run "$TMP/gitcode" "" "" "$TMP/gitcode/.claude/worktrees/wt")"
+assert_silent "C10 process in real MAIN vault (not a worktree)" \
+              "$(run "$TMP/gitvault" "" "" "$TMP/gitvault")"
+
+# --- Dedup: warn once per slug (NODEDUP off, isolated state dir) ---
+DSTATE="$TMP/dedupstate"; mkdir -p "$DSTATE"
+ded() { ( cd "$TMP/gitvault/.claude/worktrees/wt" && printf '{"cwd":"%s"}' "$TMP/gitvault" \
+            | env VAULT_WORKTREE_WARN_STATE_DIR="$DSTATE" python3 "$HOOK" ); }
+assert_fires  "D11 dedup first call"   "$(ded)"
+assert_silent "D12 dedup second call"  "$(ded)"
+
+if [ "$fail" -eq 0 ]; then echo "ALL GREEN"; else echo "HAS FAILURES"; fi
+exit $fail

--- a/scripts/install-hooks-user-level.py
+++ b/scripts/install-hooks-user-level.py
@@ -84,6 +84,8 @@ ABS_FINGERPRINTS = [
     "ai-brain-starter/hooks/block-secret-in-note.py",
     # Context-budget measurer (always-loaded text layer; MYC-619):
     "ai-brain-starter/hooks/context-budget-measure.py",
+    # Vault-in-worktree melt tripwire (3-channel detect; SessionStart + tool-time + dedup):
+    "ai-brain-starter/hooks/warn-vault-session-in-worktree.py",
 ]
 
 # Path-divergence-robust matching: an ai-brain-starter hook may be wired at the
@@ -101,6 +103,7 @@ ABS_OWNED_BASENAMES = {
     "remove-ended-worktree.py", "enforce-worktree-cap.py",
     "worktree-footprint-signal.py", "remediate-runaway-procs.py",
     "block-secret-in-note.py", "context-budget-measure.py",
+    "warn-vault-session-in-worktree.py",
 }
 
 # Hooks ai-brain-starter USED TO ship and has deliberately RETIRED. The


### PR DESCRIPTION
## What
A LOUD tripwire that fires when an Obsidian-vault session is running inside a Claude Desktop per-session git worktree, and tells the user to relaunch plain.

## Why
On a vault (repo-root == vault-root, thousands of files) a `.claude/worktrees/<slug>/` checkout lands inside Obsidian's watched tree → runaway CPU/RAM/crash, and the worktree can be silently deleted mid-session, taking worktree-only files with it. There is **no documented config switch** to stop the Desktop app creating it, so a SessionStart + tool-time tripwire is the enforceable defense.

## How
- **3 independent detection channels** (first hit wins; `.obsidian/` gate so code-repo worktrees never fire):
  - A — payload `cwd` contains the `.claude/worktrees/` segment
  - B — `transcript_path` carries the `--claude-worktrees-<slug>` marker
  - C — payload-INDEPENDENT `git rev-parse --show-toplevel` ground truth. **C is the fix**: it catches the Desktop-SessionStart case where the harness reports `cwd=main` + an unmarked transcript and A+B both go silent.
- Fail-open, 2s-bounded git call, once-per-slug dedup (warns once per session, not every turn).
- Wired on **SessionStart + UserPromptSubmit + PreToolUse(Bash)** in `hooks.json`; registered in `install-hooks-user-level.py` ownership lists.

## Test
Negative-control `warn-vault-session-in-worktree.test.sh` — 12 cases incl. a **real-git-worktree repro** of the SessionStart miss (C8) + dedup (D11/D12). 12/12 green. Affected install/boundedness integration tests green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)