### PR TITLE
diagnose: flag the worktree-on-vault Obsidian melt (MYC-576 #2/#3)

### DIFF
--- a/docs/CLOUD_SYNC.md
+++ b/docs/CLOUD_SYNC.md
@@ -111,6 +111,15 @@ behind:
   session logs, snapshots) → relocated to the sidecar with a symlink back. The
   sync daemon follows the symlink (a few bytes), never the target's churn.
 
+> **This relocation fixes the *sync* daemon, not the Obsidian *renderer*.** A
+> cloud-sync daemon follows the symlink *file* and stays out of the churn — but
+> Obsidian's own file watcher follows the symlink *back in* and indexes the
+> target anyway. So the sidecar is the right move for sync, yet it does **not**
+> cure the separate worktree-on-vault renderer melt (a Desktop per-session
+> worktree checkout doubling the vault inside the watched tree). That one has no
+> relocation fix; the only cure is to launch the vault PLAIN with the worktree
+> box unchecked. See [VAULT_WORKTREE_MELT.md](VAULT_WORKTREE_MELT.md).
+
 One command sets it up. Run it with **all Claude sessions closed and no scratch
 worktrees live** — separating the git directory orphans live worktrees, so the
 script refuses unless the window is clean (`--force` to override):

--- a/docs/VAULT_WORKTREE_MELT.md
+++ b/docs/VAULT_WORKTREE_MELT.md
@@ -1,0 +1,89 @@
+# Your vault is for docs. Machinery never lives inside it.
+
+Your brain is a git repository, and the Claude **Desktop** app has a per-session
+**worktree** checkbox. On a normal code repo that checkbox is great: it spins up
+a throwaway checkout under `.claude/worktrees/<slug>/` so parallel sessions never
+collide. On an **Obsidian vault** it is a footgun, because the vault's repo root
+*is* the vault root. The worktree is a full second copy of every note, dropped
+**inside** the folder Obsidian is watching.
+
+Obsidian then indexes the doubled tree, the single Electron renderer exhausts its
+heap, and the app OOM/crashes — a hard `EXC_BREAKPOINT` with the CPU pinned (the
+melt measured 2026-06-06). Worse, the Desktop app can silently archive that
+worktree mid-session, taking any file that lived **only** in the worktree with it.
+
+The principle is one line:
+
+> **The vault holds documents. Machinery — git internals, worktrees, caches —
+> never lives inside the Obsidian-watched tree.**
+
+This is the same invariant as [CLOUD_SYNC.md](CLOUD_SYNC.md) ("the vault may be
+synced, the machinery never is"), applied to a different daemon: there the daemon
+is iCloud/OneDrive, here it is Obsidian's own file watcher.
+
+---
+
+## The one fix that works: launch the vault PLAIN
+
+There is exactly one reliable remedy, and it is to never create the worktree:
+
+- **Desktop app:** open the vault with the per-session **worktree box
+  UNCHECKED**.
+- **Terminal:** `cd /path/to/your/vault && claude` — a plain CLI session is
+  never a worktree session.
+
+A plain (non-worktree) vault session has nothing to melt. Code isolation still
+belongs in a worktree — just on a **code** repo, in a sibling directory
+(`~/dev/<repo>-<slug>`), never inside the vault. See
+[dev-repo-worktrees](../skills/dev-repo-worktrees) for that pattern.
+
+## What does NOT work (so you don't waste a day on it)
+
+Three "obvious" fixes are all proven non-viable. Do not reach for them, and do
+not tell a user they are the fix:
+
+- **"Set the `tengu_worktree_mode` flag."** ❌ The flag does **not** gate Desktop
+  worktree creation. The real switch is the per-session checkbox stored in the
+  app's local state, not any config-readable flag. Shipping the flag as "this
+  prevents the melt" is false guidance.
+- **"Symlink `.claude/worktrees/` out of the vault."** ❌ A cloud-sync daemon
+  follows the symlink *file* (a few bytes) and stays out — which is why the
+  [CLOUD_SYNC.md](CLOUD_SYNC.md) sidecar works for *sync*. But **Obsidian's file
+  watcher follows the symlink back IN** and indexes the target anyway, so the
+  renderer still melts. Relocation does not solve *this* daemon.
+- **"Redirect creation with a WorktreeCreate hook."** ❌ The Desktop app does not
+  honor a relocation hint for where it creates the per-session worktree.
+
+Relocation is dead. Prevention (launch plain) is the whole policy.
+
+## How the brain tells you
+
+Two surfaces enforce the principle so a silent melt can't sneak up on you:
+
+| Surface | What it does |
+|---|---|
+| `hooks/warn-vault-session-in-worktree.py` | **Runtime tripwire.** On SessionStart + each prompt/tool, if this session is running inside a vault worktree it surfaces a LOUD warning on the first turn so you abort and relaunch plain *before* the melt compounds. Three detection channels (payload cwd, transcript marker, and a payload-independent `git rev-parse` ground truth); fires once per session; fail-open; bypass `VAULT_WORKTREE_WARN_BYPASS=1`. |
+| `scripts/check-worktree-on-vault.py` (diagnose check 17) | **At-rest scan.** `/diagnose` flags a vault that already has worktree checkouts inside `.claude/worktrees/`, or a `/diagnose` run launched from a worktree cwd. WARN, not FAIL — by the time the directory exists the melt already happened; the remedy is to relaunch plain and let the cleanup hooks reclaim the leftover checkouts. |
+
+Both gate on `.obsidian/` so a **code-repo** worktree never trips them — only a
+worktree inside an actual Obsidian vault is the melt class.
+
+## Already melted? Recover, then relaunch plain
+
+1. **Quit Obsidian and close the Desktop session** — stop the renderer from
+   re-indexing the doubled tree.
+2. **Relaunch the vault PLAIN** (worktree box unchecked, or `cd <vault> &&
+   claude`).
+3. **Reclaim the leftover checkouts.** The worktree-hygiene hooks remove ended
+   scratch worktrees automatically and a session-start cap reclaims any a crash
+   left behind (see [CLOUD_SYNC.md](CLOUD_SYNC.md) → "What the brain does"). To
+   force it now (snapshot-first, never blind-deletes):
+   ```bash
+   python3 ~/.claude/skills/ai-brain-starter/scripts/worktree-reclaim.py --dry-run
+   python3 ~/.claude/skills/ai-brain-starter/scripts/worktree-reclaim.py
+   ```
+4. **Confirm green:** `bash ~/.claude/skills/ai-brain-starter/scripts/diagnose.sh
+   "<vault>"` — check 17 should read OK.
+
+A vault that melts the editor it lives in isn't a vault you'll keep. Notes stay
+inside; machinery stays out; sessions run plain. That's the whole policy.

--- a/scripts/check-worktree-on-vault.py
+++ b/scripts/check-worktree-on-vault.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Guard: a git worktree is living INSIDE the Obsidian-watched vault tree.
+
+The melt
+--------
+The Claude Desktop app has a per-session "worktree" checkbox. On a CODE repo a
+worktree under `.claude/worktrees/<slug>/` is cheap and correct. On an OBSIDIAN
+VAULT (repo-root == vault-root, thousands of files) that checkbox drops a FULL
+second checkout of the vault INSIDE Obsidian's watched file tree. Obsidian's
+renderer indexes the doubled tree and OOM/crashes (the EXC_BREAKPOINT renderer
+melt measured 2026-06-06), and the worktree can be silently archived mid-session,
+taking any worktree-only files with it.
+
+Why relocation is dead (the 2026-06-11 diagnosis)
+-------------------------------------------------
+You cannot fix this by moving the worktree OUT of the watched tree:
+  * a SYMLINK out is followed back IN — Obsidian's file watcher follows symlinks,
+    so the churn re-enters the watched tree even though a cloud-sync daemon would
+    not (this is why the CLOUD_SYNC.md sidecar fixes sync but NOT this melt);
+  * a WorktreeCreate redirect is NOT honored — the Desktop app does not take a
+    relocation hint for where it creates the per-session worktree.
+And the `tengu_worktree_mode` flag does NOT gate Desktop worktree creation, so
+"set the flag" is FALSE remediation. The only honest fix is to never create the
+worktree: launch the vault PLAIN with the per-session worktree box UNCHECKED.
+
+This check is the DIAGNOSE half of that posture (the runtime half is the
+`warn-vault-session-in-worktree.py` SessionStart/tool tripwire). It is a
+DIAGNOSTIC, not an install gate: by the time `.claude/worktrees/` exists the
+melt already happened, so diagnose treats a hit as a WARN with the
+launch-unchecked remedy, never a hard FAIL.
+
+The fire condition (all three, mirroring the runtime hook's gates)
+------------------------------------------------------------------
+  1. the path is an OBSIDIAN vault  (`.obsidian/` at the root) — a code repo
+     worktree is fine, so `.obsidian/` is the discriminator;
+  2. the vault is a GIT repo        (`.git` present / inside a work tree) — the
+     Desktop worktree feature requires git, so a non-git vault cannot melt;
+  3. there is worktree EVIDENCE     — a `.claude/worktrees/<slug>/` checkout
+     physically present inside the vault, OR this very process is running from a
+     worktree cwd under the vault.
+
+Usage:
+  check-worktree-on-vault.py [VAULT]            # human-readable verdict + remedy
+  check-worktree-on-vault.py --porcelain [VAULT] # one machine-readable line
+
+Exit codes:
+  0  OK   — no worktree melting the vault tree (or not the melt class)
+  1  HIT  — a git worktree is inside the Obsidian-watched vault tree
+  2  USAGE — bad arguments
+
+Porcelain first token:
+  OK_NOT_VAULT | OK_NOT_GIT | OK_NO_WORKTREES | WORKTREE_ON_VAULT:<count>
+
+Best-effort + fail-OPEN on its own errors: a diagnostic must never crash the
+report it is part of. Anything it cannot evaluate degrades to OK_NO_WORKTREES
+(the caller can still run every other check). It NEVER writes or deletes.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+USAGE = "usage: check-worktree-on-vault.py [--porcelain] [VAULT]"
+
+# Single source of truth for the worktree segment + cwd detection. Reuse the
+# shared lib that the cleanup hooks already trust so this surface can never drift
+# from them; fall back to inline equivalents if the lib is not importable (the
+# check still works standalone, which is how diagnose runs it on an end-user box).
+WORKTREES_SEG = ".claude/worktrees"
+_current_worktree = None
+_HERE = Path(__file__).resolve().parent
+for _cand in (_HERE.parent / "hooks", _HERE.parent,
+              Path.home() / ".claude" / "skills" / "ai-brain-starter" / "hooks"):
+    if (_cand / "_lib" / "worktree_safety.py").is_file():
+        sys.path.insert(0, str(_cand))
+        try:
+            from _lib.worktree_safety import WORKTREES_SEG as _SEG  # type: ignore
+            from _lib.worktree_safety import current_worktree as _cw  # type: ignore
+            WORKTREES_SEG = _SEG
+            _current_worktree = _cw
+        except Exception:
+            pass
+        break
+
+
+def _fallback_current_worktree(cwd):
+    """Inline equivalent of worktree_safety.current_worktree for the no-lib path."""
+    marker = "/" + WORKTREES_SEG + "/"
+    s = str(cwd)
+    if marker not in s:
+        return None
+    head, tail = s.split(marker, 1)
+    slug = tail.split("/", 1)[0]
+    if not slug:
+        return None
+    return Path(head + marker + slug), slug
+
+
+def current_worktree(cwd):
+    fn = _current_worktree or _fallback_current_worktree
+    try:
+        return fn(Path(cwd).resolve())
+    except Exception:
+        return None
+
+
+def is_obsidian_vault(vault: Path) -> bool:
+    """The `.obsidian/` dir is what makes the tree Obsidian-watched. Its presence
+    is the discriminator between a vault (melts) and a plain code repo (fine)."""
+    try:
+        return (vault / ".obsidian").is_dir()
+    except OSError:
+        return False
+
+
+def is_git_repo(vault: Path) -> bool:
+    """True if `vault` is the root of (or inside) a git work tree. Bounded git
+    call; a plain `.git` dir/file short-circuits without spawning git."""
+    try:
+        if (vault / ".git").exists():
+            return True
+    except OSError:
+        pass
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(vault), "rev-parse", "--is-inside-work-tree"],
+            capture_output=True, text=True, timeout=3,
+        )
+        return out.returncode == 0 and out.stdout.strip() == "true"
+    except Exception:
+        return False
+
+
+def count_worktree_checkouts(vault: Path) -> int:
+    """Number of worktree checkouts physically present under the vault's
+    `.claude/worktrees/`. The physical footprint is what Obsidian indexes, so we
+    count directories on disk (registered or orphaned) rather than asking git —
+    an orphaned-but-present checkout melts the renderer just the same. Read-only;
+    an unreadable listing degrades to 0 (reported as OK upstream)."""
+    wt_dir = vault / ".claude" / "worktrees"
+    try:
+        if not wt_dir.is_dir():
+            return 0
+        return sum(1 for e in wt_dir.iterdir() if e.is_dir())
+    except OSError:
+        return 0
+
+
+def evaluate(vault: Path):
+    """Return (token, count). token is the porcelain first field."""
+    if not is_obsidian_vault(vault):
+        return "OK_NOT_VAULT", 0
+    if not is_git_repo(vault):
+        return "OK_NOT_GIT", 0
+
+    count = count_worktree_checkouts(vault)
+
+    # cwd channel: this very run is happening from inside a worktree that belongs
+    # to THIS vault (e.g. /diagnose launched from the worktree session). Counts as
+    # at least one live checkout even if the on-disk scan raced or was unreadable.
+    cw = current_worktree(os.getcwd())
+    if cw is not None:
+        wt_path = cw[0]
+        try:
+            owner = Path(str(wt_path).split("/" + WORKTREES_SEG + "/", 1)[0]).resolve()
+            if owner == vault.resolve() and count == 0:
+                count = 1
+        except Exception:
+            pass
+
+    if count > 0:
+        return "WORKTREE_ON_VAULT:{}".format(count), count
+    return "OK_NO_WORKTREES", 0
+
+
+def _print_human(token: str, count: int, vault: Path) -> None:
+    if token == "OK_NOT_VAULT":
+        print("OK    Not an Obsidian vault (no .obsidian/); the worktree-melt class does not apply.")
+    elif token == "OK_NOT_GIT":
+        print("OK    Vault is not a git repo; the Desktop worktree feature cannot create a checkout here.")
+    elif token == "OK_NO_WORKTREES":
+        print("OK    No git worktree inside the Obsidian-watched vault tree.")
+    elif token.startswith("WORKTREE_ON_VAULT:"):
+        print("WARN  {} git worktree checkout(s) live INSIDE the vault at {}/.claude/worktrees/."
+              .format(count, vault))
+        print("      The Desktop per-session worktree checkbox dropped a full-vault checkout inside")
+        print("      Obsidian's watched tree -> renderer OOM/crash, and the worktree can be silently")
+        print("      deleted mid-session. Relocation is DEAD: a symlink out is followed back in by")
+        print("      Obsidian's watcher, and a WorktreeCreate redirect is not honored. The flag does")
+        print("      NOT gate Desktop worktree creation, so do NOT 'set the flag'.")
+        print("      FIX: launch the vault PLAIN with the per-session worktree box UNCHECKED:")
+        print("           cd \"{}\" && claude".format(vault))
+        print("      See docs/VAULT_WORKTREE_MELT.md.")
+    else:
+        print("WARN  Could not evaluate worktree-on-vault melt risk ({}).".format(token))
+
+
+def main(argv):
+    porcelain = "--porcelain" in argv
+    args = [a for a in argv if a != "--porcelain"]
+    if len(args) > 1:
+        print(USAGE, file=sys.stderr)
+        return 2
+    raw = args[0] if args else os.environ.get("VAULT_PATH") or os.getcwd()
+    try:
+        vault = Path(raw).expanduser().resolve()
+    except Exception:
+        vault = Path(raw)
+    if not vault.is_dir():
+        # Fail-open: a bad path is "nothing to flag", not a crash of the report.
+        if porcelain:
+            print("OK_NO_WORKTREES")
+        else:
+            print("OK    Vault path not a directory; nothing to evaluate.")
+        return 0
+
+    token, count = evaluate(vault)
+
+    if porcelain:
+        print(token)
+    else:
+        _print_human(token, count, vault)
+    return 1 if token.startswith("WORKTREE_ON_VAULT:") else 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main(sys.argv[1:]))
+    except Exception:
+        # Fail-open: a diagnostic must never crash the report it runs inside.
+        try:
+            if "--porcelain" in sys.argv:
+                print("OK_NO_WORKTREES")
+        except Exception:
+            pass
+        sys.exit(0)

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -121,6 +121,7 @@ INTEGRATION_TESTS=(
   test_vault_safety_guards
   test_resource_aware_session_close
   test_cloud_sync_guard
+  test_worktree_on_vault_guard
   test_machinery_sidecar
   test_relocate_vault
   test_relocate_sweep

--- a/scripts/diagnose.sh
+++ b/scripts/diagnose.sh
@@ -483,6 +483,35 @@ else
   esac
 fi
 
+# ----- 17. Worktree-on-vault melt risk (the Desktop per-session checkout class) -----
+# A git worktree under .claude/worktrees/ is cheap+correct on a CODE repo, but on
+# an OBSIDIAN VAULT (repo-root == vault-root) it drops a full second checkout
+# INSIDE Obsidian's watched tree -> renderer OOM/crash (the 2026-06-06 melt), and
+# the worktree can be silently deleted mid-session. Relocation is dead (a symlink
+# out is followed back IN by Obsidian's watcher; a WorktreeCreate redirect is not
+# honored), and the flag does NOT gate Desktop worktree creation. The runtime hook
+# warn-vault-session-in-worktree.py is the live tripwire; this is the at-rest scan.
+section "17. Worktree-on-vault melt risk"
+CHECK_WT=""
+for c in "$(cd "$(dirname "$0")" && pwd)/check-worktree-on-vault.py" \
+         "$HOME/.claude/skills/ai-brain-starter/scripts/check-worktree-on-vault.py"; do
+  [ -f "$c" ] && CHECK_WT="$c" && break
+done
+if [ -n "$CHECK_WT" ]; then
+  wverdict="$(python3 "$CHECK_WT" --porcelain "$VAULT" 2>/dev/null)"
+  case "$wverdict" in
+    OK_NOT_VAULT|OK_NOT_GIT|OK_NO_WORKTREES)
+      ok "No git worktree inside the Obsidian-watched vault tree" ;;
+    WORKTREE_ON_VAULT:*)
+      warn "${wverdict#WORKTREE_ON_VAULT:} git worktree checkout(s) live INSIDE the vault (.claude/worktrees/)" \
+        "The Desktop per-session worktree checkbox dropped a full-vault checkout inside Obsidian's watched tree -> renderer OOM/crash, and it can be silently deleted mid-session. Relocation is DEAD (a symlink out is followed back in; a WorktreeCreate redirect is not honored) and the flag does NOT gate it. FIX: launch the vault PLAIN with the worktree box UNCHECKED: cd \"$VAULT\" && claude. See docs/VAULT_WORKTREE_MELT.md." ;;
+    *)
+      warn "Could not evaluate worktree-on-vault melt risk" "check-worktree-on-vault.py returned: ${wverdict:-<empty>}" ;;
+  esac
+else
+  warn "check-worktree-on-vault.py not found" "Cannot check whether a git worktree is melting the vault tree."
+fi
+
 # ----- summary -----
 echo
 echo "${B}Summary${N}"

