### PR TITLE
docs(session-close): rewrite the user-facing cascade brain-first, relocate dev internals

### DIFF
--- a/docs/SESSION_CLOSE.md
+++ b/docs/SESSION_CLOSE.md
@@ -1,6 +1,6 @@
 # Session close — how the cascade works
 
-When you finish a Claude Code session, a multi-step capture cascade saves your decisions, journal seeds, to-dos, time tracking, and a rebuilt session/decision log. This doc explains what runs, when, and how to control it.
+When you finish a Claude Code session, a multi-step capture cascade saves what the session produced — your belief shifts, journal seeds, decisions, to-dos, learnings, and time tracking — to your vault, so the next session builds on it instead of starting cold. That capture is the whole point; everything below is the plumbing that makes it reliable and keeps it out of your way. You do not need to be a developer to use it — most people running it journal and plan, they don't code. This doc explains what runs, when, and how to control it.
 
 ## TL;DR
 
@@ -163,6 +163,25 @@ For verbose tracing during a session, set `CLOSING_SIGNAL_DEBUG=1` and watch std
 The prior architecture relied entirely on the model "noticing" closing signals and choosing to read the cascade rule file before responding. Three brittle steps (notice signal → read rule → execute the cascade), any one of which could fail silently. Reports came back of users saying "bye" and the cascade not firing — captures lost.
 
 This architecture moves detection to a deterministic hook (Layer 1), preserves all model-required creative work in Phase 1, and adds a Haiku backstop (Layer 3) that guarantees no silent loss even if the model bails. The full cascade — every capture from the prior 7-phase spec — is preserved.
+
+## Internals (maintainer reference)
+
+Most users never need this section. It documents the engineering that keeps the Layer 3 git snapshot safe on large or busy vaults — relocated here from the user-facing rule so the rule stays plain-language. The behavior lives in the shipped hooks/scripts and is exercised by CI on every PR; this is the prose that explains it.
+
+### Worktree invariant (issue #65)
+
+When the Stop hook runs from inside a git worktree's own checkout of `session-end-hook.sh`, the `VAULT` variable resolves against the MAIN vault path, not the worktree path. The commit lands on `master`, never on `claude/<slug>`. The companion `scripts/worktree-prune.sh` refuses to delete any `claude/*` branch carrying commits not reachable from master, and points to `scripts/recover-orphan-claude-branches.py` for recovery. Both layers must hold simultaneously; `tests/integration/test_worktree_session_close.sh` enforces this on every PR. If session files ever appear to vanish after a worktree archive, run the recovery script — branches with orphan commits remain in `git for-each-ref refs/heads/claude/*` until `worktree-prune.sh` runs.
+
+### Resource-aware close (mature vaults)
+
+On a mature vault (10k–60k+ tracked files), the close-time git snapshot is the one genuinely heavy operation on the interactive path: `git add` + `git commit` read and rewrite an index that is megabytes large. If the machine is already saturated (many parallel sessions, a sync client churning, a graph build running), piling that IO on at close can pin or crash the machine right as you wrap up. Two primitives — shared by the close hook and the daily-maintenance cron via `scripts/_session_close_guard.sh` — prevent it:
+
+- **Load gate.** Before the aggregators + git snapshot, the hook reads the 1-min load average per core. At or above `CLOSE_MAX_LOAD_PER_CORE` (default `3.0`, env-overridable) it **defers** that heavy work. The cheap path (turn-end timestamp + retention) always runs. The load read fails open: a platform whose load it cannot read never defers.
+- **Close-cascade mutex.** A `set -C` (noclobber) lock at `${TMPDIR:-/tmp}/abs-close-cascade.lock` serializes concurrent closes so two never hammer the git index at once. Stale locks (dead holder PID, or older than 600s) are reclaimed. `flock(1)` is absent on stock macOS, so the portable noclobber primitive is used instead.
+
+**Nothing is lost on a deferred close.** The captured session file is already on disk (the model or the Haiku fallback wrote it). The daily-maintenance cron re-runs the aggregators and commits any session / decision / captures files a deferred close left uncommitted, so the work is snapshotted within a day rather than right now.
+
+**Heavy hygiene lives in the daily cron, never on the close path.** The full-tree / git-log-walking scripts the substrate ships (`drift-detection.py`, `check-rule-conflicts.py --scan-all`, `passive-capture.py --scan-today`) are too heavy to run at every close. They run once a day via `scripts/vault-daily-maintenance.sh`, itself load-gated + mutex-serialized + at low CPU/IO priority. Install with `scripts/install-vault-daily-maintenance.sh <vault>` (macOS launchd) or the cron line in `templates/launchd/com.abs.vault-daily-maintenance.plist.template` (Linux). See [docs/MAINTENANCE.md](MAINTENANCE.md). The CI test `tests/integration/test_resource_aware_session_close.sh` enforces the gate + the catch-up on every PR.
 
 ## Schema reference
 

