### PR TITLE
feat(watchdog): connector liveness — alert on the silent-empty 0-vs-0 gap (MYC-367)

### DIFF
--- a/hooks.json
+++ b/hooks.json
@@ -236,6 +236,11 @@
             "type": "command",
             "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/context-budget-measure.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'",
             "statusMessage": "Measuring always-loaded context budget..."
+          },
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/surface-connector-liveness.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'",
+            "statusMessage": "Checking connectors for the silent-empty (0-vs-0) gap..."
           }
         ]
       }

--- a/hooks/surface-connector-liveness.py
+++ b/hooks/surface-connector-liveness.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""SessionStart hook: surface a connector that has silently gone empty.
+
+The visible-alert half of the connector liveness watchdog (the 0-vs-0 gap). An
+ingest connector (Granola, WhatsApp, iMessage, Slack, Gmail) can keep exiting 0
+while quietly returning 0 items after a vendor changes a surface, so the brain
+goes stale with no signal. scripts/check-connector-liveness.py is the tested
+detection core + the diagnose/sunday surface; this hook is the every-session
+canary that names the broken connector at the NEXT session start.
+
+It does NOT re-implement detection — it loads the same module the integration
+test and `diagnose` exercise, so the alert and the gate can never drift.
+
+Output: silent when every connector is fresh (or none exist). One systemMessage
+block listing each connector that is silently overdue.
+
+Bypass: CONNECTOR_LIVENESS_SURFACE_BYPASS=1 in env.
+Test seam: CONNECTOR_LIVENESS_NOW=YYYY-MM-DD pins "today" (hermetic tests only).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from datetime import date, datetime
+from pathlib import Path
+
+
+def _load_check_module():
+    """Import scripts/check-connector-liveness.py by path (the hyphenated name is
+    not a legal module identifier, so spec_from_file_location is required)."""
+    script = Path(__file__).resolve().parent.parent / "scripts" / "check-connector-liveness.py"
+    if not script.is_file():
+        return None
+    spec = importlib.util.spec_from_file_location("check_connector_liveness", script)
+    if spec is None or spec.loader is None:
+        return None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def find_vault_root(cwd: Path) -> Path | None:
+    """Walk up to the vault root: a dir holding External Inputs/ or a Meta-ish
+    folder. If cwd is inside a worktree, reset to the main checkout first.
+    Mirrors find_vault_root() in surface-stranded-session-artifacts.py."""
+    parts = cwd.parts
+    if ".claude" in parts:
+        idx = parts.index(".claude")
+        if idx + 1 < len(parts) and parts[idx + 1] == "worktrees" and idx > 0:
+            cwd = Path(*parts[:idx])
+
+    p = cwd.resolve()
+    for _ in range(8):
+        if not p.is_dir():
+            break
+        if (p / "External Inputs").is_dir():
+            return p
+        try:
+            children = list(p.iterdir())
+        except OSError:
+            children = []
+        if any(c.is_dir() and c.name.endswith("Meta") for c in children):
+            return p
+        parent = p.parent
+        if parent == p:
+            break
+        p = parent
+    return None
+
+
+def _resolve_now() -> date:
+    override = os.environ.get("CONNECTOR_LIVENESS_NOW")
+    if override:
+        try:
+            return datetime.strptime(override, "%Y-%m-%d").date()
+        except ValueError:
+            pass
+    return datetime.now().date()
+
+
+def main() -> int:
+    if os.environ.get("CONNECTOR_LIVENESS_SURFACE_BYPASS"):
+        return 0
+
+    # SessionStart payload arrives on stdin (JSON). Drain so we never block.
+    try:
+        sys.stdin.read()
+    except Exception:
+        pass
+
+    # Fail silent on ANY error: a watchdog must never break session start.
+    try:
+        mod = _load_check_module()
+        if mod is None:
+            return 0
+        vault = find_vault_root(Path.cwd())
+        if vault is None:
+            return 0
+        cadence = mod._load_cadence_config(None, vault)
+        connectors = mod.discover_external_inputs(vault)
+        connectors.update(mod.discover_granola(vault))
+        if not connectors:
+            return 0
+        gaps = mod.evaluate(connectors, _resolve_now(), cadence)
+    except Exception:
+        return 0
+
+    if not gaps:
+        return 0
+
+    lines = []
+    for source, scope, silence, tol in gaps:
+        lines.append(
+            f"  - {source}/{scope}: no new data for {silence} day(s) "
+            f"(its {tol}-day tolerance is blown)."
+        )
+    msg = (
+        f"[connector-liveness] {len(gaps)} ingest connector(s) have silently "
+        f"stopped producing data (the 0-vs-0 gap — they can exit 0 while "
+        f"returning 0 items after a vendor changes a surface):\n"
+        + "\n".join(lines)
+        + "\n\nCheck each source's auth/permissions, re-run its ingest skill, "
+        "and confirm it pulls >0 items. Full report: "
+        "scripts/check-connector-liveness.py (also wired into /diagnose)."
+    )
+    print(json.dumps({"systemMessage": msg}))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-connector-liveness.py
+++ b/scripts/check-connector-liveness.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""Guard: surface a connector that silently goes empty (the "0-vs-0" gap).
+
+An ingest connector (Granola, WhatsApp, iMessage, Slack, Gmail, ...) can keep
+exiting 0 while quietly returning 0 items after a vendor changes a surface. The
+launchd exit-status watchdog catches NON-zero exits; it does NOT catch "returns
+0 when it should return >0." Origin: granola_export returned 0 transcripts for
+~3 weeks after Granola swapped its local storage (cache-v6.json -> encrypted
+DB). The exit code stayed 0; it surfaced only because a human noticed. This is a
+CLASS, not a one-off.
+
+Signal source: connectors already persist their runs, so this reads real durable
+history instead of running a live, credential-gated probe (which would soft-pass
+forever the moment the credential rots):
+
+  - WhatsApp / iMessage / Slack / Gmail (and any future ingest-* connector) write
+    `External Inputs/<Source>/<scope>/<YYYY-MM-DD>.md` with a *count* frontmatter
+    key (item_count / message_count / count). The filename date is authoritative.
+  - Granola writes `Meeting Notes/<YYYY-MM-DD> - <title> - Transcript.md`
+    (one file per meeting, no count; existence == data for that day).
+
+Detection (distinguishing "broke" from "nothing happened" without a live
+cross-signal): for each (source, scope) with an established track record, a
+connector is OVERDUE when it has been silent LONGER than it has ever been silent
+before AND longer than its configured cadence floor:
+
+    data_days  = dates that produced data (count > 0, or a countless file/transcript)
+    tolerance  = max(cadence_floor[source], longest historical gap between data_days)
+    silence    = (now - last data_day)
+    OVERDUE    = silence > tolerance        (and len(data_days) >= MIN_DATA_DAYS)
+
+A regular daily connector (tolerance ~1-2d) trips within one cadence window of a
+break; a genuinely sparse-but-on-rhythm connector (large historical gaps -> large
+tolerance) does NOT false-alarm just because it is quiet. That asymmetry is the
+whole point: 0-because-the-source-broke vs 0-because-nothing-happened.
+
+This is a DIAGNOSTIC / SessionStart surface, not an install gate: a hit is a WARN
+with the remedy, never a hard FAIL.
+
+Usage:
+  check-connector-liveness.py [--porcelain] [--now YYYY-MM-DD] [--config PATH] [VAULT]
+
+  --now      Evaluate "today" as this date (default: today). The test seam.
+  --config   JSON: {"cadence_days": {"slack": 2, ...}} merged over the defaults.
+             If omitted, also reads <vault>/Meta/connector-cadence.json when present.
+  VAULT      Vault root (default: walk up from CWD; else CWD).
+
+Exit codes:
+  0  OK    - every connector is fresh, or no connectors found
+  1  HIT   - one or more connectors are silently overdue
+  2  USAGE - bad arguments
+
+Porcelain first token: OK_ALL_FRESH | SKIP_NO_CONNECTORS | CONNECTOR_GAP:<source>:<scope>:<days_silent>
+  (one CONNECTOR_GAP line per overdue connector)
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from datetime import date, datetime
+from pathlib import Path
+
+# A connector needs at least this many data-days of history before silence can be
+# called a break. Below it there is no rhythm to judge against, so we stay quiet
+# (a brand-new or one-off ingest must not trip the watchdog).
+MIN_DATA_DAYS = 3
+
+# Per-source cadence FLOOR in days: the minimum tolerance regardless of observed
+# history, so a tight-cadence connector still gets a small grace before alarming.
+# The effective tolerance is max(this floor, the connector's own longest gap).
+DEFAULT_CADENCE_DAYS = {
+    "granola": 3,
+    "whatsapp": 3,
+    "imessage": 3,
+    "slack": 2,
+    "gmail": 2,
+    "health": 2,
+    "linear": 3,
+    "github": 7,
+    "notion": 7,
+    "youtube": 7,
+}
+FALLBACK_CADENCE_DAYS = 7
+
+USAGE = "usage: check-connector-liveness.py [--porcelain] [--now YYYY-MM-DD] [--config PATH] [VAULT]"
+
+_DATE_RE = re.compile(r"^(\d{4})-(\d{2})-(\d{2})$")
+_GRANOLA_RE = re.compile(r"^(\d{4}-\d{2}-\d{2}) - .* - Transcript\.md$")
+_COUNT_KEY_RE = re.compile(r"^[a-z_]*count\s*:\s*(-?\d+)\s*$")
+
+
+def _parse_date(s: str) -> date | None:
+    m = _DATE_RE.match(s)
+    if not m:
+        return None
+    try:
+        return date(int(m.group(1)), int(m.group(2)), int(m.group(3)))
+    except ValueError:
+        return None
+
+
+def _frontmatter_count(path: Path) -> int | None:
+    """Return the item count from an External-Inputs day file, or None if the
+    file carries no *count* key (countless file == treat as data). Reads only the
+    leading frontmatter block; no PyYAML dependency (ingest-* skills ship without
+    it). Best-effort: an unreadable file is treated as countless (None)."""
+    try:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return None
+    if not text.startswith("---"):
+        return None
+    lines = text.splitlines()
+    # lines[0] is the opening '---'; scan to the closing '---'.
+    for line in lines[1:]:
+        if line.strip() == "---":
+            break
+        m = _COUNT_KEY_RE.match(line.strip())
+        if m:
+            return int(m.group(1))
+    return None
+
+
+def _data_days_for_external_scope(scope_dir: Path) -> list[date]:
+    """Dates under External Inputs/<Source>/<scope>/ that produced data: a
+    YYYY-MM-DD.md file whose count is missing or > 0 (count == 0 is a real
+    'ran, got nothing' day and is NOT data)."""
+    days: list[date] = []
+    try:
+        entries = sorted(scope_dir.iterdir())
+    except OSError:
+        return days
+    for entry in entries:
+        if not entry.name.endswith(".md"):
+            continue
+        d = _parse_date(entry.stem)
+        if d is None:
+            continue
+        count = _frontmatter_count(entry)
+        if count is None or count > 0:
+            days.append(d)
+    return days
+
+
+def discover_external_inputs(vault: Path) -> dict[tuple[str, str], list[date]]:
+    """Map (source, scope) -> sorted unique data-days for every connector that
+    has landed files under External Inputs/."""
+    out: dict[tuple[str, str], list[date]] = {}
+    root = vault / "External Inputs"
+    if not root.is_dir():
+        return out
+    try:
+        sources = sorted(p for p in root.iterdir() if p.is_dir())
+    except OSError:
+        return out
+    for src_dir in sources:
+        source = src_dir.name.lower()
+        try:
+            scopes = sorted(p for p in src_dir.iterdir() if p.is_dir())
+        except OSError:
+            continue
+        for scope_dir in scopes:
+            days = sorted(set(_data_days_for_external_scope(scope_dir)))
+            if days:
+                out[(source, scope_dir.name)] = days
+    return out
+
+
+def discover_granola(vault: Path) -> dict[tuple[str, str], list[date]]:
+    """Granola does not use External Inputs; it drops one transcript per meeting
+    into Meeting Notes/. Each transcript is a data-day."""
+    for name in ("📝 Meeting Notes", "Meeting Notes"):
+        mdir = vault / name
+        if mdir.is_dir():
+            break
+    else:
+        return {}
+    days: list[date] = []
+    try:
+        entries = sorted(mdir.iterdir())
+    except OSError:
+        return {}
+    for entry in entries:
+        m = _GRANOLA_RE.match(entry.name)
+        if not m:
+            continue
+        d = _parse_date(m.group(1))
+        if d is not None:
+            days.append(d)
+    days = sorted(set(days))
+    return {("granola", "meetings"): days} if days else {}
+
+
+def _max_gap_days(days: list[date]) -> int:
+    """Longest gap (in days) between consecutive data-days. 0 for a single day."""
+    if len(days) < 2:
+        return 0
+    return max((days[i + 1] - days[i]).days for i in range(len(days) - 1))
+
+
+def evaluate(
+    connectors: dict[tuple[str, str], list[date]],
+    now: date,
+    cadence_days: dict[str, int],
+) -> list[tuple[str, str, int, int]]:
+    """Return [(source, scope, days_silent, tolerance)] for every overdue
+    connector, sorted for stable output. A connector is overdue when it has an
+    established rhythm and has been silent longer than the larger of its cadence
+    floor and its own longest historical quiet stretch."""
+    gaps: list[tuple[str, str, int, int]] = []
+    for (source, scope), days in connectors.items():
+        if len(days) < MIN_DATA_DAYS:
+            continue
+        floor = cadence_days.get(source, FALLBACK_CADENCE_DAYS)
+        tolerance = max(floor, _max_gap_days(days))
+        silence = (now - days[-1]).days
+        if silence > tolerance:
+            gaps.append((source, scope, silence, tolerance))
+    return sorted(gaps)
+
+
+def _detect_vault(start: Path) -> Path:
+    """Walk up from `start` looking for a vault marker; fall back to `start`."""
+    cur = start.resolve()
+    for cand in [cur, *cur.parents]:
+        if (cand / "External Inputs").is_dir() or (cand / "⚙️ Meta").is_dir() \
+                or (cand / "Meta").is_dir():
+            return cand
+    return cur
+
+
+def _load_cadence_config(config_path: Path | None, vault: Path) -> dict[str, int]:
+    cadence = dict(DEFAULT_CADENCE_DAYS)
+    paths: list[Path] = []
+    if config_path is not None:
+        paths.append(config_path)
+    else:
+        for name in ("⚙️ Meta", "Meta"):
+            paths.append(vault / name / "connector-cadence.json")
+    for p in paths:
+        if not p.is_file():
+            continue
+        try:
+            data = json.loads(p.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        overrides = data.get("cadence_days", {})
+        if isinstance(overrides, dict):
+            for k, v in overrides.items():
+                try:
+                    cadence[str(k).lower()] = int(v)
+                except (TypeError, ValueError):
+                    continue
+    return cadence
+
+
+def main(argv):
+    porcelain = "--porcelain" in argv
+    args = [a for a in argv if a != "--porcelain"]
+
+    now: date | None = None
+    config_path: Path | None = None
+    vault_arg: Path | None = None
+    i = 0
+    while i < len(args):
+        a = args[i]
+        if a == "--now":
+            i += 1
+            if i >= len(args):
+                print(USAGE, file=sys.stderr)
+                return 2
+            now = _parse_date(args[i])
+            if now is None:
+                print("--now must be YYYY-MM-DD", file=sys.stderr)
+                return 2
+        elif a == "--config":
+            i += 1
+            if i >= len(args):
+                print(USAGE, file=sys.stderr)
+                return 2
+            config_path = Path(args[i]).expanduser()
+        elif a.startswith("--"):
+            print("unknown argument: {}".format(a), file=sys.stderr)
+            print(USAGE, file=sys.stderr)
+            return 2
+        else:
+            vault_arg = Path(a).expanduser()
+        i += 1
+
+    if now is None:
+        now = datetime.now().date()
+    vault = vault_arg.resolve() if vault_arg is not None else _detect_vault(Path.cwd())
+    cadence = _load_cadence_config(config_path, vault)
+
+    connectors = discover_external_inputs(vault)
+    connectors.update(discover_granola(vault))
+
+    if not connectors:
+        if porcelain:
+            print("SKIP_NO_CONNECTORS")
+        else:
+            print("OK    No ingest connectors have landed data yet (nothing to watch).")
+        return 0
+
+    gaps = evaluate(connectors, now, cadence)
+
+    if not gaps:
+        if porcelain:
+            print("OK_ALL_FRESH")
+        else:
+            print("OK    All {} connector(s) are producing data within their "
+                  "expected cadence.".format(len(connectors)))
+        return 0
+
+    if porcelain:
+        for source, scope, silence, _tol in gaps:
+            print("CONNECTOR_GAP:{}:{}:{}".format(source, scope, silence))
+        return 1
+
+    print("WARN  {} connector(s) have silently stopped producing data "
+          "(the 0-vs-0 gap):".format(len(gaps)))
+    for source, scope, silence, tol in gaps:
+        print("      - {}/{}: no new data for {} day(s) "
+              "(longer than its {}-day tolerance).".format(source, scope, silence, tol))
+    print("      A connector can exit 0 while returning 0 items after a vendor")
+    print("      changes a surface. Check each source's auth/permissions and run")
+    print("      its ingest skill manually; confirm it pulls >0 items, then")
+    print("      re-run this check. See scripts/granola_sync.py for the origin case.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -129,6 +129,8 @@ INTEGRATION_TESTS=(
   test_cd_worktree_inline_bypass
   test_sessionstart_hook_snapshot_guard
   test_context_budget_measure
+  test_connector_liveness_watchdog
+  test_connector_liveness_surface
 )
 echo "==> (b) Shell integration: ${#INTEGRATION_TESTS[@]} tests"
 for t in "${INTEGRATION_TESTS[@]}"; do

--- a/scripts/diagnose.sh
+++ b/scripts/diagnose.sh
@@ -393,6 +393,31 @@ else
   warn "check-split-meta.py not found" "Cannot check for split Meta folders."
 fi
 
+# ----- 14b. Connector liveness (the silent-empty 0-vs-0 gap) -----
+section "14b. Connector liveness"
+CHECK_CONN=""
+for c in "$(cd "$(dirname "$0")" && pwd)/check-connector-liveness.py" \
+         "$HOME/.claude/skills/ai-brain-starter/scripts/check-connector-liveness.py"; do
+  [ -f "$c" ] && CHECK_CONN="$c" && break
+done
+if [ -n "$CHECK_CONN" ]; then
+  cverdict="$(python3 "$CHECK_CONN" --porcelain "$VAULT" 2>/dev/null)"
+  case "${cverdict%%$'\n'*}" in
+    OK_ALL_FRESH)
+      ok "All ingest connectors are producing data within their cadence" ;;
+    SKIP_NO_CONNECTORS)
+      ok "No ingest connectors have landed data yet (nothing to watch)" ;;
+    CONNECTOR_GAP:*)
+      connlist="$(printf '%s\n' "$cverdict" | grep '^CONNECTOR_GAP:' | cut -d: -f2,3 | paste -sd ',' -)"
+      warn "Connector(s) silently went empty (the 0-vs-0 gap): $connlist" \
+        "A connector can exit 0 while returning 0 items after a vendor changes a surface. Check each source's auth/permissions, re-run its ingest skill, and confirm it pulls >0 items. Detail: python3 scripts/check-connector-liveness.py \"$VAULT\"." ;;
+    *)
+      warn "Could not evaluate connector liveness" "check-connector-liveness.py returned: ${cverdict:-<empty>}" ;;
+  esac
+else
+  warn "check-connector-liveness.py not found" "Cannot check connectors for the silent-empty gap."
+fi
+
 # ----- 15. First-run context load (the wrong-cwd / generic-answer class) -----
 # The install's "ask me what you know about you" test only works if the vault's
 # personalized CLAUDE.md actually loads — which depends on launching from the