--- a/scripts/test-worktree-on-vault-guard.sh
+++ b/scripts/test-worktree-on-vault-guard.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Negative-control test for check-worktree-on-vault.py (the worktree-on-vault melt guard).
+# A guard earns trust only by FIRING on the exact thing it catches AND staying
+# SILENT on every near-miss. This asserts a HIT for a real git worktree checked
+# out inside an Obsidian vault, and OK for every negative control: a plain vault,
+# a non-git vault, a code-repo worktree (no .obsidian/), and an empty worktrees dir.
+# Run: bash scripts/test-worktree-on-vault-guard.sh
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+CHECK="$HERE/check-worktree-on-vault.py"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+fails=0
+
+# git in the temp repos needs an identity; set it LOCALLY per-repo (never global)
+# and via env as a belt-and-suspenders for a box with no ambient identity.
+export GIT_AUTHOR_NAME="ci" GIT_AUTHOR_EMAIL="ci@example.com"
+export GIT_COMMITTER_NAME="ci" GIT_COMMITTER_EMAIL="ci@example.com"
+
+mkrepo() { # DIR  -> a git repo with one commit
+  git init -q "$1"
+  git -C "$1" config user.email ci@example.com
+  git -C "$1" config user.name ci
+  printf 'x\n' > "$1/note.md"
+  git -C "$1" add -A
+  git -C "$1" commit -qm init
+}
+
+addworktree() { # REPO  SLUG  -> a real linked worktree at REPO/.claude/worktrees/SLUG
+  mkdir -p "$1/.claude/worktrees"
+  git -C "$1" worktree add -q --detach "$1/.claude/worktrees/$2" HEAD 2>/dev/null
+}
+
+assert_token() { # label  expected-prefix  vault
+  local label="$1" want="$2" v="$3" got
+  got="$(python3 "$CHECK" --porcelain "$v" 2>/dev/null)"
+  case "$got" in
+    "$want"*) echo "PASS  $label  ($got)";;
+    *)        echo "FAIL  $label  want=$want got=$got"; fails=$((fails+1));;
+  esac
+}
+
+assert_rc() { # label  want-rc  vault
+  local label="$1" want="$2" v="$3"
+  python3 "$CHECK" --porcelain "$v" >/dev/null 2>&1
+  local rc=$?
+  [ "$rc" = "$want" ] && echo "PASS  $label (rc=$rc)" || { echo "FAIL  $label want-rc=$want got-rc=$rc"; fails=$((fails+1)); }
+}
+
+# POSITIVE: a real git worktree checked out inside an Obsidian vault must HIT (exit 1).
+POS="$TMP/vault-with-worktree"
+mkrepo "$POS"
+mkdir -p "$POS/.obsidian"
+addworktree "$POS" "session-abc123"
+assert_token "real worktree inside vault" "WORKTREE_ON_VAULT" "$POS"
+assert_rc    "HIT exits 1"                1                   "$POS"
+
+# POSITIVE via cwd channel: /diagnose run FROM inside the worktree, vault passed
+# as the arg, still HITs (exercises current_worktree()). Use a vault whose on-disk
+# scan would also find it, but prove the cwd path independently by cd-ing in.
+( cd "$POS/.claude/worktrees/session-abc123" && python3 "$CHECK" --porcelain "$POS" >/dev/null 2>&1 ) \
+  && { echo "FAIL  cwd-channel want-rc=1 got-rc=0"; fails=$((fails+1)); } \
+  || echo "PASS  cwd-channel fires from inside the worktree (rc=1)"
+
+# NEGATIVE 1: plain vault (git + .obsidian/, no worktrees) -> OK (proves it is not
+# always-HIT; a guard that always fires is as useless as one that never does).
+PLAIN="$TMP/plain-vault"
+mkrepo "$PLAIN"
+mkdir -p "$PLAIN/.obsidian"
+assert_token "plain vault (no worktrees)" "OK_NO_WORKTREES" "$PLAIN"
+assert_rc    "OK exits 0"                 0                 "$PLAIN"
+
+# NEGATIVE 2: not a git repo (.obsidian/ + a stray .claude/worktrees/ dir, no .git)
+# -> OK_NOT_GIT. The Desktop worktree feature needs git; no git == no melt path.
+NOGIT="$TMP/nogit-vault"
+mkdir -p "$NOGIT/.obsidian" "$NOGIT/.claude/worktrees/stray"
+assert_token "non-git vault" "OK_NOT_GIT" "$NOGIT"
+assert_rc    "non-git exits 0" 0          "$NOGIT"
+
+# NEGATIVE 3: a CODE repo worktree (git + real worktree, NO .obsidian/) -> OK_NOT_VAULT.
+# Code-repo worktrees are cheap + correct; .obsidian/ is the discriminator.
+CODE="$TMP/code-repo"
+mkrepo "$CODE"
+addworktree "$CODE" "feature-x"
+assert_token "code-repo worktree (no .obsidian/)" "OK_NOT_VAULT" "$CODE"
+assert_rc    "code-repo exits 0"                  0              "$CODE"
+
+# NEGATIVE 4: an EMPTY .claude/worktrees/ dir (git + .obsidian/, dir but no checkout)
+# -> OK_NO_WORKTREES. The dir alone is not the melt; a live checkout is.
+EMPTY="$TMP/empty-worktrees"
+mkrepo "$EMPTY"
+mkdir -p "$EMPTY/.obsidian" "$EMPTY/.claude/worktrees"
+assert_token "empty worktrees dir" "OK_NO_WORKTREES" "$EMPTY"
+
+# NEGATIVE 5: a non-existent path -> OK (fail-open, never crash the report).
+assert_token "missing path" "OK_NO_WORKTREES" "$TMP/does-not-exist"
+
+echo
+if [ "$fails" -gt 0 ]; then echo "FAILED: $fails"; exit 1; fi
+echo "ALL TESTS PASSED"