--- a/templates/rules/session-close.md
+++ b/templates/rules/session-close.md
@@ -1,156 +1,96 @@
 ---
 creationDate: {{DATE}}
 type: rule
-purpose: Session close protocol — full cascade preserved, hook-orchestrated. Run before goodbye or context compaction.
+purpose: Session close protocol — save what the session produced to the vault, then hand off to the automatic hooks. Run before goodbye or context compaction.
 trigger: User signals session end OR context compaction imminent
 supersedes: session-end-cascade.md (deprecated; this file is the canonical source)
 ---
 
 # Session close protocol
 
-The session close cascade is layered across three coordinated mechanisms. **You don't need to read this file when the cascade fires** — the `detect-closing-signal.py` hook injects all paths and instructions into your context automatically. This file exists for documentation, debugging, and the rare manual run.
+**What a close is for: nothing the session produced gets lost.** What the user learned, decided, felt, and committed to gets written to their vault — their second brain — so the next session, and the next month, build on it instead of starting cold. Everything else in this file is plumbing that serves that one goal.
 
-## Architecture
+**Most people running this are not developers.** They journal, plan, think, run a business. Speak to them in plain language. Never narrate machinery — "git snapshot", "Bash task", "mutex", "worktree" — at them. The git/resource detail in Phase 4 runs automatically and silently; it is maintainer reference, not something the user reads or hears.
 
-| Layer | Mechanism | Responsibility |
+**You don't need to read this file when the cascade fires** — `detect-closing-signal.py` injects all paths and instructions into your context automatically. This file is documentation, debugging, and the rare manual run. Full architecture + internals: [docs/SESSION_CLOSE.md](../../docs/SESSION_CLOSE.md).
+
+## How it runs (three layers, automatic)
+
+| Layer | Mechanism | Does |
 |---|---|---|
-| 1 | `hooks/detect-closing-signal.py` (UserPromptSubmit) | Detect close signal; pre-resolve timestamp/worktree/paths; pre-build session file shell; pre-fetch decisions-with-empty-Outcome list; write marker file; inject cascade context for the model |
-| 2 | The model's turn | Run Phase 0b incomplete-work check, then scan conversation and write captures to pre-built paths in one batched tool-call block. No tool-call narration. |
-| 3 | `scripts/session-end-hook.sh` (Stop) | If marker exists: run `session-close-fallback.py` only when model bailed (empty body), then aggregators, targeted git snapshot, retention cleanup, marker cleanup. If no marker: cheap-path turn-end log only. |
+| 1 | `detect-closing-signal.py` (UserPromptSubmit) | Detect the goodbye; resolve paths; pre-build the session-file shell; inject everything you need |
+| 2 | Your turn | Surface unfinished work, scan the conversation, write captures to the vault in one batched block |
+| 3 | `session-end-hook.sh` (Stop) | Backstop + aggregate + (only if the vault is backed up by git) snapshot — automatic, silent |
 
-**Skip condition.** When the user has fewer than 5 messages this session AND no captures detected, the hook injects a "trivial — skip" instruction. The model says a clean goodbye, the Stop hook still logs a timestamp.
+**Skip condition.** Fewer than 5 user messages AND no captures = trivial. Say a warm goodbye, skip the protocol. The hook still logs a timestamp.
 
