### PR TITLE
fix(close-cascade): shared mention-vs-use close-claim detector, de-drift both Stop hooks (MYC-791)

### DIFF
--- a/hooks/_lib/closing_claim.py
+++ b/hooks/_lib/closing_claim.py
@@ -1,0 +1,142 @@
+"""closing_claim — single source of truth for "is this assistant message
+claiming to close the session?"
+
+Used by the Stop-side verify hooks (verify-session-close-cascade.py,
+verify-discoverability-on-close.py), which previously each carried their own
+DRIFTED copy of CLOSING_PATTERNS / NEGATION_PATTERNS / is_closing_claim.
+
+Hazard this guards (MYC-791, promoted to High after it tore down a worktree
+mid-session 2026-06-19): a guard that scans assistant text for close PHRASES
+false-fires when the assistant is MENTIONING those phrases rather than USING
+them — quoting a sign-off as an example, discussing the close machinery, or
+defining what does/doesn't count as a close. The distinction is USE vs MENTION.
+The live incident: a report that listed "good night" / "buenas noches" as
+quoted examples of phrases that should NOT auto-close was itself read as a
+close claim, blocked the turn, and triggered worktree archive-prep.
+
+Resolution (USE beats MENTION):
+  1. Strip MENTION spans before matching — fenced code, inline backticks,
+     markdown blockquote lines, and double-quote spans. A close phrase that
+     survives ONLY inside a mention is a reference, not a claim. (Genuine
+     closes are never quoted, so they survive stripping and still fire.)
+  2. If an explicit DISCUSSION / DEFINITIONAL marker is present (terms that do
+     not appear in a genuine first-person sign-off), it is not a claim.
+  3. Otherwise, a CLOSING_PATTERN in the stripped text IS a claim.
+
+Single-quote spans are intentionally NOT stripped: apostrophes in ordinary
+prose ("don't", "it's") would fragment the span and over-strip. Double-quote /
+backtick / code / blockquote stripping covers the realistic mention forms.
+
+Pure stdlib, no imports beyond re. Fail-open is the caller's job (a caller that
+cannot read the transcript passes "" and gets False).
+"""
+
+from __future__ import annotations
+
+import re
+
+__all__ = ["is_closing_claim", "strip_mentions", "CLOSING_PATTERNS", "DISCUSSION_MARKERS"]
+
+# Union of the two hooks' previously-duplicated pattern lists, de-drifted.
+# Matched case-insensitively (re.IGNORECASE | re.MULTILINE) against the
+# MENTION-stripped text.
+CLOSING_PATTERNS = [
+    # English — first-person closure claims
+    r"\bclosing the session\b",
+    r"\bclosing this session\b",
+    r"\bsession (?:is )?closed\b",
+    r"\bclosing now\b",
+    r"\bwrapping up\b",
+    r"\bwrapping (?:the|this) session\b",
+    r"\bsession (?:summary|wrap[- ]?up|recap)\b",
+    r"\bcascade complete\b",
+    r"\brunning the (?:close )?cascade\b",
+    r"\bwriting the session artifact\b",
+    r"\bsession[- ]end cascade (?:hook should pick up|will handle)\b",
+    r"\bsafe to archive\b.*\bworktree\b",
+    r"\bdogfood install (?:complete|done)\b.*\bsession\b",
+    r"\bsigning off\b",
+    r"\bgood ?night\b",
+    r"^closing\.?\s*$",
+    r"^##\s+.*[—-]\s*final summary",
+    r"\bfinal summary\b.*\bsession\b",
+    # Spanish — late-night / closure phrasings
+    r"\bbuenas noches\b",
+    r"\bque (?:descanses|tengas|duermas)\b",
+    r"\bhasta (?:mañana|luego|pronto)\b",
+    r"\bdulces sueños\b",
+    r"\bnos vemos mañana\b",
+    r"\bcerrando la sesión\b",
+    r"\bcierro la sesión\b",
+    r"\bsesión cerrada\b",
+    r"\bchao\b.*\b(?:ade|adelaida)\b",
+]
+
+# Discussion / definitional context — if any appears, the message is ABOUT
+# closing, not claiming it. Deliberately conservative: every term here is one
+# that does NOT appear in a genuine first-person sign-off, so this never
+# suppresses a real close (which would re-open the gallant-kalam
+# incomplete-close gap). The MENTION stripping above does the heavy lifting;
+# this is the secondary net for unquoted meta-discussion.
+DISCUSSION_MARKERS = [
+    # original NEGATION terms (union of both hooks)
+    r"how do we make sure",
+    r"did you run",
+    r"did(?:n't| not) run",
+    r"keeps not happening",
+    r"\bI should have\b",
+    r"\bhow to\b",
+    r"why did(?:n't| not)",
+    r"\bthe fix is\b",
+    r"don't (?:want to|need to) close",
+    r"\bnot closing\b",
+    r"\bbefore closing\b",
+    r"\bdiscussing\b",
+    r"\bthe rule\b",
+    # mention-vs-use / definitional — absent from a genuine sign-off
+    r"false[- ]?fire",
+    r"false[- ]?positive",
+    r"is(?:n't| not) a close",
+    r"\bthe (?:close[- ]?signal )?detector\b",
+    r"\bclosing[- ]?claim\b",
+    r"\bno longer auto[- ]?close",
+]
+
+_CODE_FENCE = re.compile(r"```[\s\S]*?```")
+_INLINE_CODE = re.compile(r"`[^`]*`")
+_BLOCKQUOTE = re.compile(r"(?m)^\s{0,3}>.*$")
+_DQUOTE = re.compile(r"\"[^\"]*\"")
+_SMART_DQUOTE = re.compile(r"[“”][^“”]*[“”]")
+
+
+def strip_mentions(text: str) -> str:
+    """Remove spans the assistant is QUOTING/SHOWING rather than asserting:
+    fenced code, inline backticks, blockquote lines, and double-quote spans
+    (straight + smart). Order matters — fences before inline code."""
+    if not text:
+        return ""
+    text = _CODE_FENCE.sub(" ", text)
+    text = _INLINE_CODE.sub(" ", text)
+    text = _BLOCKQUOTE.sub(" ", text)
+    text = _DQUOTE.sub(" ", text)
+    text = _SMART_DQUOTE.sub(" ", text)
+    return text
+
+
+def is_closing_claim(text: str) -> bool:
+    """True iff `text` is a genuine first-person session-close claim — not a
+    mention, quote, or discussion of one."""
+    if not text:
+        return False
+    # Discussion/definitional context is checked on the ORIGINAL text so an
+    # explicit "discussing the close cascade" suppresses even unstripped prose.
+    for pat in DISCUSSION_MARKERS:
+        if re.search(pat, text, re.IGNORECASE):
+            return False
+    # Close patterns are checked on the MENTION-stripped text so a sign-off
+    # quoted as an example does not count.
+    stripped = strip_mentions(text)
+    for pat in CLOSING_PATTERNS:
+        if re.search(pat, stripped, re.IGNORECASE | re.MULTILINE):
+            return True
+    return False

