### PR TITLE
fix(granola): port sync to Granola Public API; kill dead cache-v6 reader (MYC-1510)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,20 @@ description: What's new in AI Brain Starter — plain English, no jargon
 
 ---
 
+## 2026-06-22: Granola sync now uses Granola's official API
+
+If you connected Granola for meeting transcripts, the old sync read Granola's local cache file on your Mac. Granola encrypted and moved that cache in mid-May 2026, so the old script silently stopped finding anything — it exited cleanly and exported nothing, with no error to tell you it had broken.
+
+This switches Granola sync to Granola's official Public API, which keeps working across those local-storage changes:
+- **You now need a Granola API key.** Generate one in Granola (Settings → Connectors → API keys), then save it to `~/.config/granola/api-key`, or set `GRANOLA_API_KEY`.
+- **Check it's working:** `python3 scripts/granola_sync.py --health` confirms the key and connection; `--dry-run` previews what would export.
+- **Auto-export now runs every 2 hours** (the old version triggered off the cache file, which no longer exists). Re-copy `scripts/com.granola-export.plist` to `~/Library/LaunchAgents/` and reload it.
+- If the key is missing or invalid, the script now **fails loudly** instead of exiting quietly — and the connector-liveness check flags Granola if it ever goes silent again.
+
+Already using the old cache-based sync? Add an API key as above and reload the LaunchAgent; that's the whole migration.
+
+---
+
 ## 2026-06-20: your memory now actually lives in your vault
 
 The whole promise of this project is that your second brain lives in your vault. But Claude Code keeps its own memory (the things it learns about you) in a hidden system folder — `~/.claude/projects/.../memory/` — that never showed up in Obsidian and didn't follow you to another computer. The substrate assumed that folder had been linked into your vault, but nothing in the install ever did the linking. So for most people, memory was quietly accumulating in a place they couldn't see and couldn't back up.

--- a/docs/POWER_TOOLS.md
+++ b/docs/POWER_TOOLS.md
@@ -287,7 +287,7 @@ MCP (Model Context Protocol) servers extend Claude Code with structured tool acc
 
 ### Granola — meeting transcript export
 
-**What it does:** [Granola](https://granola.ai/) records and transcribes Zoom/Meet/Teams calls with AI-generated summaries. `scripts/granola_sync.py` reads Granola's local cache directly and exports the full timestamped transcript to your vault's meeting notes folder — no API key, no network call, no MCP needed. The meeting workflow rule in CLAUDE.md (see SKILL.md Phase 4) uses this to auto-cascade meeting takeaways into:
+**What it does:** [Granola](https://granola.ai/) records and transcribes Zoom/Meet/Teams calls with AI-generated summaries. `scripts/granola_sync.py` pulls the full timestamped transcript from Granola's official Public API and writes it to your vault's meeting notes folder — no MCP needed (a Granola API key is required). The meeting workflow rule in CLAUDE.md (see SKILL.md Phase 4) uses this to auto-cascade meeting takeaways into:
 
 - The meeting note itself (enriched with decisions, action items, verbatim quotes)
 - The CRM contact files for every attendee (last_interaction updated, meeting note linked)
@@ -297,16 +297,16 @@ MCP (Model Context Protocol) servers extend Claude Code with structured tool acc
 **Why it matters:** without this, you spend 20 minutes after every meeting transcribing handwritten notes and updating CRM cards. With it, Claude reads the full transcript and does the cascade in one command.
 
 **Install:**
-1. Granola must be installed and have recorded at least one meeting.
-2. Run once manually to test: `python3 scripts/granola_sync.py --dry-run`
-3. For auto-export after every meeting, install the LaunchAgent:
+1. Generate a Granola API key: Granola → Settings → Connectors → API keys. Save it to `~/.config/granola/api-key` (chmod 600), or export `GRANOLA_API_KEY`.
+2. Verify + preview: `python3 scripts/granola_sync.py --health`, then `python3 scripts/granola_sync.py --dry-run`.
+3. For auto-export every 2 hours, install the LaunchAgent:
    - Copy `scripts/com.granola-export.plist` to `~/Library/LaunchAgents/`
-   - Edit the two placeholder paths inside it (script path + your username)
+   - Edit the script path + log path inside it
    - Run: `launchctl load ~/Library/LaunchAgents/com.granola-export.plist`
 
-**Note on speaker labels:** The local cache captures your microphone as `[You]` and remote audio as a single stream (no per-person diarization). The Granola-generated summary notes are also included in the exported file.
+**Note on speaker labels:** The API labels your microphone channel as **You** and the other side as **Speaker** (no per-person diarization). The Granola-generated summary is also included in the exported file.
 
-**Source:** Reverse-engineered from Granola's local cache format by the ai-brain-starter community.
+**Source:** Granola's official Public API (`public-api.granola.ai/v1`).
 
 ---
 
@@ -427,7 +427,7 @@ This is the full stack working in concert:
 1. **You write a daily journal** via `/journal` (a custom skill, not in this catalog — set up in `/setup-brain` Phase 10). Templater auto-fills the frontmatter.
 
 2. **You run a meeting** with Granola recording. Afterward you say *"I just had a meeting with Sara"*. The meeting workflow rule in CLAUDE.md fires:
-   - The Granola MCP fetches the transcript
+   - `granola_sync.py` has already exported the transcript to your meeting notes folder (via the LaunchAgent, or run it manually)
    - Claude reads it fully
    - Updates the meeting note with decisions + action items + verbatim quotes
    - Updates Sara's CRM contact card via the mentions block (Dataview)

--- a/hooks/inject-meeting-workflow-on-trigger.py
+++ b/hooks/inject-meeting-workflow-on-trigger.py
@@ -233,9 +233,10 @@ discovery), so probe their tool stack at runtime.
    the rest:
    - **Granola** (macOS): run
      `python3 ~/.claude/skills/ai-brain-starter/scripts/granola_sync.py`
-     which reads the local cache and exports transcripts to the vault's
-     Meeting Notes folder. The script auto-detects paths — do not
-     hard-code anything. Read the most recent exported `*Transcript*.md`.
+     which pulls transcripts from Granola's Public API and exports them
+     to the vault's Meeting Notes folder (needs a Granola API key; the
+     script auto-detects paths — do not hard-code anything). Read the
+     most recent exported `*Transcript*.md`.
    - **Google Meet + Gemini**: if the google-workspace MCP is wired,
      search Drive for a Doc named `<title> - YYYY/MM/DD - Transcript`
      in the user's "Meet Recordings" folder (or whichever folder

