### PR TITLE
refactor(granola): collapse to one shared granola_core; both copies import it (MYC-1529)

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -134,6 +134,7 @@ INTEGRATION_TESTS=(
   test_connector_liveness_watchdog
   test_connector_liveness_surface
   test_granola_sync_offline
+  test_granola_core_shared
   test_agent_memory_link
   test_open_core_boundary
   test_audited_content_injection_scan

--- a/scripts/granola_core.py
+++ b/scripts/granola_core.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""
+Granola Public API -- shared core (the single source of truth for the contract).
+
+ONE module, imported by BOTH copies so they cannot drift:
+  - scripts/granola_sync.py            (this substrate's zero-config exporter)
+  - a private vault's granola_export.py (adds a Gmail follow-up drafter on top)
+
+The API contract (auth, HTTP, paging, transcript formatting, the vault filename
+contract, the incremental window, state) lives HERE. Before this module the two
+copies were ~250-line near-duplicates that had already diverged within three
+weeks (speaker labels, frontmatter, User-Agent). The original incident: the
+personal copy was migrated to the Public API weeks before this substrate copy,
+which silently exported nothing in the meantime.
+Bug class: DISCIPLINE-FIX-NOT-PORTED-TO-SUBSTRATE.
+
+WHY THE API (history): Granola migrated local storage to an encrypted SQLite DB
+around 2026-05-12. The previous reader parsed
+cache-v6.json["cache"]["state"]["transcripts"], which became an empty {} after
+the migration -> it printed "No transcripts in cache." and exited 0 for weeks
+(a silent failure: exit 0, zero output, nothing wrong-looking). The Public API
+is vendor-supported and survives local-storage migrations.
+Bug class: VENDOR-LOCAL-CACHE-SCHEMA-MIGRATION-SILENT-FAILURE.
+
+AUTH: a Granola API key, resolved in order:
+  1. GRANOLA_API_KEY environment variable
+  2. a key_file the caller passes (a bare key, or a `GRANOLA_API_KEY=...` line)
+  3. ~/.config/granola/api-key (same format)
+Generate the key in Granola: Settings > Connectors > API keys (requires a plan
+with API access). The key is read at runtime and is never written to the repo.
+
+This module has no CLI of its own -- it is imported, not run. The substrate
+exporter is scripts/granola_sync.py.
+"""
+from __future__ import annotations  # PEP 604 `X | None` annotations safe on py3.8+
+
+import gzip
+import io
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+API_BASE = "https://public-api.granola.ai/v1"
+DEFAULT_KEY_FILE = Path.home() / ".config" / "granola" / "api-key"
+DEFAULT_USER_AGENT = "ai-brain-starter-granola-export/2.0"
+
+# First-run window if no prior state (avoid pulling full history on day one).
+DEFAULT_WINDOW_DAYS = 21
+
+# Trailing re-scan applied on top of last_sync. A note's transcript/summary can
+# finalize minutes-to-days after its created_at, and the API only returns a note
+# once it is finalized. A window keyed strictly on last_sync would therefore
+# SILENTLY skip any note that finalized after the window advanced past its
+# created_at. Re-scanning a trailing window catches them; the exported-id dedup
+# keeps it idempotent. Bug class: INCREMENTAL-WINDOW-MISSES-LATE-FINALIZED-NOTES.
+SAFETY_LOOKBACK_DAYS = 4
+
+
+# --------------------------------------------------------------------------- #
+# auth + http
+# --------------------------------------------------------------------------- #
+def _read_key_file(path: Path) -> str:
+    """First non-comment line of a key file: a bare key, or `GRANOLA_API_KEY=...`."""
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("GRANOLA_API_KEY="):
+                return line.split("=", 1)[1].strip()
+            return line  # bare key on its own line
+    except OSError:
+        return ""
+    return ""
+
+
+def load_api_key(key_file: Path | None = None) -> str:
+    """Resolve a key: env GRANOLA_API_KEY -> caller key_file -> DEFAULT_KEY_FILE.
+
+    Fails LOUD (non-zero exit + named cause) when no key is found. This is the
+    anti-silent-failure guarantee: the whole reason for the API rewrite was that
+    the old cache reader exited 0 with empty output.
+    """
+    key = os.environ.get("GRANOLA_API_KEY", "").strip()
+    if not key:
+        for candidate in [key_file, DEFAULT_KEY_FILE]:
+            if candidate and Path(candidate).is_file():
+                key = _read_key_file(Path(candidate))
+                if key:
+                    break
+    if not key:
+        sys.exit(
+            "FATAL: no Granola API key found.\n"
+            "  Provide one of:\n"
+            "    - env GRANOLA_API_KEY=grn_...\n"
+            f"    - a key file (default {DEFAULT_KEY_FILE}); callers may pass another path\n"
+            "  Generate it in Granola: Settings > Connectors > API keys."
+        )
+    return key
+
+
+def api_get(path: str, key: str, retries: int = 4, user_agent: str = DEFAULT_USER_AGENT) -> dict:
+    """GET with bearer auth, gzip, and 429 backoff. Fails loud on 401/403/persistent error."""
+    url = API_BASE + path
+    headers = {
+        "Authorization": f"Bearer {key}",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "User-Agent": user_agent,
+    }
+    last_err = None
+    for attempt in range(retries):
+        try:
+            req = urllib.request.Request(url, headers=headers, method="GET")
+            with urllib.request.urlopen(req, timeout=45) as r:
+                raw = r.read()
+                if r.headers.get("Content-Encoding") == "gzip":
+                    raw = gzip.GzipFile(fileobj=io.BytesIO(raw)).read()
+            return json.loads(raw)
+        except urllib.error.HTTPError as e:
+            body = e.read()
+            try:
+                if body[:2] == b"\x1f\x8b":
+                    body = gzip.GzipFile(fileobj=io.BytesIO(body)).read()
+            except Exception:
+                pass
+            msg = body[:300].decode(errors="replace")
+            if e.code in (401, 403):
+                sys.exit(
+                    f"FATAL: Granola API {e.code} -- key invalid/expired or the plan lacks API access.\n"
+                    f"  {msg}\n  Regenerate the key in Granola: Settings > Connectors > API keys."
+                )
+            if e.code == 429:
+                wait = 2 ** attempt
+                sys.stderr.write(f"  rate-limited (429); backing off {wait}s\n")
+                time.sleep(wait)
+                last_err = e
+                continue
+            last_err = e
+            time.sleep(1 + attempt)
+        except (urllib.error.URLError, TimeoutError, OSError) as e:
+            last_err = e
+            time.sleep(1 + attempt)
+    sys.exit(f"FATAL: Granola API request failed after {retries} attempts: {path}\n  {last_err}")
+
+
+def list_notes(key: str, created_after: str | None, user_agent: str = DEFAULT_USER_AGENT) -> list[dict]:
+    """Page through /notes (newest first), following the cursor."""
+    notes: list[dict] = []
+    cursor, pages = None, 0
+    while True:
+        q = []
+        if created_after:
+            q.append("created_after=" + urllib.parse.quote(created_after))
+        if cursor:
+            q.append("cursor=" + urllib.parse.quote(cursor))
+        data = api_get("/notes" + ("?" + "&".join(q) if q else ""), key, user_agent=user_agent)
+        notes.extend(data.get("notes", []))
+        pages += 1
+        cursor = data.get("cursor")
+        if not data.get("hasMore") or not cursor or pages >= 50:
+            break
+        time.sleep(0.25)  # stay well under the rate limit
+    return notes
+
+
+# --------------------------------------------------------------------------- #
+# vault + filesystem
+# --------------------------------------------------------------------------- #
+def detect_vault_root() -> Path:
+    env_root = os.environ.get("VAULT_ROOT")
+    if env_root:
+        return Path(env_root)
+    script_dir = Path(__file__).resolve().parent
+    for candidate in [script_dir.parent, script_dir.parent.parent]:
+        if (candidate / "⚙️ Meta").is_dir() or (candidate / ".obsidian").is_dir():
+            return candidate
+    return Path.cwd()
+
+
+def detect_meeting_dir(vault_root: Path, override: str | None = None) -> Path:
+    if override:
+        return vault_root / override
+    for pattern in ["**/📝 Meeting Notes", "**/Meeting Notes"]:
+        matches = list(vault_root.glob(pattern))
+        if matches:
+            return matches[0]
+    return vault_root / "Meeting Notes"
+
+
+def safe_filename(title: str, date: str) -> str:
+    clean = re.sub(r'[/\\:*?"<>|]', "-", title or "Untitled").strip()[:60]
+    return f"{date} - {clean} - Transcript.md"
+
+
+# --------------------------------------------------------------------------- #
+# formatting
+# --------------------------------------------------------------------------- #
+def _speaker_label(source: str) -> str:
+    if source in ("microphone", "mic", "me"):
+        return "**You**"
+    # Keep the other channel as content -- never filter it. For lectures /
+    # webinars / one-on-ones where you listen more than talk, this IS the meeting.
+    return "**Speaker**"
+
+
+def _parse_dt(s: str) -> datetime:
+    try:
+        return datetime.fromisoformat((s or "").replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return datetime.now(timezone.utc)
+
+
+def format_transcript(transcript: list[dict], meeting_start: datetime) -> str:
+    """Group consecutive same-source utterances; prefix each block with relative mm:ss."""
+    blocks: list[str] = []
+    cur_src, cur_texts, cur_start = None, [], None
+
+    def flush():
+        if not cur_texts:
+            return
+        elapsed = max(0, int((cur_start - meeting_start).total_seconds()))
+        mm, ss = divmod(elapsed, 60)
+        blocks.append(f"`{mm:02d}:{ss:02d}` {_speaker_label(cur_src)}: {' '.join(cur_texts)}")
+
+    for u in transcript:
+        text = (u.get("text") or "").strip()
+        if not text:
+            continue
+        src = (u.get("speaker") or {}).get("source", "unknown")
+        ts = _parse_dt(u.get("start_time") or "")
+        if src != cur_src:
+            flush()
+            cur_src, cur_texts, cur_start = src, [text], ts
+        else:
+            cur_texts.append(text)
+    flush()
+    return "\n\n".join(blocks)
+
+
+# --------------------------------------------------------------------------- #
+# incremental window
+# --------------------------------------------------------------------------- #
+def incremental_created_after(
+    state: dict,
+    since: str | None = None,
+    window_days: int = DEFAULT_WINDOW_DAYS,
+    lookback_days: int = SAFETY_LOOKBACK_DAYS,
+) -> str:
+    """The created_after window: explicit --since, else last_sync minus a safety
+    lookback, else a first-run window. Identical math in every caller, so it lives
+    here once."""
+    if since:
+        return since if "T" in since else f"{since}T00:00:00Z"
+    last = state.get("last_sync")
+    if last:
+        lookback = datetime.now(timezone.utc) - timedelta(days=lookback_days)
+        return min(_parse_dt(last), lookback).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return (datetime.now(timezone.utc) - timedelta(days=window_days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# --------------------------------------------------------------------------- #
+# state (lives in the vault, beside the user's data -- not in the repo)
+# --------------------------------------------------------------------------- #
+def state_path_for(vault_root: Path) -> Path:
+    if (vault_root / "⚙️ Meta").exists():
+        return vault_root / "⚙️ Meta" / "scripts" / ".granola_export_state.json"
+    return vault_root / ".granola_export_state.json"
+
+
+def load_state(state_file: Path) -> dict:
+    if Path(state_file).exists():
+        try:
+            s = json.loads(Path(state_file).read_text())
+        except (OSError, json.JSONDecodeError):
+            s = {}
+    else:
+        s = {}
+    s.setdefault("exported", [])     # note ids whose transcript .md was written
+    s.setdefault("last_sync", None)  # ISO of the last successful run
+    return s
+
+
+def save_state(state_file: Path, state: dict) -> None:
+    Path(state_file).parent.mkdir(parents=True, exist_ok=True)
+    Path(state_file).write_text(json.dumps(state, indent=2))
+
+
+# --------------------------------------------------------------------------- #
+# export one note
+# --------------------------------------------------------------------------- #
+def write_transcript_md(
+    note: dict,
+    meeting_dir: Path,
+    dry_run: bool,
+    extra_frontmatter: dict | None = None,
+) -> tuple[Path | None, str]:
+    """Write one note's transcript .md. `extra_frontmatter` lets a caller add
+    keys (e.g. the personal exporter's `external_attendees`) without forking this
+    function -- the only sanctioned point of variation."""
+    title = note.get("title") or "Untitled Meeting"
+    created = note.get("created_at") or ""
+    date = created[:10] if created else datetime.now().strftime("%Y-%m-%d")
+    meeting_start = _parse_dt(created)
+    transcript = note.get("transcript") or []
+    n_utt = sum(1 for u in transcript if (u.get("text") or "").strip())
+    summary_md = (note.get("summary_markdown") or "").strip()
+    web_url = note.get("web_url") or ""
+
+    filepath = meeting_dir / safe_filename(title, date)
+    if filepath.exists():
+        return None, f"SKIP (file exists): {filepath.name}"
+
+    fm = [
+        "---",
+        f"creationDate: {date}",
+        "type: meeting",
+        "source: granola-api",
+        f"granola_id: {note.get('id', '')}",
+        f"granola_url: {web_url}",
+        f"utterances: {n_utt}",
+    ]
+    for k, v in (extra_frontmatter or {}).items():
+        fm.append(f"{k}: {v}")
+    fm.append("---")
+
+    body = format_transcript(transcript, meeting_start)
+    content = "\n".join(fm) + "\n\n"
+    content += f"# {title}\n\n"
+    content += f"*Pulled from the Granola API on {datetime.now().strftime('%Y-%m-%d %H:%M')}*\n\n"
+    if summary_md:
+        content += f"## Summary\n\n{summary_md}\n\n"
+    content += f"## Full Transcript\n\n{body or '_(empty transcript)_'}\n"
+
+    if dry_run:
+        return filepath, f"DRY-RUN would write {filepath.name} ({n_utt} utterances)"
+    meeting_dir.mkdir(parents=True, exist_ok=True)
+    filepath.write_text(content, encoding="utf-8")
+    return filepath, f"SAVED {filepath.name} ({n_utt} utterances)"

--- a/scripts/granola_sync.py
+++ b/scripts/granola_sync.py
@@ -6,6 +6,11 @@ Pulls meeting notes from Granola's official Public API and writes each meeting's
 full timestamped transcript + AI summary as markdown into your vault's meeting
 notes folder.
 
+The API contract (auth, HTTP, paging, transcript formatting, the vault filename
+contract, the incremental window, state) lives in scripts/granola_core.py -- the
+SINGLE source of truth shared with the private vault's granola_export.py so the
+two copies cannot drift. This file is the substrate's zero-config CLI on top.
+
 WHY THE API (history): Granola migrated local storage to an encrypted SQLite DB
 around 2026-05-12. The previous version of this script parsed
 cache-v6.json["cache"]["state"]["transcripts"], which became an empty {} after
@@ -34,284 +39,34 @@ EXIT CODES: 0 ok (including "0 new" -- a legitimate quiet period); 1 hard failur
 prints that plainly -- sustained silence is caught by check-connector-liveness.py
 (the 0-vs-0 watchdog), not by failing an individual run.
 """
-from __future__ import annotations  # PEP 604 `X | None` annotations safe on py3.8+
+from __future__ import annotations
 
 import argparse
-import gzip
-import io
-import json
-import os
-import re
 import sys
 import time
-import urllib.error
-import urllib.parse
-import urllib.request
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from pathlib import Path
 
-API_BASE = "https://public-api.granola.ai/v1"
-DEFAULT_KEY_FILE = Path.home() / ".config" / "granola" / "api-key"
-
-# First-run window if no prior state (avoid pulling full history on day one).
-DEFAULT_WINDOW_DAYS = 21
-
-# Trailing re-scan applied on top of last_sync. A note's transcript/summary can
-# finalize minutes-to-days after its created_at, and the API only returns a note
-# once it is finalized. A window keyed strictly on last_sync would therefore
-# SILENTLY skip any note that finalized after the window advanced past its
-# created_at. Re-scanning a trailing window catches them; the exported-id dedup
-# keeps it idempotent. Bug class: INCREMENTAL-WINDOW-MISSES-LATE-FINALIZED-NOTES.
-SAFETY_LOOKBACK_DAYS = 4
-
-
-# --------------------------------------------------------------------------- #
-# auth + http
-# --------------------------------------------------------------------------- #
-def _read_key_file(path: Path) -> str:
-    """First non-comment line of a key file: a bare key, or `GRANOLA_API_KEY=...`."""
-    try:
-        for line in path.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if not line or line.startswith("#"):
-                continue
-            if line.startswith("GRANOLA_API_KEY="):
-                return line.split("=", 1)[1].strip()
-            return line  # bare key on its own line
-    except OSError:
-        return ""
-    return ""
+# Shared Granola API core (same directory). Re-export the contract functions so
+# `import granola_sync as g; g.load_api_key/safe_filename/format_transcript`
+# keeps working for callers and tests.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from granola_core import (  # noqa: E402
+    api_get,
+    detect_meeting_dir,
+    detect_vault_root,
+    format_transcript,
+    incremental_created_after,
+    list_notes,
+    load_api_key,
+    load_state,
+    safe_filename,
+    save_state,
+    state_path_for,
+    write_transcript_md,
+)
 
 
-def load_api_key(key_file: Path | None) -> str:
-    key = os.environ.get("GRANOLA_API_KEY", "").strip()
-    if not key:
-        for candidate in [key_file, DEFAULT_KEY_FILE]:
-            if candidate and candidate.is_file():
-                key = _read_key_file(candidate)
-                if key:
-                    break
-    if not key:
-        sys.exit(
-            "FATAL: no Granola API key found.\n"
-            "  Provide one of:\n"
-            "    - env GRANOLA_API_KEY=grn_...\n"
-            f"    - a key file at {DEFAULT_KEY_FILE} (or pass --key-file PATH)\n"
-            "  Generate it in Granola: Settings > Connectors > API keys."
-        )
-    return key
-
-
-def api_get(path: str, key: str, retries: int = 4) -> dict:
-    """GET with bearer auth, gzip, and 429 backoff. Fails loud on 401/403/persistent error."""
-    url = API_BASE + path
-    headers = {
-        "Authorization": f"Bearer {key}",
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip",
-        "User-Agent": "ai-brain-starter-granola-export/2.0",
-    }
-    last_err = None
-    for attempt in range(retries):
-        try:
-            req = urllib.request.Request(url, headers=headers, method="GET")
-            with urllib.request.urlopen(req, timeout=45) as r:
-                raw = r.read()
-                if r.headers.get("Content-Encoding") == "gzip":
-                    raw = gzip.GzipFile(fileobj=io.BytesIO(raw)).read()
-            return json.loads(raw)
-        except urllib.error.HTTPError as e:
-            body = e.read()
-            try:
-                if body[:2] == b"\x1f\x8b":
-                    body = gzip.GzipFile(fileobj=io.BytesIO(body)).read()
-            except Exception:
-                pass
-            msg = body[:300].decode(errors="replace")
-            if e.code in (401, 403):
-                sys.exit(
-                    f"FATAL: Granola API {e.code} -- key invalid/expired or the plan lacks API access.\n"
-                    f"  {msg}\n  Regenerate the key in Granola: Settings > Connectors > API keys."
-                )
-            if e.code == 429:
-                wait = 2 ** attempt
-                sys.stderr.write(f"  rate-limited (429); backing off {wait}s\n")
-                time.sleep(wait)
-                last_err = e
-                continue
-            last_err = e
-            time.sleep(1 + attempt)
-        except (urllib.error.URLError, TimeoutError, OSError) as e:
-            last_err = e
-            time.sleep(1 + attempt)
-    sys.exit(f"FATAL: Granola API request failed after {retries} attempts: {path}\n  {last_err}")
-
-
-def list_notes(key: str, created_after: str | None) -> list[dict]:
-    """Page through /notes (newest first), following the cursor."""
-    notes: list[dict] = []
-    cursor, pages = None, 0
-    while True:
-        q = []
-        if created_after:
-            q.append("created_after=" + urllib.parse.quote(created_after))
-        if cursor:
-            q.append("cursor=" + urllib.parse.quote(cursor))
-        data = api_get("/notes" + ("?" + "&".join(q) if q else ""), key)
-        notes.extend(data.get("notes", []))
-        pages += 1
-        cursor = data.get("cursor")
-        if not data.get("hasMore") or not cursor or pages >= 50:
-            break
-        time.sleep(0.25)  # stay well under the rate limit
-    return notes
-
-
-# --------------------------------------------------------------------------- #
-# vault + filesystem
-# --------------------------------------------------------------------------- #
-def detect_vault_root() -> Path:
-    env_root = os.environ.get("VAULT_ROOT")
-    if env_root:
-        return Path(env_root)
-    script_dir = Path(__file__).resolve().parent
-    for candidate in [script_dir.parent, script_dir.parent.parent]:
-        if (candidate / "⚙️ Meta").is_dir() or (candidate / ".obsidian").is_dir():
-            return candidate
-    return Path.cwd()
-
-
-def detect_meeting_dir(vault_root: Path, override: str | None = None) -> Path:
-    if override:
-        return vault_root / override
-    for pattern in ["**/📝 Meeting Notes", "**/Meeting Notes"]:
-        matches = list(vault_root.glob(pattern))
-        if matches:
-            return matches[0]
-    return vault_root / "Meeting Notes"
-
-
-def safe_filename(title: str, date: str) -> str:
-    clean = re.sub(r'[/\\:*?"<>|]', "-", title or "Untitled").strip()[:60]
-    return f"{date} - {clean} - Transcript.md"
-
-
-# --------------------------------------------------------------------------- #
-# formatting
-# --------------------------------------------------------------------------- #
-def _speaker_label(source: str) -> str:
-    if source in ("microphone", "mic", "me"):
-        return "**You**"
-    # Keep the other channel as content -- never filter it. For lectures /
-    # webinars / one-on-ones where you listen more than talk, this IS the meeting.
-    return "**Speaker**"
-
-
-def _parse_dt(s: str) -> datetime:
-    try:
-        return datetime.fromisoformat((s or "").replace("Z", "+00:00"))
-    except (ValueError, AttributeError):
-        return datetime.now(timezone.utc)
-
-
-def format_transcript(transcript: list[dict], meeting_start: datetime) -> str:
-    """Group consecutive same-source utterances; prefix each block with relative mm:ss."""
-    blocks: list[str] = []
-    cur_src, cur_texts, cur_start = None, [], None
-
-    def flush():
-        if not cur_texts:
-            return
-        elapsed = max(0, int((cur_start - meeting_start).total_seconds()))
-        mm, ss = divmod(elapsed, 60)
-        blocks.append(f"`{mm:02d}:{ss:02d}` {_speaker_label(cur_src)}: {' '.join(cur_texts)}")
-
-    for u in transcript:
-        text = (u.get("text") or "").strip()
-        if not text:
-            continue
-        src = (u.get("speaker") or {}).get("source", "unknown")
-        ts = _parse_dt(u.get("start_time") or "")
-        if src != cur_src:
-            flush()
-            cur_src, cur_texts, cur_start = src, [text], ts
-        else:
-            cur_texts.append(text)
-    flush()
-    return "\n\n".join(blocks)
-
-
-# --------------------------------------------------------------------------- #
-# state (lives in the vault, beside the user's data -- not in the repo)
-# --------------------------------------------------------------------------- #
-def state_path_for(vault_root: Path) -> Path:
-    if (vault_root / "⚙️ Meta").exists():
-        return vault_root / "⚙️ Meta" / "scripts" / ".granola_export_state.json"
-    return vault_root / ".granola_export_state.json"
-
-
-def load_state(state_file: Path) -> dict:
-    if state_file.exists():
-        try:
-            s = json.loads(state_file.read_text())
-        except (OSError, json.JSONDecodeError):
-            s = {}
-    else:
-        s = {}
-    s.setdefault("exported", [])   # note ids whose transcript .md was written
-    s.setdefault("last_sync", None)  # ISO of the last successful run
-    return s
-
-
-def save_state(state_file: Path, state: dict) -> None:
-    state_file.parent.mkdir(parents=True, exist_ok=True)
-    state_file.write_text(json.dumps(state, indent=2))
-
-
-# --------------------------------------------------------------------------- #
-# export one note
-# --------------------------------------------------------------------------- #
-def write_transcript_md(note: dict, meeting_dir: Path, dry_run: bool) -> tuple[Path | None, str]:
-    title = note.get("title") or "Untitled Meeting"
-    created = note.get("created_at") or ""
-    date = created[:10] if created else datetime.now().strftime("%Y-%m-%d")
-    meeting_start = _parse_dt(created)
-    transcript = note.get("transcript") or []
-    n_utt = sum(1 for u in transcript if (u.get("text") or "").strip())
-    summary_md = (note.get("summary_markdown") or "").strip()
-    web_url = note.get("web_url") or ""
-
-    filepath = meeting_dir / safe_filename(title, date)
-    if filepath.exists():
-        return None, f"SKIP (file exists): {filepath.name}"
-
-    body = format_transcript(transcript, meeting_start)
-    content = (
-        "---\n"
-        f"creationDate: {date}\n"
-        "type: meeting\n"
-        "source: granola-api\n"
-        f"granola_id: {note.get('id', '')}\n"
-        f"granola_url: {web_url}\n"
-        f"utterances: {n_utt}\n"
-        "---\n\n"
-        f"# {title}\n\n"
-        f"*Pulled from the Granola API on {datetime.now().strftime('%Y-%m-%d %H:%M')}*\n\n"
-    )
-    if summary_md:
-        content += f"## Summary\n\n{summary_md}\n\n"
-    content += f"## Full Transcript\n\n{body or '_(empty transcript)_'}\n"
-
-    if dry_run:
-        return filepath, f"DRY-RUN would write {filepath.name} ({n_utt} utterances)"
-    meeting_dir.mkdir(parents=True, exist_ok=True)
-    filepath.write_text(content, encoding="utf-8")
-    return filepath, f"SAVED {filepath.name} ({n_utt} utterances)"
-
-
-# --------------------------------------------------------------------------- #
-# main
-# --------------------------------------------------------------------------- #
 def run_health(key: str) -> int:
     try:
         data = api_get("/notes", key)
@@ -344,16 +99,7 @@ def main() -> None:
     state_file = state_path_for(vault_root)
     state = load_state(state_file)
 
-    # incremental window (with safety lookback so late-finalized notes aren't skipped)
-    if args.since:
-        created_after = args.since if "T" in args.since else f"{args.since}T00:00:00Z"
-    elif state.get("last_sync"):
-        lookback = datetime.now(timezone.utc) - timedelta(days=SAFETY_LOOKBACK_DAYS)
-        created_after = min(_parse_dt(state["last_sync"]), lookback).strftime("%Y-%m-%dT%H:%M:%SZ")
-    else:
-        created_after = (datetime.now(timezone.utc) - timedelta(days=DEFAULT_WINDOW_DAYS)).strftime(
-            "%Y-%m-%dT%H:%M:%SZ"
-        )
+    created_after = incremental_created_after(state, args.since)
 
     print(f"Granola export | created_after={created_after} | dry_run={args.dry_run}")
     notes = list_notes(key, created_after)

--- a/tests/integration/test_granola_core_shared.sh
+++ b/tests/integration/test_granola_core_shared.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Network-free regression test for scripts/granola_core.py -- the SHARED Granola
+# API core, and the structural guarantee that scripts/granola_sync.py does not
+# re-vendor it.
+#
+# WHY THIS EXISTS (MYC-1529): the Granola API contract used to live as two
+# near-duplicate copies (this substrate's granola_sync.py + a private vault's
+# granola_export.py). The personal copy was migrated to the Public API three
+# weeks before the substrate copy, which silently exported nothing in between.
+# Bug class: DISCIPLINE-FIX-NOT-PORTED-TO-SUBSTRATE. The durable fix is ONE
+# module both copies import, so the contract cannot drift.
+#
+# This test pins two things the network cannot change:
+#   1. NO RE-VENDOR (the structural guarantee + its own negative control). The
+#      contract functions exposed by granola_sync MUST be the very same objects
+#      defined in granola_core (identity, `is`). If a future edit copy-pastes one
+#      back into granola_sync, identity breaks and this test fails loudly -- that
+#      is the whole anti-drift mechanism, and it is silent only while the two are
+#      genuinely one.
+#   2. The core's pure-function contracts: the external-attendee frontmatter
+#      variation point (write_transcript_md extra_frontmatter) and the
+#      incremental window math (incremental_created_after).
+#
+# Self-contained. Exit 0 = pass. Exit 1 = fail with details.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+[ -f scripts/granola_core.py ] || { echo "FAIL: scripts/granola_core.py not found" >&2; exit 1; }
+[ -f scripts/granola_sync.py ] || { echo "FAIL: scripts/granola_sync.py not found" >&2; exit 1; }
+
+python3 - "$REPO_ROOT" <<'PY'
+import sys, pathlib, tempfile, re
+repo = pathlib.Path(sys.argv[1])
+sys.path.insert(0, str(repo / "scripts"))
+import granola_core as core
+import granola_sync as g
+from datetime import datetime, timezone
+
+fails = []
+def check(cond, msg):
+    print(("PASS: " if cond else "FAIL: ") + msg)
+    if not cond:
+        fails.append(msg)
+
+# (1) NO RE-VENDOR: granola_sync re-exports the SAME objects from granola_core.
+# This identity check IS the anti-drift guarantee and its own negative control:
+# the day someone forks a function back into granola_sync, `is` becomes False.
+for name in ("api_get", "list_notes", "format_transcript", "safe_filename",
+             "load_api_key", "write_transcript_md", "load_state", "save_state",
+             "incremental_created_after"):
+    same = getattr(g, name, None) is getattr(core, name, object())
+    check(same, f"(1) granola_sync.{name} is the shared granola_core.{name} (no re-vendor)")
+
+# (2) write_transcript_md: substrate mode omits external_attendees; the personal
+# exporter injects it via extra_frontmatter WITHOUT forking the function.
+note = {
+    "id": "n_123",
+    "title": "Q3 / Plan: ops",   # also exercises filename sanitization
+    "created_at": "2026-06-22T15:00:00Z",
+    "web_url": "https://granola.ai/n_123",
+    "summary_markdown": "We agreed on the plan.",
+    "transcript": [
+        {"text": "kickoff", "speaker": {"source": "microphone"}, "start_time": "2026-06-22T15:00:01Z"},
+        {"text": "sounds good", "speaker": {"source": "speaker"}, "start_time": "2026-06-22T15:00:04Z"},
+    ],
+}
+with tempfile.TemporaryDirectory() as d:
+    mdir = pathlib.Path(d)
+    fp, _msg = core.write_transcript_md(note, mdir, dry_run=False)
+    body = fp.read_text(encoding="utf-8")
+    check("source: granola-api" in body, "(2a) substrate frontmatter has source: granola-api")
+    check("external_attendees" not in body, "(2b) substrate frontmatter omits external_attendees")
+    check("**You**" in body and "**Speaker**" in body, "(2c) both transcript channels kept")
+    # filename obeys the liveness watchdog regex (illegal chars sanitized)
+    LIVENESS_RE = re.compile(r"^\d{4}-\d{2}-\d{2} - .* - Transcript\.md$")
+    check(bool(LIVENESS_RE.match(fp.name)) and "/" not in fp.name and ":" not in fp.name,
+          f"(2d) filename sanitized + matches liveness regex: {fp.name!r}")
+
+with tempfile.TemporaryDirectory() as d:
+    mdir = pathlib.Path(d)
+    note2 = dict(note, id="n_456", title="Vendor sync")
+    fp2, _ = core.write_transcript_md(
+        note2, mdir, dry_run=False,
+        extra_frontmatter={"external_attendees": "Dana <dana@example.com>"},
+    )
+    body2 = fp2.read_text(encoding="utf-8")
+    check("external_attendees: Dana <dana@example.com>" in body2,
+          "(2e) extra_frontmatter injects external_attendees (personal-exporter mode)")
+
+# (3) incremental_created_after: --since override, an OLD last_sync (older than
+# the safety lookback) is honored verbatim, and a fresh state yields a window.
+check(core.incremental_created_after({}, since="2026-05-01") == "2026-05-01T00:00:00Z",
+      "(3a) --since date is normalized to ISO midnight Z")
+old = core.incremental_created_after({"last_sync": "2026-01-01T00:00:00Z"})
+check(old == "2026-01-01T00:00:00Z", f"(3b) old last_sync honored (min with lookback): {old!r}")
+firstrun = core.incremental_created_after({})
+check(firstrun.endswith("Z") and firstrun < datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+      f"(3c) first-run window is a past ISO-Z instant: {firstrun!r}")
+
+sys.exit(1 if fails else 0)
+PY
+
+echo "test_granola_core_shared: all checks passed"


### PR DESCRIPTION
Collapses the Granola Public-API contract into ONE shared module so the public substrate exporter `granola_sync.py` and the private vault's `granola_export.py` cannot drift.

## What
- New `scripts/granola_core.py` owns the contract: `load_api_key`, `api_get`, `list_notes`, `format_transcript`, `safe_filename`, `write_transcript_md`, state, and `incremental_created_after`.
- `granola_sync.py` becomes a thin CLI that re-exports the core (its public function names are unchanged).
- `write_transcript_md` gains an `extra_frontmatter` hook so the private exporter adds its `external_attendees` line without forking the function — the only sanctioned variation point.

## Why
Bug class `DISCIPLINE-FIX-NOT-PORTED-TO-SUBSTRATE`: the personal copy moved to the Public API three weeks before this substrate copy, which silently exported nothing in the gap. The two copies had already micro-drifted (`_speaker_label`, frontmatter, User-Agent). One module means nothing to drift.

## Guard
`tests/integration/test_granola_core_shared.sh` asserts `granola_sync` re-exports the *same objects* from `granola_core` (object identity is the anti-drift guarantee and its own negative control — verified locally that a simulated re-vendor flips the check to FAIL). Wired into `scripts/ci.sh`; the existing `test_granola_sync_offline.sh` stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)