### PR TITLE
chore: bump plugin version 1.5.0 → 1.5.1 to match RELEASES.md (MYC-1339 follow-up)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "ai-brain-starter",
       "source": "./",
       "description": "The operating system for Claude Code. Memory, accountability, journaling, knowledge graphs, pattern recognition, and first-principles analysis — one install, every session compounds.",
-      "version": "1.5.0"
+      "version": "1.5.1"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-brain-starter",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Set up or upgrade an AI-powered Obsidian vault with journaling, knowledge graphs, pattern recognition, and meeting workflows. Includes skills for daily journaling, weekly insights, graphify knowledge graphs, humanizer, and more.",
   "author": {
     "name": "Adelaida Diaz-Roa",


### PR DESCRIPTION
## Summary
- Bumps `version` in `.claude-plugin/plugin.json` from `1.5.0` → `1.5.1`
- Bumps `version` in `.claude-plugin/marketplace.json` from `1.5.0` → `1.5.1`
- No other files touched; diff is exactly two lines

Fixes the drift introduced when MYC-1339 (PR #225) updated `docs/RELEASES.md` to announce v1.5.1 but did not bump the manifests.

## Test plan
- [ ] Diff confirms exactly two changed lines (both version strings)
- [ ] No personal data or secrets in diff
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)