--- a/phases/phase-00-install.md
+++ b/phases/phase-00-install.md
@@ -107,9 +107,9 @@ Ask:
 > "Do you use Granola for meeting notes?"
 
 **If YES:**
-1. "Granola is wired via a local script — no API key or MCP needed. Run `python3 scripts/granola_sync.py --dry-run` to test it. It reads from Granola's local cache, so Granola must be installed and have recorded at least one meeting."
-2. For auto-export after every meeting, offer to install the LaunchAgent: "Edit the two placeholder paths in `scripts/com.granola-export.plist`, copy it to `~/Library/LaunchAgents/`, then run `launchctl load ~/Library/LaunchAgents/com.granola-export.plist`."
-3. Store `GRANOLA=local` so the meeting workflow rule knows to Glob for `*- Transcript.md` files.
+1. "Granola syncs via its official Public API. Generate an API key in Granola (Settings > Connectors > API keys), save it to `~/.config/granola/api-key` (chmod 600), then run `python3 scripts/granola_sync.py --health` to verify the key and `python3 scripts/granola_sync.py --dry-run` to preview what would export."
+2. For auto-export every 2 hours, offer to install the LaunchAgent: "Set the script path + log path in `scripts/com.granola-export.plist`, copy it to `~/Library/LaunchAgents/`, then run `launchctl load ~/Library/LaunchAgents/com.granola-export.plist`."
+3. Store `GRANOLA=api` so the meeting workflow rule knows to Glob for `*- Transcript.md` files.
 
 **If NO / "I don't use Granola":**
 - Store `NO_GRANOLA=true` so the meeting workflow rule installs in 'manual' mode.

--- a/phases/phase-11-external-tools.md
+++ b/phases/phase-11-external-tools.md
@@ -72,10 +72,10 @@ Store the answer as `MEETING_TOOLS` (a list — could be multiple). Then for eac
 
 #### 1. Granola
 
