### PR TITLE
fix(open-core): restore agentic-os + security-snapshot; convert guard to allowlist (MYC-1339)

### DIFF
--- a/.github/free-tier-allowlist.txt
+++ b/.github/free-tier-allowlist.txt
@@ -1,0 +1,59 @@
+# free-tier-allowlist.txt
+#
+# Each line is a directory path (relative to repo root) that is DELIBERATELY
+# shipped in the public free substrate, plus a rationale tag explaining WHY.
+#
+# Rationale tags (one per line):
+#   teaching         — teaches the open-core pattern; single-user, no per-tenant concerns
+#   personal         — personal journaling / floor / coaching scaffolding; no paid feature
+#   lead-magnet      — self-labeled free lead magnet (see SKILL.md)
+#   template-MYC254  — intentional free template per MYC-254 (codified Done decision)
+#   ingest-exemplar  — single-user OAuth ingest showing the connector pattern (not multi-tenant)
+#   safety           — security hygiene that protects the user, not a paid feature gate
+#
+# GUARD BEHAVIOR: scripts/check-open-core-boundary.sh reads this file.
+# Any skill under skills/ or capability-pack-shaped top-level dir NOT in this list → CI FAIL.
+# Missing or empty file → CI FAIL (fail-closed by design).
+#
+# To add a new free-tier entry: append a line + rationale tag + update ADR-0001 if the
+# category is new. PR description must cite the codified free-decision (Done ticket /
+# self-label / boundary doc).
+
+# ── Top-level capability packs ──────────────────────────────────────────────
+agentic-os                                 # template-MYC254
+
+# ── skills/ directory entries (one per skill dir) ───────────────────────────
+skills/_shared                             # teaching
+skills/backfill-journal-body-context       # personal
+skills/coach                               # personal
+skills/coaching                            # personal
+skills/daily-journal                       # personal
+skills/deconstruct                         # teaching
+skills/diagnose                            # teaching
+skills/doubt-driven-development            # teaching
+skills/evolve                              # teaching
+skills/for-my-team                         # teaching
+skills/graphify                            # teaching
+skills/health-context                      # personal
+skills/health-doctor                       # personal
+skills/health-setup                        # personal
+skills/ingest-github                       # ingest-exemplar
+skills/ingest-health                       # ingest-exemplar
+skills/ingest-youtube                      # ingest-exemplar
+skills/insights                            # personal
+skills/instinct-export                     # teaching
+skills/instinct-import                     # teaching
+skills/interview-me                        # personal
+skills/longitudinal                        # personal
+skills/meeting-todos                       # teaching
+skills/nano-banana                         # teaching
+skills/note-todos                          # teaching
+skills/patterns                            # teaching
+skills/repurpose-talk                      # teaching
+skills/resolver-query                      # teaching
+skills/rise                                # personal
+skills/second-brain-mapping                # teaching
+skills/secret-warn                         # safety
+skills/security-snapshot                   # lead-magnet
+skills/setup-vault-types                   # teaching
+skills/sunday-review                       # teaching

--- a/agentic-os/INSTALL.sh
+++ b/agentic-os/INSTALL.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# agentic-os/INSTALL.sh - drop the agentic-OS kernel + agents + contexts + rules +
+# data scaffold into a target repo. One command, idempotent, no network.
+#
+#   bash agentic-os/INSTALL.sh [TARGET_DIR]      (default: current directory)
+#
+# Lands:
+#   TARGET/CLAUDE.md                       the kernel (orchestrator)        [*]
+#   TARGET/.claude/agents/*.md             pinned specialist agents
+#   TARGET/.claude/contexts/*.md           posture modes
+#   TARGET/.claude/rules/<lang>/hooks.md   paths-scoped per-language rules
+#   TARGET/.claude/hooks/*.py              the validator + paths-scoped hook
+#   TARGET/data/                           durable project-memory scaffold
+#
+# [*] An existing TARGET/CLAUDE.md is NOT overwritten; the kernel is written to
+#     TARGET/CLAUDE.agentic-os.md for you to merge by hand.
+set -euo pipefail
+
+SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+TARGET="${1:-.}"
+mkdir -p "$TARGET"
+TARGET="$(cd "$TARGET" && pwd)"
+
+echo "agentic-os: installing into $TARGET"
+
+mkdir -p \
+  "$TARGET/.claude/agents" \
+  "$TARGET/.claude/contexts" \
+  "$TARGET/.claude/rules" \
+  "$TARGET/.claude/hooks" \
+  "$TARGET/data"
+
+# Kernel - never clobber an existing CLAUDE.md.
+if [ -e "$TARGET/CLAUDE.md" ]; then
+  cp "$SRC/kernel/CLAUDE.md" "$TARGET/CLAUDE.agentic-os.md"
+  echo "  note: TARGET/CLAUDE.md exists - kernel written to CLAUDE.agentic-os.md (merge by hand)"
+else
+  cp "$SRC/kernel/CLAUDE.md" "$TARGET/CLAUDE.md"
+  echo "  + CLAUDE.md (kernel)"
+fi
+
+# Agents (pinned model + tool surface).
+cp "$SRC"/agents/*.md "$TARGET/.claude/agents/"
+echo "  + .claude/agents/"
+
+# Contexts (posture modes).
+cp "$SRC"/contexts/*.md "$TARGET/.claude/contexts/"
+echo "  + .claude/contexts/"
+
+# Rules (one dir per language; copy each lang's hooks.md).
+for lang_dir in "$SRC"/rules/*/; do
+  [ -d "$lang_dir" ] || continue
+  lang="$(basename "$lang_dir")"
+  mkdir -p "$TARGET/.claude/rules/$lang"
+  cp "${lang_dir}hooks.md" "$TARGET/.claude/rules/$lang/hooks.md"
+done
+echo "  + .claude/rules/"
+
+# Hooks - the validator + the paths-scoped-rules auto-apply hook.
+cp "$SRC/bin/validate_agents.py" "$TARGET/.claude/hooks/validate_agents.py"
+cp "$SRC/bin/paths_scoped_rules.py" "$TARGET/.claude/hooks/paths_scoped_rules.py"
+chmod +x "$TARGET/.claude/hooks/validate_agents.py" "$TARGET/.claude/hooks/paths_scoped_rules.py"
+echo "  + .claude/hooks/"
+
+# Data scaffold (includes README.md + .gitkeep).
+cp -R "$SRC"/data/. "$TARGET/data/"
+echo "  + data/"
+
+# Settings snippet to wire the paths-scoped-rules hook (PostToolUse on Write|Edit).
+cat >"$TARGET/.claude/settings.agentic-os.json" <<'JSON'
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          { "type": "command", "command": "python3 .claude/hooks/paths_scoped_rules.py" }
+        ]
+      }
+    ]
+  }
+}
+JSON
+echo "  + .claude/settings.agentic-os.json"
+
+cat <<'EOF'
+
+agentic-os installed. Next:
+  1. Merge .claude/settings.agentic-os.json into .claude/settings.json
+     (wires paths_scoped_rules as a PostToolUse hook so rules auto-apply on edit).
+  2. Validate the agent tool-surface boundary:
+       python3 .claude/hooks/validate_agents.py .claude/agents
+  3. Replace the placeholder mission line at the bottom of CLAUDE.md with yours.
+EOF