--- a/hooks/verify-discoverability-on-close.py
+++ b/hooks/verify-discoverability-on-close.py
@@ -28,37 +28,22 @@ import sys
 from datetime import datetime, timedelta
 from pathlib import Path
 
+# Shared close-claim detector - single source of truth (_lib/closing_claim.py).
+# MENTION-vs-USE aware. Replaces this hook's previously-duplicated (and drifted)
+# CLOSING_PATTERNS / NEGATION_PATTERNS / _is_closing_claim. MYC-791.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    from _lib.closing_claim import is_closing_claim  # noqa: E402
+except Exception:  # fail-open: if the lib cannot load, never block a close
+    def is_closing_claim(_text: str) -> bool:  # type: ignore
+        return False
+
 VAULT_ROOT = Path(os.environ.get("VAULT_ROOT", str(Path.home() / "vault")))
 VERIFIER = VAULT_ROOT / "⚙️ Meta" / "scripts" / "discoverability-verifier.py"
 
-# Reuse the same closing-claim patterns as verify-session-close-cascade.py
-# so the two hooks fire on the same surface area.
-CLOSING_PATTERNS = [
-    r"\bclosing the session\b",
-    r"\bclosing this session\b",
-    r"\bsession closed\b",
-    r"\bsession is closed\b",
-    r"\bclosing now\b",
-    r"\bwrapping up\b",
-    r"\bwrapping the session\b",
-    r"\bgood ?night\b",
-    r"\bsigning off\b",
-    r"\bque (descanses|tengas|duermas)\b",
-    r"\bbuenas noches\b",
-    r"\bhasta (mañana|luego|pronto)\b",
-    r"^## .* — final summary",
-    r"^closing\.?$",
-]
-
-NEGATION_PATTERNS = [
-    r"don't (want to|need to) close",
-    r"not closing",
-    r"before closing",
-    r"discussing",
-    r"the rule",
-    r"why didn't",
-    r"the fix is",
-]
+# Closing-claim detection now lives in the shared _lib/closing_claim.py
+# imported above (de-drifted from verify-session-close-cascade.py, with
+# MENTION-vs-USE guards). MYC-791.
 
 
 def _get_last_assistant_text(transcript_path: str) -> str:
@@ -85,18 +70,6 @@ def _get_last_assistant_text(transcript_path: str) -> str:
         if text_parts:
             return "\n".join(text_parts)
     return ""
-
-
-def _is_closing_claim(text: str) -> bool:
-    if not text:
-        return False
-    for pat in NEGATION_PATTERNS:
-        if re.search(pat, text, re.IGNORECASE):
-            return False
-    for pat in CLOSING_PATTERNS:
-        if re.search(pat, text, re.IGNORECASE | re.MULTILINE):
-            return True
-    return False
 
 
 def _run_verifier() -> tuple[bool, str]:
@@ -147,7 +120,7 @@ def main() -> int:
 
     transcript_path = payload.get("transcript_path", "")
     last_text = _get_last_assistant_text(transcript_path)
-    if not _is_closing_claim(last_text):
+    if not is_closing_claim(last_text):
         return 0
 
     clean, gap_report = _run_verifier()

--- a/hooks/verify-session-close-cascade.py
+++ b/hooks/verify-session-close-cascade.py
@@ -53,6 +53,18 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+# Shared close-claim detector - single source of truth (_lib/closing_claim.py).
+# MENTION-vs-USE aware: a sign-off QUOTED as an example or DISCUSSED as meta is
+# not a close claim. Replaces this hook's previously-duplicated CLOSING_PATTERNS
+# / NEGATION_PATTERNS / is_closing_claim (which had drifted from the copy in
+# verify-discoverability-on-close.py). MYC-791.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    from _lib.closing_claim import is_closing_claim  # noqa: E402
+except Exception:  # fail-open: if the lib cannot load, never block a close
+    def is_closing_claim(_text: str) -> bool:  # type: ignore
+        return False
+
 VAULT_ROOT = Path(os.environ.get("VAULT_ROOT", str(Path.home() / "vault")))
 
 