-- **No MCP needed.** `scripts/granola_sync.py` reads Granola's local cache directly and exports full transcripts to the meeting notes folder.
-- **Tell them:** "Granola is wired via a local script — no API key needed. Run `python3 scripts/granola_sync.py --dry-run` to test it. For auto-export after every meeting, install the LaunchAgent in `scripts/com.granola-export.plist` (edit the two placeholder paths, then `launchctl load` it)."
+- **No MCP needed.** `scripts/granola_sync.py` pulls full transcripts from Granola's official Public API and writes them to the meeting notes folder.
+- **Tell them:** "Granola syncs via its Public API. Generate a key in Granola (Settings > Connectors > API keys), save it to `~/.config/granola/api-key`, then run `python3 scripts/granola_sync.py --health` to verify it and `--dry-run` to preview. For auto-export every 2 hours, install the LaunchAgent in `scripts/com.granola-export.plist` (set the script + log paths, then `launchctl load` it)."
 - **Discovery rule for the meeting workflow CLAUDE.md section:**
-  > Glob the meeting-notes folder for files matching `*- Transcript.md` modified in the last 24 hours. The script auto-exports when Granola's cache changes. If missing, run `python3 scripts/granola_sync.py` manually. Read the file fully — it's the source of truth.
+  > Glob the meeting-notes folder for files matching `*- Transcript.md` modified in the last 24 hours. The LaunchAgent re-syncs every 2 hours; if a just-ended meeting is missing, run `python3 scripts/granola_sync.py` manually (Granola can take a few minutes to finalize a transcript). Read the file fully — it's the source of truth.
 
 #### 2. Google Meet + Gemini
 

--- a/scripts/com.granola-export.plist
+++ b/scripts/com.granola-export.plist
@@ -3,13 +3,19 @@
 <plist version="1.0">
 <!--
   Granola auto-export LaunchAgent
-  Fires granola_sync.py whenever Granola updates its local cache (i.e. after each meeting).
+
+  Runs granola_sync.py every 2 hours to pull new meeting transcripts from the
+  Granola Public API into your vault. (Granola no longer exposes a local cache
+  file to watch, so this polls on an interval instead of a WatchPaths trigger.)
 
   Install:
-    1. Edit ProgramArguments below — set the path to granola_sync.py in your vault.
-    2. Edit StandardOutPath / StandardErrorPath to point to your vault's log directory.
-    3. Copy this file to ~/Library/LaunchAgents/
-    4. Run: launchctl load ~/Library/LaunchAgents/com.granola-export.plist
+    1. Put your Granola API key at ~/.config/granola/api-key (chmod 600), or set
+       GRANOLA_API_KEY in this plist's EnvironmentVariables (commented below).
+       Generate the key in Granola: Settings > Connectors > API keys.
+    2. Edit ProgramArguments below — set the absolute path to granola_sync.py.
+    3. Edit StandardOutPath / StandardErrorPath to point to your vault's log directory.
+    4. Copy this file to ~/Library/LaunchAgents/
+    5. Run: launchctl load ~/Library/LaunchAgents/com.granola-export.plist
 -->
 <dict>
     <key>Label</key>
@@ -17,19 +23,25 @@
     <key>ProgramArguments</key>
     <array>
         <string>/usr/bin/python3</string>
-        <!-- Replace with the absolute path to granola_sync.py in your vault -->
+        <!-- Replace with the absolute path to granola_sync.py -->
         <string>/path/to/your/vault/scripts/granola_sync.py</string>
     </array>
-    <key>WatchPaths</key>
-    <array>
-        <string>/Users/YOUR_USERNAME/Library/Application Support/Granola/cache-v6.json</string>
-    </array>
+    <!-- Optional: provide the API key here instead of ~/.config/granola/api-key.
+         If you do, keep this plist OUT of any cloud-synced or shared folder.
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>GRANOLA_API_KEY</key>
+        <string>grn_REPLACE_ME</string>
+    </dict>
+    -->
+    <key>StartInterval</key>
+    <integer>7200</integer>
     <key>StandardOutPath</key>
     <!-- Replace with your vault's log directory -->
     <string>/path/to/your/vault/.granola_export.log</string>
     <key>StandardErrorPath</key>
     <string>/path/to/your/vault/.granola_export.log</string>
     <key>RunAtLoad</key>
-    <false/>
+    <true/>
 </dict>
 </plist>

