### PR TITLE
feat(floors): ship 34 per-floor stubs so journal wikilinks resolve to rich graph nodes

### DIFF
--- a/floors.md
+++ b/floors.md
@@ -4,6 +4,8 @@ The journal tags every entry with a Floor: the emotional consciousness level you
 
 This file is the reference. What the floors are, how they work, how to use them.
 
+Each floor also has its own note at [`floors/<Name>.md`](floors/) — graphify uses those so journal entries tagged `[[Fear]]` resolve to a node with body content, elevator-emotion edges, shadow-twin links, and a pointer to the writing series. Regenerate them from this table with `scripts/generate_floor_stubs.py` if you change the canonical list below.
+
 ---
 
 ## The framework, in one paragraph

--- a/floors/Acceptance.md
+++ b/floors/Acceptance.md
@@ -1,0 +1,40 @@
+---
+type: floor
+floor_number: 23
+floor_name: Acceptance
+floor_level: Middle
+aliases: [Aceptación, "Floor 23", "Piso 23"]
+---
+
+# Acceptance · Aceptación
+
+**Floor 23 · Middle tier**
+
+Making peace with reality (not Resignation).
+
+Part of the middle tier: see [[Middle Floors]].
+
+## Shadow twin
+
+**[[Resignation]] (6)** is the shadow of **Acceptance (23)**.
+
+> 'I've given up' vs 'I've made peace'
+
+Most "Acceptance" people claim is actually [[Resignation]]. The difference is whether you are still bracing.
+
+## How to use this floor
+
+- **Name it.** "I'm on Acceptance," not "I'm in Acceptance." The naming reduces the charge.
+- **Look for the elevator.** What carried you here? A conversation, a meal, a meeting, a thought. The elevator is the actual lesson.
+- **Check the shadow twin** (above) if there is one.
+
+## Narrative form
+
+The 34-floor framework started as a writing project. Each floor gets a lived-experience chapter in [[The High-Rise Series]]:
+
+- English: [https://adelaidadiazroa.substack.com](https://adelaidadiazroa.substack.com)
+- Español: [https://perspectivasblog.substack.com](https://perspectivasblog.substack.com)
+
+## Reference
+
+See [[floors|All 34 floors]] for the canonical list. The framework is MIT-licensed and lives in the public substrate.

--- a/floors/Anger.md
+++ b/floors/Anger.md
@@ -1,0 +1,38 @@
+---
+type: floor
+floor_number: 16
+floor_name: Anger
+floor_level: Low
+aliases: [Rabia, "Floor 16", "Piso 16"]
+---
+
+# Anger · Rabia
+
+**Floor 16 · Low tier**
+
+Directed energy, 'this is wrong,' disrespect.
+
+Part of the low tier: see [[Low Floors]].
+
+## Elevators involving this floor
+
+- **Jealousy** = [[Fear]] + [[Desire]] + **Anger**
+
+These are movements between floors, not floors themselves. The journal tags the floor you land on; the elevator name describes the trip.
+
+## How to use this floor
+
+- **Name it.** "I'm on Anger," not "I'm in Anger." The naming reduces the charge.
+- **Look for the elevator.** What carried you here? A conversation, a meal, a meeting, a thought. The elevator is the actual lesson.
+- **Check the shadow twin** (above) if there is one.
+
+## Narrative form
+
+The 34-floor framework started as a writing project. Each floor gets a lived-experience chapter in [[The High-Rise Series]]:
+
+- English: [https://adelaidadiazroa.substack.com](https://adelaidadiazroa.substack.com)
+- Español: [https://perspectivasblog.substack.com](https://perspectivasblog.substack.com)
+
+## Reference
+
+See [[floors|All 34 floors]] for the canonical list. The framework is MIT-licensed and lives in the public substrate.

--- a/floors/Apathy.md
+++ b/floors/Apathy.md
@@ -1,0 +1,40 @@
+---
+type: floor
+floor_number: 5
+floor_name: Apathy
+floor_level: Low
+aliases: [Apatía, "Floor 5", "Piso 5"]
+---
+
+# Apathy · Apatía
+
+**Floor 5 · Low tier**
+
+'nothing matters,' checked out, numb.
+
+Part of the low tier: see [[Low Floors]].
+
+## Shadow twin
+
+**Apathy (5)** is the shadow of **[[Neutrality]] (21)**.
+
+> 'I don't care' vs 'I'm not attached'
+
+When Apathy shows up easily, check whether [[Neutrality]] is what you actually mean. The difference is whether you are still bracing.
+
+## How to use this floor
+
+- **Name it.** "I'm on Apathy," not "I'm in Apathy." The naming reduces the charge.
+- **Look for the elevator.** What carried you here? A conversation, a meal, a meeting, a thought. The elevator is the actual lesson.
+- **Check the shadow twin** (above) if there is one.
+
+## Narrative form
+
+The 34-floor framework started as a writing project. Each floor gets a lived-experience chapter in [[The High-Rise Series]]:
+
+- English: [https://adelaidadiazroa.substack.com](https://adelaidadiazroa.substack.com)
+- Español: [https://perspectivasblog.substack.com](https://perspectivasblog.substack.com)
+
+## Reference
+
+See [[floors|All 34 floors]] for the canonical list. The framework is MIT-licensed and lives in the public substrate.

--- a/floors/Belonging.md
+++ b/floors/Belonging.md
@@ -1,0 +1,32 @@
+---
+type: floor
+floor_number: 28
+floor_name: Belonging
+floor_level: High
+aliases: [Pertenencia, "Floor 28", "Piso 28"]
+---
+
+# Belonging · Pertenencia
+
+**Floor 28 · High tier**
+
+Being received, 'I'm in the right room'.
+
+Part of the high tier: see [[High Floors]].
+
+## How to use this floor
+
+- **Name it.** "I'm on Belonging," not "I'm in Belonging." The naming reduces the charge.
+- **Look for the elevator.** What carried you here? A conversation, a meal, a meeting, a thought. The elevator is the actual lesson.
+- **Check the shadow twin** (above) if there is one.
+
+## Narrative form
+
+The 34-floor framework started as a writing project. Each floor gets a lived-experience chapter in [[The High-Rise Series]]:
+
+- English: [https://adelaidadiazroa.substack.com](https://adelaidadiazroa.substack.com)
+- Español: [https://perspectivasblog.substack.com](https://perspectivasblog.substack.com)
+
+## Reference
+
+See [[floors|All 34 floors]] for the canonical list. The framework is MIT-licensed and lives in the public substrate.

--- a/floors/Boredom.md
+++ b/floors/Boredom.md
@@ -1,0 +1,32 @@
+---
+type: floor
+floor_number: 9
+floor_name: Boredom
+floor_level: Low
+aliases: [Aburrimiento, "Floor 9", "Piso 9"]
+---
+
+# Boredom · Aburrimiento
+
+**Floor 9 · Low tier**
+
+Restless, understimulated, the trampoline floor.
+
+Part of the low tier: see [[Low Floors]].
+
+## How to use this floor
+
+- **Name it.** "I'm on Boredom," not "I'm in Boredom." The naming reduces the charge.
+- **Look for the elevator.** What carried you here? A conversation, a meal, a meeting, a thought. The elevator is the actual lesson.
+- **Check the shadow twin** (above) if there is one.
+
+## Narrative form
+
+The 34-floor framework started as a writing project. Each floor gets a lived-experience chapter in [[The High-Rise Series]]:
+
+- English: [https://adelaidadiazroa.substack.com](https://adelaidadiazroa.substack.com)
+- Español: [https://perspectivasblog.substack.com](https://perspectivasblog.substack.com)
+
+## Reference
+
+See [[floors|All 34 floors]] for the canonical list. The framework is MIT-licensed and lives in the public substrate.

--- a/floors/Compassion.md
+++ b/floors/Compassion.md
@@ -1,0 +1,32 @@
+---
+type: floor
+floor_number: 26
+floor_name: Compassion
+floor_level: High
+aliases: [Compasión, "Floor 26", "Piso 26"]
+---
+
+# Compassion · Compasión
+
+**Floor 26 · High tier**
+
+Feeling others' pain without collapsing.
+
+Part of the high tier: see [[High Floors]].
+
+## How to use this floor
+
+- **Name it.** "I'm on Compassion," not "I'm in Compassion." The naming reduces the charge.
+- **Look for the elevator.** What carried you here? A conversation, a meal, a meeting, a thought. The elevator is the actual lesson.
+- **Check the shadow twin** (above) if there is one.
+
+## Narrative form
+
+The 34-floor framework started as a writing project. Each floor gets a lived-experience chapter in [[The High-Rise Series]]:
+
+- English: [https://adelaidadiazroa.substack.com](https://adelaidadiazroa.substack.com)
+- Español: [https://perspectivasblog.substack.com](https://perspectivasblog.substack.com)
+
+## Reference
+
+See [[floors|All 34 floors]] for the canonical list. The framework is MIT-licensed and lives in the public substrate.

--- a/floors/Confusion.md
+++ b/floors/Confusion.md
@@ -1,0 +1,32 @@
+---
+type: floor
+floor_number: 7
+floor_name: Confusion
+floor_level: Low
+aliases: [Confusión, "Floor 7", "Piso 7"]
+---
+
+# Confusion · Confusión
+
+**Floor 7 · Low tier**
+
+Mind reaching and failing, contradictory thoughts.
+
+Part of the low tier: see [[Low Floors]].
+
+## How to use this floor
+
+- **Name it.** "I'm on Confusion," not "I'm in Confusion." The naming reduces the charge.
+- **Look for the elevator.** What carried you here? A conversation, a meal, a meeting, a thought. The elevator is the actual lesson.
+- **Check the shadow twin** (above) if there is one.
+
+## Narrative form
+
+The 34-floor framework started as a writing project. Each floor gets a lived-experience chapter in [[The High-Rise Series]]:
+
+- English: [https://adelaidadiazroa.substack.com](https://adelaidadiazroa.substack.com)
+- Español: [https://perspectivasblog.substack.com](https://perspectivasblog.substack.com)
+
+## Reference
+
+See [[floors|All 34 floors]] for the canonical list. The framework is MIT-licensed and lives in the public substrate.

--- a/floors/Contempt.md
+++ b/floors/Contempt.md
@@ -1,0 +1,32 @@
+---
+type: floor
+floor_number: 17
+floor_name: Contempt
+floor_level: Low
+aliases: [Desprecio, "Floor 17", "Piso 17"]
+---
+
+# Contempt · Desprecio
+
+**Floor 17 · Low tier**
+
+'you are beneath me,' cold dismissal.
+
+Part of the low tier: see [[Low Floors]].
+
+## How to use this floor
+
+- **Name it.** "I'm on Contempt," not "I'm in Contempt." The naming reduces the charge.
+- **Look for the elevator.** What carried you here? A conversation, a meal, a meeting, a thought. The elevator is the actual lesson.
+- **Check the shadow twin** (above) if there is one.
+
+## Narrative form
+
+The 34-floor framework started as a writing project. Each floor gets a lived-experience chapter in [[The High-Rise Series]]:
+
+- English: [https://adelaidadiazroa.substack.com](https://adelaidadiazroa.substack.com)
+- Español: [https://perspectivasblog.substack.com](https://perspectivasblog.substack.com)
+
+## Reference
+
+See [[floors|All 34 floors]] for the canonical list. The framework is MIT-licensed and lives in the public substrate.

--- a/floors/Courage.md
+++ b/floors/Courage.md
@@ -1,0 +1,32 @@
+---
+type: floor
+floor_number: 19
+floor_name: Courage
+floor_level: Middle
+aliases: [Valentía, "Floor 19", "Piso 19"]
+---
+
+# Courage · Valentía
+
+**Floor 19 · Middle tier**
+
+Taking action despite fear, doing the hard thing.
+
+Part of the middle tier: see [[Middle Floors]].
+
+## How to use this floor
+
+- **Name it.** "I'm on Courage," not "I'm in Courage." The naming reduces the charge.
+- **Look for the elevator.** What carried you here? A conversation, a meal, a meeting, a thought. The elevator is the actual lesson.
+- **Check the shadow twin** (above) if there is one.
+
+## Narrative form
+
+The 34-floor framework started as a writing project. Each floor gets a lived-experience chapter in [[The High-Rise Series]]:
+
+- English: [https://adelaidadiazroa.substack.com](https://adelaidadiazroa.substack.com)
+- Español: [https://perspectivasblog.substack.com](https://perspectivasblog.substack.com)
+
+## Reference
+
+See [[floors|All 34 floors]] for the canonical list. The framework is MIT-licensed and lives in the public substrate.

--- a/floors/Desire.md
+++ b/floors/Desire.md
@@ -1,0 +1,46 @@
+---
+type: floor
+floor_number: 15
+floor_name: Desire
+floor_level: Low
+aliases: [Deseo, "Floor 15", "Piso 15"]
+---
+
+# Desire · Deseo
+
+**Floor 15 · Low tier**
+
+Wanting, craving, reaching, ambition mixed with lack.
+
+Part of the low tier: see [[Low Floors]].
+
+## Elevators involving this floor
+
+- **Jealousy** = [[Fear]] + **Desire** + [[Anger]]
+
+These are movements between floors, not floors themselves. The journal tags the floor you land on; the elevator name describes the trip.
+
+## Shadow twin
+
+**Desire (15)** is the shadow of **[[Love]] (29)**.
+
+> 'I want from you' vs 'I give to you'
+
+When Desire shows up easily, check whether [[Love]] is what you actually mean. The difference is whether you are still bracing.
+
+## How to use this floor
+
+- **Name it.** "I'm on Desire," not "I'm in Desire." The naming reduces the charge.
+- **Look for the elevator.** What carried you here? A conversation, a meal, a meeting, a thought. The elevator is the actual lesson.
+- **Check the shadow twin** (above) if there is one.
+
+## Narrative form
+
+The 34-floor framework started as a writing project. Each floor gets a lived-experience chapter in [[The High-Rise Series]]:
+
+- English: [https://adelaidadiazroa.substack.com](https://adelaidadiazroa.substack.com)
+- Español: [https://perspectivasblog.substack.com](https://perspectivasblog.substack.com)
+
+## Reference
+
+See [[floors|All 34 floors]] for the canonical list. The framework is MIT-licensed and lives in the public substrate.

--- a/floors/Disappointment.md
+++ b/floors/Disappointment.md
@@ -1,0 +1,32 @@
+---
+type: floor
+floor_number: 11
+floor_name: Disappointment
+floor_level: Low
+aliases: [Decepción, "Floor 11", "Piso 11"]
+---
+
+# Disappointment · Decepción
+
+**Floor 11 · Low tier**
+
+Gap between hope and what arrived.
+
+Part of the low tier: see [[Low Floors]].
+
+## How to use this floor
+
+- **Name it.** "I'm on Disappointment," not "I'm in Disappointment." The naming reduces the charge.
+- **Look for the elevator.** What carried you here? A conversation, a meal, a meeting, a thought. The elevator is the actual lesson.
+- **Check the shadow twin** (above) if there is one.
+
+## Narrative form
+
+The 34-floor framework started as a writing project. Each floor gets a lived-experience chapter in [[The High-Rise Series]]:
+
+- English: [https://adelaidadiazroa.substack.com](https://adelaidadiazroa.substack.com)
+- Español: [https://perspectivasblog.substack.com](https://perspectivasblog.substack.com)
+
+## Reference
+
+See [[floors|All 34 floors]] for the canonical list. The framework is MIT-licensed and lives in the public substrate.

--- a/floors/Disgust.md
+++ b/floors/Disgust.md
@@ -1,0 +1,32 @@
+---
+type: floor
+floor_number: 1
+floor_name: Disgust
+floor_level: Low
+aliases: [Asco, "Floor 1", "Piso 1"]
+---
+
+# Disgust · Asco
+
+**Floor 1 · Low tier**
+
+Outward rejection, visceral 'get it away from me'.
+
+Part of the low tier: see [[Low Floors]].
+
+## How to use this floor
+
+- **Name it.** "I'm on Disgust," not "I'm in Disgust." The naming reduces the charge.
+- **Look for the elevator.** What carried you here? A conversation, a meal, a meeting, a thought. The elevator is the actual lesson.
+- **Check the shadow twin** (above) if there is one.
+
+## Narrative form
+
+The 34-floor framework started as a writing project. Each floor gets a lived-experience chapter in [[The High-Rise Series]]:
+
+- English: [https://adelaidadiazroa.substack.com](https://adelaidadiazroa.substack.com)
+- Español: [https://perspectivasblog.substack.com](https://perspectivasblog.substack.com)
+
+## Reference
+
+See [[floors|All 34 floors]] for the canonical list. The framework is MIT-licensed and lives in the public substrate.

--- a/floors/Embarrassment.md
+++ b/floors/Embarrassment.md
@@ -1,0 +1,32 @@
+---
+type: floor
+floor_number: 3
+floor_name: Embarrassment
+floor_level: Low
+aliases: [Bochorno, "Floor 3", "Piso 3"]
+---
+
+# Embarrassment · Bochorno
+
+**Floor 3 · Low tier**
+
+Social exposure, temporary, recoverable.
+
+Part of the low tier: see [[Low Floors]].
+
+## How to use this floor
+
+- **Name it.** "I'm on Embarrassment," not "I'm in Embarrassment." The naming reduces the charge.
+- **Look for the elevator.** What carried you here? A conversation, a meal, a meeting, a thought. The elevator is the actual lesson.
+- **Check the shadow twin** (above) if there is one.
+
+## Narrative form
+
+The 34-floor framework started as a writing project. Each floor gets a lived-experience chapter in [[The High-Rise Series]]:
+
+- English: [https://adelaidadiazroa.substack.com](https://adelaidadiazroa.substack.com)
+- Español: [https://perspectivasblog.substack.com](https://perspectivasblog.substack.com)
+
+## Reference
+
+See [[floors|All 34 floors]] for the canonical list. The framework is MIT-licensed and lives in the public substrate.

--- a/floors/Excitement.md
+++ b/floors/Excitement.md
@@ -1,0 +1,32 @@
+---
+type: floor
+floor_number: 31
+floor_name: Excitement
+floor_level: High
+aliases: [Entusiasmo, "Floor 31", "Piso 31"]
+---
+
+# Excitement · Entusiasmo
+
+**Floor 31 · High tier**
+
+Anticipatory joy, body saying yes.
+
+Part of the high tier: see [[High Floors]].
+
+## How to use this floor
+
+- **Name it.** "I'm on Excitement," not "I'm in Excitement." The naming reduces the charge.
+- **Look for the elevator.** What carried you here? A conversation, a meal, a meeting, a thought. The elevator is the actual lesson.
+- **Check the shadow twin** (above) if there is one.
+
+## Narrative form
+
+The 34-floor framework started as a writing project. Each floor gets a lived-experience chapter in [[The High-Rise Series]]:
+
+- English: [https://adelaidadiazroa.substack.com](https://adelaidadiazroa.substack.com)
+- Español: [https://perspectivasblog.substack.com](https://perspectivasblog.substack.com)
+
+## Reference
+
+See [[floors|All 34 floors]] for the canonical list. The framework is MIT-licensed and lives in the public substrate.

--- a/floors/Fear.md
+++ b/floors/Fear.md
@@ -1,0 +1,39 @@
+---
+type: floor
+floor_number: 13
+floor_name: Fear
+floor_level: Low
+aliases: [Miedo, "Floor 13", "Piso 13"]
+---
+
+# Fear · Miedo
+
+**Floor 13 · Low tier**
+
+Anxiety, 'what if,' imposter feelings.
+
+Part of the low tier: see [[Low Floors]].
+
+## Elevators involving this floor
+
+- **Awe** = **Fear** + [[Wonder]]
+- **Jealousy** = **Fear** + [[Desire]] + [[Anger]]
+
+These are movements between floors, not floors themselves. The journal tags the floor you land on; the elevator name describes the trip.
+
+## How to use this floor
+
+- **Name it.** "I'm on Fear," not "I'm in Fear." The naming reduces the charge.
+- **Look for the elevator.** What carried you here? A conversation, a meal, a meeting, a thought. The elevator is the actual lesson.
+- **Check the shadow twin** (above) if there is one.
+
+## Narrative form
+
+The 34-floor framework started as a writing project. Each floor gets a lived-experience chapter in [[The High-Rise Series]]:
+
+- English: [https://adelaidadiazroa.substack.com](https://adelaidadiazroa.substack.com)
+- Español: [https://perspectivasblog.substack.com](https://perspectivasblog.substack.com)
+
+## Reference
+
+See [[floors|All 34 floors]] for the canonical list. The framework is MIT-licensed and lives in the public substrate.

--- a/floors/Frustration.md
+++ b/floors/Frustration.md
@@ -1,0 +1,32 @@
+---
+type: floor
+floor_number: 14
+floor_name: Frustration
+floor_level: Low
+aliases: [Frustración, "Floor 14", "Piso 14"]
+---
+
+# Frustration · Frustración
+
+**Floor 14 · Low tier**
+
+Blocked energy, 'this should be working'.
+
+Part of the low tier: see [[Low Floors]].
+
+## How to use this floor
+
+- **Name it.** "I'm on Frustration," not "I'm in Frustration." The naming reduces the charge.
+- **Look for the elevator.** What carried you here? A conversation, a meal, a meeting, a thought. The elevator is the actual lesson.
+- **Check the shadow twin** (above) if there is one.
+
+## Narrative form
+
+The 34-floor framework started as a writing project. Each floor gets a lived-experience chapter in [[The High-Rise Series]]:
+
+- English: [https://adelaidadiazroa.substack.com](https://adelaidadiazroa.substack.com)
+- Español: [https://perspectivasblog.substack.com](https://perspectivasblog.substack.com)
+
+## Reference
+
+See [[floors|All 34 floors]] for the canonical list. The framework is MIT-licensed and lives in the public substrate.

--- a/floors/Gratitude.md
+++ b/floors/Gratitude.md
@@ -1,0 +1,32 @@
+---
+type: floor
+floor_number: 30
+floor_name: Gratitude
+floor_level: High
+aliases: [Gratitud, "Floor 30", "Piso 30"]
+---
+
+# Gratitude · Gratitud
+
+**Floor 30 · High tier**
+
+Presence recognizing abundance.
+
+Part of the high tier: see [[High Floors]].
+
+## How to use this floor
+
+- **Name it.** "I'm on Gratitude," not "I'm in Gratitude." The naming reduces the charge.
+- **Look for the elevator.** What carried you here? A conversation, a meal, a meeting, a thought. The elevator is the actual lesson.
+- **Check the shadow twin** (above) if there is one.
+
+## Narrative form
+
+The 34-floor framework started as a writing project. Each floor gets a lived-experience chapter in [[The High-Rise Series]]:
+
+- English: [https://adelaidadiazroa.substack.com](https://adelaidadiazroa.substack.com)
+- Español: [https://perspectivasblog.substack.com](https://perspectivasblog.substack.com)
+
+## Reference
+
+See [[floors|All 34 floors]] for the canonical list. The framework is MIT-licensed and lives in the public substrate.

--- a/floors/Grief.md
+++ b/floors/Grief.md
@@ -1,0 +1,39 @@
+---
+type: floor
+floor_number: 10
+floor_name: Grief
+floor_level: Low
+aliases: [Duelo, "Floor 10", "Piso 10"]
+---
+
+# Grief · Duelo
+
+**Floor 10 · Low tier**
+
+Loss, sadness, missing someone or something.
+
+Part of the low tier: see [[Low Floors]].
+
+## Elevators involving this floor
+
+- **Nostalgia** = **Grief** + [[Love]]
+- **Bittersweet** = **Grief** + [[Joy]]
+
+These are movements between floors, not floors themselves. The journal tags the floor you land on; the elevator name describes the trip.
+
+## How to use this floor
+
+- **Name it.** "I'm on Grief," not "I'm in Grief." The naming reduces the charge.
+- **Look for the elevator.** What carried you here? A conversation, a meal, a meeting, a thought. The elevator is the actual lesson.
+- **Check the shadow twin** (above) if there is one.
+
+## Narrative form
+
+The 34-floor framework started as a writing project. Each floor gets a lived-experience chapter in [[The High-Rise Series]]:
+
+- English: [https://adelaidadiazroa.substack.com](https://adelaidadiazroa.substack.com)
+- Español: [https://perspectivasblog.substack.com](https://perspectivasblog.substack.com)
+
+## Reference
+
+See [[floors|All 34 floors]] for the canonical list. The framework is MIT-licensed and lives in the public substrate.

--- a/floors/Guilt.md
+++ b/floors/Guilt.md
@@ -1,0 +1,32 @@
+---
+type: floor
+floor_number: 4
+floor_name: Guilt
+floor_level: Low
+aliases: [Culpa, "Floor 4", "Piso 4"]
+---
+
+# Guilt · Culpa
+
+**Floor 4 · Low tier**
+
+'I should be doing more,' letting people down.
+
+Part of the low tier: see [[Low Floors]].
+
+## How to use this floor
+
+- **Name it.** "I'm on Guilt," not "I'm in Guilt." The naming reduces the charge.
+- **Look for the elevator.** What carried you here? A conversation, a meal, a meeting, a thought. The elevator is the actual lesson.
+- **Check the shadow twin** (above) if there is one.
+
+## Narrative form
+
+The 34-floor framework started as a writing project. Each floor gets a lived-experience chapter in [[The High-Rise Series]]:
+
+- English: [https://adelaidadiazroa.substack.com](https://adelaidadiazroa.substack.com)
+- Español: [https://perspectivasblog.substack.com](https://perspectivasblog.substack.com)
+
+## Reference
+
+See [[floors|All 34 floors]] for the canonical list. The framework is MIT-licensed and lives in the public substrate.

--- a/floors/High Floors.md
+++ b/floors/High Floors.md
@@ -1,0 +1,26 @@
+---
+type: floor-tier
+tier: High
+aliases: [Pisos Altos]
+---
+
+# High Floors · Pisos Altos
+
+Generative: 25-34. The generative tier. Where the energy gives.
+
+Floors **25-34**:
+
+- 25. [[Trust]] (Confianza) — quiet confidence that things hold
+- 26. [[Compassion]] (Compasión) — feeling others' pain without collapsing
+- 27. [[Humility]] (Humildad) — accurate self-perception, 'I was wrong about'
+- 28. [[Belonging]] (Pertenencia) — being received, 'I'm in the right room'
+- 29. [[Love]] (Amor) — connection, warmth, giving freely
+- 30. [[Gratitude]] (Gratitud) — presence recognizing abundance
+- 31. [[Excitement]] (Entusiasmo) — anticipatory joy, body saying yes
+- 32. [[Wonder]] (Asombro) — awe at what exists, expansion
+- 33. [[Joy]] (Alegría) — delight, fun, laughter, alive
+- 34. [[Peace]] (Paz) — stillness, nothing to fix, enough as-is
+
+## Reference
+
+See [[floors|All 34 floors]] for the full canonical list with energies, Spanish names, elevator emotions, and shadow twins.

--- a/floors/Hope.md
+++ b/floors/Hope.md
@@ -1,0 +1,32 @@
+---
+type: floor
+floor_number: 20
+floor_name: Hope
+floor_level: Middle
+aliases: [Esperanza, "Floor 20", "Piso 20"]
+---
+
+# Hope · Esperanza
+
+**Floor 20 · Middle tier**
+
+Future-facing trust, steady forward momentum.
+
+Part of the middle tier: see [[Middle Floors]].
+
+## How to use this floor
+
+- **Name it.** "I'm on Hope," not "I'm in Hope." The naming reduces the charge.
+- **Look for the elevator.** What carried you here? A conversation, a meal, a meeting, a thought. The elevator is the actual lesson.
+- **Check the shadow twin** (above) if there is one.
+
+## Narrative form
+
+The 34-floor framework started as a writing project. Each floor gets a lived-experience chapter in [[The High-Rise Series]]:
+
+- English: [https://adelaidadiazroa.substack.com](https://adelaidadiazroa.substack.com)
+- Español: [https://perspectivasblog.substack.com](https://perspectivasblog.substack.com)
+
+## Reference
+
+See [[floors|All 34 floors]] for the canonical list. The framework is MIT-licensed and lives in the public substrate.

--- a/floors/Humility.md
+++ b/floors/Humility.md
@@ -1,0 +1,32 @@
+---
+type: floor
+floor_number: 27
+floor_name: Humility
+floor_level: High
+aliases: [Humildad, "Floor 27", "Piso 27"]
+---
+
+# Humility · Humildad
+
+**Floor 27 · High tier**
+
+Accurate self-perception, 'I was wrong about'.
+
+Part of the high tier: see [[High Floors]].
+
+## How to use this floor
+
+- **Name it.** "I'm on Humility," not "I'm in Humility." The naming reduces the charge.
+- **Look for the elevator.** What carried you here? A conversation, a meal, a meeting, a thought. The elevator is the actual lesson.
+- **Check the shadow twin** (above) if there is one.
+
+## Narrative form
+
+The 34-floor framework started as a writing project. Each floor gets a lived-experience chapter in [[The High-Rise Series]]:
+
+- English: [https://adelaidadiazroa.substack.com](https://adelaidadiazroa.substack.com)
+- Español: [https://perspectivasblog.substack.com](https://perspectivasblog.substack.com)
+
+## Reference
+
+See [[floors|All 34 floors]] for the canonical list. The framework is MIT-licensed and lives in the public substrate.

--- a/floors/Hurt.md
+++ b/floors/Hurt.md
@@ -1,0 +1,32 @@
+---
+type: floor
+floor_number: 12
+floor_name: Hurt
+floor_level: Low
+aliases: [Herida, "Floor 12", "Piso 12"]
+---
+
+# Hurt · Herida
+
+**Floor 12 · Low tier**
+
+Breach in a relationship, 'how could they'.
+
+Part of the low tier: see [[Low Floors]].
+
+## How to use this floor
+
+- **Name it.** "I'm on Hurt," not "I'm in Hurt." The naming reduces the charge.
+- **Look for the elevator.** What carried you here? A conversation, a meal, a meeting, a thought. The elevator is the actual lesson.
+- **Check the shadow twin** (above) if there is one.
+
+## Narrative form
+
+The 34-floor framework started as a writing project. Each floor gets a lived-experience chapter in [[The High-Rise Series]]:
+
+- English: [https://adelaidadiazroa.substack.com](https://adelaidadiazroa.substack.com)
+- Español: [https://perspectivasblog.substack.com](https://perspectivasblog.substack.com)
+
+## Reference
+
+See [[floors|All 34 floors]] for the canonical list. The framework is MIT-licensed and lives in the public substrate.

--- a/floors/Joy.md
+++ b/floors/Joy.md
@@ -1,0 +1,39 @@
+---
+type: floor
+floor_number: 33
+floor_name: Joy
+floor_level: High
+aliases: [Alegría, "Floor 33", "Piso 33"]
+---
+
+# Joy · Alegría
+
+**Floor 33 · High tier**
+
+Delight, fun, laughter, alive.
+
+Part of the high tier: see [[High Floors]].
+
+## Elevators involving this floor
+
+- **Schadenfreude** = [[Pride]] + **Joy (corrupted)**
+- **Bittersweet** = [[Grief]] + **Joy**
+
+These are movements between floors, not floors themselves. The journal tags the floor you land on; the elevator name describes the trip.
+
+## How to use this floor
+
+- **Name it.** "I'm on Joy," not "I'm in Joy." The naming reduces the charge.
+- **Look for the elevator.** What carried you here? A conversation, a meal, a meeting, a thought. The elevator is the actual lesson.
+- **Check the shadow twin** (above) if there is one.
+
+## Narrative form
+
+The 34-floor framework started as a writing project. Each floor gets a lived-experience chapter in [[The High-Rise Series]]:
+
+- English: [https://adelaidadiazroa.substack.com](https://adelaidadiazroa.substack.com)
+- Español: [https://perspectivasblog.substack.com](https://perspectivasblog.substack.com)
+
+## Reference
+
+See [[floors|All 34 floors]] for the canonical list. The framework is MIT-licensed and lives in the public substrate.

--- a/floors/Loneliness.md
+++ b/floors/Loneliness.md
@@ -1,0 +1,32 @@
+---
+type: floor
+floor_number: 8
+floor_name: Loneliness
+floor_level: Low
+aliases: [Soledad, "Floor 8", "Piso 8"]
+---
+
+# Loneliness · Soledad
+
+**Floor 8 · Low tier**
+
+Surrounded but unfound, no one gets it.
+
+Part of the low tier: see [[Low Floors]].
+
+## How to use this floor
+
+- **Name it.** "I'm on Loneliness," not "I'm in Loneliness." The naming reduces the charge.
+- **Look for the elevator.** What carried you here? A conversation, a meal, a meeting, a thought. The elevator is the actual lesson.
+- **Check the shadow twin** (above) if there is one.
+
+## Narrative form
+
+The 34-floor framework started as a writing project. Each floor gets a lived-experience chapter in [[The High-Rise Series]]:
+
+- English: [https://adelaidadiazroa.substack.com](https://adelaidadiazroa.substack.com)
+- Español: [https://perspectivasblog.substack.com](https://perspectivasblog.substack.com)
+
+## Reference
+
+See [[floors|All 34 floors]] for the canonical list. The framework is MIT-licensed and lives in the public substrate.

--- a/floors/Love.md
+++ b/floors/Love.md
@@ -1,0 +1,47 @@
+---
+type: floor
+floor_number: 29
+floor_name: Love
+floor_level: High
+aliases: [Amor, "Floor 29", "Piso 29"]
+---
+
+# Love · Amor
+
+**Floor 29 · High tier**
+
+Connection, warmth, giving freely.
+
+Part of the high tier: see [[High Floors]].
+
+## Elevators involving this floor
+
+- **Nostalgia** = [[Grief]] + **Love**
+- **Vulnerability** = [[Shame]] + **Love**
+
+These are movements between floors, not floors themselves. The journal tags the floor you land on; the elevator name describes the trip.
+
+## Shadow twin
+
+**[[Desire]] (15)** is the shadow of **Love (29)**.
+
+> 'I want from you' vs 'I give to you'
+
+Most "Love" people claim is actually [[Desire]]. The difference is whether you are still bracing.
+
+## How to use this floor
+
+- **Name it.** "I'm on Love," not "I'm in Love." The naming reduces the charge.
+- **Look for the elevator.** What carried you here? A conversation, a meal, a meeting, a thought. The elevator is the actual lesson.
+- **Check the shadow twin** (above) if there is one.
+
+## Narrative form
+
+The 34-floor framework started as a writing project. Each floor gets a lived-experience chapter in [[The High-Rise Series]]:
+
+- English: [https://adelaidadiazroa.substack.com](https://adelaidadiazroa.substack.com)
+- Español: [https://perspectivasblog.substack.com](https://perspectivasblog.substack.com)
+
+## Reference
+
+See [[floors|All 34 floors]] for the canonical list. The framework is MIT-licensed and lives in the public substrate.

--- a/floors/Low Floors.md
+++ b/floors/Low Floors.md
@@ -1,0 +1,34 @@
+---
+type: floor-tier
+tier: Low
+aliases: [Pisos Bajos]
+---
+
+# Low Floors · Pisos Bajos
+
+Reactive: 1-18. The reactive tier. Where the charge lives.
+
+Floors **1-18**:
+
+- 1. [[Disgust]] (Asco) — outward rejection, visceral 'get it away from me'
+- 2. [[Shame]] (Vergüenza) — 'I'm such an idiot,' self-disgust, hiding
+- 3. [[Embarrassment]] (Bochorno) — social exposure, temporary, recoverable
+- 4. [[Guilt]] (Culpa) — 'I should be doing more,' letting people down
+- 5. [[Apathy]] (Apatía) — 'nothing matters,' checked out, numb
+- 6. [[Resignation]] (Resignación) — defeated 'it is what it is' (not making peace)
+- 7. [[Confusion]] (Confusión) — mind reaching and failing, contradictory thoughts
+- 8. [[Loneliness]] (Soledad) — surrounded but unfound, no one gets it
+- 9. [[Boredom]] (Aburrimiento) — restless, understimulated, the trampoline floor
+- 10. [[Grief]] (Duelo) — loss, sadness, missing someone or something
+- 11. [[Disappointment]] (Decepción) — gap between hope and what arrived
+- 12. [[Hurt]] (Herida) — breach in a relationship, 'how could they'
+- 13. [[Fear]] (Miedo) — anxiety, 'what if,' imposter feelings
+- 14. [[Frustration]] (Frustración) — blocked energy, 'this should be working'
+- 15. [[Desire]] (Deseo) — wanting, craving, reaching, ambition mixed with lack
+- 16. [[Anger]] (Rabia) — directed energy, 'this is wrong,' disrespect
+- 17. [[Contempt]] (Desprecio) — 'you are beneath me,' cold dismissal
+- 18. [[Pride]] (Orgullo) — proving something, need for external validation
+
+## Reference
+
+See [[floors|All 34 floors]] for the full canonical list with energies, Spanish names, elevator emotions, and shadow twins.

--- a/floors/Middle Floors.md
+++ b/floors/Middle Floors.md
@@ -1,0 +1,22 @@
+---
+type: floor-tier
+tier: Middle
+aliases: [Pisos Medios]
+---
+
+# Middle Floors · Pisos Medios
+
+Transitional: 19-24. The transitional tier. The climb up.
+
+Floors **19-24**:
+
+- 19. [[Courage]] (Valentía) — taking action despite fear, doing the hard thing
+- 20. [[Hope]] (Esperanza) — future-facing trust, steady forward momentum
+- 21. [[Neutrality]] (Neutralidad) — calm observation, processing without charge
+- 22. [[Willingness]] (Disposición) — optimistic restart, curiosity replaces fear
+- 23. [[Acceptance]] (Aceptación) — making peace with reality (not Resignation)
+- 24. [[Reason]] (Razón) — analytical, strategic, clear-headed
+
+## Reference
+
+See [[floors|All 34 floors]] for the full canonical list with energies, Spanish names, elevator emotions, and shadow twins.

--- a/floors/Neutrality.md
+++ b/floors/Neutrality.md
@@ -1,0 +1,40 @@
+---
+type: floor
+floor_number: 21
+floor_name: Neutrality
+floor_level: Middle
+aliases: [Neutralidad, "Floor 21", "Piso 21"]
+---
+
+# Neutrality · Neutralidad
+
+**Floor 21 · Middle tier**
+
+Calm observation, processing without charge.
+
+Part of the middle tier: see [[Middle Floors]].
+
+## Shadow twin
+
+**[[Apathy]] (5)** is the shadow of **Neutrality (21)**.
+
+> 'I don't care' vs 'I'm not attached'
+
+Most "Neutrality" people claim is actually [[Apathy]]. The difference is whether you are still bracing.
+
+## How to use this floor
+
+- **Name it.** "I'm on Neutrality," not "I'm in Neutrality." The naming reduces the charge.
+- **Look for the elevator.** What carried you here? A conversation, a meal, a meeting, a thought. The elevator is the actual lesson.
+- **Check the shadow twin** (above) if there is one.
+
+## Narrative form
+
+The 34-floor framework started as a writing project. Each floor gets a lived-experience chapter in [[The High-Rise Series]]:
+
+- English: [https://adelaidadiazroa.substack.com](https://adelaidadiazroa.substack.com)
+- Español: [https://perspectivasblog.substack.com](https://perspectivasblog.substack.com)
+
+## Reference
+
+See [[floors|All 34 floors]] for the canonical list. The framework is MIT-licensed and lives in the public substrate.

--- a/floors/Peace.md
+++ b/floors/Peace.md
@@ -1,0 +1,32 @@
+---
+type: floor
+floor_number: 34
+floor_name: Peace
+floor_level: High
+aliases: [Paz, "Floor 34", "Piso 34"]
+---
+
+# Peace · Paz
+
+**Floor 34 · High tier**
+
+Stillness, nothing to fix, enough as-is.
+
+Part of the high tier: see [[High Floors]].
+
+## How to use this floor
+
+- **Name it.** "I'm on Peace," not "I'm in Peace." The naming reduces the charge.
+- **Look for the elevator.** What carried you here? A conversation, a meal, a meeting, a thought. The elevator is the actual lesson.
+- **Check the shadow twin** (above) if there is one.
+
+## Narrative form
+
+The 34-floor framework started as a writing project. Each floor gets a lived-experience chapter in [[The High-Rise Series]]:
+
+- English: [https://adelaidadiazroa.substack.com](https://adelaidadiazroa.substack.com)
+- Español: [https://perspectivasblog.substack.com](https://perspectivasblog.substack.com)
+
+## Reference
+
+See [[floors|All 34 floors]] for the canonical list. The framework is MIT-licensed and lives in the public substrate.

--- a/floors/Pride.md
+++ b/floors/Pride.md
@@ -1,0 +1,46 @@
+---
+type: floor
+floor_number: 18
+floor_name: Pride
+floor_level: Low
+aliases: [Orgullo, "Floor 18", "Piso 18"]
+---
+
+# Pride · Orgullo
+
+**Floor 18 · Low tier**
+
+Proving something, need for external validation.
+
+Part of the low tier: see [[Low Floors]].
+
+## Elevators involving this floor
+
+- **Schadenfreude** = **Pride** + [[Joy]]
+
+These are movements between floors, not floors themselves. The journal tags the floor you land on; the elevator name describes the trip.
+
+## Shadow twin
+
+**Pride (18)** is the shadow of **[[Trust]] (25)**.
+
+> 'I need you to see me' vs 'I see myself'
+
+When Pride shows up easily, check whether [[Trust]] is what you actually mean. The difference is whether you are still bracing.
+
+## How to use this floor
+
+- **Name it.** "I'm on Pride," not "I'm in Pride." The naming reduces the charge.
+- **Look for the elevator.** What carried you here? A conversation, a meal, a meeting, a thought. The elevator is the actual lesson.
+- **Check the shadow twin** (above) if there is one.
+
+## Narrative form
+
+The 34-floor framework started as a writing project. Each floor gets a lived-experience chapter in [[The High-Rise Series]]:
+
+- English: [https://adelaidadiazroa.substack.com](https://adelaidadiazroa.substack.com)
+- Español: [https://perspectivasblog.substack.com](https://perspectivasblog.substack.com)
+
+## Reference
+
+See [[floors|All 34 floors]] for the canonical list. The framework is MIT-licensed and lives in the public substrate.

--- a/floors/Reason.md
+++ b/floors/Reason.md
@@ -1,0 +1,32 @@
+---
+type: floor
+floor_number: 24
+floor_name: Reason
+floor_level: Middle
+aliases: [Razón, "Floor 24", "Piso 24"]
+---
+
+# Reason · Razón
+
+**Floor 24 · Middle tier**
+
+Analytical, strategic, clear-headed.
+
+Part of the middle tier: see [[Middle Floors]].
+
+## How to use this floor
+
+- **Name it.** "I'm on Reason," not "I'm in Reason." The naming reduces the charge.
+- **Look for the elevator.** What carried you here? A conversation, a meal, a meeting, a thought. The elevator is the actual lesson.
+- **Check the shadow twin** (above) if there is one.
+
+## Narrative form
+
+The 34-floor framework started as a writing project. Each floor gets a lived-experience chapter in [[The High-Rise Series]]:
+
+- English: [https://adelaidadiazroa.substack.com](https://adelaidadiazroa.substack.com)
+- Español: [https://perspectivasblog.substack.com](https://perspectivasblog.substack.com)
+
+## Reference
+
+See [[floors|All 34 floors]] for the canonical list. The framework is MIT-licensed and lives in the public substrate.

--- a/floors/Resignation.md
+++ b/floors/Resignation.md
@@ -1,0 +1,40 @@
+---
+type: floor
+floor_number: 6
+floor_name: Resignation
+floor_level: Low
+aliases: [Resignación, "Floor 6", "Piso 6"]
+---
+
+# Resignation · Resignación
+
+**Floor 6 · Low tier**
+
+Defeated 'it is what it is' (not making peace).
+
+Part of the low tier: see [[Low Floors]].
+
+## Shadow twin
+
+**Resignation (6)** is the shadow of **[[Acceptance]] (23)**.
+
+> 'I've given up' vs 'I've made peace'
+
+When Resignation shows up easily, check whether [[Acceptance]] is what you actually mean. The difference is whether you are still bracing.
+
+## How to use this floor
+
+- **Name it.** "I'm on Resignation," not "I'm in Resignation." The naming reduces the charge.
+- **Look for the elevator.** What carried you here? A conversation, a meal, a meeting, a thought. The elevator is the actual lesson.
+- **Check the shadow twin** (above) if there is one.
+
+## Narrative form
+
+The 34-floor framework started as a writing project. Each floor gets a lived-experience chapter in [[The High-Rise Series]]:
+
+- English: [https://adelaidadiazroa.substack.com](https://adelaidadiazroa.substack.com)
+- Español: [https://perspectivasblog.substack.com](https://perspectivasblog.substack.com)
+
+## Reference
+
+See [[floors|All 34 floors]] for the canonical list. The framework is MIT-licensed and lives in the public substrate.

--- a/floors/Shame.md
+++ b/floors/Shame.md
@@ -1,0 +1,38 @@
+---
+type: floor
+floor_number: 2
+floor_name: Shame
+floor_level: Low
+aliases: [Vergüenza, "Floor 2", "Piso 2"]
+---
+
+# Shame · Vergüenza
+
+**Floor 2 · Low tier**
+
+'I'm such an idiot,' self-disgust, hiding.
+
+Part of the low tier: see [[Low Floors]].
+
+## Elevators involving this floor
+
+- **Vulnerability** = **Shame** + [[Love]]
+
+These are movements between floors, not floors themselves. The journal tags the floor you land on; the elevator name describes the trip.
+
+## How to use this floor
+
+- **Name it.** "I'm on Shame," not "I'm in Shame." The naming reduces the charge.
+- **Look for the elevator.** What carried you here? A conversation, a meal, a meeting, a thought. The elevator is the actual lesson.
+- **Check the shadow twin** (above) if there is one.
+
+## Narrative form
+
+The 34-floor framework started as a writing project. Each floor gets a lived-experience chapter in [[The High-Rise Series]]:
+
+- English: [https://adelaidadiazroa.substack.com](https://adelaidadiazroa.substack.com)
+- Español: [https://perspectivasblog.substack.com](https://perspectivasblog.substack.com)
+
+## Reference
+
+See [[floors|All 34 floors]] for the canonical list. The framework is MIT-licensed and lives in the public substrate.

--- a/floors/The High-Rise Series.md
+++ b/floors/The High-Rise Series.md
@@ -1,0 +1,17 @@
+---
+type: writing-project
+aliases: ["High-Rise", "The High-Rise", "La Torre"]
+---
+
+# The High-Rise Series
+
+A lived-experience writing project: each of the 34 floors gets its own chapter. Not theory. Not a self-help ladder. One person walking the building she lives in.
+
+Read the series:
+
+- English: [https://adelaidadiazroa.substack.com](https://adelaidadiazroa.substack.com)
+- Español: [https://perspectivasblog.substack.com](https://perspectivasblog.substack.com)
+
+The framework underneath the chapters (canonical 34-floor list, energies, Spanish names, tiers, elevator emotions, shadow twins) lives at [[floors|floors]]. Every floor note links back here.
+
+The framework is MIT-licensed and lives in the public substrate. The chapters are the author's writing and live behind their own license on Substack.

--- a/floors/Trust.md
+++ b/floors/Trust.md
@@ -1,0 +1,40 @@
+---
+type: floor
+floor_number: 25
+floor_name: Trust
+floor_level: High
+aliases: [Confianza, "Floor 25", "Piso 25"]
+---
+
+# Trust · Confianza
+
+**Floor 25 · High tier**
+
+Quiet confidence that things hold.
+
+Part of the high tier: see [[High Floors]].
+
+## Shadow twin
+
+**[[Pride]] (18)** is the shadow of **Trust (25)**.
+
+> 'I need you to see me' vs 'I see myself'
+
+Most "Trust" people claim is actually [[Pride]]. The difference is whether you are still bracing.
+
+## How to use this floor
+
+- **Name it.** "I'm on Trust," not "I'm in Trust." The naming reduces the charge.
+- **Look for the elevator.** What carried you here? A conversation, a meal, a meeting, a thought. The elevator is the actual lesson.
+- **Check the shadow twin** (above) if there is one.
+
+## Narrative form
+
+The 34-floor framework started as a writing project. Each floor gets a lived-experience chapter in [[The High-Rise Series]]:
+
+- English: [https://adelaidadiazroa.substack.com](https://adelaidadiazroa.substack.com)
+- Español: [https://perspectivasblog.substack.com](https://perspectivasblog.substack.com)
+
+## Reference
+
+See [[floors|All 34 floors]] for the canonical list. The framework is MIT-licensed and lives in the public substrate.

--- a/floors/Willingness.md
+++ b/floors/Willingness.md
@@ -1,0 +1,32 @@
+---
+type: floor
+floor_number: 22
+floor_name: Willingness
+floor_level: Middle
+aliases: [Disposición, "Floor 22", "Piso 22"]
+---
+
+# Willingness · Disposición
+
+**Floor 22 · Middle tier**
+
+Optimistic restart, curiosity replaces fear.
+
+Part of the middle tier: see [[Middle Floors]].
+
+## How to use this floor
+
+- **Name it.** "I'm on Willingness," not "I'm in Willingness." The naming reduces the charge.
+- **Look for the elevator.** What carried you here? A conversation, a meal, a meeting, a thought. The elevator is the actual lesson.
+- **Check the shadow twin** (above) if there is one.
+
+## Narrative form
+
+The 34-floor framework started as a writing project. Each floor gets a lived-experience chapter in [[The High-Rise Series]]:
+
+- English: [https://adelaidadiazroa.substack.com](https://adelaidadiazroa.substack.com)
+- Español: [https://perspectivasblog.substack.com](https://perspectivasblog.substack.com)
+
+## Reference
+
+See [[floors|All 34 floors]] for the canonical list. The framework is MIT-licensed and lives in the public substrate.

--- a/floors/Wonder.md
+++ b/floors/Wonder.md
@@ -1,0 +1,38 @@
+---
+type: floor
+floor_number: 32
+floor_name: Wonder
+floor_level: High
+aliases: [Asombro, "Floor 32", "Piso 32"]
+---
+
+# Wonder · Asombro
+
+**Floor 32 · High tier**
+
+Awe at what exists, expansion.
+
+Part of the high tier: see [[High Floors]].
+
+## Elevators involving this floor
+
+- **Awe** = [[Fear]] + **Wonder**
+
+These are movements between floors, not floors themselves. The journal tags the floor you land on; the elevator name describes the trip.
+
+## How to use this floor
+
+- **Name it.** "I'm on Wonder," not "I'm in Wonder." The naming reduces the charge.
+- **Look for the elevator.** What carried you here? A conversation, a meal, a meeting, a thought. The elevator is the actual lesson.
+- **Check the shadow twin** (above) if there is one.
+
+## Narrative form
+
+The 34-floor framework started as a writing project. Each floor gets a lived-experience chapter in [[The High-Rise Series]]:
+
+- English: [https://adelaidadiazroa.substack.com](https://adelaidadiazroa.substack.com)
+- Español: [https://perspectivasblog.substack.com](https://perspectivasblog.substack.com)
+
+## Reference
+
+See [[floors|All 34 floors]] for the canonical list. The framework is MIT-licensed and lives in the public substrate.

--- a/scripts/generate_floor_stubs.py
+++ b/scripts/generate_floor_stubs.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Generate one stub note per Floor + tier-index notes for the public substrate.
+
+The substrate ships `floors.md` (one table). The `daily-journal` skill tags every
+entry with wikilinks like `[[Fear]]` and `[[Low Floors]]`. Without per-floor
+notes, those wikilinks resolve to empty bare-string nodes in the graph.
+
+This script emits 34 floor stubs + 3 tier-index notes at `floors/<Name>.md`.
+Bodies are the framework (energy line, elevator emotions involving the floor,
+shadow-twin links, Substack series links) — not lived-experience prose.
+
+Re-run after any change to the 34-floor canonical list in floors.md.
+"""
+
+from pathlib import Path
+from textwrap import dedent
+
+ROOT = Path(__file__).resolve().parent.parent
+OUT = ROOT / "floors"
+
+SUBSTACK_EN = "https://adelaidadiazroa.substack.com"
+SUBSTACK_ES = "https://perspectivasblog.substack.com"
+
+FLOORS = [
+    (1,  "Disgust",       "Asco",          "Low",    "outward rejection, visceral 'get it away from me'"),
+    (2,  "Shame",          "Vergüenza",     "Low",    "'I'm such an idiot,' self-disgust, hiding"),
+    (3,  "Embarrassment",  "Bochorno",      "Low",    "social exposure, temporary, recoverable"),
+    (4,  "Guilt",          "Culpa",         "Low",    "'I should be doing more,' letting people down"),
+    (5,  "Apathy",         "Apatía",        "Low",    "'nothing matters,' checked out, numb"),
+    (6,  "Resignation",    "Resignación",   "Low",    "defeated 'it is what it is' (not making peace)"),
+    (7,  "Confusion",      "Confusión",     "Low",    "mind reaching and failing, contradictory thoughts"),
+    (8,  "Loneliness",     "Soledad",       "Low",    "surrounded but unfound, no one gets it"),
+    (9,  "Boredom",        "Aburrimiento",  "Low",    "restless, understimulated, the trampoline floor"),
+    (10, "Grief",          "Duelo",         "Low",    "loss, sadness, missing someone or something"),
+    (11, "Disappointment", "Decepción",     "Low",    "gap between hope and what arrived"),
+    (12, "Hurt",           "Herida",        "Low",    "breach in a relationship, 'how could they'"),
+    (13, "Fear",           "Miedo",         "Low",    "anxiety, 'what if,' imposter feelings"),
+    (14, "Frustration",    "Frustración",   "Low",    "blocked energy, 'this should be working'"),
+    (15, "Desire",         "Deseo",         "Low",    "wanting, craving, reaching, ambition mixed with lack"),
+    (16, "Anger",          "Rabia",         "Low",    "directed energy, 'this is wrong,' disrespect"),
+    (17, "Contempt",       "Desprecio",     "Low",    "'you are beneath me,' cold dismissal"),
+    (18, "Pride",          "Orgullo",       "Low",    "proving something, need for external validation"),
+    (19, "Courage",        "Valentía",      "Middle", "taking action despite fear, doing the hard thing"),
+    (20, "Hope",           "Esperanza",     "Middle", "future-facing trust, steady forward momentum"),
+    (21, "Neutrality",     "Neutralidad",   "Middle", "calm observation, processing without charge"),
+    (22, "Willingness",    "Disposición",   "Middle", "optimistic restart, curiosity replaces fear"),
+    (23, "Acceptance",     "Aceptación",    "Middle", "making peace with reality (not Resignation)"),
+    (24, "Reason",         "Razón",         "Middle", "analytical, strategic, clear-headed"),
+    (25, "Trust",          "Confianza",     "High",   "quiet confidence that things hold"),
+    (26, "Compassion",     "Compasión",     "High",   "feeling others' pain without collapsing"),
+    (27, "Humility",       "Humildad",      "High",   "accurate self-perception, 'I was wrong about'"),
+    (28, "Belonging",      "Pertenencia",   "High",   "being received, 'I'm in the right room'"),
+    (29, "Love",           "Amor",          "High",   "connection, warmth, giving freely"),
+    (30, "Gratitude",      "Gratitud",      "High",   "presence recognizing abundance"),
+    (31, "Excitement",     "Entusiasmo",    "High",   "anticipatory joy, body saying yes"),
+    (32, "Wonder",         "Asombro",       "High",   "awe at what exists, expansion"),
+    (33, "Joy",            "Alegría",       "High",   "delight, fun, laughter, alive"),
+    (34, "Peace",          "Paz",           "High",   "stillness, nothing to fix, enough as-is"),
+]
+
+ELEVATORS = {
+    "Nostalgia":     [(10, "Grief"), (29, "Love")],
+    "Awe":           [(13, "Fear"), (32, "Wonder")],
+    "Jealousy":      [(13, "Fear"), (15, "Desire"), (16, "Anger")],
+    "Schadenfreude": [(18, "Pride"), (33, "Joy (corrupted)")],
+    "Vulnerability": [(2, "Shame"), (29, "Love")],
+    "Bittersweet":   [(10, "Grief"), (33, "Joy")],
+}
+
+SHADOWS = {
+    6:  (23, "Acceptance", "'I've given up' vs 'I've made peace'"),
+    5:  (21, "Neutrality", "'I don't care' vs 'I'm not attached'"),
+    15: (29, "Love",       "'I want from you' vs 'I give to you'"),
+    18: (25, "Trust",      "'I need you to see me' vs 'I see myself'"),
+}
+SHADOW_INVERSE = {high: (low, low_name, tell) for low, (high, _, tell) in SHADOWS.items()
+                  for low_name in [next(f[1] for f in FLOORS if f[0] == low)]}
+
+TIER_INDEX = {
+    "Low":    ("Low Floors",    "Pisos Bajos",    "Reactive: 1-18. The reactive tier. Where the charge lives.",      1, 18),
+    "Middle": ("Middle Floors", "Pisos Medios",   "Transitional: 19-24. The transitional tier. The climb up.",       19, 24),
+    "High":   ("High Floors",   "Pisos Altos",    "Generative: 25-34. The generative tier. Where the energy gives.", 25, 34),
+}
+
+TIER_LEVEL = {"Low": "Low", "Middle": "Middle", "High": "High"}
+
+
+def elevators_for(num: int) -> list[tuple[str, list[tuple[int, str]]]]:
+    return [(name, members) for name, members in ELEVATORS.items()
+            if any(m[0] == num or m[1].startswith(name[:4]) for m in members)
+            and any(m[0] == num for m in members)]
+
+
+def floor_body(num: int, en: str, es: str, tier: str, energy: str) -> str:
+    elevators = elevators_for(num)
+    shadow_block = ""
+    if num in SHADOWS:
+        high_num, high_name, tell = SHADOWS[num]
+        shadow_block = dedent(f"""
+            ## Shadow twin
+
+            **{en} ({num})** is the shadow of **[[{high_name}]] ({high_num})**.
+
+            > {tell}
+
+            When {en} shows up easily, check whether [[{high_name}]] is what you actually mean. The difference is whether you are still bracing.
+        """).strip() + "\n\n"
+    elif num in SHADOW_INVERSE:
+        low_num, low_name, tell = SHADOW_INVERSE[num]
+        shadow_block = dedent(f"""
+            ## Shadow twin
+
+            **[[{low_name}]] ({low_num})** is the shadow of **{en} ({num})**.
+
+            > {tell}
+
+            Most "{en}" people claim is actually [[{low_name}]]. The difference is whether you are still bracing.
+        """).strip() + "\n\n"
+
+    elevator_block = ""
+    if elevators:
+        lines = []
+        for elev_name, members in elevators:
+            parts = []
+            for m_num, m_name in members:
+                if m_num == num:
+                    parts.append(f"**{m_name}**")
+                else:
+                    base_name = m_name.split(" (")[0]
+                    parts.append(f"[[{base_name}]]")
+            lines.append(f"- **{elev_name}** = " + " + ".join(parts))
+        elevator_block = "## Elevators involving this floor\n\n" + "\n".join(lines) + "\n\nThese are movements between floors, not floors themselves. The journal tags the floor you land on; the elevator name describes the trip.\n\n"
+
+    tier_name = TIER_INDEX[tier][0]
+
+    body = dedent(f"""\
+        ---
+        type: floor
+        floor_number: {num}
+        floor_name: {en}
+        floor_level: {tier}
+        aliases: [{es}, "Floor {num}", "Piso {num}"]
+        ---
+
+        # {en} · {es}
+
+        **Floor {num} · {tier} tier**
+
+        {energy[0].upper() + energy[1:]}.
+
+        Part of the {tier.lower()} tier: see [[{tier_name}]].
+
+        """)
+
+    if elevator_block:
+        body += elevator_block
+
+    if shadow_block:
+        body += shadow_block
+
+    body += dedent(f"""\
+        ## How to use this floor
+
+        - **Name it.** "I'm on {en}," not "I'm in {en}." The naming reduces the charge.
+        - **Look for the elevator.** What carried you here? A conversation, a meal, a meeting, a thought. The elevator is the actual lesson.
+        - **Check the shadow twin** (above) if there is one.
+
+        ## Narrative form
+
+        The 34-floor framework started as a writing project. Each floor gets a lived-experience chapter in [[The High-Rise Series]]:
+
+        - English: [{SUBSTACK_EN}]({SUBSTACK_EN})
+        - Español: [{SUBSTACK_ES}]({SUBSTACK_ES})
+
+        ## Reference
+
+        See [[floors|All 34 floors]] for the canonical list. The framework is MIT-licensed and lives in the public substrate.
+        """)
+
+    return body
+
+
+def tier_body(tier: str) -> str:
+    en, es, blurb, lo, hi = TIER_INDEX[tier]
+    rows = [f"- {n}. [[{f_en}]] ({f_es}) — {energy}" for n, f_en, f_es, t, energy in FLOORS if t == tier]
+    return dedent(f"""\
+        ---
+        type: floor-tier
+        tier: {tier}
+        aliases: [{es}]
+        ---
+
+        # {en} · {es}
+
+        {blurb}
+
+        Floors **{lo}-{hi}**:
+
+        """) + "\n".join(rows) + dedent(f"""
+
+        ## Reference
+
+        See [[floors|All 34 floors]] for the full canonical list with energies, Spanish names, elevator emotions, and shadow twins.
+        """)
+
+
+SERIES_BODY = dedent(f"""\
+    ---
+    type: writing-project
+    aliases: ["High-Rise", "The High-Rise", "La Torre"]
+    ---
+
+    # The High-Rise Series
+
+    A lived-experience writing project: each of the 34 floors gets its own chapter. Not theory. Not a self-help ladder. One person walking the building she lives in.
+
+    Read the series:
+
+    - English: [{SUBSTACK_EN}]({SUBSTACK_EN})
+    - Español: [{SUBSTACK_ES}]({SUBSTACK_ES})
+
+    The framework underneath the chapters (canonical 34-floor list, energies, Spanish names, tiers, elevator emotions, shadow twins) lives at [[floors|floors]]. Every floor note links back here.
+
+    The framework is MIT-licensed and lives in the public substrate. The chapters are the author's writing and live behind their own license on Substack.
+    """)
+
+
+def main():
+    OUT.mkdir(exist_ok=True)
+    written = []
+    for num, en, es, tier, energy in FLOORS:
+        path = OUT / f"{en}.md"
+        path.write_text(floor_body(num, en, es, tier, energy))
+        written.append(str(path.relative_to(ROOT)))
+    for tier in ("Low", "Middle", "High"):
+        en, _, _, _, _ = TIER_INDEX[tier]
+        path = OUT / f"{en}.md"
+        path.write_text(tier_body(tier))
+        written.append(str(path.relative_to(ROOT)))
+    series_path = OUT / "The High-Rise Series.md"
+    series_path.write_text(SERIES_BODY)
+    written.append(str(series_path.relative_to(ROOT)))
+    print(f"Wrote {len(written)} files:")
+    for p in written:
+        print(f"  {p}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why

The substrate ships one \`floors.md\` (a 34-row table). The \`daily-journal\` skill writes \`*Floor: [[Fear]] · [[Low Floors]]*\` on every entry. Without per-floor notes, those wikilinks resolve to bare-string nodes in graphify: name only, no body, no Substack link, no shadow-twin or elevator-emotion edges.

Adelaida's personal graph looks rich because her vault has ~75 standalone floor notes from her writing project (private). Installer graphs and her graph diverge by exactly that.

## What ships

- **\`floors/<Name>.md\`** — 34 stubs (EN+ES aliases, tier link, elevator emotions involving the floor, shadow-twin cross-link when applicable, Substack series pointer)
- **\`floors/Low Floors.md\` / \`Middle Floors.md\` / \`High Floors.md\`** — tier index notes daily-journal also wikilinks
- **\`floors/The High-Rise Series.md\`** — outbound resolution target for every floor stub (per license-hygiene the framework + series name are deliberately public)
- **\`scripts/generate_floor_stubs.py\`** — regenerate from the canonical table

Bodies are the framework (energy + tier + elevators + shadow twin + Substack pointer), not lived-experience prose.

## Effect

A fresh installer's graph, after a month of journaling: every floor becomes a 30+ in-degree node with body content + shadow-twin edges + elevator-emotion edges + tier-cluster edges + Substack outbound. The High-Rise becomes the spine of their consciousness graph instead of 34 bare strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)