-**Closing signals.** EN/ES/PT language packs at `templates/closing-signals/*.json`. Includes explicit slash commands (`/close`, `/wrap-up`, `/bye`, `/cerrar`, `/tchau`), high-confidence natural-language closes ("bye", "thanks that's all", "good night", "ttyl", "chao", "nos vemos", "tchau", "valeu"), emoji-only farewells, and ambiguous signals ("ok", "cool", "perfect") that trigger a one-line confirmation before the cascade. False-positive guards exclude code blocks, quoted "bye", "done with X" mid-conversation transitions, and meta-questions about close signals.
+**Closing signals + custom signals.** EN/ES/PT packs at `templates/closing-signals/*.json`; explicit slash forms (`/close`, `/bye`, `/cerrar`, `/tchau`); false-positive guards (quoted "bye", "done with X" transitions, meta-questions). Extend via `closingSignals.custom: [...]` in CLAUDE.md.
 
-**Custom signals.** Users can extend per-language via `closingSignals.custom: ["k thx", "okkk"]` in CLAUDE.md frontmatter or inline.
+## Phase 0b — Unfinished business (you, FIRST)
 
-## Phase 0b — Incomplete-work gate (model, FIRST)
+Before writing anything, surface — in PLAIN language — anything the user started this session but didn't finish: a draft half-written, a decision they were weighing, a task they meant to do, a document still open. For each: "Want to finish this now, or leave it for next time?" Wait for their call before continuing.
 
-Before any writes. Surface anything that did not finish this session:
+*Coding sessions only:* if and only if this was a build session, also surface background jobs still running, anything killed mid-run, or a pipeline phase that errored. Skip this entirely for non-dev sessions — they have none of these.
 
-- Background tasks still running (`run_in_background: true` Bash calls).
-- Tasks killed mid-run (any `TaskStop` or pipeline phase aborted).
-- Pipeline phases that didn't complete (graphify stage, second-brain-mapping phase, imports/exports that errored).
-- Commands that errored and were not retried.
+If nothing is unfinished: say so and continue.
 
-For each, ask the user: "Finish now, or close and leave for next session?" Wait for the call. Do NOT proceed until every incomplete item is finished or explicitly deferred.
+## Phase 1 — Scan the conversation (you, one pass)
 
-If nothing is incomplete: say "No incomplete work" and continue.
+One read of the conversation. Compose everything in memory, then write in Phase 2. **Lead with what compounds the user's thinking; the optional buckets come last and only when they apply.**
 
-## Phase 1 — Single-pass conversation scan (model)
+**Belief shifts.** Does the user end believing something different than they started? That is the most valuable capture — the first journal seed.
 
-One pass through the conversation. All output buckets composed in memory before writing.
+**Journal seeds.** VERBATIM quotes where the user revealed a belief, an observation, a change of mind. Tag emotional ones `[emotional]`. Never reword. → `Session Captures.md`.
 
-**Belief shift check.** Does the user end the session believing something different? If yes, that's the first journal seed.
+**Decisions.** New decisions: one file per decision in `Decisions/{timestamp}-{slug}.md` with frontmatter (`type: decision`, date, stakes, outcome placeholder). Capture the REASONING, not just the outcome. Backfill the Outcome on any prior decision (the hook pre-lists the open ones) this session resolved.
 
-**Journal seeds.** VERBATIM quotes where the user revealed a belief, observation, or change of mind. Tag emotional ones `[emotional]`. Never reword. Destination: `Session Captures.md`.
+**To-dos.** File to the user's canonical to-do destination(s). Self-contained rule: every task carries a `[context prefix]` OR wikilink OR URL OR file path so it stands alone out of session. Reconcile: check off (`- [x]`) anything completed this session, matched by substance.
 
