### PR TITLE
fix(close-signal): guard definitional/quoted close phrases + add personal customOnly/suppress knobs

### DIFF
--- a/hooks/detect-closing-signal.py
+++ b/hooks/detect-closing-signal.py
@@ -48,6 +48,14 @@ Environment variables (all optional):
   CLOSING_SIGNAL_DEBUG — set to 1 for stderr trace
   ANTHROPIC_API_KEY — required only if CLOSING_SIGNAL_DETECTION=hybrid
 
+User config (CLAUDE.md at the resolved vault root, all optional):
+  closingSignals.custom: ["...", ...]   — ADD literal phrases that always fire
+                                          (highest-authority positive tier).
+  closingSignals.suppress: ["...", ...] — SUBTRACT literal phrases that never
+                                          fire, even if a pack matches.
+  closingSignals.customOnly: true       — fire ONLY on `custom`; skip the shared
+                                          packs entirely (deliberate-close-only).
+
 Output marker file:
   ~/.claude/.closing-signal-{session_id}.json
   Contains: timestamp, matched signal, language, confidence, pre-resolved paths
@@ -144,6 +152,26 @@ def load_language_packs(langs: list[str]) -> dict:
     return merged
 
 
+def _extract_quoted_phrases(raw: str) -> list[str]:
+    r"""Extract phrases from an inline array like ["a", "b's done", 'c'].
+
+    Handles BOTH double- and single-quoted entries and, crucially, allows an
+    apostrophe INSIDE a double-quoted entry ("i'm done", "that's all"). The
+    previous extractor (``[\"']([^\"']+)[\"']``) treated every quote char as a
+    delimiter, so it fragmented on an inner apostrophe — silently corrupting
+    any phrase containing one (e.g. "let's close this session" became the stray
+    token "let", which then matched "let me" everywhere, and "i'm done" became
+    "i", which matched the "i" in "this"). Returns each phrase re.escaped for
+    literal substring matching.
+    """
+    items: list[str] = []
+    for dq, sq in re.findall(r'"([^"]*)"|\'([^\']*)\'', raw):
+        phrase = (dq or sq).strip()
+        if phrase:
+            items.append(re.escape(phrase))
+    return items
+
+
 def load_user_custom_signals(vault_root: Path) -> list[str]:
     """Read user's CLAUDE.md for closingSignals.custom: [...]."""
     claude_md = vault_root / "CLAUDE.md"
@@ -161,11 +189,67 @@ def load_user_custom_signals(vault_root: Path) -> list[str]:
     )
     if not match:
         return []
-    raw = match.group(1)
-    items = []
-    for piece in re.findall(r"[\"']([^\"']+)[\"']", raw):
-        items.append(re.escape(piece.strip()))
-    return items
+    return _extract_quoted_phrases(match.group(1))
+
+
+def load_user_suppress_signals(vault_root: Path) -> list[str]:
+    """Read user's CLAUDE.md for closingSignals.suppress: [...].
+
+    SUBTRACTIVE counterpart to closingSignals.custom. Each entry is a literal
+    phrase that must NEVER fire a close for this user — even when a shared
+    language pack would otherwise match it. Checked right after strict_guards
+    (so it overrides both custom and the packs). This lets a user narrow the
+    shared default ("i'm done" / "good night" stop closing *for them*) without
+    weakening the public pack for everyone. Opt-in: an absent key yields an
+    empty list, so default behavior is byte-identical to before.
+    """
+    claude_md = vault_root / "CLAUDE.md"
+    if not claude_md.is_file():
+        return []
+    try:
+        text = claude_md.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    match = re.search(
+        r"closingSignals\.suppress\s*[:=]\s*\[([^\]]*)\]",
+        text,
+        re.IGNORECASE,
+    )
+    if not match:
+        return []
+    return _extract_quoted_phrases(match.group(1))
+
+
+def load_user_custom_only(vault_root: Path) -> bool:
+    """Read user's CLAUDE.md for closingSignals.customOnly: true|false.
+
+    When true, ONLY the user's closingSignals.custom patterns participate in
+    positive detection — the shared en/es/pt language-pack tiers are skipped
+    entirely. The always-on negative tiers (strict_guards, suppress) still
+    apply. This is the "deliberate close only" mode: natural sign-offs (bye /
+    good night / i'm done / ya está / thanks that's all) no longer fire for
+    this user; only their explicit custom phrases do. Opt-in: absent or false
+    leaves the shared packs participating exactly as before.
+
+    Footgun: customOnly true with an EMPTY closingSignals.custom list means
+    nothing fires at all (only-my-zero-phrases). Pair it with a populated
+    custom list.
+    """
+    claude_md = vault_root / "CLAUDE.md"
+    if not claude_md.is_file():
+        return False
+    try:
+        text = claude_md.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    match = re.search(
+        r"closingSignals\.customOnly\s*[:=]\s*(true|false|yes|no|on|off|1|0)",
+        text,
+        re.IGNORECASE,
+    )
+    if not match:
+        return False
+    return match.group(1).lower() in ("true", "yes", "on", "1")
 
 
 def is_false_positive(prompt: str, guards: list) -> bool:
@@ -186,10 +270,23 @@ def is_false_positive(prompt: str, guards: list) -> bool:
     return False
 
 
-def classify_signal(prompt: str, packs: dict, custom: list[str]) -> tuple[str | None, str | None]:
+def classify_signal(
+    prompt: str,
+    packs: dict,
+    custom: list[str],
+    suppress: list[str] | None = None,
+    custom_only: bool = False,
+) -> tuple[str | None, str | None]:
     """Return (confidence, matched_pattern) or (None, None) if no match.
 
     Confidence levels: explicit > high > ambiguous > emoji.
+
+    Negative tiers (both default off, so behavior is unchanged when unset):
+      suppress    — literal phrases that NEVER fire for this user; overrides
+                    custom + packs. From closingSignals.suppress in CLAUDE.md.
+      custom_only — when True, only `custom` participates as a positive tier;
+                    the shared en/es/pt pack tiers are skipped. From
+                    closingSignals.customOnly in CLAUDE.md.
     """
     if not prompt or not prompt.strip():
         return (None, None)
@@ -214,6 +311,14 @@ def classify_signal(prompt: str, packs: dict, custom: list[str]) -> tuple[str | 
         log_debug("strict guard matched, suppressing ALL tiers")
         return (None, None)
 
+    # SUPPRESS (personal, subtractive): phrases the user has declared are
+    # NEVER a close for them. Checked right after strict_guards — before
+    # custom and the shared packs — so it overrides every positive tier.
+    # Opt-in via closingSignals.suppress; empty by default (no-op).
+    if suppress and is_false_positive(text, suppress):
+        log_debug("user suppress phrase matched, suppressing ALL tiers")
+        return (None, None)
+
     # User custom patterns are highest authority — always win, FP guard skipped
     for pattern in custom:
         try:
@@ -221,6 +326,15 @@ def classify_signal(prompt: str, packs: dict, custom: list[str]) -> tuple[str | 
                 return ("explicit", pattern)
         except re.error:
             continue
+
+    # customOnly (personal): the user opted into deliberate-close-only mode.
+    # Do NOT fall through to the shared language-pack tiers — only their custom
+    # phrases (checked just above) plus the always-on negative tiers
+    # (strict_guards, suppress) participate. Natural sign-offs no longer fire.
+    # Opt-in via closingSignals.customOnly; default false (no-op).
+    if custom_only:
+        log_debug("customOnly set and no custom match — skipping shared pack tiers")
+        return (None, None)
 
     # Strong tiers (explicit, high_confidence) override FP guards
     for level in ("explicit", "high_confidence"):
@@ -788,8 +902,12 @@ def main() -> int:
         ]
         packs = load_language_packs(langs)
         custom = load_user_custom_signals(vault_root)
+        suppress = load_user_suppress_signals(vault_root)
+        custom_only = load_user_custom_only(vault_root)
 
-        confidence, matched = classify_signal(prompt, packs, custom)
+        confidence, matched = classify_signal(
+            prompt, packs, custom, suppress, custom_only
+        )
 
         # Hybrid: ambiguous matches OR no match get a Haiku second look
         if confidence in (None, "ambiguous"):

--- a/scripts/test-closing-signals.py
+++ b/scripts/test-closing-signals.py
@@ -126,12 +126,78 @@ FIXTURES: list[tuple[str, str, str | None]] = [
     ("neg-ok-now", "ok now I want to refactor", None),
     ("neg-bueno-entonces", "bueno, entonces sigamos", None),
     ("neg-beleza-agora", "beleza, agora vamos para o próximo", None),
+
+    # === Meta-definition of close signals — MUST NOT fire (MYC-1266) ===
+    # The message DEFINES/lists close phrases and contains the literal phrase
+    # "lets close this session" as an EXAMPLE. Without the definitional
+    # strict_guard this matches high_confidence; with it, suppressed.
+    ("neg-definitional-convention",
+     "session close isn't i'm done or ya esta or anything other than "
+     "lets close this session or start closing cascade", None),
+    ("neg-isnt-a-close-signal", "'good night' isn't a close signal for me", None),
+    ("neg-only-these-trigger",
+     "the only phrases that close the session are 'close this session' "
+     "and 'start closing cascade'", None),
+    ("neg-other-than-close",
+     'anything other than "close this session" should not trigger it', None),
 ]
 
 
-def run_detector(prompt: str) -> dict:
-    """Pipe prompt through the detector hook, return parsed JSON."""
+# === Config-dependent fixtures (MYC-1266): (id, prompt, expected, claude_md) ===
+# Seed a CLAUDE.md with per-user closingSignals.* keys to exercise the
+# customOnly + suppress tiers. _CUSTOM_ONLY_MD = deliberate-close-only;
+# _SUPPRESS_MD = subtract a few phrases while the shared packs still fire.
+_CUSTOM_ONLY_MD = (
+    'closingSignals.custom: ["close this session", "lets close this session", '
+    '"start closing cascade"]\n'
+    "closingSignals.customOnly: true\n"
+)
+_SUPPRESS_MD = (
+    "closingSignals.suppress: [\"i'm done\", \"ya está\", \"good night\"]\n"
+)
+
+CONFIG_FIXTURES: list[tuple[str, str, str | None, str]] = [
+    # customOnly: only the explicit custom phrases fire; natural sign-offs off.
+    ("co-start-cascade", "start closing cascade", "explicit", _CUSTOM_ONLY_MD),
+    ("co-close-session", "close this session", "explicit", _CUSTOM_ONLY_MD),
+    ("co-lets-close", "lets close this session", "explicit", _CUSTOM_ONLY_MD),
+    ("co-bye-off", "bye", None, _CUSTOM_ONLY_MD),
+    ("co-good-night-off", "good night", None, _CUSTOM_ONLY_MD),
+    ("co-im-done-off", "i'm done", None, _CUSTOM_ONLY_MD),
+    ("co-thanks-off", "thanks, that's all", None, _CUSTOM_ONLY_MD),
+    ("co-ya-esta-off", "ya está", None, _CUSTOM_ONLY_MD),
+    ("co-ttyl-off", "ttyl", None, _CUSTOM_ONLY_MD),
+    # definitional message must NOT fire even though it contains the literal
+    # custom phrase "lets close this session" (strict_guard beats custom).
+    ("co-definitional-off",
+     "session close isn't i'm done or ya esta or anything other than "
+     "lets close this session or start closing cascade", None, _CUSTOM_ONLY_MD),
+
+    # suppress (customOnly off): named phrases never fire; others still do.
+    ("sup-im-done-off", "i'm done", None, _SUPPRESS_MD),
+    ("sup-ya-esta-off", "ya está", None, _SUPPRESS_MD),
+    ("sup-good-night-off", "good night", None, _SUPPRESS_MD),
+    ("sup-bye-still-fires", "bye", "high_confidence", _SUPPRESS_MD),
+    ("sup-close-session-still-fires", "close this session", "high_confidence", _SUPPRESS_MD),
+]
+
+
+def run_detector(prompt: str, claude_md: str | None = None) -> dict:
+    """Pipe prompt through the detector hook, return parsed JSON.
+
+    When claude_md is provided, it is written to a CLAUDE.md at the temp vault
+    root so the per-user keys (closingSignals.custom / .suppress / .customOnly)
+    are exercised. VAULT_ROOT is pinned to the temp dir so the test is hermetic
+    and never reads the developer's real vault CLAUDE.md.
+    """
     with tempfile.TemporaryDirectory() as tmp:
+        if claude_md is not None:
+            (Path(tmp) / "CLAUDE.md").write_text(claude_md, encoding="utf-8")
+        # The detector skips the cascade (passthrough) unless a Meta/ dir
+        # exists to write artifacts into (verify_meta_dir). Create one so the
+        # test is hermetic and self-contained — it must NOT depend on an
+        # inherited VAULT_ROOT pointing at a real vault (CI has none).
+        (Path(tmp) / "Meta").mkdir(exist_ok=True)
         hook_input = json.dumps({
             "prompt": prompt,
             "session_id": "test-harness",
@@ -139,6 +205,7 @@ def run_detector(prompt: str) -> dict:
         })
         env = {**os.environ}
         env["CLOSING_SIGNAL_DETECTION"] = "regex"  # never call Haiku in tests
+        env["VAULT_ROOT"] = tmp  # hermetic: read THIS tmp's CLAUDE.md, not the dev box's
         env.pop("ANTHROPIC_API_KEY", None)
         try:
             proc = subprocess.run(
@@ -183,10 +250,14 @@ def main() -> int:
         print(f"FAIL: detector not found at {DETECTOR}")
         return 1
 
-    fixtures = FIXTURES
+    # Unify default fixtures (no CLAUDE.md) with config-dependent fixtures.
+    all_fixtures: list[tuple[str, str, str | None, str | None]] = (
+        [(fid, prompt, expected, None) for fid, prompt, expected in FIXTURES]
+        + list(CONFIG_FIXTURES)
+    )
     if args.fixture:
-        fixtures = [f for f in FIXTURES if f[0] == args.fixture]
-        if not fixtures:
+        all_fixtures = [f for f in all_fixtures if f[0] == args.fixture]
+        if not all_fixtures:
             print(f"FAIL: fixture not found: {args.fixture}")
             return 1
 
@@ -194,8 +265,8 @@ def main() -> int:
     failed = 0
     failures = []
 
-    for fid, prompt, expected in fixtures:
-        result = run_detector(prompt)
+    for fid, prompt, expected, claude_md in all_fixtures:
+        result = run_detector(prompt, claude_md)
         actual = detected_confidence(result)
         ok = actual == expected
         if args.verbose or not ok:

--- a/templates/closing-signals/en.json
+++ b/templates/closing-signals/en.json
@@ -1,6 +1,6 @@
 {
   "language": "en",
-  "_comment": "English closing signals. Patterns are Python regex with case-insensitive matching. The hook compiles them with re.IGNORECASE | re.MULTILINE. Add to 'custom' in CLAUDE.md frontmatter to extend per-user.",
+  "_comment": "English closing signals. Patterns are Python regex with case-insensitive matching. The hook compiles them with re.IGNORECASE | re.MULTILINE. Per-user tuning in CLAUDE.md: 'closingSignals.custom' ADDS always-fire phrases; 'closingSignals.suppress' SUBTRACTS never-fire phrases (overrides packs); 'closingSignals.customOnly: true' fires ONLY on custom and skips these shared tiers (deliberate-close-only).",
 
   "explicit": [
     "^/(close|wrap-?up|bye|done|finish)\\b",
@@ -121,6 +121,22 @@
     {
       "_comment": "Prompt is clearly a question / request about closing behavior rather than a sign-off itself (auto archiv|keep firing|keep creating|keep writing).",
       "pattern": "\\b(auto[\\s-]?archiv|keep\\s+firing|keep\\s+creating|keep\\s+writing|over[\\s-]?firing|over[\\s-]?triggering|spurious|false[\\s-]?positive|extra\\s+stubs?|empty\\s+stubs?)\\b"
+    },
+    {
+      "_comment": "Meta-DEFINITION: a close-signal NOUN PHRASE ('session close', 'close signal', 'closing cascade') immediately tied to is/isn't/means/counts-as/should — the user is DEFINING what counts as a close, not issuing one ('session close isn't ...', 'the close signal means ...'). Codified 2026-06-19 (MYC-1266) after a definitional message containing the literal custom phrase fired the explicit tier. Tight noun+verb adjacency so a genuine imperative close ('lets close this session', 'start closing cascade') is NOT suppressed.",
+      "pattern": "\\b(session\\s+close|close\\s+signal|closing\\s+signal|closing\\s+cascade|close\\s+trigger|close\\s+phrase)\\b.{0,40}\\b(is\\s?n'?t|are\\s?n'?t|is\\s+not|means?|counts?\\s+as|should|shouldn'?t|do\\s?n'?t)\\b"
+    },
+    {
+      "_comment": "Meta-DEFINITION: 'isn't / is not / don't (count) ... a close|closing signal|trigger|phrase|command' — describing what is or isn't a close trigger. Requires the explicit 'close/closing <signal-word>' phrase so 'this isn't working, end the session' (a genuine close) is NOT caught.",
+      "pattern": "\\b(is\\s?n'?t|are\\s?n'?t|is\\s+not|are\\s+not|do\\s?n'?t|does\\s?n'?t)\\b.{0,40}\\b(a\\s+|the\\s+|my\\s+)?(close|closing|session[\\s-]?close)\\s*(signal|trigger|phrase|command|cascade|word)\\b"
+    },
+    {
+      "_comment": "Meta-ENUMERATION: 'anything other than ...' / 'the only close|closing|valid|way|phrase|trigger|thing ...' near a close/session/cascade word — listing the ONLY valid triggers, not issuing one ('anything other than \"close this session\"'). A genuine close never says 'anything other than'.",
+      "pattern": "\\b(anything\\s+other\\s+than|other\\s+than|the\\s+only\\s+(close|closing|valid|way|phrase|trigger|thing))\\b.{0,120}\\b(close|closing|cascade|session)\\b"
+    },
+    {
+      "_comment": "Meta-QUESTION about a close word — 'what does ttyl mean?', 'how do I say bye?', 'what's an example of a sign-off?'. Asking ABOUT a close phrase is referenced content, never a close itself. Promoted to strict because the weak-tier meta-question FP guard does NOT override a high_confidence match on the bare close word. MYC-1266 (same family as the definitional guards above).",
+      "pattern": "\\b(what|how|why|when|where|who|define|defines|explain|mean[s]?|spell[s]?|example\\s+of|stand[s]?\\s+for)\\b.{0,40}\\b(bye|ttyl|cya|gn|good\\s*night|wrapping|signing\\s+off|sign[\\s-]?off|close\\s+(this|the|out|up)\\s+session|closing\\s+cascade)\\b"
     }
   ]
 }


### PR DESCRIPTION
## What

`detect-closing-signal.py` false-fired on messages that DEFINE or QUOTE a close phrase. The custom literal-substring tier deliberately skips the false-positive guards, so a clarifying message containing `lets close this session` as an *example* fired the whole close cascade.

## Changes

1. **`en.json` strict_guards** — three definitional/meta guards so *referencing* a close phrase never fires one:
   - "session close isn't X" / "X is not a close signal"
   - "anything other than 'close this session'"
   - "what does ttyl mean?" (a question *about* a close word — pre-existing latent false-fire)

   Tight noun+verb adjacency keeps genuine imperative closes (`lets close this session`, `start closing cascade`) firing.
2. **Two opt-in, default-off personal knobs** read from CLAUDE.md (mirror `closingSignals.custom`):
   - `closingSignals.suppress: [...]` — literal phrases that NEVER fire (overrides custom + packs).
   - `closingSignals.customOnly: true` — fire ONLY on `custom`; skip the shared language-pack tiers (deliberate-close-only).

   Default behavior is byte-identical when both are unset.
3. **`_extract_quoted_phrases()`** — shared parser that fixes the apostrophe-fragmentation bug in the custom/suppress arrays (`"i'm done"` fragmented to a stray `"i"`, `"let's close"` to a stray `"let"`). Now handles apostrophes inside double-quoted entries, which also eliminates the documented `"let"` false-positive.

## Tests

- Extends `scripts/test-closing-signals.py` with the exact triggering message + the customOnly/suppress matrices (negative + positive controls).
- Made the harness hermetic (pins VAULT_ROOT + creates `Meta/`), which surfaced a pre-existing latent failure (question-about-ttyl) now fixed by the meta-question strict guard.
- 93/93 unit + 39 integration + shellcheck green locally (`bash scripts/ci.sh`).

MYC-1266

🤖 Generated with [Claude Code](https://claude.com/claude-code)