--- a/skills/diagnose/SKILL.md
+++ b/skills/diagnose/SKILL.md
@@ -91,6 +91,7 @@ Most "Claude is broken" reports trace to one of:
 | 11 | Vault on a local disk, not a consumer cloud-sync root | Move it local (docs/CLOUD_SYNC.md) | Could not evaluate the path |
 | 12 | Vault has an off-machine backup | Set one up: `bash scripts/vault-backup.sh setup` (docs/BACKUP.md) | Backup configured but no snapshot yet |
 | 13 | No repeated Obsidian renderer crashes (macOS; skips elsewhere) | - | Heavy indexer likely OOM-ing the renderer on a large vault: restricted mode -> Dataview only -> add others one at a time (see the obsidian-plugins rule, "Large-vault plugin posture") |
+| 14b | Ingest connectors still producing data (the silent-empty 0-vs-0 gap) | - | A connector exited 0 but returned 0 items (a vendor changed a surface): check its auth/permissions, re-run its ingest skill, confirm it pulls >0 items |
 
 ## When to suggest /diagnose proactively
 
@@ -99,6 +100,7 @@ Most "Claude is broken" reports trace to one of:
 - User says "I just did a git pull and something feels off"
 - User says "my friend installed it but it's broken"
 - User says "Obsidian keeps crashing when I open it" / "Obsidian won't open" (likely a heavy-indexer renderer OOM on a large vault - check 13)
