### PR TITLE
fix(context-budget): refuse to record a baseline from a non-project cwd (MYC-1243)

### DIFF
--- a/docs/context-budget.md
+++ b/docs/context-budget.md
@@ -28,13 +28,24 @@ drifts. This is the same `ARTIFACT-WITHOUT-MEASUREMENT` class as token economics
 It is a measure-and-warn ratchet, not a framework: fail-open (never crash-blocks a
 session start), frequency-capped (warns at most once/day), silent when healthy.
 
+**Scope safety.** The floor must reflect a real project session, not whatever
+directory the command happened to run in. The discovery walks up from the cwd to
+find the project's `CLAUDE.md` / `MEMORY.md` / `CONTEXT.md`; run from a non-project
+directory (e.g. a bare home dir) it sees *only* the global kernel. To stop that from
+recording a global-only floor that masks real drift, a baseline is written **only
+from a project-anchored discovery**: `--accept` from a non-project directory refuses
+(nonzero exit), the SessionStart ratchet just skips, and the baseline records its
+file-*kind* set so a later, narrower discovery never silently ratchets the floor down.
+
 ## Using it
 
 ```bash
 # See the table any time:
 python3 ~/.claude/hooks/context-budget-measure.py --report
 
-# Acknowledge an intentional growth as the new baseline floor:
+# Acknowledge an intentional growth as the new baseline floor.
+# Run this from your PROJECT ROOT — from a non-project directory it refuses
+# (it would otherwise record a global-only floor and mask real drift).
 python3 ~/.claude/hooks/context-budget-measure.py --accept
 
 # Prove it fires/stays-silent correctly (positive + negative control):

--- a/hooks/context-budget-measure.py
+++ b/hooks/context-budget-measure.py
@@ -23,6 +23,20 @@ you slim back, OR run `--accept` to acknowledge an intentional add as the new
 floor. A shrink updates the floor silently. This is a measure-and-warn ratchet,
 NOT a governance framework — match the guard to the recurrence rate.
 
+Scope safety (the floor must reflect a real project session, not whatever cwd
+the command happened to run in). `discover()` finds the project CLAUDE.md /
+MEMORY.md / CONTEXT.md by walking up from cwd; run from a NON-project cwd (e.g.
+a bare home dir) it finds ONLY the global kernel, so a naive `--accept` / silent
+ratchet there would record a global-only floor that clobbers a real multi-file
+floor and silently kills drift detection. Two guards prevent that:
+  • a baseline is recorded ONLY from a project-anchored discovery (at least one
+    project-scoped file present) — `--accept` from a non-project cwd refuses
+    fail-loud + exits nonzero; the SessionStart ratchet just skips,
+  • the recorded baseline persists its file-KIND set, so a later discovery that
+    is a strict SUBSET of those kinds (a narrower scope) never silently ratchets
+    the floor down.
+Bug class: GUARD-RECORDS-BASELINE-FROM-WRONG-SCOPE (cwd-relative-fragility).
+
 Fail-open: a SessionStart nudge must NEVER crash-block a session.
 Freq-capped: warns at most once per day.
 Bypass:  CONTEXT_BUDGET_BYPASS=1
@@ -33,6 +47,7 @@ Modes:
   (no args, reads stdin JSON)  SessionStart hook mode — emits additionalContext or no-ops
   --report                     print the table to stdout (human / CLI)
   --accept                     set the baseline floor to the current total
+                               (refuses + exits nonzero from a non-project cwd)
   --self-test                  positive + negative control; exit 0 iff all pass
 
 Bug class: ALWAYS-LOADED-TEXT-UNMEASURED (sibling of ARTIFACT-WITHOUT-MEASUREMENT).
@@ -41,6 +56,8 @@ MEMORY.md for the total but does NOT duplicate its cliff warning.
 """
 from __future__ import annotations
 
+import contextlib
+import io
 import json
 import os
 import re
@@ -54,6 +71,11 @@ GLOBAL_CEILING = int(os.environ.get("CONTEXT_BUDGET_GLOBAL_CEILING", 40000))
 # growth tolerance: absorb normal small adds, catch real drift
 TOL_BYTES = int(os.environ.get("CONTEXT_BUDGET_TOL_BYTES", 4096))
 TOL_FRAC = float(os.environ.get("CONTEXT_BUDGET_TOL_FRAC", 0.02))
+
+# The global kernel is loaded from a fixed path regardless of cwd, so it is the
+# one file that is ALWAYS discoverable. Any OTHER kind means we found a real
+# project — see is_project_anchored().
+GLOBAL_KIND = "global CLAUDE.md"
 
 HOME = Path.home()
 BASELINE_PATH = HOME / ".claude" / ".context-budget-baseline.json"
@@ -142,7 +164,7 @@ def discover(cwd: str) -> list[dict]:
         items.append({"path": str(path), "kind": kind, "bytes": size,
                       "ceiling": ceiling, "defer_to": defer_to})
 
-    add(HOME / ".claude" / "CLAUDE.md", "global CLAUDE.md", GLOBAL_CEILING)
+    add(HOME / ".claude" / "CLAUDE.md", GLOBAL_KIND, GLOBAL_CEILING)
     add(_project_file(cwd, "CLAUDE.md"), "project CLAUDE.md", None)
     add(_memory_md(cwd), "MEMORY.md", None, defer_to="check-memory-md-cap.py")
     add(_project_file(cwd, "CONTEXT.md"), "project CONTEXT.md", None)
@@ -161,6 +183,22 @@ def discover(cwd: str) -> list[dict]:
     return out
 
 
+def is_project_anchored(items: list[dict]) -> bool:
+    """True iff discovery found at least one project-scoped file (not just the
+    global kernel). A bare home / non-project cwd discovers only the global
+    CLAUDE.md, so a baseline recorded there is a too-narrow floor that would
+    clobber a real multi-file floor and silently kill drift detection."""
+    return any(it["kind"] != GLOBAL_KIND for it in items)
+
+
+def safe_to_record(items: list[dict], ev: dict) -> bool:
+    """A discovery is safe to persist as the baseline floor only when it is
+    project-anchored AND does not narrow the scope of an existing baseline.
+    This is the single gate both the silent ratchet and (Guard A half) --accept
+    consult before writing."""
+    return is_project_anchored(items) and not ev["scope_narrowed"]
+
+
 # --- baseline persistence ------------------------------------------------------
 def load_baseline() -> dict | None:
     try:
@@ -169,10 +207,11 @@ def load_baseline() -> dict | None:
         return None
 
 
-def save_baseline(total: int, files: dict) -> None:
+def save_baseline(total: int, files: dict, kinds: list[str] | None = None) -> None:
     try:
         BASELINE_PATH.write_text(
-            json.dumps({"total": total, "files": files}, ensure_ascii=False, indent=2),
+            json.dumps({"total": total, "files": files, "kinds": kinds or []},
+                       ensure_ascii=False, indent=2),
             encoding="utf-8",
         )
     except Exception:
@@ -197,11 +236,26 @@ def mark_warned() -> None:
 def evaluate(items: list[dict], baseline: dict | None) -> dict:
     """Pure decision function (no I/O) so the self-test can drive it directly.
 
-    Returns {total, ceiling_hits, grew, growth_bytes, ratchet_down}."""
+    Returns {total, ceiling_hits, grew, growth_bytes, ratchet_down, base_total,
+    cur_kinds, scope_narrowed, missing_kinds}.
+
+    scope_narrowed = the recorded baseline knew about a file KIND we no longer
+    discover (current kinds are a strict subset of the baseline's). A drop in
+    total that comes from missing files — not a real slim — must NOT ratchet the
+    floor down to a narrower scope."""
     total = sum(it["bytes"] for it in items)
     ceiling_hits = [it for it in items
                     if it["ceiling"] is not None and it["bytes"] > it["ceiling"]]
     base_total = baseline.get("total") if baseline else None
+
+    cur_kinds = [it["kind"] for it in items]
+    cur_kset = set(cur_kinds)
+    base_kinds = set((baseline or {}).get("kinds") or [])
+    missing_kinds = sorted(base_kinds - cur_kset)
+    # only meaningful once a baseline persisted its kinds (older baselines have
+    # none -> base_kinds empty -> never narrowed, the safe backward-compat default)
+    scope_narrowed = bool(missing_kinds)
+
     grew = False
     growth = 0
     ratchet_down = False
@@ -217,7 +271,8 @@ def evaluate(items: list[dict], baseline: dict | None) -> dict:
             growth = total - base_total
     return {"total": total, "ceiling_hits": ceiling_hits, "grew": grew,
             "growth_bytes": growth, "ratchet_down": ratchet_down,
-            "base_total": base_total}
+            "base_total": base_total, "cur_kinds": cur_kinds,
+            "scope_narrowed": scope_narrowed, "missing_kinds": missing_kinds}
 
 
 def _kb(n: int) -> str:
@@ -243,6 +298,11 @@ def render_report(items: list[dict], ev: dict) -> str:
         delta = ev["total"] - ev["base_total"]
         sign = "+" if delta >= 0 else ""
         lines.append(f"  baseline floor {_kb(ev['base_total'])} (Δ {sign}{delta} B)")
+    if ev["missing_kinds"]:
+        lines.append(
+            f"  ⚠️ narrower scope than the floor — missing {ev['missing_kinds']} "
+            f"(run from your project root; the floor is NOT being ratcheted here)"
+        )
     return "\n".join(lines)
 
 
@@ -291,9 +351,15 @@ def hook_mode():
     ev = evaluate(items, baseline)
     files_map = {it["path"]: it["bytes"] for it in items}
 
-    # Ratchet the floor DOWN silently when at/below baseline (records the new low).
-    if ev["ratchet_down"]:
-        save_baseline(ev["total"], files_map)
+    # Ratchet the floor DOWN silently when at/below baseline (records the new
+    # low) — but ONLY from a scope that is safe to record. A non-project cwd
+    # (global-only discovery) or a narrower kind-set than the floor would
+    # otherwise clobber a good multi-file floor and silently disable drift
+    # detection. This is a deliberate, evaluated skip (the floor is preserved),
+    # not a silent no-op: being in a non-project cwd is legitimate and not
+    # actionable, so hook mode stays quiet; --report / --accept carry the signal.
+    if ev["ratchet_down"] and safe_to_record(items, ev):
+        save_baseline(ev["total"], files_map, ev["cur_kinds"])
 
     msg = build_warning(items, ev)
     if msg is None or warned_today():
@@ -307,8 +373,8 @@ def hook_mode():
     }))
 
 
-def report_mode():
-    items = discover(os.getcwd())
+def report_mode(cwd: str | None = None):
+    items = discover(cwd or os.getcwd())
     ev = evaluate(items, load_baseline())
     print(render_report(items, ev))
     msg = build_warning(items, ev)
@@ -316,16 +382,49 @@ def report_mode():
         print("\n" + msg)
 
 
-def accept_mode():
-    items = discover(os.getcwd())
+def accept_mode(cwd: str | None = None) -> int:
+    """Record the current always-loaded total as the baseline floor.
+
+    Refuses (nonzero) when discovery is NOT project-anchored — i.e. the command
+    is running from a non-project cwd where only the global kernel is visible.
+    Recording there would set a too-narrow floor that masks real drift in every
+    project session. A narrowing relative to an existing multi-file baseline from
+    a real project root is allowed (intentional slim) but noted."""
+    cwd = cwd or os.getcwd()
+    items = discover(cwd)
+    if not is_project_anchored(items):
+        n = len(items)
+        print(
+            f"refusing to record a baseline: this looks like a non-project cwd — "
+            f"discovered only the global kernel ({n} file{'' if n == 1 else 's'}, "
+            f"no project CLAUDE.md / MEMORY.md / CONTEXT.md). A baseline recorded "
+            f"here would be a too-narrow floor that masks real drift in your "
+            f"project sessions. Re-run --accept from your project root.",
+            file=sys.stderr,
+        )
+        return 1
     total = sum(it["bytes"] for it in items)
-    save_baseline(total, {it["path"]: it["bytes"] for it in items})
-    print(f"baseline floor set to {_kb(total)} ({total} B)")
+    base = load_baseline()
+    missing = sorted(set((base or {}).get("kinds") or []) - {it["kind"] for it in items})
+    if missing:
+        print(
+            f"note: recording a narrower floor than the previous baseline — "
+            f"missing {missing}. Recording anyway (explicit --accept from a "
+            f"project root)."
+        )
+    save_baseline(total, {it["path"]: it["bytes"] for it in items},
+                  [it["kind"] for it in items])
+    kinds = ", ".join(it["kind"] for it in items)
+    print(f"baseline floor set to {_kb(total)} ({total} B), {len(items)} files: {kinds}")
+    return 0
 
 
 def self_test() -> int:
-    """Positive (over-ceiling fires) + negative (lean is silent) + drift + shrink.
-    Drives the pure evaluate() so no real home files are touched."""
+    """Positive (over-ceiling fires) + negative (lean is silent) + drift + shrink
+    + scope-safety (the GUARD-RECORDS-BASELINE-FROM-WRONG-SCOPE fix). Drives the
+    pure evaluate()/predicates so no real home files are touched, plus end-to-end
+    discover()/accept_mode() against a synthesized temp HOME."""
+    global HOME, BASELINE_PATH
     fails = []
 
     def mk(bytes_, kind, ceiling, defer=None):
@@ -333,14 +432,14 @@ def self_test() -> int:
                 "ceiling": ceiling, "defer_to": defer}
 
     # 1. POSITIVE: a global CLAUDE.md over the 40KB ceiling must fire.
-    items = [mk(74100, "global CLAUDE.md", GLOBAL_CEILING),
+    items = [mk(74100, GLOBAL_KIND, GLOBAL_CEILING),
              mk(10000, "project CONTEXT.md", None)]
     ev = evaluate(items, {"total": 84100})  # baseline == current -> no growth
     if not ev["ceiling_hits"] or build_warning(items, ev) is None:
         fails.append("POSITIVE: over-ceiling did not fire")
 
     # 2. NEGATIVE: a lean layer at/under the floor and ceilings must be silent.
-    items = [mk(30000, "global CLAUDE.md", GLOBAL_CEILING),
+    items = [mk(30000, GLOBAL_KIND, GLOBAL_CEILING),
              mk(8000, "project CONTEXT.md", None)]
     ev = evaluate(items, {"total": 40000})  # current 38000 < baseline -> shrink
     if build_warning(items, ev) is not None:
@@ -349,22 +448,49 @@ def self_test() -> int:
         fails.append("SHRINK: did not ratchet the floor down")
 
     # 3. DRIFT: total grows past floor + tolerance -> warn (no ceiling hit).
-    items = [mk(20000, "global CLAUDE.md", GLOBAL_CEILING),
+    items = [mk(20000, GLOBAL_KIND, GLOBAL_CEILING),
              mk(20000, "project CLAUDE.md", None)]
     ev = evaluate(items, {"total": 30000})  # +10000 over 30000 floor >> tol
     if not ev["grew"] or build_warning(items, ev) is None:
         fails.append("DRIFT: growth past baseline did not fire")
 
     # 4. TOLERANCE: a tiny add under tolerance must NOT warn.
-    items = [mk(30500, "global CLAUDE.md", GLOBAL_CEILING)]
+    items = [mk(30500, GLOBAL_KIND, GLOBAL_CEILING)]
     ev = evaluate(items, {"total": 30000})  # +500 < max(4096, 2%) tol
     if ev["grew"]:
         fails.append("TOLERANCE: tiny add false-fired")
 
-    # 5. END-TO-END: real discover() + a synthesized over-ceiling global file in a
+    # 5. ANCHOR: project-anchored detection (global-only vs has-project-file).
+    if is_project_anchored([mk(40000, GLOBAL_KIND, GLOBAL_CEILING)]):
+        fails.append("ANCHOR: global-only discovery wrongly deemed project-anchored")
+    if not is_project_anchored([mk(40000, GLOBAL_KIND, GLOBAL_CEILING),
+                                mk(5000, "project CLAUDE.md", None)]):
+        fails.append("ANCHOR: project file present but not anchored")
+
+    # 6. SCOPE-NARROWED: a baseline recorded with 4 kinds, then a global-only
+    #    discovery, must register narrowed AND must NOT be safe to record — the
+    #    silent ratchet has to skip rather than clobber the multi-file floor.
+    base4_kinds = [GLOBAL_KIND, "project CLAUDE.md", "MEMORY.md", "project CONTEXT.md"]
+    items = [mk(39751, GLOBAL_KIND, GLOBAL_CEILING)]  # the real-world bug input
+    ev = evaluate(items, {"total": 134000, "kinds": base4_kinds})
+    if not ev["scope_narrowed"]:
+        fails.append("SCOPE: global-only vs 4-kind baseline not flagged as narrowed")
+    if not ev["ratchet_down"]:
+        fails.append("SCOPE: 39.8K < 134K should compute ratchet_down (pre-guard)")
+    if safe_to_record(items, ev):
+        fails.append("SCOPE: global-only discovery was wrongly deemed safe to record")
+
+    # 7. NOT-NARROWED: a real multi-file discovery at/under a same-kind floor is
+    #    safe to record (the legitimate shrink path still ratchets).
+    items = [mk(30000, GLOBAL_KIND, GLOBAL_CEILING),
+             mk(8000, "project CLAUDE.md", None)]
+    ev = evaluate(items, {"total": 50000, "kinds": [GLOBAL_KIND, "project CLAUDE.md"]})
+    if ev["scope_narrowed"] or not safe_to_record(items, ev):
+        fails.append("NOT-NARROWED: same-kind shrink wrongly blocked from ratchet")
+
+    # 8. END-TO-END: real discover() + a synthesized over-ceiling global file in a
     #    temp HOME proves the I/O path, not just the pure function. Isolate from a
     #    live CLAUDE_PROJECT_DIR so the real vault files can't leak into the check.
-    global HOME, BASELINE_PATH
     old_home, old_base = HOME, BASELINE_PATH
     old_proj = os.environ.pop("CLAUDE_PROJECT_DIR", None)
     try:
@@ -375,7 +501,7 @@ def self_test() -> int:
             HOME = Path(td)
             BASELINE_PATH = Path(td) / ".claude" / ".context-budget-baseline.json"
             its = discover(td)
-            g = [i for i in its if i["kind"] == "global CLAUDE.md"]
+            g = [i for i in its if i["kind"] == GLOBAL_KIND]
             ev2 = evaluate(its, None)
             if not g or not ev2["ceiling_hits"]:
                 fails.append("E2E: temp-home over-ceiling not detected")
@@ -386,11 +512,56 @@ def self_test() -> int:
         if old_proj is not None:
             os.environ["CLAUDE_PROJECT_DIR"] = old_proj
 
+    # 9. E2E ACCEPT — negative control (the regression this ticket fixes): from a
+    #    non-project cwd, --accept must REFUSE and must NOT write a baseline file;
+    #    positive control: from a project cwd (has a CLAUDE.md) it accepts and
+    #    persists the kind set.
+    old_home, old_base = HOME, BASELINE_PATH
+    old_proj = os.environ.pop("CLAUDE_PROJECT_DIR", None)
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            tdp = Path(td)
+            (tdp / ".claude").mkdir(parents=True)
+            (tdp / ".claude" / "CLAUDE.md").write_text("g" * 39751, encoding="utf-8")
+            HOME = tdp
+            BASELINE_PATH = tdp / ".claude" / ".context-budget-baseline.json"
+
+            # NEGATIVE: a bare subdir with no project CLAUDE.md/MEMORY/CONTEXT.
+            bare = tdp / "elsewhere"
+            bare.mkdir()
+            with contextlib.redirect_stdout(io.StringIO()), \
+                    contextlib.redirect_stderr(io.StringIO()):
+                rc = accept_mode(cwd=str(bare))
+            if rc == 0:
+                fails.append("E2E-ACCEPT-NEG: --accept from non-project cwd did not refuse")
+            if BASELINE_PATH.exists():
+                fails.append("E2E-ACCEPT-NEG: refusal still wrote a baseline file")
+
+            # POSITIVE: a project cwd with a CLAUDE.md -> accept + persist kinds.
+            proj = tdp / "proj"
+            proj.mkdir()
+            (proj / "CLAUDE.md").write_text("p" * 6000, encoding="utf-8")
+            with contextlib.redirect_stdout(io.StringIO()), \
+                    contextlib.redirect_stderr(io.StringIO()):
+                rc2 = accept_mode(cwd=str(proj))
+            if rc2 != 0:
+                fails.append("E2E-ACCEPT-POS: --accept from project cwd refused unexpectedly")
+            saved = load_baseline()
+            if not saved or "project CLAUDE.md" not in (saved.get("kinds") or []):
+                fails.append("E2E-ACCEPT-POS: accepted baseline missing persisted kinds")
+    except Exception as e:
+        fails.append(f"E2E-ACCEPT: raised {e}")
+    finally:
+        HOME, BASELINE_PATH = old_home, old_base
+        if old_proj is not None:
+            os.environ["CLAUDE_PROJECT_DIR"] = old_proj
+
     if fails:
         for f in fails:
             print(f"FAIL: {f}")
         return 1
-    print("OK: context-budget-measure self-test passed (positive + negative + drift + tolerance + e2e)")
+    print("OK: context-budget-measure self-test passed "
+          "(positive + negative + drift + tolerance + anchor + scope + e2e + accept-refusal)")
     return 0
 
 
@@ -401,14 +572,15 @@ def main():
         report_mode()
         return
     if "--accept" in sys.argv:
-        accept_mode()
-        return
+        sys.exit(accept_mode())
     hook_mode()
 
 
 if __name__ == "__main__":
     try:
         main()
+    except SystemExit:
+        raise
     except Exception:
         # never crash-block a session start
         noop()


### PR DESCRIPTION
Fixes MYC-1243.

`context-budget-measure.py` `discover()` walks up from the cwd to find the project `CLAUDE.md` / `MEMORY.md` / `CONTEXT.md`. Run from a non-project cwd (e.g. a bare home dir) it sees only the global kernel, so `--accept` and the silent SessionStart ratchet recorded a global-only floor — clobbering a real multi-file floor and silently disabling drift detection (the per-file ceiling check still worked, so it looked healthy).

- `is_project_anchored()` gates baseline writes on a project-scoped file being present. `--accept` from a non-project cwd refuses + exits nonzero; the SessionStart ratchet skips instead of overwriting a good floor.
- The baseline now persists its file-*kind* set; `evaluate()` flags `scope_narrowed` when the current kinds are a strict subset of the recorded floor, so a narrower discovery never silently ratchets it down. `safe_to_record()` is the single gate both the ratchet and `--accept` consult.
- `--self-test` gains: anchor detection, `scope_narrowed`/`safe_to_record`, and end-to-end accept-refusal (negative control) + accept-from-project (positive control).
- `docs/context-budget.md`: scope-safety note + `--accept` must run from the project root.

DHH-scoped: a fail-loud check on baseline write, not a new framework; fail-open + frequency-cap discipline preserved. Local parity: `--self-test` green under Python 3.9, `py_compile` 3.9 OK, ruff clean.

🤖 Authored by Claude (Opus 4.8) via Claude Code.