--- a/agentic-os/README.md
+++ b/agentic-os/README.md
@@ -1,0 +1,67 @@
+# agentic-os — a clean agentic OS you can install into any repo
+
+A minimal, declarative "operating system" for a coding agent: a small kernel that
+orchestrates, specialist agents with **pinned models and tool surfaces**,
+user-selectable **posture modes**, and **per-language quality rules that
+auto-apply by file glob**. One command drops it into a fresh repo.
+
+It is built on one idea: **the safety and quality boundaries should be declarative**
+— readable in a markdown file, enforced by the harness, and checkable in CI — not
+buried in prose the model may or may not follow.
+
+## The four primitives
+
+| Primitive | Where | What it gives you |
+|---|---|---|
+| **Kernel** | `kernel/CLAUDE.md` | A small COO/orchestrator. Routes work to agents in a plain markdown table. Stays under 100 lines — detail lives in the files it points to. |
+| **Pinned agents** | `agents/*.md` | One specialist per file. `model:` pinned (heavy for planning, light for execution) and `tools:` pinned. A read-only `planner`/`reviewer` lists only `Read, Grep, Glob` and so **cannot** `Write` — a declarative safety boundary the harness enforces. |
+| **Posture modes** | `contexts/*.md` | `dev` / `review` / `research` / `security`. Switch how you operate mid-session ("switch to review") without a full skill invocation. |
+| **Paths-scoped rules** | `rules/<lang>/hooks.md` | Each rule declares a `paths:` glob (`**/*.ts`). When you edit a matching file, its checks auto-apply — zero per-file config. Add a language by dropping a folder. |
+
+## Install
+
+```sh
+bash agentic-os/INSTALL.sh /path/to/your/repo
+```
+
+Lands `CLAUDE.md` (kernel) + `.claude/agents/` + `.claude/contexts/` +
+`.claude/rules/<lang>/` + `.claude/hooks/` + a `data/` memory scaffold, plus a
+`settings.agentic-os.json` snippet that wires the auto-apply hook. An existing
+`CLAUDE.md` is never overwritten.
+
+## The two enforcement mechanisms (not just templates)
+
+Both load-bearing boundaries are **checkable**, each shipped with a negative
+control that proves it fails on a violation:
+
+- **`bin/validate_agents.py`** parses every agent spec and FAILS if a read-only
+  role declares a mutating tool (`Write`/`Edit`/`Bash`/…) or omits its `model`
+  pin. A `role: planner` that lists `Write` is rejected, so the lie never ships.
+
+  ```sh
+  python3 .claude/hooks/validate_agents.py .claude/agents
+  ```
+
+- **`bin/paths_scoped_rules.py`** is the auto-apply hook. Given an edited path it
+  surfaces the matching language rules; on a non-matching path it stays silent
+  (fail-open — it never blocks an edit). Wired as a `PostToolUse(Write|Edit)` hook.
+
+Run the whole invariant + negative-control suite:
+
+```sh
+bash scripts/test-agentic-os.sh
+```
+
+## Why declarative
+
+Prose rules degrade — the model follows them most of the time. A `tools:` list is
+different: the harness will not hand an agent a tool it did not declare, so
+"read-only" is a fact, not a hope. The kernel stays small so the agent's context
+stays lean. The rules ride a glob so they cannot be forgotten on a new file. Every
+boundary is one grep away from being audited.
+
+## What Mycelium adds
+
+This template is the free, public pattern. Mycelium's client install pack wraps it
+with per-client agents and rules, a security layer, CI wiring, and onboarding — the
+hardened, supported version for a team. The pattern here is yours to use either way.

--- a/agentic-os/agents/README.md
+++ b/agentic-os/agents/README.md
@@ -1,0 +1,35 @@
+# Agents
+
+Each agent is one specialist, one domain, under 100 lines. The frontmatter is a
+**declarative contract** the harness enforces:
+
+| Field | Meaning |
+|---|---|
+| `name` | how the kernel routes to it |
+| `description` | when to use it (the router reads this) |
+| `role` | `planner` / `reviewer` / `research` are **read-only** roles; `resolver` writes |
+| `tools` | the EXACT tool surface. Claude Code restricts the agent to this list — a tool not listed cannot be called |
+| `model` | pinned per agent: heavier model for planning, lighter for execution |
+
+## The safety boundary is the `tools:` list
+
+A read-only agent (`planner` / `reviewer`) lists only `Read, Grep, Glob`. It
+**cannot** `Write`, `Edit`, or run `Bash` — not by policy, by construction. The
+harness will not hand it a tool it did not declare.
+
+That invariant is checkable. `validate_agents.py` (shipped to `.claude/hooks/`)
+parses every spec and FAILS if a read-only role declares a mutating tool, or if an
+agent is missing its `model` pin. Run it in CI:
+
+```sh
+python3 .claude/hooks/validate_agents.py .claude/agents
+```
+
+A `role: planner` that lists `Write` is a contradiction — the validator rejects it
+so the lie never ships.
+
+## Adding an agent
+
+Drop a `<name>.md` with the five frontmatter fields, keep it under 100 lines, give
+it one job. Read-only by default; grant write tools only to a `resolver`-class
+agent that needs them.

--- a/agentic-os/agents/planner.md
+++ b/agentic-os/agents/planner.md
@@ -1,0 +1,36 @@
+---
+name: planner
+description: Decomposes a task into a concrete, ordered implementation plan. Use BEFORE any code is written for non-trivial work. Read-only by construction — it cannot edit files, so it can never "just fix it" and skip the plan.
+role: planner
+tools: [Read, Grep, Glob]
+model: opus
+---
+
+# Planner
+
+You produce the plan. You do not implement it. Your tool surface is read-only
+(`Read`, `Grep`, `Glob`) — you physically cannot Write, Edit, or run Bash, and
+that is the point: planning stays planning.
+
+## What you do
+
+1. **Understand** the request and the relevant code before proposing anything.
+   Read the files that matter; trace the seams; do not guess.
+2. **Surface assumptions** explicitly — list 2-5 you are making about scope,
+   constraints, and intent. Wrong assumptions are the top cause of rework.
+3. **Decompose** into the smallest ordered steps a `resolver` can execute, each
+   with a clear done-condition and the file(s) it touches.
+4. **Name the risks** — the one or two ways this plan could go wrong — in a single
+   line each. Do not gate the plan behind them; name them and move on.
+
+## What you return
+
+A numbered plan. For each step: what changes, which file(s), and how to verify it.
+End with the single highest-leverage step to do first. Hand off to `resolver` for
+execution and `reviewer` for the check.
+
+## What you never do
+
+- Edit a file or run a command (your tools do not allow it).
+- Pad the plan with steps that do not change behavior.
+- Decide it is "simple enough to skip planning" — if you were invoked, plan.

--- a/agentic-os/agents/resolver.md
+++ b/agentic-os/agents/resolver.md
@@ -1,0 +1,35 @@
+---
+name: resolver
+description: Implements a planned change — edits files, runs commands, makes tests pass. The only agent with write authority. Use it to execute a planner's plan or apply a reviewer's confirmed fix, never to decide scope on its own.
+role: resolver
+tools: [Read, Write, Edit, Bash, Grep, Glob]
+model: sonnet
+---
+
+# Resolver
+
+You execute. You have write authority (`Write`, `Edit`, `Bash`) — the only agent
+that does — so you are the one place a mistake actually mutates the repo. Move
+carefully and verify.
+
+## What you do
+
+1. **Work from a plan.** Execute the `planner`'s steps or the `reviewer`'s
+   confirmed fix. If there is no plan and the task is non-trivial, ask for one.
+2. **Smallest change that satisfies the step.** Match the surrounding code's
+   style, naming, and idiom. Do not refactor adjacent code uninvited.
+3. **Run the per-language checks** the `paths_scoped_rules` hook surfaces for the
+   files you touched (typecheck, format, lint) before claiming done.
+4. **Verify behavior**, not just types. Run the test or the command and read the
+   output. Evidence before assertion.
+
+## What you return
+
+The change, plus the verification you ran and its result. If a check failed, say
+so with the output — never claim green you did not see.
+
+## What you never do
+
+- Expand scope past the plan without surfacing it first.
+- Commit or push unless explicitly asked, or your project rules say to.
+- Claim "done / verified" without a command output that proves it.

--- a/agentic-os/agents/reviewer.md
+++ b/agentic-os/agents/reviewer.md
@@ -1,0 +1,35 @@
+---
+name: reviewer
+description: Reviews a change for correctness, security, and convention adherence. Use AFTER a resolver edit and BEFORE merge. Read-only by construction — it reports findings, it does not "fix while reviewing" (which hides the bug behind a silent edit).
+role: reviewer
+tools: [Read, Grep, Glob]
+model: sonnet
+---
+
+# Reviewer
+
+You find what is wrong. You do not change it. Your tool surface is read-only
+(`Read`, `Grep`, `Glob`) — so a finding is a finding, never a silent fix that
+nobody sees in the diff.
+
+## What you do
+
+1. **Read the diff** and the code around it. Understand intent before judging.
+2. **Look for, in priority order:** correctness bugs, security issues
+   (injection, auth bypass, SSRF, secret leakage), then convention drift.
+3. **Trace the worst-case input** through the change. What does a hostile or
+   malformed input do here?
+4. **Check the seam**, not just the unit: does the producer match the consumer?
+
+## What you return
+
+A findings list, each as: `severity` (critical / high / medium / low), the
+`file:line`, what is wrong, and the smallest fix. If you find nothing real, say so
+plainly — do not invent findings to look thorough. Hand confirmed fixes to
+`resolver`.
+
+## What you never do
+
+- Edit a file (your tools do not allow it) — report, don't patch.
+- Approve on style while a correctness bug stands.
+- Pad with nitpicks that do not change behavior or risk.