+- User says "my brain feels stale" / "I haven't seen any new Granola/WhatsApp/Slack/Gmail notes in a while" / "<source> stopped showing up" (likely a silently-empty connector - check 14b)
 - After every major upgrade prompt during /setup-brain
 
 Do NOT use /diagnose as an email-capture surface. If `~/.claude/.ai-brain-starter-email-on-file` is missing, that is fine and never a finding — the email is optional, and the only places it is ever asked are the setup interview (Phase 24.4) and the once-per-update post-pull nudge. Never tell the user to fetch or paste a token.

--- a/tests/integration/test_connector_liveness_surface.sh
+++ b/tests/integration/test_connector_liveness_surface.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Test: surface-connector-liveness.py — the SessionStart visible-alert half of
+# the connector liveness watchdog (MYC-367).
+#
+# The ticket's Done criterion requires a VISIBLE alert when a connector silently
+# goes empty. scripts/check-connector-liveness.py is the tested detection core;
+# this hook is what actually surfaces it at session start. This test proves the
+# end-to-end surface: a broken connector produces a systemMessage that names it,
+# a healthy vault is silent, and the bypass env silences it.
+#
+# The hook reads the vault from CWD (like the sibling SessionStart hooks) and
+# honors CONNECTOR_LIVENESS_NOW for a hermetic "today". Uses the PRODUCTION
+# default cadences (no --config), so the fixture matches those defaults.
+#
+# Self-contained: tmpdir vault, no network. Exit 0 = pass.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOK="$REPO_ROOT/hooks/surface-connector-liveness.py"
+if [ ! -f "$HOOK" ]; then
+  echo "FAIL: surface hook not found at $HOOK" >&2
+  exit 1
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+export CONNECTOR_LIVENESS_NOW="2026-06-13"
+
+ext() { # <vault> <Source> <scope> <date> <count>
+  local d="$1/External Inputs/$2/$3"
+  mkdir -p "$d"
+  printf -- '---\ntype: external-input\nscope: %s\ndate: %s\ncount: %s\n---\nbody\n' \
+    "$3" "$4" "$5" > "$d/$4.md"
+}
+
+# run_hook <vault> -> echoes the systemMessage ("" when silent)
+run_hook() {
+  ( cd "$1" && printf '{}' | python3 "$HOOK" 2>/dev/null ) \
+    | python3 -c "import json,sys; raw=sys.stdin.read().strip(); print(json.loads(raw).get('systemMessage','') if raw else '')"
+}
+
+# --- Assertion 1: healthy-only vault -> silent -----------------------------
+VH="$TMP/healthy"
+for day in 07 08 09 10 11 12; do ext "$VH" WhatsApp founders "2026-06-$day" 5; done
+OUT="$(run_hook "$VH")"
+if [ -n "$OUT" ]; then
+  echo "FAIL(1): hook spoke for a healthy vault; got: $OUT" >&2
+  exit 1
+fi
+echo "PASS(1): hook silent when all connectors are fresh"
+
+# --- Assertion 2: broken connector -> systemMessage names it ---------------
+VB="$TMP/broken"
+for day in 07 08 09 10 11 12; do ext "$VB" WhatsApp founders "2026-06-$day" 5; done   # healthy
+for day in 01 02 03 04 05 06 07 08 09; do ext "$VB" Slack eng "2026-06-$day" 7; done  # silent since 06-09
+OUT="$(run_hook "$VB")"
+if [ -z "$OUT" ]; then
+  echo "FAIL(2): hook silent when Slack #eng is broken" >&2
+  exit 1
+fi
+case "$OUT" in
+  *slack/eng*) echo "PASS(2): hook surfaces a systemMessage naming the broken connector" ;;
+  *) echo "FAIL(2): systemMessage did not name slack/eng; got: $OUT" >&2; exit 1 ;;
+esac
+
+# --- Assertion 3: healthy connector NOT named in the alert -----------------
+case "$OUT" in
+  *founders*) echo "FAIL(3): healthy WhatsApp falsely named in the alert; got: $OUT" >&2; exit 1 ;;
+  *) echo "PASS(3): healthy connector not named" ;;
+esac
+
+# --- Assertion 4: bypass env silences the hook -----------------------------
+OUT="$(CONNECTOR_LIVENESS_SURFACE_BYPASS=1 run_hook "$VB")"
+if [ -n "$OUT" ]; then
+  echo "FAIL(4): bypass env did not silence the hook; got: $OUT" >&2
+  exit 1
+fi
+echo "PASS(4): CONNECTOR_LIVENESS_SURFACE_BYPASS silences the hook"
+
+echo
+echo "All assertions passed. connector-liveness SessionStart surface holds."