--- a/scripts/granola_sync.py
+++ b/scripts/granola_sync.py
@@ -1,32 +1,175 @@
 #!/usr/bin/env python3
 """
-Granola local cache → Obsidian vault transcript export.
+Granola -> Obsidian vault transcript export (official Public API).
 
-Reads Granola's local cache directly — no API key, no network call.
-Exports full timestamped transcripts as markdown to your vault's meeting
-notes folder. Works on any Mac with Granola installed.
+Pulls meeting notes from Granola's official Public API and writes each meeting's
+full timestamped transcript + AI summary as markdown into your vault's meeting
+notes folder.
 
-Auto-run setup (fires when Granola updates its cache after each meeting):
-  launchctl load ~/Library/LaunchAgents/com.granola-export.plist
+WHY THE API (history): Granola migrated local storage to an encrypted SQLite DB
+around 2026-05-12. The previous version of this script parsed
+cache-v6.json["cache"]["state"]["transcripts"], which became an empty {} after
+the migration -> it printed "No transcripts in cache." and exited 0 for weeks
+(a silent failure: exit 0, zero output, nothing wrong-looking). The Public API
+is vendor-supported and survives local-storage migrations.
+Bug class: VENDOR-LOCAL-CACHE-SCHEMA-MIGRATION-SILENT-FAILURE.
 
-Usage:
-  python3 granola_sync.py              # export all cached transcripts
-  python3 granola_sync.py --dry-run   # show what would be exported
+AUTH: a Granola API key, resolved in order:
+  1. GRANOLA_API_KEY environment variable
+  2. --key-file PATH (a file with the bare key, or a `GRANOLA_API_KEY=...` line)
+  3. ~/.config/granola/api-key (same format)
+Generate the key in Granola: Settings > Connectors > API keys (requires a plan
+with API access). The key is read at runtime and is never written to the repo.
+
+USAGE:
+  python3 granola_sync.py                 # export new transcripts since last run
+  python3 granola_sync.py --dry-run       # show what would be exported; write nothing
+  python3 granola_sync.py --since 2026-05-01   # override the created_after window
+  python3 granola_sync.py --health        # verify key + API connectivity; exit 0/1
   python3 granola_sync.py --vault-root /path/to/vault
   python3 granola_sync.py --meeting-dir "Meeting Notes"
+
+EXIT CODES: 0 ok (including "0 new" -- a legitimate quiet period); 1 hard failure
+(missing/invalid key, API unreachable). A run that succeeds but returns 0 notes
+prints that plainly -- sustained silence is caught by check-connector-liveness.py
+(the 0-vs-0 watchdog), not by failing an individual run.
 """
+from __future__ import annotations  # PEP 604 `X | None` annotations safe on py3.8+
 
 import argparse
+import gzip
+import io
 import json
 import os
 import re
 import sys