--- a/skills/diagnose/SKILL.md
+++ b/skills/diagnose/SKILL.md
@@ -92,6 +92,7 @@ Most "Claude is broken" reports trace to one of:
 | 12 | Vault has an off-machine backup | Set one up: `bash scripts/vault-backup.sh setup` (docs/BACKUP.md) | Backup configured but no snapshot yet |
 | 13 | No repeated Obsidian renderer crashes (macOS; skips elsewhere) | - | Heavy indexer likely OOM-ing the renderer on a large vault: restricted mode -> Dataview only -> add others one at a time (see the obsidian-plugins rule, "Large-vault plugin posture") |
 | 14b | Ingest connectors still producing data (the silent-empty 0-vs-0 gap) | - | A connector exited 0 but returned 0 items (a vendor changed a surface): check its auth/permissions, re-run its ingest skill, confirm it pulls >0 items |
+| 17 | No git worktree living inside the Obsidian-watched vault tree | - | The Desktop per-session worktree checkbox dropped a checkout under `.claude/worktrees/` inside the vault -> renderer OOM/crash. Relocation is dead; the flag does NOT gate it. Relaunch the vault PLAIN with the worktree box UNCHECKED (`cd <vault> && claude`). See docs/VAULT_WORKTREE_MELT.md |
 
 ## When to suggest /diagnose proactively
 