--- a/tests/integration/test_connector_liveness_watchdog.sh
+++ b/tests/integration/test_connector_liveness_watchdog.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Test: check-connector-liveness.py — the connector liveness watchdog (MYC-367).
+#
+# Bug class: SILENT-EMPTY-CONNECTOR (the "0-vs-0" gap). A connector (Granola,
+# WhatsApp, iMessage, Slack, Gmail) silently returns 0 items after a vendor
+# changes a surface. The launchd exit-status watchdog catches NON-zero exits but
+# not "returns 0 when it should return >0." Origin: granola_export returned 0
+# transcripts for ~3 weeks after Granola changed its local storage; exit code
+# stayed 0 and nobody noticed.
+#
+# This is the NEGATIVE-CONTROL test the ticket's Done criterion requires: point
+# connectors at stale/empty sources and confirm the alert fires within one
+# expected-cadence window — AND confirm a connector that is merely IDLE (silent,
+# but within its own demonstrated rhythm) does NOT raise a false alarm. That
+# second half is the whole point: distinguish "0 because nothing happened" from
+# "0 because the source broke."
+#
+# Signal source: connectors already persist their runs. WhatsApp/iMessage/Slack/
+# Gmail write External Inputs/<Source>/<scope>/<YYYY-MM-DD>.md with a *count*
+# frontmatter key; Granola writes Meeting Notes/<YYYY-MM-DD> - <title> -
+# Transcript.md. The watchdog reads that history — no live credential-gated
+# probe (which would soft-pass forever).
+#
+# Determinism: the script takes --now <YYYY-MM-DD> (the time seam) and --config
+# (per-source cadence floors) so this test is hermetic and not coupled to the
+# wall clock or the production default cadences.
+#
+# Assertions:
+#   1. Empty vault (no connectors) -> SKIP_NO_CONNECTORS, exit 0.
+#   2. Only-healthy vault -> OK_ALL_FRESH, exit 0.
+#   3. A regular connector gone silent past one window -> CONNECTOR_GAP, exit 1.
+#   4. A within-window connector is NOT flagged (no false positive).
+#   5. A sparse-but-on-rhythm connector is NOT flagged (idle != broke).
+#   6. Granola gone silent past its window IS flagged (the origin incident).
+#   7. A connector still RUNNING but returning count:0 after a regular history
+#      IS flagged (the literal 0-vs-0 gap).
+#
+# Self-contained: tmpdir fake vault, no network, no MCP. Exit 0 = pass.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/check-connector-liveness.py"
+if [ ! -f "$SCRIPT" ]; then
+  echo "FAIL: watchdog script not found at $SCRIPT" >&2
+  exit 1
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+NOW="2026-06-13"
+CONFIG="$TMP/cadence.json"
+cat > "$CONFIG" <<'JSON'
+{ "cadence_days": {
+    "slack": 2, "whatsapp": 3, "imessage": 3, "gmail": 2, "granola": 3
+} }
+JSON
+
+# write an External Inputs day-file with a given item count
+ext() { # <vault> <Source> <scope> <date> <count>
+  local d="$1/External Inputs/$2/$3"
+  mkdir -p "$d"
+  cat > "$d/$4.md" <<EOF
+---
+type: external-input
+scope: $3
+date: $4
+count: $5
+ingested_at: ${4}T09:00:00-05:00
+---
+body
+EOF
+}
+
+# write a Granola transcript file for a date
+granola() { # <vault> <date> <title>
+  local d="$1/📝 Meeting Notes"
+  mkdir -p "$d"
+  echo "transcript" > "$d/$2 - $3 - Transcript.md"
+}
+
+run() { # <vault> -> porcelain stdout; also captures exit code in RC
+  set +e
+  OUT="$(python3 "$SCRIPT" --porcelain --now "$NOW" --config "$CONFIG" "$1" 2>/dev/null)"
+  RC=$?
+  set -e
+}
+
+# --- Assertion 1: empty vault -> SKIP --------------------------------------
+V1="$TMP/v1"; mkdir -p "$V1"
+run "$V1"
+if [ "$RC" != 0 ] || [ "${OUT%%$'\n'*}" != "SKIP_NO_CONNECTORS" ]; then
+  echo "FAIL(1): empty vault should SKIP_NO_CONNECTORS exit 0; got rc=$RC out=[$OUT]" >&2
+  exit 1
+fi
+echo "PASS(1): empty vault -> SKIP_NO_CONNECTORS"
+
+# --- Assertion 2: only-healthy vault -> OK ---------------------------------
+V2="$TMP/v2"; mkdir -p "$V2"
+# WhatsApp founders: data every day up to the day before NOW -> silence 1 day
+for day in 07 08 09 10 11 12; do ext "$V2" WhatsApp founders "2026-06-$day" 5; done
+run "$V2"
+if [ "$RC" != 0 ] || [ "${OUT%%$'\n'*}" != "OK_ALL_FRESH" ]; then
+  echo "FAIL(2): healthy vault should be OK_ALL_FRESH exit 0; got rc=$RC out=[$OUT]" >&2
+  exit 1
+fi
+echo "PASS(2): only-healthy vault -> OK_ALL_FRESH"
+
+# --- Build the full mixed fixture for assertions 3-7 -----------------------
+V="$TMP/v"; mkdir -p "$V"
+
+# (3) Slack #eng: regular daily, last data 06-09, now 06-13 -> silent 4 > 2 (BROKE)
+for day in 01 02 03 04 05 06 07 08 09; do ext "$V" Slack eng "2026-06-$day" 7; done
+
+# (4) iMessage family: regular daily through 06-12 -> silent 1 (HEALTHY, within window)
+for day in 06 07 08 09 10 11 12; do ext "$V" iMessage family "2026-06-$day" 3; done
+
+# (5) Gmail newsletters: sparse but on a ~15-day rhythm; last data 05-31 ->
+#     silent 13 days, but its own max gap is 15 -> NOT overdue (IDLE, not broke)
+ext "$V" Gmail newsletters "2026-05-01" 2
+ext "$V" Gmail newsletters "2026-05-16" 2
+ext "$V" Gmail newsletters "2026-05-31" 2
+
+# (6) Granola: regular every ~2 days, last 06-08, now 06-13 -> silent 5 > 3 (BROKE)
+granola "$V" "2026-06-02" "Standup"
+granola "$V" "2026-06-04" "Design sync"
+granola "$V" "2026-06-06" "Roadmap"
+granola "$V" "2026-06-08" "1-on-1"
+
+# (7) Slack #marketing: regular data 06-01..06-05, then STILL RUNNING but
+#     returning count:0 every day 06-06..06-12 -> last *data* 06-05, silent 8
+#     > 2 (the literal 0-vs-0: connector alive, source went empty) (BROKE)
+for day in 01 02 03 04 05; do ext "$V" Slack marketing "2026-06-$day" 4; done
+for day in 06 07 08 09 10 11 12; do ext "$V" Slack marketing "2026-06-$day" 0; done
+
+run "$V"
+
+# Assertion 3: the broken connectors must flag with non-zero exit
+if [ "$RC" = 0 ]; then
+  echo "FAIL(3): expected non-zero exit when connectors are broken; out=[$OUT]" >&2
+  exit 1
+fi
+case "$OUT" in
+  *CONNECTOR_GAP:slack:eng:*) echo "PASS(3): broken Slack #eng flagged" ;;
+  *) echo "FAIL(3): Slack #eng (silent 4d, daily rhythm) not flagged; out=[$OUT]" >&2; exit 1 ;;
+esac
+
+# Assertion 4: the within-window connector must NOT be flagged
+case "$OUT" in
+  *imessage:family*) echo "FAIL(4): healthy within-window iMessage falsely flagged; out=[$OUT]" >&2; exit 1 ;;
+  *) echo "PASS(4): healthy iMessage not flagged" ;;
+esac
+
+# Assertion 5: the sparse-but-on-rhythm connector must NOT be flagged
+case "$OUT" in
+  *gmail:newsletters*) echo "FAIL(5): idle sparse Gmail falsely flagged (idle != broke); out=[$OUT]" >&2; exit 1 ;;
+  *) echo "PASS(5): sparse-on-rhythm Gmail not flagged (idle distinguished from broke)" ;;
+esac
+
+# Assertion 6: Granola (the origin incident) must be flagged
+case "$OUT" in
+  *CONNECTOR_GAP:granola:*) echo "PASS(6): silent Granola flagged (origin incident covered)" ;;
+  *) echo "FAIL(6): Granola (silent 5d, ~2d rhythm) not flagged; out=[$OUT]" >&2; exit 1 ;;
+esac
+
+# Assertion 7: the 0-vs-0 case (running but returning 0) must be flagged
+case "$OUT" in
+  *CONNECTOR_GAP:slack:marketing:*) echo "PASS(7): 0-vs-0 Slack #marketing flagged (returns 0 when it should return >0)" ;;
+  *) echo "FAIL(7): Slack #marketing (running but count:0 after regular data) not flagged; out=[$OUT]" >&2; exit 1 ;;
+esac
+
+echo
+echo "All assertions passed. connector-liveness watchdog invariant holds."