-from datetime import datetime, timezone
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-CACHE_PATH = Path.home() / "Library/Application Support/Granola/cache-v6.json"
+API_BASE = "https://public-api.granola.ai/v1"
+DEFAULT_KEY_FILE = Path.home() / ".config" / "granola" / "api-key"
+
+# First-run window if no prior state (avoid pulling full history on day one).
+DEFAULT_WINDOW_DAYS = 21
+
+# Trailing re-scan applied on top of last_sync. A note's transcript/summary can
+# finalize minutes-to-days after its created_at, and the API only returns a note
+# once it is finalized. A window keyed strictly on last_sync would therefore
+# SILENTLY skip any note that finalized after the window advanced past its
+# created_at. Re-scanning a trailing window catches them; the exported-id dedup
+# keeps it idempotent. Bug class: INCREMENTAL-WINDOW-MISSES-LATE-FINALIZED-NOTES.
+SAFETY_LOOKBACK_DAYS = 4
 
 
+# --------------------------------------------------------------------------- #
+# auth + http
+# --------------------------------------------------------------------------- #
+def _read_key_file(path: Path) -> str:
+    """First non-comment line of a key file: a bare key, or `GRANOLA_API_KEY=...`."""
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("GRANOLA_API_KEY="):
+                return line.split("=", 1)[1].strip()
+            return line  # bare key on its own line
+    except OSError:
+        return ""
+    return ""
+
+
+def load_api_key(key_file: Path | None) -> str:
+    key = os.environ.get("GRANOLA_API_KEY", "").strip()
+    if not key:
+        for candidate in [key_file, DEFAULT_KEY_FILE]:
+            if candidate and candidate.is_file():
+                key = _read_key_file(candidate)
+                if key:
+                    break
+    if not key:
+        sys.exit(
+            "FATAL: no Granola API key found.\n"
+            "  Provide one of:\n"
+            "    - env GRANOLA_API_KEY=grn_...\n"
+            f"    - a key file at {DEFAULT_KEY_FILE} (or pass --key-file PATH)\n"
+            "  Generate it in Granola: Settings > Connectors > API keys."
+        )
+    return key
+
+
+def api_get(path: str, key: str, retries: int = 4) -> dict:
+    """GET with bearer auth, gzip, and 429 backoff. Fails loud on 401/403/persistent error."""
+    url = API_BASE + path
+    headers = {
+        "Authorization": f"Bearer {key}",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "User-Agent": "ai-brain-starter-granola-export/2.0",
+    }
+    last_err = None
+    for attempt in range(retries):
+        try:
+            req = urllib.request.Request(url, headers=headers, method="GET")
+            with urllib.request.urlopen(req, timeout=45) as r:
+                raw = r.read()
+                if r.headers.get("Content-Encoding") == "gzip":
+                    raw = gzip.GzipFile(fileobj=io.BytesIO(raw)).read()
+            return json.loads(raw)
+        except urllib.error.HTTPError as e:
+            body = e.read()
+            try:
+                if body[:2] == b"\x1f\x8b":
+                    body = gzip.GzipFile(fileobj=io.BytesIO(body)).read()
+            except Exception:
+                pass
+            msg = body[:300].decode(errors="replace")
+            if e.code in (401, 403):
+                sys.exit(
+                    f"FATAL: Granola API {e.code} -- key invalid/expired or the plan lacks API access.\n"
+                    f"  {msg}\n  Regenerate the key in Granola: Settings > Connectors > API keys."
+                )
+            if e.code == 429:
+                wait = 2 ** attempt
+                sys.stderr.write(f"  rate-limited (429); backing off {wait}s\n")
+                time.sleep(wait)
+                last_err = e
+                continue
+            last_err = e
+            time.sleep(1 + attempt)
+        except (urllib.error.URLError, TimeoutError, OSError) as e:
+            last_err = e
+            time.sleep(1 + attempt)
+    sys.exit(f"FATAL: Granola API request failed after {retries} attempts: {path}\n  {last_err}")
+
+
+def list_notes(key: str, created_after: str | None) -> list[dict]:
+    """Page through /notes (newest first), following the cursor."""
+    notes: list[dict] = []
+    cursor, pages = None, 0
+    while True:
+        q = []
+        if created_after:
+            q.append("created_after=" + urllib.parse.quote(created_after))
+        if cursor:
+            q.append("cursor=" + urllib.parse.quote(cursor))
+        data = api_get("/notes" + ("?" + "&".join(q) if q else ""), key)
+        notes.extend(data.get("notes", []))
+        pages += 1
+        cursor = data.get("cursor")
+        if not data.get("hasMore") or not cursor or pages >= 50:
+            break
+        time.sleep(0.25)  # stay well under the rate limit
+    return notes
+
+
+# --------------------------------------------------------------------------- #
+# vault + filesystem
+# --------------------------------------------------------------------------- #
 def detect_vault_root() -> Path:
     env_root = os.environ.get("VAULT_ROOT")
     if env_root:
@@ -38,7 +181,7 @@ def detect_vault_root() -> Path:
     return Path.cwd()
 
 
-def detect_meeting_dir(vault_root: Path, override: str = None) -> Path:
+def detect_meeting_dir(vault_root: Path, override: str | None = None) -> Path:
     if override:
         return vault_root / override
     for pattern in ["**/📝 Meeting Notes", "**/Meeting Notes"]:
@@ -48,176 +191,205 @@ def detect_meeting_dir(vault_root: Path, override: str = None) -> Path:
     return vault_root / "Meeting Notes"
 
 
-def load_state(state_file: Path) -> dict:
-    if state_file.exists():
-        with open(state_file) as f:
-            return json.load(f)
-    return {"exported": []}
-
-
-def save_state(state_file: Path, state: dict):
-    state_file.parent.mkdir(parents=True, exist_ok=True)
-    with open(state_file, "w") as f:
-        json.dump(state, f, indent=2)
-
-
 def safe_filename(title: str, date: str) -> str:
-    clean = re.sub(r'[/\\:*?"<>|]', "-", title).strip()[:60]
+    clean = re.sub(r'[/\\:*?"<>|]', "-", title or "Untitled").strip()[:60]
     return f"{date} - {clean} - Transcript.md"
 
 
