### PR TITLE
fix(granola): disclose API plan-gating + route no-API users to alternatives; add offline test (MYC-1528)

### DIFF
--- a/docs/POWER_TOOLS.md
+++ b/docs/POWER_TOOLS.md
@@ -296,6 +296,8 @@ MCP (Model Context Protocol) servers extend Claude Code with structured tool acc
 
 **Why it matters:** without this, you spend 20 minutes after every meeting transcribing handwritten notes and updating CRM cards. With it, Claude reads the full transcript and does the cascade in one command.
 
+**Requires a Granola plan with API access.** Open Granola → Settings → Connectors. If there is no **API keys** section, your plan does not include the API — use Google Meet + Gemini, Otter, or manual notes instead.
+
 **Install:**
 1. Generate a Granola API key: Granola → Settings → Connectors → API keys. Save it to `~/.config/granola/api-key` (chmod 600), or export `GRANOLA_API_KEY`.
 2. Verify + preview: `python3 scripts/granola_sync.py --health`, then `python3 scripts/granola_sync.py --dry-run`.

--- a/phases/phase-00-install.md
+++ b/phases/phase-00-install.md
@@ -107,9 +107,10 @@ Ask:
 > "Do you use Granola for meeting notes?"
 
 **If YES:**
-1. "Granola syncs via its official Public API. Generate an API key in Granola (Settings > Connectors > API keys), save it to `~/.config/granola/api-key` (chmod 600), then run `python3 scripts/granola_sync.py --health` to verify the key and `python3 scripts/granola_sync.py --dry-run` to preview what would export."
-2. For auto-export every 2 hours, offer to install the LaunchAgent: "Set the script path + log path in `scripts/com.granola-export.plist`, copy it to `~/Library/LaunchAgents/`, then run `launchctl load ~/Library/LaunchAgents/com.granola-export.plist`."
-3. Store `GRANOLA=api` so the meeting workflow rule knows to Glob for `*- Transcript.md` files.
+1. **Check plan access first — Granola's API needs a paid Granola plan.** Have them open Granola → Settings → Connectors. If there is no **API keys** section, their plan does not include API access, so the script cannot sync. Route them to Google Meet + Gemini, Otter, or manual notes instead (same options as the "If NO" branch) and skip the rest of this step.
+2. If they have API access: "Generate an API key (Settings > Connectors > API keys), save it to `~/.config/granola/api-key` (chmod 600), then run `python3 scripts/granola_sync.py --health` to verify the key and `python3 scripts/granola_sync.py --dry-run` to preview what would export."
+3. For auto-export every 2 hours, offer to install the LaunchAgent: "Set the script path + log path in `scripts/com.granola-export.plist`, copy it to `~/Library/LaunchAgents/`, then run `launchctl load ~/Library/LaunchAgents/com.granola-export.plist`."
+4. Store `GRANOLA=api` so the meeting workflow rule knows to Glob for `*- Transcript.md` files.
 
 **If NO / "I don't use Granola":**
 - Store `NO_GRANOLA=true` so the meeting workflow rule installs in 'manual' mode.

--- a/phases/phase-11-external-tools.md
+++ b/phases/phase-11-external-tools.md
@@ -72,6 +72,7 @@ Store the answer as `MEETING_TOOLS` (a list — could be multiple). Then for eac
 
 #### 1. Granola
 