@@ -101,6 +102,7 @@ Most "Claude is broken" reports trace to one of:
 - User says "my friend installed it but it's broken"
 - User says "Obsidian keeps crashing when I open it" / "Obsidian won't open" (likely a heavy-indexer renderer OOM on a large vault - check 13)
 - User says "my brain feels stale" / "I haven't seen any new Granola/WhatsApp/Slack/Gmail notes in a while" / "<source> stopped showing up" (likely a silently-empty connector - check 14b)
+- User says "Obsidian melted / pegged the CPU after I opened a Claude Desktop session" / "the vault doubled itself" / "there's a `.claude/worktrees` folder full of copies of my vault" (likely a worktree-on-vault checkout - check 17; relaunch PLAIN with the worktree box unchecked)
 - After every major upgrade prompt during /setup-brain
 
 Do NOT use /diagnose as an email-capture surface. If `~/.claude/.ai-brain-starter-email-on-file` is missing, that is fine and never a finding — the email is optional, and the only places it is ever asked are the setup interview (Phase 24.4) and the once-per-update post-pull nudge. Never tell the user to fetch or paste a token.

--- a/tests/integration/test_worktree_on_vault_guard.sh
+++ b/tests/integration/test_worktree_on_vault_guard.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# CI integration wrapper - runs the worktree-on-vault melt-guard negative-control
+# suite (scripts/test-worktree-on-vault-guard.sh) as part of scripts/ci.sh. Thin:
+# logic lives next to the script it exercises.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+exec bash "$ROOT/scripts/test-worktree-on-vault-guard.sh"