### PR DESCRIPTION
Closes MYC-367 — https://linear.app/myceliumai/issue/MYC-367

## Problem
A connector (Granola, WhatsApp, iMessage, Slack, Gmail) can keep **exiting 0 while quietly returning 0 items** after a vendor changes a surface. The launchd exit-status watchdog catches non-zero exits — not "returns 0 when it should return >0." That's the 0-vs-0 gap.

Origin (in the ticket): `granola_export` returned 0 transcripts for ~3 weeks after Granola swapped its local storage (cache-v6.json → encrypted DB). Exit code stayed 0; it surfaced only because a human noticed. This is a **class**, not a one-off.

## Approach
The connectors already persist their runs, so this reads **real durable history** instead of a live, credential-gated probe (which would soft-pass forever the moment the credential rots):
- WhatsApp / iMessage / Slack / Gmail → `External Inputs/<Source>/<scope>/<YYYY-MM-DD>.md` with a `*count*` frontmatter key.
- Granola → `Meeting Notes/<YYYY-MM-DD> - <title> - Transcript.md`.

**Detection (broke vs. nothing-happened, without a live cross-signal):** a connector is OVERDUE when it has an established rhythm (≥3 data-days) and has been silent **longer than `max(cadence floor, its own longest historical gap)`**. A regular daily connector trips within one cadence window of a break; a genuinely sparse-but-on-rhythm connector does *not* false-alarm just because it's quiet. That asymmetry is the whole point.