--- a/agentic-os/bin/paths_scoped_rules.py
+++ b/agentic-os/bin/paths_scoped_rules.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""paths_scoped_rules.py - auto-apply per-language rules by path glob (MYC-254).
+
+Each rules/<lang>/hooks.md declares `paths:` globs in its frontmatter. Given an
+edited file path, this surfaces the matching rule block(s) - zero per-file config,
+the glob does the routing. Two entry points:
+
+  CLI:   paths_scoped_rules.py --path src/foo.ts
+         Prints the matching rule heading(s); used in CI and by a human.
+
+  Hook:  as a Claude Code PostToolUse(Write|Edit) hook, reads the hook JSON on
+         stdin, pulls tool_input.file_path, and prints the matching guidance so the
+         model sees which language rules govern the file it just touched.
+
+The rules dir resolves to <script_dir>/../rules, correct both in the template
+(agentic-os/bin -> agentic-os/rules) and after install (.claude/hooks ->
+.claude/rules). Override with AGENTIC_OS_RULES_DIR.
+
+Fail-open: any unexpected condition returns 0 with no output, so a PostToolUse
+hook can never block the client's edit.
+"""
+from __future__ import annotations
+
+import fnmatch
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def rules_dir():
+    env = os.environ.get("AGENTIC_OS_RULES_DIR")
+    if env:
+        return Path(env)
+    return Path(__file__).resolve().parent.parent / "rules"
+
+
+def split_frontmatter(text):
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return None
+    body = []
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            return body
+        body.append(lines[i])
+    return None
+
+
+def parse_paths(fm_lines):
+    """Pull the `paths:` globs (inline list or block list) from frontmatter lines."""
+    i = 0
+    n = len(fm_lines)
+    while i < n:
+        line = fm_lines[i].strip()
+        if line.startswith("paths:"):
+            val = line.partition(":")[2].strip()
+            if val.startswith("[") and val.endswith("]"):
+                return [g.strip().strip("\"'") for g in val[1:-1].split(",") if g.strip()]
+            if val == "":
+                globs = []
+                j = i + 1
+                while j < n and fm_lines[j].lstrip().startswith("- "):
+                    globs.append(fm_lines[j].lstrip()[2:].strip().strip("\"'"))
+                    j += 1
+                return globs
+            return [val.strip("\"'")]
+        i += 1
+    return []
+
+
+def name_of(fm_lines, fallback):
+    for line in fm_lines:
+        s = line.strip()
+        if s.startswith("name:"):
+            return s.partition(":")[2].strip().strip("\"'") or fallback
+    return fallback
+
+
+def match_path(path, glob):
+    # fnmatch's `*` already spans `/`, so `*.ts` matches src/a/b.ts. We also add the
+    # `**/`-stripped variant so a root-level file (no slash) matches `**/*.ts` too.
+    candidates = {glob}
+    if glob.startswith("**/"):
+        candidates.add(glob[3:])
+    return any(fnmatch.fnmatch(path, g) for g in candidates)
+
+
+def matching_rules(path):
+    """Return [(name, hooks_md_path)] for every rule whose globs match `path`."""
+    out = []
+    rd = rules_dir()
+    if not rd.is_dir():
+        return out
+    for hooks_md in sorted(rd.glob("*/hooks.md")):
+        fm = split_frontmatter(hooks_md.read_text(encoding="utf-8"))
+        if fm is None:
+            continue
+        globs = parse_paths(fm)
+        if any(match_path(path, g) for g in globs):
+            out.append((name_of(fm, hooks_md.parent.name), hooks_md))
+    return out
+
+
+def render(path, rules):
+    lines = []
+    for name, hooks_md in rules:
+        lines.append(f"[paths-scoped rule: {name}] matched {path}")
+        lines.append(f"  rules: {hooks_md}")
+    return "\n".join(lines)
+
+
+def file_path_from_stdin():
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:  # noqa: BLE001 - hook must fail open on any malformed stdin
+        return None
+    tool_input = payload.get("tool_input") or {}
+    return tool_input.get("file_path") or tool_input.get("path")
+
+
+def main(argv):
+    # CLI mode (--path) prints plain text for a human / CI. Hook mode (stdin tool
+    # JSON) MUST emit the PostToolUse additionalContext envelope: plain stdout from
+    # a hook is NOT surfaced to the model, so a bare print would make the rule
+    # auto-apply cosmetic. The arriving input decides the mode.
+    cli_path = None
+    if "--path" in argv:
+        idx = argv.index("--path")
+        if idx + 1 < len(argv):
+            cli_path = argv[idx + 1]
+
+    if cli_path is not None:
+        rules = matching_rules(cli_path)
+        if rules:
+            sys.stdout.write(render(cli_path, rules) + "\n")
+        return 0
+
+    # Hook mode: read the edited path from the PostToolUse tool JSON on stdin.
+    if sys.stdin.isatty():
+        return 0  # no --path and no piped input: nothing to evaluate
+    path = file_path_from_stdin()
+    if not path:
+        return 0  # malformed / missing file_path -> fail open, never block the edit
+    rules = matching_rules(path)
+    if not rules:
+        return 0  # non-matching path -> emit nothing (no context added)
+
+    sys.stdout.write(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PostToolUse",
+            "additionalContext": render(path, rules),
+        }
+    }) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/agentic-os/bin/validate_agents.py
+++ b/agentic-os/bin/validate_agents.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""validate_agents.py - enforce the declarative tool-surface safety boundary.
+
+MYC-254. A read-only agent (role planner / reviewer / research, or `readonly: true`)
+MUST NOT declare a mutating tool (Write / Edit / MultiEdit / NotebookEdit / Bash).
+Claude Code restricts a subagent to exactly its `tools:` list, so a tool absent
+from the list cannot be called - absence IS the enforcement. This validator makes
+that invariant checkable and FAILS LOUD on a violation, so a "read-only" planner
+that lies about its tools never ships.
+
+Usage:
+    validate_agents.py <agents-dir> [<agents-dir> ...]
+
+Exit 0  every agent spec is clean (or the dir holds no specs).
+Exit 1  at least one violation (printed to stderr).
+Exit 2  bad input (missing / unreadable directory).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+MUTATING_TOOLS = {"Write", "Edit", "MultiEdit", "NotebookEdit", "Bash"}
+READONLY_ROLES = {"planner", "reviewer", "research", "researcher"}
+# Claude Code accepts the bare aliases or a full model id; an invalid value has no
+# documented safe fallback, so a typo would silently mis-pin. `_model_ok` rejects it.
+MODEL_ALIASES = {"opus", "sonnet", "haiku", "inherit"}
+
+
+def _model_ok(model):
+    m = model.strip().lower()
+    return m in MODEL_ALIASES or m.startswith("claude-")
+
+
+def split_frontmatter(text):
+    """Return the list of frontmatter lines between the first two `---`, or None."""
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return None
+    body = []
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            return body
+        body.append(lines[i])
+    return None  # unterminated frontmatter == not a valid spec
+
+
+def parse_frontmatter(fm_lines):
+    """Tiny YAML subset: `key: value` plus block lists (`key:` then `  - item`)."""
+    data = {}
+    i = 0
+    n = len(fm_lines)
+    while i < n:
+        line = fm_lines[i].strip()
+        i += 1
+        if not line or line.startswith("#") or ":" not in line:
+            continue
+        key, _, val = line.partition(":")
+        key = key.strip()
+        val = val.strip()
+        if val == "":
+            items = []
+            while i < n and fm_lines[i].lstrip().startswith("- "):
+                items.append(fm_lines[i].lstrip()[2:].strip())
+                i += 1
+            data[key] = items if items else ""
+        else:
+            data[key] = val
+    return data
+
+
+def parse_tools(value):
+    """Accept an inline `[A, B]` list, an already-parsed block list, or a scalar."""
+    if isinstance(value, list):
+        return [v.strip().strip("\"'") for v in value if v.strip()]
+    v = value.strip()
+    if v.startswith("[") and v.endswith("]"):
+        return [t.strip().strip("\"'") for t in v[1:-1].split(",") if t.strip()]
+    if v == "":
+        return []
+    return [v.strip("\"'")]
+
+
+def validate_file(path):
+    """Return (is_agent_spec, [violations]) for one markdown file."""
+    text = path.read_text(encoding="utf-8")
+    fm = split_frontmatter(text)
+    if fm is None:
+        return (False, [])
+    data = parse_frontmatter(fm)
+    if "name" not in data:
+        return (False, [])  # frontmatter doc that is not an agent spec (e.g. README)
+
+    rel = path.name
+    violations = []
+
+    model = data.get("model", "")
+    if not (isinstance(model, str) and model.strip()):
+        violations.append(f"{rel}: missing `model:` pin (every agent must pin a model)")
+    elif not _model_ok(model):
+        violations.append(
+            f"{rel}: invalid `model:` value '{model.strip()}' - use opus/sonnet/haiku/inherit "
+            f"or a full claude-* id (an invalid alias has no documented fallback)"
+        )
+
+    if "tools" not in data:
+        violations.append(f"{rel}: missing `tools:` (declare the exact tool surface)")
+        return (True, violations)
+    tools = parse_tools(data["tools"])
+    if not tools:
+        violations.append(f"{rel}: empty `tools:` list")
+        return (True, violations)
+
+    role = data.get("role", "")
+    role = role.strip().lower() if isinstance(role, str) else ""
+    readonly_flag = str(data.get("readonly", "")).strip().lower() in {"true", "yes", "1"}
+    is_readonly = role in READONLY_ROLES or readonly_flag
+
+    declared_mutators = sorted(set(tools) & MUTATING_TOOLS)
+    if is_readonly and declared_mutators:
+        violations.append(
+            f"{rel}: read-only role '{role or 'readonly'}' declares mutating tool(s) "
+            f"{declared_mutators} - a read-only agent must not be able to "
+            f"{', '.join(declared_mutators)}"
+        )
+    return (True, violations)
+
+
+def main(argv):
+    dirs = argv[1:]
+    if not dirs:
+        sys.stderr.write("usage: validate_agents.py <agents-dir> [...]\n")
+        return 2
+
+    specs = []
+    for d in dirs:
+        p = Path(d)
+        if not p.exists():
+            sys.stderr.write(f"validate_agents: no such directory: {d}\n")
+            return 2
+        if p.is_dir():
+            specs.extend(sorted(p.glob("*.md")))
+        else:
+            specs.append(p)
+
+    all_violations = []
+    checked = 0
+    for spec in specs:
+        is_spec, violations = validate_file(spec)
+        if not is_spec:
+            continue
+        checked += 1
+        all_violations.extend(violations)
+
+    if all_violations:
+        sys.stderr.write("validate_agents: FAIL - declarative tool-surface boundary violated\n")
+        for v in all_violations:
+            sys.stderr.write(f"  - {v}\n")
+        return 1
+
+    if checked == 0:
+        sys.stderr.write("validate_agents: no agent specs found (nothing to check)\n")
+        return 0
+
+    print(f"validate_agents: OK - {checked} agent spec(s) clean")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/agentic-os/contexts/dev.md
+++ b/agentic-os/contexts/dev.md
@@ -1,0 +1,19 @@
+---
+name: dev
+posture: build
+description: Default building posture — implement, edit, run, iterate.
+---
+
+# Posture: dev
+
+You are building. Optimize for a correct, small, verified change.
+
+- **Plan first** for anything non-trivial: route to `planner`, then `resolver`.
+- **Smallest change** that satisfies the requirement. Match surrounding style.
+- **Run the per-language checks** the paths-scoped rules surface for files you
+  touch (typecheck, format, lint) before claiming done.
+- **Verify behavior, not types.** Run the test or command; read the output.
+- **TDD is the floor** for non-trivial logic: one failing test before the code.
+
+Switch out of this posture for critique (`review`), investigation (`research`),
+or hardening (`security`).

--- a/agentic-os/contexts/research.md
+++ b/agentic-os/contexts/research.md
@@ -1,0 +1,21 @@
+---
+name: research
+posture: investigate
+description: Investigate and explain — read-only, no edits, evidence-cited.
+---
+
+# Posture: research
+
+You are investigating, not changing. Edits are off the table in this posture.
+
+- **Answer from the code**, not from memory. Open the files; trace the calls.
+- **Cite** every claim with a `file:line` so it can be checked.
+- **Map before you conclude:** what calls what, where state lives, which seam
+  carries the contract.
+- **Surface uncertainty** instead of guessing. "I did not verify X" beats a
+  confident wrong answer.
+- **No mutation.** If the investigation implies a change, hand the finding to
+  `planner` and switch to `dev` posture to act on it.
+
+Return a structured explanation: the answer, the evidence, and the one open
+question that would most change the conclusion.

--- a/agentic-os/contexts/review.md
+++ b/agentic-os/contexts/review.md
@@ -1,0 +1,21 @@
+---
+name: review
+posture: critique
+description: Critique a change before it ships — correctness, security, conventions.
+---
+
+# Posture: review
+
+You are critiquing, not building. Find what is wrong; do not silently fix it.
+
+- **Read intent first**, then judge against it.
+- **Priority order:** correctness bugs → security (injection, auth bypass, SSRF,
+  secret leakage) → convention drift. A style nit never outranks a real bug.
+- **Trace the worst-case input** through the change.
+- **Check the seam:** does the producer match the consumer? Verify the end-to-end
+  path, not two isolated units.
+- **Report, don't patch.** Hand confirmed fixes to `resolver`; route through
+  `dev` posture to apply them.
+
+Findings: `severity` + `file:line` + what's wrong + smallest fix. Say "nothing
+real" plainly rather than inventing findings.

--- a/agentic-os/contexts/security.md
+++ b/agentic-os/contexts/security.md
@@ -1,0 +1,24 @@
+---
+name: security
+posture: adversarial
+description: Threat-model and harden a surface — think like an attacker, fail closed.
+---
+
+# Posture: security
+
+You are the adversary now. Assume input is hostile and the happy path is a
+distraction.
+
+- **Enumerate the surface:** every input, every external call, every place a
+  secret or PII could flow.
+- **Five lenses on any LLM/agent surface:** input validation, retrieval, dialog,
+  execution (tool authority), output. Name the missing rail for each stage.
+- **Trace an attacker-controlled string** end to end: injection, traversal, SSRF,
+  auth bypass, secret exfiltration.
+- **Fail closed.** A guard that errors should deny, not pass. A loader that can't
+  evaluate a rule should warn loudly, never silently no-op.
+- **Every guard ships a negative control** — a test that proves it BLOCKS its
+  target, not just that it passes on clean input.
+
+Return: the threat surfaces, the concrete attack for each, and the smallest
+fail-closed mitigation. Hand fixes to `resolver` via `dev` posture.

--- a/agentic-os/data/README.md
+++ b/agentic-os/data/README.md
@@ -1,0 +1,19 @@
+# data/ — durable project memory
+
+This directory is where your agentic OS remembers things across sessions. The
+kernel reads it at the start of non-trivial work and writes decisions here so the
+next session inherits them instead of rediscovering them.
+
+Suggested layout (create as you need them):
+
+- `decisions/` — one file per hard-to-reverse decision: what, why, the trade-off,
+  and the date. The next session reads these before re-litigating a settled call.
+- `context.md` — the project's ubiquitous language: the terms your team uses and
+  exactly what they mean, so the model never paraphrases a canonical name.
+- `glossary.md` — domain terms an outsider would not know.
+
+Keep entries short and factual. This is a log the agents trust, so never write a
+claim here you have not verified.
+
+`.gitkeep` keeps the directory tracked while it is empty — delete it once you add
+real content.

--- a/agentic-os/kernel/CLAUDE.md
+++ b/agentic-os/kernel/CLAUDE.md
@@ -1,0 +1,61 @@
+# Kernel
+
+This file is the **kernel** of your agentic OS. It is small and declarative on
+purpose: it routes work to specialist agents and posture modes, it does not do
+the work itself. Keep it under 100 lines. Detail lives in the files it points to,
+never inline here.
+
+## Role: orchestrator (COO)
+
+You are the orchestrator. Your job is to read the request, pick the right
+specialist, and delegate. You plan and route; the agents execute. Bias toward
+delegation over doing everything in the main thread.
+
+- **Decompose** a task into the smallest specialist-sized pieces.
+- **Delegate** each piece to the agent whose tool surface fits (see routing).
+- **Verify** the result before accepting it. Never ship an unverified claim.
+- **Stay small**: if this kernel grows past 100 lines, move detail into an
+  agent, a context, or a rule file and leave a one-line pointer here.
+
+## Routing (work type → agent)
+
+Pick the most specific match. Agents live in `.claude/agents/`.
+
+| Work | Agent | Tool surface |
+|---|---|---|
+| Plan / design / decompose / break down a task | `planner` | read-only |
+| Review / critique / find bugs / audit a diff | `reviewer` | read-only |
+| Implement / edit files / run commands / fix | `resolver` | read + write |
+
+A read-only agent **cannot** mutate your repo — that is enforced by its declared
+`tools:` list, not by good intentions (see `.claude/agents/README` and the
+validator at `.claude/hooks/validate_agents.py`).
+
+## Posture (how to operate right now)
+
+Posture modes live in `.claude/contexts/`. Load one mid-session to change how you
+work without a full skill invocation: say "switch to <mode>" and read that file.
+
+| Mode | Use it when |
+|---|---|
+| `dev` | building or changing code |
+| `review` | critiquing a change before it ships |
+| `research` | investigating, read-only, no edits |
+| `security` | threat-modeling or hardening a surface |
+
+## Per-language rules (auto-applied)
+
+Quality rules live in `.claude/rules/<lang>/hooks.md`, each scoped by a `paths:`
+glob. When you edit a file, the matching language rules apply automatically — the
+`paths_scoped_rules` hook surfaces them. You do not wire rules per file; the glob
+does it. Add a language by dropping a new `rules/<lang>/hooks.md`.
+
+## Memory
+
+Durable project state lives in `data/` (decisions, context, notes). Read it at the
+start of non-trivial work; write decisions there so the next session inherits them.
+
+---
+
+This kernel is a template. Replace this section with your project's one-paragraph
+mission so every agent inherits the same context. Keep that paragraph short.

--- a/agentic-os/rules/python/hooks.md
+++ b/agentic-os/rules/python/hooks.md
@@ -1,0 +1,20 @@
+---
+name: python
+paths: ["**/*.py"]
+description: Quality rules applied automatically to Python files on edit.
+---
+
+# Python rules
+
+These apply automatically when you edit a `.py` file — the `paths_scoped_rules`
+hook matches the glob above and surfaces this block. No per-file wiring.
+
+- **Lint clean.** `ruff check` (or flake8) passes on touched files.
+- **Types check** where annotated: `mypy` / `pyright` on the module you edited.
+- **No `print()` debugging** and no stray `breakpoint()` in committed code.
+- **`from __future__ import annotations`** if the project targets Python < 3.10
+  and you use `X | None` syntax in annotations.
+- **No bare `except:`** — catch the specific exception; never swallow silently.
+
+Tune this list to your stack. The glob (`paths:`) decides which files it governs;
+edit the glob, not the wiring.

--- a/agentic-os/rules/typescript/hooks.md
+++ b/agentic-os/rules/typescript/hooks.md
@@ -1,0 +1,21 @@
+---
+name: typescript
+paths: ["**/*.ts", "**/*.tsx"]
+description: Quality rules applied automatically to TypeScript files on edit.
+---
+
+# TypeScript rules
+
+These apply automatically when you edit a `.ts` / `.tsx` file — the
+`paths_scoped_rules` hook matches the glob above and surfaces this block. No
+per-file wiring.
+
+- **Types must check.** `tsc --noEmit` passes — no type errors, no new `any`.
+- **Format.** `prettier --check` (or your formatter) on touched files.
+- **No `console.log`** in committed code — use the project logger.
+- **No `// @ts-ignore`** without a one-line reason on the same line.
+- **Imports resolve.** No unused imports; no deep relative `../../../` when an
+  alias exists.
+
+Tune this list to your stack. The glob (`paths:`) decides which files it governs;
+edit the glob, not the wiring.

--- a/agentic-os/tests/fixtures/bad_model/agent.md
+++ b/agentic-os/tests/fixtures/bad_model/agent.md
@@ -1,0 +1,13 @@
+---
+name: typo-model
+description: NEGATIVE CONTROL — an agent whose model: is not a valid Claude Code alias. validate_agents.py MUST reject it; Claude Code does not document a safe fallback for an invalid model value, so a typo would silently mis-pin. Never installed.
+role: reviewer
+tools: [Read, Grep, Glob]
+model: gpt4o
+---
+
+# Bad model (fixture)
+
+`model: gpt4o` is not a valid Claude Code model alias (`opus` / `sonnet` / `haiku`
+/ `inherit`, or a full `claude-*` id). The validator must FAIL on it so a typo
+never ships a silently mis-pinned agent.

--- a/agentic-os/tests/fixtures/bad_planner.md
+++ b/agentic-os/tests/fixtures/bad_planner.md
@@ -1,0 +1,14 @@
+---
+name: planner
+description: NEGATIVE CONTROL — a read-only planner role that wrongly declares mutating tools. validate_agents.py MUST reject this. It exists only to prove the guard fails on a violation; it is never installed.
+role: planner
+tools: [Read, Grep, Glob, Write, Edit]
+model: opus
+---
+
+# Bad planner (fixture)
+
+This file is a poisoned fixture. A `role: planner` is declared read-only, but its
+`tools:` list includes `Write` and `Edit` — a contradiction that would hand the
+"read-only" planner real mutation authority. `validate_agents.py` must FAIL on it.
+If the validator ever passes this, the declarative tool-surface boundary is dead.

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -11,6 +11,23 @@ For full development history including internal refactors and bug fixes, see [`C
 
 ---
 
+## 2026-06-20 — v1.5.1: restore agentic-os + security-snapshot; harden open-core guard (MYC-1339)
+
+v1.5.0 over-pruned two intentional free assets that were misclassified as boundary violations.
+
+**Restored:**
+
+- **`agentic-os/`** — free multi-agent template (MYC-254, codified Done). The paid moat is the runtime enforcement, not this teaching template. Anyone who cloned before v1.5.0 already had it; it should never have been removed.
+- **`skills/security-snapshot`** — self-labeled "Free lead magnet for consulting practices" in its own SKILL.md. A passive SSL/HTTP-header hygiene scan — not an audit product.
+
+**Also hardened:**
+
+The open-core boundary guard (`scripts/check-open-core-boundary.sh`) is now **allowlist-based**: every `skills/` subdirectory and every capability-pack-shaped top-level directory must appear in `.github/free-tier-allowlist.txt` (with a rationale tag) or CI fails. Default = blocked. The prior v1 denylist ran green while both restored assets were present; the allowlist model closes that gap. A 4-case negative-control test (`tests/integration/test_open_core_boundary.sh`) proves the guard fails on an unlisted path.
+
+**No action required for existing installs.** If you were on v1.5.0 and want `agentic-os/` back, `git pull` to v1.5.1. If you are doing a fresh install, bootstrap picks it up automatically.
+
+---
+
 ## 2026-05-09 — v1.3.1: vertical-healthcare actually-complete
 
 v1.3.0 advertised "vertical-healthcare completion" but only landed 4 of the 9 files the pack needs. Without `README.md` and `SKILL.md`, skill discovery did not register the pack, so `/vertical-healthcare init` was inert. v1.3.1 lands the 5 missing files: README, SKILL, the Epic and Cerner FHIR connectors, and the typed-memory schema. The pack is now functionally installable.
@@ -76,7 +93,7 @@ Nothing is auto-applied. The output is a folder of drafts plus a `REVIEW.md` che
 
 Structured-signal-first: deterministic Python parser does the heavy lifting (channels, users, headings, paths, frequencies). The model only synthesizes the residual ambiguous cases. Drafts without provenance are a bug, not a feature.
 
-Run with `/extract-rules-from-vault <dump-path>`. (This skill was removed in v1.5.0 as part of the open-core boundary enforcement.)
+Run with `/extract-rules-from-vault <dump-path>`. (This skill was removed in v1.5.0 as a paid-tier capability; it is not part of the free substrate.)
 
 **No action required** for existing installs. The skill is opt-in.
 

--- a/docs/adr/0001-open-core-boundary.md
+++ b/docs/adr/0001-open-core-boundary.md
@@ -1,6 +1,7 @@
 ---
 status: accepted
 date: 2026-05-09
+amended: 2026-06-20
 ---
 
 ## Context
@@ -21,6 +22,7 @@ In scope and shipped publicly:
 - Single-user connectors (OAuth-per-install Slack/Notion/Linear/Gmail/GitHub ingest)
 - Closed-loop episodic-to-procedural memory architecture (`Meta/Learnings/` + promotion script)
 - The teaching pattern itself (this ADR is part of it)
+- **Deliberately free assets** — a public asset that maps to a paid capability is NOT a boundary violation if it is a deliberate free ship-decision (codified Done ticket / self-label in SKILL.md / entry in `.github/free-tier-allowlist.txt`). See "Intentional free set" below.
 
 ## Why
 
@@ -36,3 +38,46 @@ In scope and shipped publicly:
 - Hookify-style rules (`warn-public-repo-create`, `warn-mit-on-content-repo`) belong in maintainer forks, not in the substrate itself
 - The CONTEXT.md "Open-core boundary" term defines this and survives across maintainer rotations
 - This is permanent. Reversal would require a fundamental shift in commercial model (pivot to consulting-only or training-only) or a workflow becoming so commoditized that no paying client values the runtime version
+
+## Guard model (v2, 2026-06-20 — MYC-1339)
+
+### v1 denylist (introduced 2026-06-18, MYC-1338) — insufficient
+
+`scripts/check-open-core-boundary.sh` v1 used a denylist: fail on `^skills/vertical-*/`, `^skills/influencer-pack/`, `^skills/*/connectors/`, `^skills/*/decision-audit/`. This model was blind to:
+
+- Unknown skill names (a non-listed leaked path passes silently)
+- Top-level capability packs (e.g. `agentic-os/`) — none of the patterns matched
+- Intentional free assets that happen to map to paid capabilities
+
+The v1 guard ran GREEN while both `agentic-os/` and `skills/security-snapshot/` were present, because neither matched any denylist pattern. Root cause: **Guard verified on proxy, not harm** (MEMORY.md pattern `feedback_guard_verified_on_proxy_not_harm.md`).
+
+### v2 allowlist (MYC-1339)
+
+The guard now maintains a canonical allowlist at `.github/free-tier-allowlist.txt`. Any `skills/` subdirectory or capability-pack-shaped top-level dir **not in the allowlist** causes CI to fail. Default = blocked.
+
+- Allowlist entries carry a rationale tag: `teaching | personal | lead-magnet | template-MYC254 | ingest-exemplar | safety`
+- The existing denylist patterns are kept as belt-and-suspenders
+- **Fail closed**: a missing or empty allowlist exits non-zero immediately
+- **Negative control**: `tests/integration/test_open_core_boundary.sh` (4 cases) proves the guard fails on a synthetic premium path (EXIT 1) and passes on the clean tree (EXIT 0). Wired into CI via `scripts/ci.sh`.
+
+## Intentional free set
+
+Some assets map to paid capabilities but are **deliberately shipped free**. These are in the allowlist and are NOT boundary violations:
+
+| Asset | Rationale | Codified decision |
+|---|---|---|
+| `agentic-os/` | Free template teaching the multi-agent pattern | MYC-254 (Done) — "ai-brain-starter (public template teaches the pattern)" |
+| `skills/security-snapshot/` | Self-labeled "Free lead magnet for consulting practices" in SKILL.md | Self-label in SKILL.md |
+| `skills/ingest-github/`, `skills/ingest-youtube/`, `skills/ingest-health/` | Single-user OAuth ingest exemplars showing the connector pattern; no per-tenant concerns | Kept in v1.5.0 prune (MYC-1338) |
+
+## Lesson — intentional-free-check before removing a public asset (MYC-1338 regression)
+
+MYC-1338 removed `agentic-os/` and `skills/security-snapshot/` as boundary violations. Both were intentional free assets — the MYC-1338 audit treated "maps to a paid capability" as "leak" without checking:
+
+1. Is there a codified Done ticket recording a deliberate free-ship decision? (MYC-254 for `agentic-os`)
+2. Does the SKILL.md carry a self-label like "Free lead magnet"? (`security-snapshot`)
+3. Is the path in the allowlist?
+
+In open-core, many free patterns map to paid capabilities — that IS the model. The paid moat is the runtime enforcement, not the teaching pattern. **Removing a deliberately free teaching asset undoes the open-core strategy, not enforces it.**
+
+Before removing any public asset for boundary reasons, check these three gates. If any is present, the asset is intentionally free and must stay (or be deliberately re-decided with a new ADR amendment, not silently pruned). Citation: MYC-254 (template decision), MYC-1338 (the regression), MYC-1339 (the fix + this amendment).

--- a/scripts/check-open-core-boundary.sh
+++ b/scripts/check-open-core-boundary.sh
@@ -1,48 +1,144 @@
 #!/usr/bin/env bash
 #
-# check-open-core-boundary.sh - fail-loud guard for ADR-0001 (open-core boundary).
+# check-open-core-boundary.sh — allowlist-model guard for ADR-0001 (open-core boundary).
 #
-# The public ai-brain-starter substrate teaches the PATTERN. It must never ship
-# paid-runtime content: per-vertical workflow packs, multi-tenant connector specs,
-# or legal-grade audit-analytics templates. Those belong to the private runtime.
+# MODEL (v2, MYC-1339):
+#   An ALLOWLIST (.github/free-tier-allowlist.txt) encodes the DELIBERATE free-tier set.
+#   Any skill dir under skills/ or any capability-pack-shaped top-level dir NOT in the
+#   allowlist → FAIL. Default = blocked.
 #
-# This guard FAILS if any such content reappears - by name OR by the structural
-# shape it always takes (a connectors/ or decision-audit/ subtree under a skill).
-# Structure over names: a future "vertical-realestate" carrying a connectors/ dir
-# is caught even though its name is on no list.
+#   This replaces the v1 denylist (which was blind to gaps: it only flagged known names
+#   and structural subtrees, and could not catch unknown paths or the top-level agentic-os
+#   regression). The denylist patterns are kept as belt-and-suspenders: they catch
+#   explicitly-named leaked paths even if the allowlist is mis-populated.
 #
-# Verified safe at introduction (2026-06-18): no in-scope skill uses a connectors/
-# or decision-audit/ subtree, so the structural patterns below cannot false-positive
-# on substrate content.
+# FAIL CLOSED:
+#   Missing or empty .github/free-tier-allowlist.txt → EXIT 1 (never silent-pass).
+#
+# Compatible with bash 3 (macOS default) — no mapfile / declare -A.
 #
 # Source of truth: docs/adr/0001-open-core-boundary.md
-# Runs in: .github/workflows/open-core-boundary.yml (CI) and locally pre-push.
+# Allowlist data:  .github/free-tier-allowlist.txt
+# Runs in:         .github/workflows/open-core-boundary.yml (CI) and locally pre-push.
 #
 set -euo pipefail
 cd "$(git rev-parse --show-toplevel)"
 
-violations="$(git ls-files \
+ALLOWLIST=".github/free-tier-allowlist.txt"
+HAS_ERROR=0
+VIOLATION_FILE="$(mktemp)"
+trap 'rm -f "${VIOLATION_FILE}"' EXIT
+
+# ── Helper: is_allowed <path> ────────────────────────────────────────────────
+# Returns 0 if path appears in the allowlist (exact first-token match), 1 otherwise.
+is_allowed() {
+  local needle="$1"
+  grep -v '^\s*#' "${ALLOWLIST}" | grep -v '^\s*$' | awk '{print $1}' \
+    | grep -qxF "${needle}"
+}
+
+# ── 0. Fail closed: allowlist file must exist and be non-empty ───────────────
+
+if [ ! -f "${ALLOWLIST}" ]; then
+  echo "OPEN-CORE BOUNDARY ERROR: allowlist file '${ALLOWLIST}' is missing." >&2
+  echo "This guard fails closed. Create the file before merging." >&2
+  echo "See docs/adr/0001-open-core-boundary.md for the allowlist format." >&2
+  exit 1
+fi
+
+allowed_count="$(grep -v '^\s*#' "${ALLOWLIST}" | grep -v '^\s*$' | grep -c . || echo 0)"
+if [ "${allowed_count}" -eq 0 ]; then
+  echo "OPEN-CORE BOUNDARY ERROR: allowlist file '${ALLOWLIST}' is empty (or all comments)." >&2
+  echo "This guard fails closed. A non-empty allowlist is required." >&2
+  exit 1
+fi
+
+# ── 1. Check every skills/ subdirectory against the allowlist ────────────────
+
+while IFS= read -r skill_dir; do
+  [[ "${skill_dir}" == "skills" ]] && continue
+  if ! is_allowed "${skill_dir}"; then
+    echo "ALLOWLIST_GAP: '${skill_dir}' is under skills/ but not in ${ALLOWLIST}  -> paid-tier content or unreviewed addition" >> "${VIOLATION_FILE}"
+    HAS_ERROR=1
+  fi
+done < <(git ls-files skills/ | awk -F'/' '{print $1"/"$2}' | sort -u | grep -v '^skills/$')
+
+# ── 2. Check capability-pack-shaped top-level dirs against the allowlist ─────
+#
+# Heuristic: a top-level dir (not skills/, not dot-dirs, not standard repo dirs) that
+# contains:  agents/ + (kernel/ or contexts/ or rules/)   — agentic-OS shape
+# OR:        a SKILL.md at its root                        — skills-pack shape
+#
+# Standard non-pack dirs (never need to be in the allowlist):
+STANDARD_DIRS=".agents .claude-plugin .github .git commands docs floors for-teams git-hooks hooks meeting-todos para-equipos phases scripts services skills templates tests themes"
+
+while IFS= read -r top_dir; do
+  # Skip dot-prefixed dirs
+  case "${top_dir}" in .*) continue ;; esac
+  # Skip standard dirs (word-boundary match)
+  if echo " ${STANDARD_DIRS} " | grep -qF " ${top_dir} "; then
+    continue
+  fi
+
+  # Detect capability-pack shape
+  is_pack=0
+  # Shape A: has agents/ subdir AND (kernel/ or contexts/ or rules/)
+  if git ls-files "${top_dir}/agents/" 2>/dev/null | grep -q .; then
+    if git ls-files "${top_dir}/kernel/" "${top_dir}/contexts/" "${top_dir}/rules/" 2>/dev/null | grep -q .; then
+      is_pack=1
+    fi
+  fi
+  # Shape B: has a SKILL.md at its root
+  if git ls-files "${top_dir}/SKILL.md" 2>/dev/null | grep -q .; then
+    is_pack=1
+  fi
+
+  if [ "${is_pack}" -eq 1 ]; then
+    if ! is_allowed "${top_dir}"; then
+      echo "ALLOWLIST_GAP: top-level capability pack '${top_dir}/' is not in ${ALLOWLIST}  -> paid-tier content or unreviewed addition" >> "${VIOLATION_FILE}"
+      HAS_ERROR=1
+    fi
+  fi
+done < <(git ls-files | awk -F'/' 'NF>1{print $1}' | sort -u)
+
+# ── 3. Belt-and-suspenders denylist (v1 structural patterns, kept as backstop) ──
+#
+# These catch known paid-tier names/structures even if the allowlist is mis-populated.
+
+while IFS= read -r path; do
+  [ -z "${path}" ] && continue
+  echo "DENYLIST_HIT: '${path}'  -> explicit paid-tier structural pattern (vertical-*, influencer-pack, connectors/, decision-audit/)" >> "${VIOLATION_FILE}"
+  HAS_ERROR=1
+done < <(git ls-files \
   | grep -E \
       -e '^skills/vertical-[^/]+/' \
       -e '^skills/influencer-pack/' \
       -e '^skills/[^/]+/connectors/' \
       -e '^skills/[^/]+/decision-audit/' \
-  || true)"
+  || true)
 
-if [ -n "${violations}" ]; then
+# ── 4. Report ────────────────────────────────────────────────────────────────
+
+if [ "${HAS_ERROR}" -eq 1 ]; then
   {
     echo "OPEN-CORE BOUNDARY VIOLATION (ADR-0001)."
     echo
-    echo "The public substrate must not ship per-vertical packs, multi-tenant"
-    echo "connectors, or audit-analytics content. These tracked paths cross the"
-    echo "boundary and belong in the private paid runtime instead:"
+    echo "The public substrate must not ship unreviewed or paid-tier content."
+    echo "Each violation below must be resolved before merge:"
     echo
-    while IFS= read -r path; do echo "  - ${path}"; done <<< "${violations}"
+    while IFS= read -r v; do
+      echo "  - ${v}"
+    done < "${VIOLATION_FILE}"
     echo
-    echo "If this is intentional, it requires an explicit ADR-0001 re-eval, not a"
-    echo "silent merge. See docs/adr/0001-open-core-boundary.md."
+    echo "To add a legitimate free-tier path: add it to ${ALLOWLIST} with a"
+    echo "rationale tag (teaching|personal|lead-magnet|template-MYC254|"
+    echo "ingest-exemplar|safety) and reference the codified free-decision"
+    echo "(Done ticket / self-label / ADR-0001 entry)."
+    echo
+    echo "See docs/adr/0001-open-core-boundary.md for full boundary definition."
   } >&2
   exit 1
 fi
 
-echo "open-core boundary OK: no paid-runtime content in the public substrate."
+echo "open-core boundary OK: all skills/ and capability packs are in the allowlist."
+echo "  Allowlist: ${ALLOWLIST} (${allowed_count} entries)"

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -133,6 +133,7 @@ INTEGRATION_TESTS=(
   test_connector_liveness_watchdog
   test_connector_liveness_surface
   test_agent_memory_link
+  test_open_core_boundary
 )
 echo "==> (b) Shell integration: ${#INTEGRATION_TESTS[@]} tests"
 for t in "${INTEGRATION_TESTS[@]}"; do

--- a/skills/security-snapshot/SKILL.md
+++ b/skills/security-snapshot/SKILL.md
@@ -1,0 +1,107 @@
+---
+type: skill
+name: security-snapshot
+description: Generate a client-ready security hygiene snapshot for a prospect domain. Free lead magnet for consulting practices. Outputs a markdown report covering SSL/TLS grade, HTTP security headers, email authentication (SPF/DMARC), and server fingerprint leaks. Use when the user says /security-snapshot, /snapshot [domain], "run a security check on X", or "generate a security report for [company]". Do NOT use for penetration testing, internal infrastructure audits, or application-layer vulnerability assessment. This is a passive, unauthenticated scan for conversation-starter value, not a full audit.
+argument-hint: "<domain> [--company 'Display Name']"
+tool_access:
+  - Bash
+  - Read
+  - Write
+policy_constraints:
+  - rule: Only run passive, unauthenticated scans against the public-facing domain
+    exception_handling: Refuse to run if the request implies authenticated probing or penetration testing
+  - rule: Never store credentials or PII in the report or output directory
+    exception_handling: Strip any unexpected credential-shaped strings before writing the markdown file
+  - rule: Cap external API usage to the documented endpoints (SSL Labs, public DNS lookups, headers fetch)
+    exception_handling: Abort and report partial results if a required endpoint is unavailable rather than fall back to an undocumented service
+required_inputs:
+  - name: domain
+    type: string
+    required: true
+    description: The public domain to scan (e.g. example.com). Must resolve via public DNS.
+  - name: company
+    type: string
+    required: false
+    description: Display name for the company, used in the report header. Defaults to the domain.
+output_shape:
+  format: markdown-file
+  fields:
+    report_path: absolute path to the saved markdown report
+    sections:
+      - ssl_tls_grade
+      - http_security_headers
+      - email_authentication
+      - server_fingerprint
+    summary_grade: overall hygiene grade (A through F) printed to stdout
+---
+
+When the user types /security-snapshot [domain] or asks for a security check on a prospect, run the security snapshot generator and deliver a client-ready report.
+
+## Why this skill exists
+
+Prospects rarely have budget for a full security audit upfront, but they will read a free one-page report that exposes real issues with their public-facing setup. This skill generates that report in under 3 minutes and opens the door for a paid follow-up on security work, AI implementation, or adjacent consulting.
+
+## Command
+
+```bash
+python3 "$HOME/.claude/skills/ai-brain-starter/scripts/security-snapshot.py" <domain> --company "<Display Name>"
+```
+
+The script ships with the starter repo. Output goes to `$SNAPSHOTS_DIR` if set, otherwise `$VAULT_ROOT/security-snapshots/` if `VAULT_ROOT` is set, otherwise a `security-snapshots/` folder next to wherever you run the command from. It takes 60-180 seconds because SSL Labs is slow. The script prints the saved report path to stdout and progress to stderr.
+
+## Workflow
+
+1. **Get the domain.** If the user only gave a company name, ask for the domain (e.g., "Is it acme.com or acmecorp.com?"). Do not guess.
+2. **Run the script.** Use Bash with a long timeout (180000ms) because SSL Labs polling is slow.
+3. **Read the output.** The script saves to `$SNAPSHOTS_DIR/<domain>/<YYYY-MM-DD>-snapshot.md` (defaults to `$VAULT_ROOT/security-snapshots/` when `SNAPSHOTS_DIR` is unset). Read the file before summarizing.
+4. **Summarize for the user.** Do NOT dump the full report into chat. Give:
+   - Top 3 findings by severity with one-line reasons
+   - SSL grade
+   - Whether SPF + DMARC are both present
+   - Path to the saved report
+5. **Offer the follow-up.** If there are high or critical findings, offer to draft the outreach email that pairs with the report. Match the user's own outreach voice, do not invent a new one.
+
+## Voice rules for the delivered report
+
+The script produces the base report. If the user asks you to customize or rewrite any section before sending, follow the generic voice rules in `templates/rules/voice-firewall.md`:
+
+- No em dashes. Use commas, colons, periods, or parentheses.
+- No exclamation marks. Anywhere.
+- No hype language ("leverage synergies", "game-changing"). Facts plus plain severity.
+- No claims the scan did not verify. The report already lists what was NOT checked. Keep that section intact.
+
+## When NOT to use this skill
+
+- For the user's own domains. Those are internal audits, not lead magnets. Use the script directly without the prospect-facing wrapper (edit the signature block or use `--out` to write to an internal folder).
+- For a full penetration test. The script is passive recon only. If a prospect needs an actual pentest, route them to a licensed pentester.
+- For ongoing monitoring. One-shot snapshots only. If a prospect needs continuous monitoring, that is a paid engagement to scope separately.
+- For domains in active DDoS or incident response. The scan is visible in their logs and will add noise at the worst possible time.
+
+## Optional enhancements (document, do not auto-run)
+
+The script does not currently cover these because they need paid API keys or explicit authorization. Offer to add manually when relevant:
+
+- **Have I Been Pwned domain search** (paid, ~$4/mo). Shows how many of their employee emails appear in past breaches. Highest-impact finding a prospect will see.
+- **AbuseIPDB lookup** (free tier with key). Checks if their server IPs appear on abuse blocklists.
+- **VirusTotal URL scan** (free tier with key). Checks if their domain is flagged by any of 70+ threat intel engines.
+- **DNS zone transfer attempt** (no auth needed). If their nameservers allow AXFR, that is a critical finding.
+
+## Output location
+
+```
+$SNAPSHOTS_DIR/
+├── acme.com/
+│   ├── 2026-04-16-snapshot.md
+│   └── 2026-07-22-snapshot.md       (if re-run later)
+└── another-prospect.co/
+    └── 2026-04-18-snapshot.md
+```
+
+One folder per domain. Re-running on the same day overwrites. Running weeks later creates a new dated file so you can track improvement (or lack of it) across conversations.
+
+## Rules
+
+- **Never fabricate findings.** If the script could not reach a service, the report says so. Do not invent severity ratings.
+- **Always verify the saved file exists before telling the user.** If save fails, tell the user immediately, never silently.
+- **The report is client-ready.** Do not add personal notes, internal thoughts, or CRM commentary inside the report file. Those go in a separate note if needed.
+- **Respect the domain.** Only run this on domains of companies you are actually prospecting, companies that have asked for it, or your own domains. Do not bulk-scan the internet.

--- a/tests/integration/test_open_core_boundary.sh
+++ b/tests/integration/test_open_core_boundary.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# tests/integration/test_open_core_boundary.sh
+#
+# Verifies the open-core boundary guard (scripts/check-open-core-boundary.sh):
+#   POSITIVE: current tree (clean, restored) → EXIT 0
+#   NEGATIVE: synthetic premium path added   → EXIT 1
+#   FAIL-CLOSED: allowlist file removed      → EXIT 1
+#
+# Part of MYC-1339 negative-control requirement. The guard earns trust only by
+# failing on the exact harm it prevents.
+#
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+GUARD="scripts/check-open-core-boundary.sh"
+ALLOWLIST=".github/free-tier-allowlist.txt"
+PASS=0
+FAIL=0
+
+_ok()   { echo "  [PASS] $1"; PASS=$((PASS+1)); }
+_fail() { echo "  [FAIL] $1"; FAIL=$((FAIL+1)); }
+
+echo "==> test_open_core_boundary"
+
+# ── Test 1: POSITIVE — clean tree must exit 0 ────────────────────────────────
+if bash "${GUARD}" >/dev/null 2>&1; then
+  _ok "clean tree → guard exits 0"
+else
+  _fail "clean tree → guard exited non-zero (unexpected FAIL on good tree)"
+fi
+
+# ── Test 2: NEGATIVE — unallowlisted skills/ entry must exit non-zero ─────────
+PROBE_DIR="skills/__premium_probe__"
+mkdir -p "${PROBE_DIR}"
+echo "type: skill" > "${PROBE_DIR}/SKILL.md"
+git add "${PROBE_DIR}/SKILL.md"
+
+if bash "${GUARD}" >/dev/null 2>&1; then
+  _fail "premium probe '${PROBE_DIR}' → guard exited 0 (should have FAILED)"
+else
+  _ok "premium probe '${PROBE_DIR}' → guard exits non-zero (correct FAIL)"
+fi
+
+git rm -f "${PROBE_DIR}/SKILL.md" >/dev/null 2>&1 || true
+rm -rf "${PROBE_DIR}" 2>/dev/null || true
+
+# ── Test 3: FAIL-CLOSED — missing allowlist must exit non-zero ───────────────
+mv "${ALLOWLIST}" "${ALLOWLIST}.bak"
+if bash "${GUARD}" >/dev/null 2>&1; then
+  _fail "missing allowlist → guard exited 0 (should have FAILED closed)"
+else
+  _ok "missing allowlist → guard exits non-zero (fail-closed correct)"
+fi
+mv "${ALLOWLIST}.bak" "${ALLOWLIST}"
+
+# ── Test 4: FAIL-CLOSED — empty allowlist must exit non-zero ─────────────────
+EMPTY_TMP="$(mktemp)"
+cp "${ALLOWLIST}" "${ALLOWLIST}.bak"
+echo "# only comments" > "${ALLOWLIST}"
+if bash "${GUARD}" >/dev/null 2>&1; then
+  _fail "empty allowlist → guard exited 0 (should have FAILED closed)"
+else
+  _ok "empty allowlist → guard exits non-zero (fail-closed correct)"
+fi
+mv "${ALLOWLIST}.bak" "${ALLOWLIST}"
+rm -f "${EMPTY_TMP}"
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo
+echo "  open_core_boundary: ${PASS} passed, ${FAIL} failed"
+if [ "${FAIL}" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Fixes a regression from MYC-1338 (PR #224, squash-merge commit 30100de) that over-pruned two intentional free assets, and hardens the open-core guard from a denylist to an allowlist model.

### Part A — restore intentional-free assets

- **`agentic-os/`** restored from 30100de~1. Deliberate free template per MYC-254 (codified Done). The paid moat is runtime enforcement, not the teaching template. Removing it contradicted the open-core "pattern ships free" model.
- **`skills/security-snapshot/`** restored. SKILL.md self-labels it "Free lead magnet for consulting practices" — intentional free ship-decision, not a boundary violation.

Root cause of mis-removal: MYC-1338 treated "maps to a paid capability" as "leak" without checking for a codified free-decision (Done ticket / self-label / allowlist entry). In open-core, free patterns mapping to paid capabilities IS the model.

### Part B — allowlist-model guard

The v1 denylist (`vertical-*`, `connectors/`, `decision-audit/`) ran GREEN while both restored assets were present. It was blind to unknown skill names and top-level dirs.

New model:
- `.github/free-tier-allowlist.txt`: canonical free-tier set with rationale tags (`teaching|personal|lead-magnet|template-MYC254|ingest-exemplar|safety`)
- `scripts/check-open-core-boundary.sh` v2: any `skills/` subdir or capability-pack-shaped top-level dir NOT in the allowlist → EXIT 1. Default = blocked.
- Fail closed: missing or empty allowlist → EXIT 1 immediately.
- v1 denylist patterns kept as belt-and-suspenders.

### Negative control (4 cases, wired into CI)

`tests/integration/test_open_core_boundary.sh`:
- clean tree → EXIT 0 ✓
- synthetic `skills/__premium_probe__` → EXIT 1 ✓  
- missing allowlist → EXIT 1 ✓
- empty allowlist → EXIT 1 ✓

### Doubt-pass summary

- `grep -qxF` is literal exact-match (no regex injection from skill names)
- `git ls-files` canonicalizes paths (no traversal bypass)
- Workflow triggers on `pull_request` + `push: branches: [main]` (all commit counts)
- No `concurrency: cancel-in-progress` on main (correct)
- Underscore bypass (`vertical_foo`) caught by allowlist, not just denylist ✓
- Root-level `skills/connectors/` caught by allowlist ✓
- Variation of allowlisted name rejected by exact-match ✓

### Also updated

- `docs/adr/0001-open-core-boundary.md`: records allowlist model, v1 denylist failure, intentional-free-check lesson (cites MYC-254 + MYC-1338)
- `docs/RELEASES.md`: v1.5.1 user-facing note + corrected extract-rules-from-vault removal description

## Test plan

- [x] `bash scripts/check-open-core-boundary.sh` on clean tree → passes
- [x] Negative control: premium probe → EXIT 1
- [x] `ci-test` locally: 41 integration tests green (including `test_open_core_boundary`)
- [x] `shellcheck` clean
- [x] PII scrub: no personal data in new/modified files
- [ ] CI green on this PR

Closes MYC-1339

🤖 Generated with [Claude Code](https://claude.com/claude-code)