### PR DESCRIPTION
Completes **MYC-576** after the runtime DETECT+WARN hook ([PR #206](https://github.com/mycelium-hq/ai-brain-starter/pull/206), work item #1) by adding the **at-rest half** of the worktree-on-vault melt guard: work items **#2 (diagnose check)** and **#3 (onboarding doc)**.

## The melt
The Claude **Desktop** per-session *worktree* checkbox drops a full second checkout under `.claude/worktrees/<slug>/`. On a code repo that's cheap and correct; on an **Obsidian vault** (repo-root == vault-root) it lands *inside* Obsidian's watched tree → renderer OOM/crash (the 2026-06-06 melt), and the worktree can be silently deleted mid-session.

## What's here
- **`scripts/check-worktree-on-vault.py`** — porcelain check (`OK_NOT_VAULT | OK_NOT_GIT | OK_NO_WORKTREES | WORKTREE_ON_VAULT:<n>`). Fires only when **(`.obsidian/` vault)** AND **(git repo)** AND **(a worktree checkout inside `.claude/worktrees/` OR a worktree-cwd run)**. Reuses `hooks/_lib/worktree_safety.py` (single source of truth); read-only; fail-open.
- **`scripts/diagnose.sh` section 17** + **`skills/diagnose/SKILL.md`** row + proactive trigger.
- **`tests/integration/test_worktree_on_vault_guard.sh`** — real-`git worktree` positive repro + 5 negative controls (plain vault, non-git, code-repo worktree, empty dir, missing path), registered in `scripts/ci.sh`.
- **`docs/VAULT_WORKTREE_MELT.md`** — the **docs-only-vault** principle + **launch-unchecked** guidance, the **relocation-is-dead** finding (a symlink out is followed back in by Obsidian's watcher; a WorktreeCreate redirect isn't honored), cross-linked from `CLOUD_SYNC.md` so the sync-vs-renderer symlink distinction doesn't read as a contradiction.

## Guardrail honored
Per the 2026-06-11 diagnosis: **no `tengu_worktree_mode` flag-enforcer** — the flag does not gate Desktop worktree creation, so "set the flag" would be false remediation. The honest posture is DETECT + WARN + launch-plain.

## Verification
- New guard suite: 11/11 (positive HIT + cwd channel + 5 negative controls).
- Full `scripts/ci.sh`: py_compile (273 files) + **42** integration tests + shellcheck — all green.
- `diagnose.sh` WARNs on a real worktree test vault; OK on a plain vault.
- Privacy/personal-data scrub clean; `bash -n` clean.

**Done =** ai-brain-starter `diagnose` flags the worktree-on-vault melt on a real test vault; onboarding doc states the docs-only-vault principle + launch-unchecked guidance; CI green; scrub clean. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)