+- **Heads-up: Granola's API needs a paid Granola plan.** Have them check Granola → Settings → Connectors for an **API keys** section. If it is not there, their plan lacks API access — route them to Google Meet + Gemini, Otter, or manual notes (the options below) instead of this one.
 - **No MCP needed.** `scripts/granola_sync.py` pulls full transcripts from Granola's official Public API and writes them to the meeting notes folder.
 - **Tell them:** "Granola syncs via its Public API. Generate a key in Granola (Settings > Connectors > API keys), save it to `~/.config/granola/api-key`, then run `python3 scripts/granola_sync.py --health` to verify it and `--dry-run` to preview. For auto-export every 2 hours, install the LaunchAgent in `scripts/com.granola-export.plist` (set the script + log paths, then `launchctl load` it)."
 - **Discovery rule for the meeting workflow CLAUDE.md section:**

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -133,6 +133,7 @@ INTEGRATION_TESTS=(
   test_context_budget_measure
   test_connector_liveness_watchdog
   test_connector_liveness_surface
+  test_granola_sync_offline
   test_agent_memory_link
   test_open_core_boundary
   test_audited_content_injection_scan

--- a/tests/integration/test_granola_sync_offline.sh
+++ b/tests/integration/test_granola_sync_offline.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Network-free regression test for scripts/granola_sync.py.
+#
+# granola_sync.py is the Granola Public-API exporter (MYC-1510). Its critical
+# guarantees do not need the network to verify:
+#   1. FAIL-LOUD on no key. The whole reason for the API rewrite was that the
+#      old cache reader exited 0 with empty output (a silent connector). With no
+#      key, the script MUST exit non-zero AND say so -- never the silent exit 0.
+#   2. Key-file parsing: a bare key on its own line, OR a `GRANOLA_API_KEY=...`
+#      line. Env var beats file.
+#   3. Filename contract: safe_filename() output MUST match the regex
+#      check-connector-liveness.py uses to count Granola data-days
+#      (`^\d{4}-\d{2}-\d{2} - .* - Transcript\.md$`). If these drift, the
+#      liveness watchdog silently stops seeing Granola.
+#   4. format_transcript keeps BOTH speaker channels (mic == You, other ==
+#      Speaker). Dropping the non-mic channel guts lectures/webinars/1:1s where
+#      the user listens more than talks (codified lesson, originally 7 dropped
+#      transcripts).
+#
+# Self-contained. Exit 0 = pass. Exit 1 = fail with details.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+SCRIPT="scripts/granola_sync.py"
+FAILED=0
+fail() { echo "FAIL: $1" >&2; FAILED=$((FAILED + 1)); }
+
+[ -f "$SCRIPT" ] || { echo "FAIL: $SCRIPT not found" >&2; exit 1; }
+
+# --- (1) FAIL-LOUD on no key (the anti-silent-failure guarantee) -------------
+TMP_HOME="$(mktemp -d)"
+trap 'rm -rf "$TMP_HOME"' EXIT
+set +e
+OUT="$(env -u GRANOLA_API_KEY HOME="$TMP_HOME" python3 "$SCRIPT" --health 2>&1)"
+CODE=$?
+set -e
+if [ "$CODE" -eq 0 ]; then
+  fail "(1) --health with no key exited 0 (silent). Must fail loud."
+else
+  echo "PASS(1a): no key -> non-zero exit ($CODE)"
+fi
+case "$OUT" in
+  *"no Granola API key"*) echo "PASS(1b): no key -> says 'no Granola API key'" ;;
+  *) fail "(1b) no-key output did not name the missing key. out=[$OUT]" ;;
+esac
+
+# --- (2)-(5) pure-function contracts (no network) ----------------------------
+python3 - "$REPO_ROOT" <<'PY'
+import sys, pathlib, tempfile, re
+repo = pathlib.Path(sys.argv[1])
+sys.path.insert(0, str(repo / "scripts"))
+import granola_sync as g
+from datetime import datetime, timezone
+
+fails = []
+def check(cond, msg):
+    print(("PASS: " if cond else "FAIL: ") + msg)
+    if not cond:
+        fails.append(msg)
+
+# (2) key-file parsing: bare key
+with tempfile.TemporaryDirectory() as d:
+    kf = pathlib.Path(d) / "api-key"
+    kf.write_text("grn_barekey_123\n")
+    check(g.load_api_key(kf) == "grn_barekey_123", "(2a) bare-key file parses")
+    # (2b) KEY=value line
+    kf.write_text("# comment\nGRANOLA_API_KEY=grn_eqform_456\n")
+    check(g.load_api_key(kf) == "grn_eqform_456", "(2b) GRANOLA_API_KEY= line parses")
+    # (2c) env beats file
+    import os
+    os.environ["GRANOLA_API_KEY"] = "grn_envwins_789"
+    check(g.load_api_key(kf) == "grn_envwins_789", "(2c) env var beats key file")
+    del os.environ["GRANOLA_API_KEY"]
+
+# (3) filename contract MUST match the liveness watchdog's regex
+LIVENESS_RE = re.compile(r"^\d{4}-\d{2}-\d{2} - .* - Transcript\.md$")
+fn = g.safe_filename("A/B", "2026-06-22")
+check(fn == "2026-06-22 - A-B - Transcript.md", f"(3a) safe_filename exact: {fn!r}")
+check(bool(LIVENESS_RE.match(fn)), "(3b) safe_filename matches liveness regex")
+# illegal chars are sanitized, never leak into the filename
+fn2 = g.safe_filename('Q3: plan/ops*', "2026-01-02")
+check(bool(LIVENESS_RE.match(fn2)) and "/" not in fn2 and ":" not in fn2,
+      f"(3c) illegal chars sanitized: {fn2!r}")
+
+# (4) format_transcript keeps BOTH channels
+start = datetime(2026, 6, 22, 12, 0, 0, tzinfo=timezone.utc)
+transcript = [
+    {"text": "hi there", "speaker": {"source": "microphone"}, "start_time": "2026-06-22T12:00:01Z"},
+    {"text": "hello back", "speaker": {"source": "speaker"}, "start_time": "2026-06-22T12:00:05Z"},
+]
+out = g.format_transcript(transcript, start)
+check("**You**" in out, "(4a) mic channel labeled You")
+check("**Speaker**" in out and "hello back" in out, "(4b) other channel kept as Speaker")
+
+sys.exit(1 if fails else 0)
+PY
+PY_CODE=$?
+[ "$PY_CODE" -eq 0 ] || fail "(2-4) pure-function contract check failed (see above)"
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "test_granola_sync_offline: $FAILED failure(s)" >&2
+  exit 1
+fi
+echo "test_granola_sync_offline: all checks passed"


### PR DESCRIPTION
Follow-up to #231 (MYC-1510), found by the are-we-done re-audit.

## Problem
The Public-API port requires a Granola **API key**, which Granola gates to **paid plans**. The old cache reader worked on *any* plan (the CHANGELOG said "free, pro, business"). The install flow told a free/Pro Granola user to "generate an API key" with **no warning and no fallback** — a fresh onboarding dead-end.

## Fix
- **phase-00 / phase-11 / POWER_TOOLS**: check for an **API keys** section first; if absent, route the user to Gemini / Otter / manual instead of a dead-end. Keyed on the *observable* (no API-keys section), not a hard price tier.
- **`tests/integration/test_granola_sync_offline.sh`** (network-free, registered in `ci.sh`): locks `granola_sync.py`'s contracts — fail-loud on no key (the anti-silent-failure guarantee), key-file parsing (bare + `KEY=val` + env-precedence), the `safe_filename` ↔ liveness-watchdog regex contract, and both speaker channels kept.

## Verification
- New test green (10 checks), shellcheck clean.
- Full CI green locally: py_compile (260) + **44** integration tests + shellcheck. Scrub clean.

Closes MYC-1528. Relates #231 (MYC-1510), MYC-366 (in-app guided connect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)