## What's here
- `scripts/check-connector-liveness.py` — the watchdog core (`--porcelain`, `--now` test seam, `--config` cadence overrides).
- `hooks/surface-connector-liveness.py` — SessionStart visible alert; **imports** the tested core so the alert and the gate can't drift. Wired into `hooks.json`.
- `scripts/diagnose.sh` §14b + `skills/diagnose/SKILL.md` row.
- Both tests registered in `scripts/ci.sh` `INTEGRATION_TESTS`.

## Test plan (Done criterion = negative-control)
`tests/integration/test_connector_liveness_watchdog.sh` — proves a simulated vendor break alerts within one cadence window, **and** that an idle-but-on-rhythm connector is NOT flagged:
- broken daily Slack (silent 4d) → flagged ✅
- within-window iMessage → not flagged ✅
- sparse-on-rhythm Gmail (~15d) → not flagged ✅ (idle ≠ broke)
- silent Granola (origin incident) → flagged ✅
- running-but-returning-`count:0` Slack → flagged ✅ (literal 0-vs-0)

`tests/integration/test_connector_liveness_surface.sh` — proves the alert is actually **visible**: SessionStart hook emits a `systemMessage` naming the broken connector, stays silent when healthy, honors the bypass env.

Verified locally: full `scripts/ci.sh` green (py_compile on 268 files @ Python 3.9.6 + 38 integration tests), `scripts/shellcheck.sh` clean, `hooks.json` valid JSON, real-vault smoke returns `SKIP_NO_CONNECTORS` (graceful, no false alarm).

## Honest scope note
The ticket's "calendar shows meetings but 0 ingested" live cross-signal is **approximated** by each connector's own demonstrated rhythm (the strongest *local* signal). A live MCP cross-signal is documented future work — deliberately **not** built as a credential-gated probe, which would soft-pass forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)