### PR TITLE
docs(funnel): UTM-tag first-week Substack links so install traffic is attributable

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ El bootstrap es idempotente — al re-correrlo después de un `git pull` instala
 
 Tu vault queda vivo apenas termina el instalador. La primera semana, lo que importa es el hábito: corré `/journal` cada noche, corré `/second-brain-mapping` cuando tus notas estén adentro, y preguntá "¿qué pensaría el panel?" antes de cualquier decisión importante. Para el día ocho vas a sentir para qué sirve el cerebro.
 
-El recorrido: [Tu primera semana con tu segundo cerebro](https://perspectivasblog.substack.com/p/tu-primera-semana-con-tu-segundo). Vale leerlo la noche que instalás.
+El recorrido: [Tu primera semana con tu segundo cerebro](https://perspectivasblog.substack.com/p/tu-primera-semana-con-tu-segundo?utm_source=ai-brain-starter&utm_medium=readme&utm_campaign=first-week). Vale leerlo la noche que instalás.
 
 ### Qué es gratis, y qué agrega Mycelium
 
@@ -311,7 +311,7 @@ Todo lo de arriba es gratis, MIT, y tuyo. El vault vive en tu disco y la intelig
 
 Your vault is live the moment the installer finishes. For the first week, the habit is what matters: run `/journal` each night, run `/second-brain-mapping` once your notes are in, and ask "what would the panel think?" before any real decision. By day eight you feel what the brain is for.
 
-The walkthrough: [Your First Week With Your Second Brain](https://adelaidadiazroa.substack.com/p/your-first-week-with-your-second). Worth reading the night you install.
+The walkthrough: [Your First Week With Your Second Brain](https://adelaidadiazroa.substack.com/p/your-first-week-with-your-second?utm_source=ai-brain-starter&utm_medium=readme&utm_campaign=first-week). Worth reading the night you install.
 
 ### Joining an existing team vault
 

--- a/phases/phase-19-23-finish.md
+++ b/phases/phase-19-23-finish.md
@@ -391,7 +391,7 @@ Tell the user in their PRIMARY_LANGUAGE only. Show one link, matching their lang
 >
 > Week 1 will feel quiet. If you do these three things, by day eight you'll feel what the brain is for. If you skip them, the vault sits in your Obsidian folder doing nothing.
 >
-> Longer walkthrough: https://adelaidadiazroa.substack.com/p/your-first-week-with-your-second
+> Longer walkthrough: https://adelaidadiazroa.substack.com/p/your-first-week-with-your-second?utm_source=ai-brain-starter&utm_medium=install&utm_campaign=first-week&utm_content=phase24
 >
 > Read it tonight. Stuck on anything? Just say so in any session."
 
@@ -407,7 +407,7 @@ Tell the user in their PRIMARY_LANGUAGE only. Show one link, matching their lang
 >
 > La primera semana se va a sentir callada. Si hacés estas tres cosas, para el día ocho vas a sentir para qué sirve el cerebro. Si te las saltás, el vault se queda en tu carpeta de Obsidian sin hacer nada.
 >
-> Recorrido más largo: https://perspectivasblog.substack.com/p/tu-primera-semana-con-tu-segundo
+> Recorrido más largo: https://perspectivasblog.substack.com/p/tu-primera-semana-con-tu-segundo?utm_source=ai-brain-starter&utm_medium=install&utm_campaign=first-week&utm_content=phase24
 >
 > Leelo esta noche. ¿Atascado en algo? Solo decilo en cualquier sesión."
 


### PR DESCRIPTION
## Why

Adelaida asked why install finishers aren't showing up at the *Your First Week With Your Second Brain* post. Investigation (against `origin/main`):

- **The wire already exists** — SKILL.md Phase 24 is mandatory and prints the language-conditional first-week link with inline orientation.
- **Top-of-funnel is healthy** — 516 unique clones / 14d (Repo Traffic Dashboard).
- **The post is starved** — 100 views *lifetime*; referrers are 59% email / 21% direct / 12% substack-app / 3% google, and **0% github/install**.

Root cause for the invisibility: install-flow clicks open the post from the **Claude Code terminal**, which sends **no HTTP referrer**, so every click buckets as `direct` in Substack analytics. The funnel can't be seen or measured.

## Change

UTM-tag all four first-week link instances (query-params only, no copy/flow change):

| Surface | tag |
|---|---|
| README EN/ES | `utm_medium=readme` |
| Phase 24 EN/ES handoff | `utm_medium=install&utm_content=phase24` |

Now Substack growth-sources can separate install-flow arrivals from README arrivals, and terminal clicks stop hiding in `direct`.

## Not in this PR (separate lever)
Reach: Phase 24 sits at the tail of a 25-phase flow the installer often truncates before. Fixing that is a measurement-first job (instrument Phase-24 reach from install telemetry) — not a copy-jam into the mechanical journaling phase. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)