-def format_transcript(utterances: list, meeting_start: datetime) -> str:
-    """Group consecutive utterances by source into labeled paragraphs."""
-    paragraphs = []
-    current_source = None
-    current_texts = []
-    current_start = None
+# --------------------------------------------------------------------------- #
+# formatting
+# --------------------------------------------------------------------------- #
+def _speaker_label(source: str) -> str:
+    if source in ("microphone", "mic", "me"):
+        return "**You**"
+    # Keep the other channel as content -- never filter it. For lectures /
+    # webinars / one-on-ones where you listen more than talk, this IS the meeting.
+    return "**Speaker**"
+
+
+def _parse_dt(s: str) -> datetime:
+    try:
+        return datetime.fromisoformat((s or "").replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return datetime.now(timezone.utc)
+
+
+def format_transcript(transcript: list[dict], meeting_start: datetime) -> str:
+    """Group consecutive same-source utterances; prefix each block with relative mm:ss."""
+    blocks: list[str] = []
+    cur_src, cur_texts, cur_start = None, [], None
 
     def flush():
-        if not current_texts:
+        if not cur_texts:
             return
-        text = " ".join(current_texts)
-        if current_source == "microphone":
-            label = "**You**"
-        elif current_source and current_source != "system":
-            label = f"**{current_source.replace('_', ' ').title()}**"
-        else:
-            return  # skip system messages
-        elapsed = max(0, (current_start - meeting_start).total_seconds())
-        mins, secs = divmod(int(elapsed), 60)
-        paragraphs.append(f"`{mins:02d}:{secs:02d}` {label}: {text}")
+        elapsed = max(0, int((cur_start - meeting_start).total_seconds()))
+        mm, ss = divmod(elapsed, 60)
+        blocks.append(f"`{mm:02d}:{ss:02d}` {_speaker_label(cur_src)}: {' '.join(cur_texts)}")
 
-    for u in utterances:
-        source = u.get("source", "unknown")
-        if source == "system":
-            continue
-        text = u.get("text", "").strip()
+    for u in transcript:
+        text = (u.get("text") or "").strip()
         if not text:
             continue
-        ts_str = u.get("start_timestamp", "")
-        try:
-            ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
-        except (ValueError, AttributeError):
-            ts = meeting_start
-
-        if source != current_source:
+        src = (u.get("speaker") or {}).get("source", "unknown")
+        ts = _parse_dt(u.get("start_time") or "")
+        if src != cur_src:
             flush()
-            current_source = source
-            current_texts = [text]
-            current_start = ts
+            cur_src, cur_texts, cur_start = src, [text], ts
         else:
-            current_texts.append(text)
-
+            cur_texts.append(text)
     flush()
-    return "\n\n".join(paragraphs)
+    return "\n\n".join(blocks)
 
 
-def export_one(doc_id: str, doc: dict, utterances: list,
-               meeting_dir: Path, dry_run: bool = False):
-    title = doc.get("title", "Untitled Meeting")
-    created = doc.get("created_at", "")
-    date = created[:10] if created else datetime.now().strftime("%Y-%m-%d")
+# --------------------------------------------------------------------------- #
+# state (lives in the vault, beside the user's data -- not in the repo)
+# --------------------------------------------------------------------------- #
+def state_path_for(vault_root: Path) -> Path:
+    if (vault_root / "⚙️ Meta").exists():
+        return vault_root / "⚙️ Meta" / "scripts" / ".granola_export_state.json"
+    return vault_root / ".granola_export_state.json"
 
-    try:
-        meeting_start = datetime.fromisoformat(created.replace("Z", "+00:00"))
-    except (ValueError, AttributeError):
-        meeting_start = datetime.now(timezone.utc)
 
-    non_system = [u for u in utterances if u.get("source") != "system"]
-    utterance_count = len(non_system)
-
-    filename = safe_filename(title, date)
-    filepath = meeting_dir / filename
-
-    if filepath.exists():
-        return None, f"SKIP (exists): {filename}"
-
-    transcript_text = format_transcript(utterances, meeting_start)
-    notes_md = (doc.get("notes_markdown") or "").strip()
-
-    content = f"""---
-creationDate: {date}
-type: meeting
-source: granola-local
-granola_id: {doc_id}
-utterances: {utterance_count}
----
-
-# {title}
-
-*Exported from Granola local cache — {date}*
-
-"""
-    if notes_md:
-        content += f"## Granola Notes\n\n{notes_md}\n\n"
-
-    if transcript_text:
-        content += f"## Full Transcript\n\n{transcript_text}\n"
+def load_state(state_file: Path) -> dict:
+    if state_file.exists():
+        try:
+            s = json.loads(state_file.read_text())
+        except (OSError, json.JSONDecodeError):
+            s = {}
     else:
-        content += "*No transcript available for this meeting.*\n"
+        s = {}
+    s.setdefault("exported", [])   # note ids whose transcript .md was written
+    s.setdefault("last_sync", None)  # ISO of the last successful run
+    return s
+
+
+def save_state(state_file: Path, state: dict) -> None:
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+    state_file.write_text(json.dumps(state, indent=2))
+
+
+# --------------------------------------------------------------------------- #
+# export one note
+# --------------------------------------------------------------------------- #
+def write_transcript_md(note: dict, meeting_dir: Path, dry_run: bool) -> tuple[Path | None, str]:
+    title = note.get("title") or "Untitled Meeting"
+    created = note.get("created_at") or ""
+    date = created[:10] if created else datetime.now().strftime("%Y-%m-%d")
+    meeting_start = _parse_dt(created)
+    transcript = note.get("transcript") or []
+    n_utt = sum(1 for u in transcript if (u.get("text") or "").strip())
+    summary_md = (note.get("summary_markdown") or "").strip()
+    web_url = note.get("web_url") or ""
+
+    filepath = meeting_dir / safe_filename(title, date)
+    if filepath.exists():
+        return None, f"SKIP (file exists): {filepath.name}"
+
+    body = format_transcript(transcript, meeting_start)
+    content = (
+        "---\n"
+        f"creationDate: {date}\n"
+        "type: meeting\n"
+        "source: granola-api\n"
+        f"granola_id: {note.get('id', '')}\n"
+        f"granola_url: {web_url}\n"
+        f"utterances: {n_utt}\n"
+        "---\n\n"
+        f"# {title}\n\n"
+        f"*Pulled from the Granola API on {datetime.now().strftime('%Y-%m-%d %H:%M')}*\n\n"
+    )
+    if summary_md:
+        content += f"## Summary\n\n{summary_md}\n\n"
+    content += f"## Full Transcript\n\n{body or '_(empty transcript)_'}\n"
 
     if dry_run:
-        return filename, f"DRY RUN: {filename} ({utterance_count} utterances)"
-
+        return filepath, f"DRY-RUN would write {filepath.name} ({n_utt} utterances)"
     meeting_dir.mkdir(parents=True, exist_ok=True)
     filepath.write_text(content, encoding="utf-8")
-    return filename, f"SAVED: {filename} ({utterance_count} utterances)"
+    return filepath, f"SAVED {filepath.name} ({n_utt} utterances)"
 
 
-def main():
-    parser = argparse.ArgumentParser(
-        description="Export Granola meeting transcripts to Obsidian vault"
+# --------------------------------------------------------------------------- #
+# main
+# --------------------------------------------------------------------------- #
+def run_health(key: str) -> int:
+    try:
+        data = api_get("/notes", key)
+        n = len(data.get("notes", []))
+        print(f"HEALTH OK: API reachable, key valid, {n} note(s) in first page.")
+        return 0
+    except SystemExit as e:
+        print(f"HEALTH FAIL: {e}")
+        return 1
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description="Export Granola meeting transcripts to an Obsidian vault via the Public API"
     )
-    parser.add_argument("--vault-root", type=Path)
-    parser.add_argument("--meeting-dir", help="Meeting notes folder (relative to vault root)")
-    parser.add_argument("--dry-run", action="store_true")
-    args = parser.parse_args()
+    ap.add_argument("--vault-root", type=Path)
+    ap.add_argument("--meeting-dir", help="Meeting notes folder (relative to vault root)")
+    ap.add_argument("--key-file", type=Path, help="File containing the Granola API key")
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--since", help="created_after override (YYYY-MM-DD or ISO)")
+    ap.add_argument("--health", action="store_true")
+    args = ap.parse_args()
 
-    if not CACHE_PATH.exists():
-        print(f"Granola cache not found: {CACHE_PATH}")
-        print("Make sure Granola is installed and has been run at least once.")
-        sys.exit(1)
-
-    with open(CACHE_PATH, encoding="utf-8") as f:
-        state_data = json.load(f)["cache"]["state"]
-
-    transcripts = state_data.get("transcripts", {})
-    documents = state_data.get("documents", {})
-
-    if not transcripts:
-        print("No transcripts in Granola cache.")
-        return
+    key = load_api_key(args.key_file)
+    if args.health:
+        sys.exit(run_health(key))
 
     vault_root = (args.vault_root or detect_vault_root()).resolve()
     meeting_dir = detect_meeting_dir(vault_root, args.meeting_dir)
-    state_file = vault_root / "⚙️ Meta" / "scripts" / ".granola_export_state.json"
-    if not (vault_root / "⚙️ Meta").exists():
-        state_file = vault_root / ".granola_export_state.json"
-
+    state_file = state_path_for(vault_root)
     state = load_state(state_file)
-    exported_ids = set(state.get("exported", []))
 
-    newly_exported = []
-    for doc_id, utterances in transcripts.items():
-        if doc_id in exported_ids:
+    # incremental window (with safety lookback so late-finalized notes aren't skipped)
+    if args.since:
+        created_after = args.since if "T" in args.since else f"{args.since}T00:00:00Z"
+    elif state.get("last_sync"):
+        lookback = datetime.now(timezone.utc) - timedelta(days=SAFETY_LOOKBACK_DAYS)
+        created_after = min(_parse_dt(state["last_sync"]), lookback).strftime("%Y-%m-%dT%H:%M:%SZ")
+    else:
+        created_after = (datetime.now(timezone.utc) - timedelta(days=DEFAULT_WINDOW_DAYS)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+
+    print(f"Granola export | created_after={created_after} | dry_run={args.dry_run}")
+    notes = list_notes(key, created_after)
+    print(f"API returned {len(notes)} note(s) in window.")
+    if not notes:
+        print("  0 notes in this window. If meetings should appear, run `--health` to")
+        print("  verify the key/connection. Sustained silence is flagged by")
+        print("  scripts/check-connector-liveness.py (the 0-vs-0 watchdog).")
+
+    exported = set(state.get("exported", []))
+    run_started = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    n_exported = 0
+
+    for meta in notes:
+        nid = meta.get("id")
+        if not nid or nid in exported:
             continue
+        note = api_get(f"/notes/{nid}?include=transcript", key)
+        fp, msg = write_transcript_md(note, meeting_dir, args.dry_run)
+        print(f"  [{nid[:12]}] {msg}")
+        if fp and not args.dry_run:
+            exported.add(nid)
+            n_exported += 1
+        elif fp and args.dry_run:
+            n_exported += 1
+        time.sleep(0.25)
 
-        doc = documents.get(doc_id)
-        if not doc:
-            print(f"SKIP (no document): {doc_id[:8]}...")
-            continue
-
-        filename, msg = export_one(doc_id, doc, utterances, meeting_dir, args.dry_run)
-        print(msg)
-
-        if filename and not args.dry_run:
-            newly_exported.append(doc_id)
-
-    if newly_exported:
-        state["exported"].extend(newly_exported)
+    if not args.dry_run:
+        state["exported"] = sorted(exported)
+        state["last_sync"] = run_started
         save_state(state_file, state)
 
-    print(f"Done. {len(newly_exported)} exported.")
+    print(
+        f"Done. {n_exported} exported."
+        + ("  [DRY-RUN, nothing written]" if args.dry_run else "")
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem
`scripts/granola_sync.py` read `~/Library/Application Support/Granola/cache-v6.json`. Granola deprecated that local cache ~2026-05-12 (encrypted-DB migration), so on current Granola the reader returns `{}` and exits 0 — a **silent-empty connector** for any installer who picks Granola. The docs told users "no API key needed," which is no longer true.

## Fix
- **`granola_sync.py`**: rewritten on Granola's official Public API (`public-api.granola.ai/v1`). Key via `GRANOLA_API_KEY` / `~/.config/granola/api-key` / `--key-file`. Fails loud on missing/invalid key (no more silent exit-0). Adds `--health` + `--dry-run`; incremental window with a late-finalized-note safety lookback. Clean-room — no personal data; the Gmail follow-up drafter stays in the paid runtime (MYC-366).
- **`com.granola-export.plist`**: `WatchPaths`(dead cache) → `StartInterval` 7200 (2h poll), since there's no cache file to watch.
- **`phase-00` / `phase-11` / `POWER_TOOLS`**: "no API key needed / reads local cache" → real API-key setup.
- **`inject-meeting-workflow` hook**: fallback Granola instruction → API.
- **`CHANGELOG`**: user-facing migration entry.

The connector-liveness watchdog already covers Granola (filename format unchanged), so a future silent break is flagged.

## Verification
- **Live API**: `--health` → key valid, 10 notes; `--dry-run --since 2026-06-18` → pulled 8 real notes, wrote nothing.
- **Fail-loud**: no key → `FATAL`, exit 1 (was: silent exit 0).
- **CI**: `scripts/ci.sh` green — py_compile (260) + 43 integration tests + shellcheck. Personal-data scrub clean.
- `git grep cache-v6 -- scripts/` → only the history docstring remains.

Closes MYC-1510.

🤖 Generated with [Claude Code](https://claude.com/claude-code)