@@ -101,62 +113,10 @@ def runner_installed() -> bool:
     """
     return RUNNER_SCRIPT.is_file()
 
-# High-confidence closing-claim patterns. Conservative — only matches when the
-# model is CLAIMING closure, not discussing the rule meta.
-#
-# Patterns extended 2026-05-11 after the gallant-kalam miss: the previous
-# regex set required literal "closing the session" / "closing this session",
-# but the model can claim closure via summary-style markdown headers
-# ("## Session ... — final summary") or one-word "Closing." replies. Both
-# slip past the old patterns. New patterns cover those forms.
-CLOSING_PATTERNS = [
-    # 2026-05-12 fix: dropped `\.?$` anchors. Previous version required the
-    # closing phrase to END a line; "Closing the session. Writing the artifact..."
-    # slipped through because "session." was mid-line. Now matches anywhere.
-    r"\bclosing the session\b",
-    r"\bclosing this session\b",
-    r"\bsession is closed\b",
-    r"\bsession[- ]end cascade hook should pick up\b",
-    r"\bsession[- ]end cascade will handle\b",
-    r"\bsafe to archive\b.*\bworktree\b",
-    r"\bcascade complete\b",
-    # 2026-05-11 additions — summary-style closure claims
-    r"^closing\.?\s*$",                     # bare "Closing." reply
-    r"^##\s+Session\s+.+—\s*final summary",  # ## Session ... — final summary
-    r"\bfinal summary\b.*\bsession\b",
-    r"\bsession (?:summary|wrap[- ]?up|recap)\b",
-    r"\bdogfood install (?:complete|done)\b.*\bsession\b",
-    # 2026-05-12 additions — late-night close phrasings the model uses
-    r"\bgood night\b",
-    r"\bwriting the session artifact\b",
-    r"\brunning the (?:close )?cascade\b",
-    # 2026-05-13 additions — Spanish closing phrasings (caught after the
-    # funny-golick-fe8400 miss where "Que descanses, Ade" slipped past the
-    # English-only patterns and 5 files almost got discarded at archive)
-    r"\bque descanses\b",
-    r"\bbuenas noches\b",
-    r"\bhasta mañana\b",
-    r"\bdulces sueños\b",
-    r"\bnos vemos mañana\b",
-    r"\bcerrando la sesión\b",
-    r"\bcierro la sesión\b",
-    r"\bsesión cerrada\b",
-    r"\bchao\b.*\b(ade|adelaida)\b",
-]
-
-# Negation contexts — phrases that mean the model is DISCUSSING closure, not
-# claiming it. If any of these appear, skip the check.
-NEGATION_PATTERNS = [
-    r"how do we make sure",
-    r"did you run",
-    r"didn't run",
-    r"did not run",
-    r"keeps not happening",
-    r"\bI should have\b",
-    r"how to ",
-    r"why didn't",
-    r"the fix is",
-]
+# Closing-claim detection (the pattern lists + the matcher) now lives in the
+# shared _lib/closing_claim.py imported at the top, so this hook and
+# verify-discoverability-on-close.py share ONE de-drifted source with the
+# MENTION-vs-USE guards. MYC-791.
 
 
 def get_last_assistant_text(transcript_path: str) -> str:
@@ -191,21 +151,6 @@ def extract_worktree_slug(cwd: str) -> str:
     """Extract the worktree slug from a cwd like .../worktrees/<slug>/..."""
     m = re.search(r"/worktrees/([^/]+)", cwd or "")
     return m.group(1) if m else ""
-
-
-def is_closing_claim(text: str) -> bool:
-    """True iff the text claims session closure (and isn't a discussion of it)."""
-    if not text:
-        return False
-    # Skip if any negation context appears — model is discussing, not claiming
-    for pat in NEGATION_PATTERNS:
-        if re.search(pat, text, re.IGNORECASE):
-            return False
-    # Look for a closing claim
-    for pat in CLOSING_PATTERNS:
-        if re.search(pat, text, re.IGNORECASE | re.MULTILINE):
-            return True
-    return False
 
 
 def session_file_exists_for_today(worktree_slug: str) -> bool:

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -98,6 +98,7 @@ INTEGRATION_TESTS=(
   test_phase_doc_slash_commands_installed
   test_reconcile_ff_invariant
   test_detect_closing_signal_worktree
+  test_closing_claim_shared
   test_meta_resolver
   test_meta_resolution_guard
   test_split_meta

--- a/tests/integration/test_closing_claim_shared.sh
+++ b/tests/integration/test_closing_claim_shared.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# test_closing_claim_shared.sh — negative + positive controls for the shared
+# close-claim detector (hooks/_lib/closing_claim.py), the single source of
+# truth used by BOTH Stop-side verify hooks. MYC-791.
+#
+# Headline negative control = the EXACT case that tore down a worktree on
+# 2026-06-19: an assistant report that QUOTES sign-offs as examples and
+# DISCUSSES the close detector must NOT be read as a close claim. Positive
+# controls prove genuine first-person closes still fire (no over-suppression,
+# which would re-open the gallant-kalam incomplete-close gap).
+set -euo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+python3 - "$REPO" <<'PY'
+import sys
+from pathlib import Path
+repo = Path(sys.argv[1])
+sys.path.insert(0, str(repo / "hooks"))
+from _lib.closing_claim import is_closing_claim
+
+cases = [
+    # ---- NEGATIVE: mention / discussion, NOT a claim ----
+    ("report quoting sign-offs + discussing the detector (2026-06-19 incident)",
+     'These no longer auto-close: "good night", "buenas noches", "thanks". '
+     'The close-signal detector false-fires on quoted text.', False),
+    ("sign-offs only inside double-quotes, NO discussion marker (pure stripping)",
+     'The two example phrases are "good night" and "buenas noches".', False),
+    ("blockquoted draft containing a sign-off (MYC-791 original case)",
+     "Gratitude draft for your approval:\n> Gracias por todo. Buenas noches\nReady?", False),
+    ("code-fenced sign-off",
+     "Example pattern target:\n```\nbuenas noches\n```\nThat is the regex.", False),
+    ("inline-code sign-off", "The phrase `closing the session` is the trigger.", False),
+    ("definitional statement", "'good night' is not a close signal for me.", False),
+    ("meta discussion of the detector", "the detector keeps firing; the fix is a guard.", False),
+    # ---- POSITIVE: genuine first-person close claims (must still fire) ----
+    ("genuine close", "Closing the session now and writing the artifact.", True),
+    ("genuine spanish sign-off, unquoted", "Listo. Buenas noches a todos.", True),
+    ("genuine final-summary header", "## Session 2026-06-19 — final summary", True),
+    ("genuine good night, unquoted", "All shipped. Good night!", True),
+    ("genuine running the cascade", "Running the cascade now.", True),
+]
+fails = 0
+for label, text, expected in cases:
+    got = is_closing_claim(text)
+    if got != expected:
+        fails += 1
+        print(f"FAIL [{label}] expected={expected} got={got}")
+    else:
+        print(f"PASS [{label}] -> {got}")
+if fails:
+    print(f"\n{fails} failure(s).")
+    sys.exit(1)
+print("\nAll closing-claim mention-vs-use assertions passed.")
+PY
+echo "PASS: shared closing-claim detector (mention-vs-use) holds"


### PR DESCRIPTION
## What

The two Stop-side verify hooks (`verify-session-close-cascade.py`, `verify-discoverability-on-close.py`) each carried their **own drifted copy** of `CLOSING_PATTERNS` / `NEGATION_PATTERNS` / `is_closing_claim`. Both false-fired on assistant text that **mentions** close phrases (quotes a sign-off as an example, discusses the close machinery) rather than **using** them.

On 2026-06-19 this caused real damage: a report that listed `"good night"` / `"buenas noches"` as quoted examples of phrases that should *not* auto-close was itself read as a close claim — it blocked the turn and triggered worktree archive-prep (the worktree was torn down mid-session).

This is the Stop-side sibling of the prompt-side bug fixed in #217 (MYC-1266). Same bug class: **a detector for X must not fire on text that references X.**

## Changes

1. **New `hooks/_lib/closing_claim.py`** — single source of truth. `is_closing_claim()`:
   - strips MENTION spans (fenced code, inline backticks, blockquote lines, double-quote spans) before matching, so a sign-off quoted as an example does not count;
   - applies a conservative discussion/definitional allowlist containing only terms **absent from a genuine sign-off**, so it never over-suppresses a real close (which would re-open the gallant-kalam incomplete-close gap);
   - genuine unquoted first-person closes still fire.
2. **Both Stop hooks import it**; their duplicated pattern lists + matchers are removed (no more cross-hook drift).
3. **`tests/integration/test_closing_claim_shared.sh`** — negative controls (the exact incident, MYC-791's original blockquote-draft case, pure quote-stripping with no discussion marker, definitional + meta-discussion) and positive controls (genuine closes still fire). Wired into `scripts/ci.sh`.

## Tests

`bash scripts/ci.sh` green: 269 py_compile + 40 integration + shellcheck. The pre-existing cascade tests (`test_verify_cascade_failsafe`, `test_worktree_session_close`, `test_resource_aware_session_close`) still pass — delegating to the lib did not change hook plumbing.

MYC-791

🤖 Generated with [Claude Code](https://claude.com/claude-code)