-**Writing note candidates.** If the user has a Substack/blog setup configured in CLAUDE.md, apply kill conditions before drafting:
-- No "I" + something that happened today ("I checked", "I shipped", "I felt")
-- No startup-blogger / LinkedIn-thought-leader tone
-- No "look at me" ego framing
-- Must read as universal observation, not diary
-- Must stand alone without session context
-- If bilingual configured (e.g., EN+ES Substack pair), draft both.
-- File to user's Content Drafts file (path defined in CLAUDE.md) or Captures under "Ideas & Strategy."
+**Learnings — what to do better.** What did this session teach about how the user works, or how their system should work? A cleaner way to do a recurring thing, a friction point worth removing, a process that should change, an optimization worth applying. Capture it to the vault (Captures under "Learnings", or the user's improvements file if one is configured) so the brain compounds instead of just logging. **If an optimization is safe to apply right now, apply it — don't just note it.**
 
-**Actionable content.** Strategy fragments, product insights, partnership leads. File to canonical location per the vault map; default to Captures.
+**Delegations.** Items for other people: add to the team to-do with `@Name`, and draft the message the user sends in one click.
 
-**To-dos** (separated by canonical destination — personal vs team). Apply self-contained capture rule: every task includes a `[Context prefix in brackets]` OR a wikilink OR a direct URL OR a file path so it stands alone when surfaced out of session context.
+**Writing notes** *(only if a Substack/blog is configured in CLAUDE.md).* Kill conditions before drafting: no "I + happened-today" diary, no LinkedIn-thought-leader tone, no ego framing; must read as a universal observation that stands alone. Bilingual setup → draft both languages. → Content Drafts file or Captures.
 
-**To-do reconciliation.** Check off (`- [x]`) completed items in Get to-do, team to-do, Current Priorities. Match by substance, not exact wording. Partial completion: leave unchecked, append progress note.
+**Time tracking** *(only if the vault uses it).* `- HH:MM - HH:MM | Category | Brief`. Verify start < end.
 
-**Decision logging.** New decisions: create per-decision file in `Decisions/{timestamp}-{slug}.md` with frontmatter (`type: decision`, worktree, decision_date, floor, stakes, speed, outcome placeholder, pattern placeholder). Include the reasoning, not just the outcome.
+**GitHub issues** *(only if this was a coding session that filed any).* Log to `Open GitHub Issues.md`. Skip otherwise.
 
-**Decision outcome backfill.** The hook pre-fetches files in `Decisions/` with blank Outcome (listed in the injected context). If this session resolved any of those, fill in the Outcome.
+## Phase 2 — Write to the vault (you, one batched block)
 
-**Delegations.** Items for others: add to team to-do with `@Name`. Draft the message (Slack, WhatsApp, email) the user can send in one click.
+All edits in parallel. No read-write ping-pong. No tool-call narration.
 
-**GitHub issues.** If any filed this session: log to `Open GitHub Issues.md`.
+**Session file.** Fill the pre-built shell the hook created (headers already there — fill the bodies). Capture commitments in the user's exact words.
 
-**Time tracking entry** (if vault uses it, per CLAUDE.md). Format: `- HH:MMam/pm - HH:MMam/pm | Category | Brief`. Categories defined in the time-tracking file. Verify start < end. Infer category from conversation.
+**Decision files.** Create at the pre-resolved `Decisions/` path with frontmatter.
 
-## Phase 2 — Batch writes (model, single tool-call block)
+**Append, never overwrite.** Wikilink people, projects, concepts. Leave enough context to make sense in 6 months.
 
-All accumulated edits written in parallel. No interleaved read-write cycles. No tool-call narration.
+**Vault firewall.** Personal content → personal vault. Team/business → team vault. Ambiguous → personal. Never leak personal content into a shared vault.
 
-**Session file.** Fill the pre-built shell at the path the hook injected. Sections (`## What happened`, `## Decisions`, `## Captures`, `## To-dos filed`, `## Delegations`, `## Pending / incomplete`) are already there — just fill the bodies. Verbatim rule: capture commitments in the user's exact words.
+## Phase 3 — Goodbye (you, one line)
 
-**Per-decision files.** Create at the pre-resolved Decisions/ path with frontmatter.
+Tell the user plainly what you saved: "Saved to your vault: N decisions, M to-dos, the belief shift about Y. Anything I missed?" Then a warm goodbye in their language. No machinery, no phase names, no file paths unless they ask.
 
-**Append, never overwrite.** Wikilink people, projects, concepts. Enough context for 6 months.
+## Phase 4 — Automatic finalization (the Stop hook — you do nothing)
 
-**Vault firewall.** Personal to personal vault. Team/business to team vault. Ambiguous defaults to personal. Never let personal content leak into the team vault.
+Runs after your turn with zero involvement from you, and silently from the user's view:
 
-## Phase 3 — Final summary (model, one line)
+1. **Backstop.** If the session file is still empty (you bailed), a Haiku fallback fills it from the transcript (needs `ANTHROPIC_API_KEY`; without it, leaves a recovery flag for next time).
+2. **Aggregate.** Rebuilds Last Session.md + Decision Log.md.
+3. **Backup snapshot.** If — and only if — the vault is backed up by git, the hook saves a snapshot of just the files this close touched. The promise to the user is plain: *their work is saved automatically.* The mechanics (explicit-path staging, worktree safety, resource-gating on large vaults) live in [docs/SESSION_CLOSE.md](../../docs/SESSION_CLOSE.md) — not something the user or you think about. A vault that is not git-tracked simply skips this; the captures are already on disk.
+4. **Cleanup.** Retention sweep + marker removal.
 
-"Filed X seeds, Y to-dos (yours: A, delegations: B), Z decisions, checked off M items. Anything I missed?"
+**Nothing is lost, ever.** The session file is on disk before this phase runs. If the snapshot is deferred (busy machine) the daily maintenance job commits it within a day. Heavy hygiene (drift scans, full-tree walks) never runs on the close path — it lives in that daily job.
 
-Then say goodbye in the user's primary language. Warm, no machinery narration.
+## Recovery, manual run, config, opt-out
 
-## Phase 4 — Hook finalization (automatic, runs after model's turn ends)
-
-The Stop hook runs without your involvement:
-
-1. **Haiku fallback.** If the session file body is still empty (you bailed), `scripts/session-close-fallback.py` calls Haiku 4.5 with the conversation transcript and fills the file. Flagged for next-session review. Requires `ANTHROPIC_API_KEY`; without it, leaves a "fallback unavailable" notice + partial-flag for `recover-last-close.py` to retry later.
-2. **Aggregators.** `aggregate-sessions.py` rebuilds Last Session.md, `aggregate-decisions.py` rebuilds Decision Log.md. **Resource-gated** (see below): deferred to the daily cron when the machine is saturated or a sibling close holds the cascade mutex.
-3. **Targeted git snapshot.** Only if the vault is git-tracked. Stages explicit paths only (session file, decision files, captures file, aggregated views). Never `git add -A`. Waits up to 60s for any concurrent index lock. No push (vaults are typically local-only snapshot repos). **Drift scan first:** also `git status -s` the rules/, sessions/, decisions/, and captures-file paths to catch pre-existing dirty state from prior closes that never committed. Append matched paths to the explicit list. Catches edits made in a previous session whose own cascade missed them. Failure mode is silent until a worktree archive prompt threatens to discard the residue. **Resource-gated** (see below): on a saturated machine this snapshot is the one heavy op on the close path, so it is deferred and the daily cron commits it later.
-
-   **Worktree invariant (issue #65).** When the hook runs from inside a worktree's own checkout of `session-end-hook.sh`, the `VAULT` variable is resolved against the MAIN vault path, not the worktree path. The commit lands on `master`, never on `claude/<slug>`. The companion `scripts/worktree-prune.sh` refuses to delete any `claude/*` branch with commits not reachable from master and points to `scripts/recover-orphan-claude-branches.py` for recovery. Both layers must hold simultaneously; the CI test at `tests/integration/test_worktree_session_close.sh` enforces this on every PR. If you ever see session files disappear after worktree archive, run the recovery script — branches with orphan commits are still in `git for-each-ref refs/heads/claude/*` until `worktree-prune.sh` runs.
-4. **Retention cleanup.** Stubs older than 7 days deleted; substantive sessions older than 7 days archived to `Sessions/Archive/`.
-5. **Marker cleanup.** Removes `~/.claude/.closing-signal-{session_id}.json`.
-
-### Resource-aware close (mature vaults)
-
-On a mature vault (10k-60k+ tracked files), the close-time git snapshot is the one genuinely heavy operation on the interactive path: `git add` + `git commit` read and rewrite an index that is megabytes large. If the machine is already saturated (many parallel sessions, a sync client churning, a graph build running), piling that IO on at close can pin or crash the machine right when you are wrapping up. Two primitives, shared by the close hook and the daily-maintenance cron via `scripts/_session_close_guard.sh`, fix this:
-
-- **Load gate.** Before the aggregators + git snapshot, the hook checks the 1-min load average per core. At or above `CLOSE_MAX_LOAD_PER_CORE` (default `3.0`, env-overridable) it **defers** that heavy work. The cheap path (turn-end timestamp + retention) always runs. The load read fails open: a platform whose load it cannot read never defers.
-- **Close-cascade mutex.** A `set -C` (noclobber) lock at `${TMPDIR:-/tmp}/abs-close-cascade.lock` serializes concurrent closes so two never hammer the git index at once. Stale locks (dead holder PID, or older than 600s) are reclaimed. flock(1) is absent on stock macOS, so the portable noclobber primitive is used instead.
-
-**Nothing is lost on a deferred close.** The captured session file is already on disk (the model or the Haiku fallback wrote it). The daily-maintenance cron re-runs the aggregators and commits any session / decision / captures files a deferred close left uncommitted, so the work is snapshotted within a day instead of right now.
-
-**Heavy hygiene lives in the daily cron, never on the close path.** The full-tree / git-log-walking scripts the substrate ships (`drift-detection.py`, `check-rule-conflicts.py --scan-all`, `passive-capture.py --scan-today`) are too heavy to run at every close. They run once a day via `scripts/vault-daily-maintenance.sh`, itself load-gated + mutex-serialized + at low CPU/IO priority. Install the schedule with `scripts/install-vault-daily-maintenance.sh <vault>` (macOS launchd) or the cron line in `templates/launchd/com.abs.vault-daily-maintenance.plist.template` (Linux). See [docs/MAINTENANCE.md](../../docs/MAINTENANCE.md). The CI test `tests/integration/test_resource_aware_session_close.sh` enforces the gate + the catch-up on every PR.
-
-## Recovery + rollback
-
-- `python3 scripts/recover-last-close.py` — if a partial-flag exists (model bailed + no API key), retry the fallback now that the API key is available, OR open the file in `$EDITOR` for manual completion.
-- `python3 scripts/recover-last-close.py --list` — list all partial flags.
-- `python3 scripts/undo-last-close.py` — move the most recent session file + co-located decisions to an `.undone-{timestamp}/` archive folder, optionally revert the git commit, re-run aggregators. Always interactive unless `--yes`.
-
-## Manual invocation (for power users)
-
-If you want to trigger the cascade explicitly without saying "bye" out loud, type any of these and the detector treats them as explicit close commands:
-
-- `/close`, `/wrap-up`, `/bye`, `/done`, `/finish`
-- `/cerrar`, `/terminar`, `/chao`
-- `/fechar`, `/encerrar`, `/tchau`
-
-These are not registered slash commands — they are detector keywords. Typing them in any conversation fires Layer 1 the same as a natural-language close, with explicit-confidence routing (no ambiguity check).
-
-## Configuration (CLAUDE.md frontmatter or settings)
-
-- `closingSignals.custom: ["..."]` — extra patterns to match as explicit closes.
-- `closeDetection: regex | hybrid` — `hybrid` adds a Haiku fallback for ambiguous prompts (requires `ANTHROPIC_API_KEY`).
-- `sessionCloseFeedback: silent | minimal | verbose` — visibility of the cascade. Default `silent`. `minimal` adds one summary line. `verbose` shows phase-by-phase.
-
-## Skip + opt-out
-
-- Trivial sessions (<5 user messages, no captures) skip the cascade automatically.
-- To temporarily disable detection in a session: `export CLOSING_SIGNAL_DETECTION=off` in the shell where Claude Code launched.
-- To uninstall entirely: remove the UserPromptSubmit + Stop hook entries from `hooks.json` and the `hooks/detect-closing-signal.py` script.
-
-## Errors
-
-All hook errors fail-open (never block the user) and are logged to `~/.claude/logs/session-close-errors.log` for debugging. Common issues:
-
-- "fallback unavailable" — `ANTHROPIC_API_KEY` not set; run `recover-last-close.py` later.
-- "git index.lock held >60s" — concurrent session is mid-commit; snapshot skipped, will retry next close.
-- "language pack not found" — check `templates/closing-signals/*.json` exists and `CLOSING_SIGNAL_LANGS` env var is correct.
-
-## Telemetry (opt-in)
-
-Set `cascadeTelemetry: true` in CLAUDE.md frontmatter to log anonymized cascade-fire rate, completion rate, and language-match distribution to `~/.claude/logs/cascade-telemetry.jsonl`. Useful for the maintainer's quarterly runbook iteration. No content captured, only structural counts.
+- **Recover a bailed close:** `python3 scripts/recover-last-close.py` (`--list` to see flags). **Undo:** `python3 scripts/undo-last-close.py` (interactive).
+- **Trigger manually:** type `/close`, `/bye`, `/done`, `/cerrar`, `/tchau`, etc. — detector keywords, not registered commands.
+- **Config (CLAUDE.md frontmatter):** `closingSignals.custom: [...]`, `closeDetection: regex|hybrid`, `sessionCloseFeedback: silent|minimal|verbose` (default silent).
+- **Skip / off:** trivial sessions auto-skip; `export CLOSING_SIGNAL_DETECTION=off` for one shell; remove the hook entries from `hooks.json` to uninstall.
+- **Errors** fail open (never block the user), logged to `~/.claude/logs/session-close-errors.log`. Full internals, schema, resource-gating, worktree invariant: [docs/SESSION_CLOSE.md](../../docs/SESSION_CLOSE.md).
 
 ## Why this rule exists
 
-Prior architecture relied entirely on the model "noticing" closing signals and choosing to read this rule file before responding. Three brittle steps (notice signal → read rule → execute), any one failing silently. The new architecture moves detection to a deterministic hook (Layer 1), preserves all model-required creative work in Phase 1, and adds a Haiku backstop (Layer 3) that guarantees no silent loss even if the model bails. The full cascade — every capture from the prior 7-phase spec — is preserved.
+The job is simple and human: when a session ends, what the user thought, decided, and committed to is saved to their second brain — automatically, in plain language, with nothing lost. Earlier versions buried that behind developer machinery (git internals, background-task checks, issue logging) that most users — who journal and plan, not code — never needed to see. This version leads with the capture and keeps the plumbing backstage. Detection is deterministic (Layer 1), the capture is yours (Phases 0b-3), and a Haiku backstop (Layer 3) guarantees no silent loss even if you bail.


### PR DESCRIPTION
## Why

The installed session-close rule (`templates/rules/session-close.md`) led with developer machinery — "background Bash tasks", "TaskStop", a **GitHub issues** capture bucket sitting as a peer to journal seeds, and deep git/worktree/mutex internals. Most people running ai-brain-starter journal and plan; they don't code. A non-dev reading the cascade met plumbing before it ever said "save what you learned and decided."

## What changed (prose only — no behavior change)

- **Lead with the brain outcome.** Plain-language open: save what the user learned, decided, felt, and committed to. Explicit instruction: never narrate machinery (git/Bash/mutex) at the user.
- **Phase 0b "Unfinished business"** in human terms; the Bash/Task jargon is gated to a *coding-sessions-only* parenthetical.
- **Demote** GitHub issues + time tracking + writing notes to *only-if-applicable* buckets, after the brain-first ones.
- **Add a Learnings capture** — what to do better / optimizations worth applying — so the brain compounds, not just logs.
- **Keep durability, relabel it** (per the Norman dissent on the panel): one plain line — "if your vault is backed up by git, a snapshot is saved automatically" — and the worktree-invariant + resource-aware internals move to `docs/SESSION_CLOSE.md` under **Internals (maintainer reference)**. Nothing is lost; the behavior still lives in the hooks/scripts and CI still enforces it.

## Safety

No hooks or scripts touched. `verify-session-close-cascade.py` and the worktree/resource integration tests assert hook + script behavior, not this prose, so the rewrite doesn't move any required check.

Panel: Tiago Forte / Julie Zhuo / Karri Saarinen / Don Norman (dissent) / Jackie Kennedy Onassis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)