### PR TITLE
fix(warn-vault hook): kill per-call git subprocess on plain-session hot path (MYC-1176)

### DIFF
--- a/hooks/_lib/guard_telemetry.py
+++ b/hooks/_lib/guard_telemetry.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Opt-in guard fire+status logger -> ~/.claude/guard-fires.jsonl  (MYC-285).
+
+The forward path for fleet fire telemetry. Read by
+`⚙️ Meta/scripts/guard-fleet-telemetry.py` to compute per-guard fire counts +
+the dead-guard / uninstrumented split. Hookify rules are instrumented by
+construction (the dispatcher logs every match); STANDALONE hooks are not — this
+closes that gap one hook at a time.
+
+ADOPT in a standalone hook by adding ONE line at its fire/decision point:
+
+    import sys, os
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))   # if not already
+    from _lib.guard_telemetry import log_fire
+    log_fire("my-hook-basename", status="warned")   # blocked / fired / bypassed
+
+status taxonomy (mirrors hookify + pre-push-doubt so heeded-vs-bypassed math
+works fleet-wide): "fired" (default) · "warned" · "blocked" · "bypassed".
+
+FAIL-OPEN by construction. A telemetry write must NEVER break a fail-open hook,
+so every error is swallowed silently. Use the hook's own basename (sans .py) as
+`name` so the report attributes fires to the right guard.
+"""
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+
+LOG_PATH = os.environ.get(
+    "GUARD_FIRES_LOG", os.path.expanduser("~/.claude/guard-fires.jsonl"))
+
+
+def log_fire(name, status="fired", **ctx):
+    """Append one fire record. Returns True on write, False on any failure.
+
+    ctx values that aren't JSON-serializable are coerced to str so a bad
+    extra field can never drop the record.
+    """
+    try:
+        rec = {
+            "ts": datetime.now(timezone.utc).astimezone().isoformat(),
+            "name": str(name),
+            "status": str(status),
+        }
+        for k, v in ctx.items():
+            try:
+                json.dumps(v)
+            except (TypeError, ValueError):
+                v = str(v)
+            rec[k] = v
+        with open(LOG_PATH, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(rec, ensure_ascii=False) + "\n")
+        return True
+    except Exception:
+        return False

--- a/hooks/warn-vault-session-in-worktree.py
+++ b/hooks/warn-vault-session-in-worktree.py
@@ -1,62 +1,84 @@
 #!/usr/bin/env python3
 """LOUD tripwire: this session is running inside an Obsidian-vault git worktree.
 
-The Claude Desktop app's per-session "worktree" checkbox creates a
-`.claude/worktrees/<slug>/` checkout. On a CODE repo that is cheap and correct.
-On an OBSIDIAN VAULT (repo-root == vault-root, thousands of files) that checkout
-lands INSIDE Obsidian's watched file tree -> runaway CPU / RAM / crash, AND the
-worktree can be silently archived/deleted mid-session, taking any worktree-only
-files with it. A vault must run PLAIN (no worktree); code isolation belongs in a
-sibling worktree on a CODE repo, never inside the vault.
+The bug (MYC-575): the Claude Desktop app's per-session "worktree" checkbox
+creates a `.claude/worktrees/<slug>/` checkout. On a CODE repo that is cheap and
+correct. On an OBSIDIAN VAULT (repo-root == vault-root, ~6.5K+ files) that
+checkout lands INSIDE Obsidian's watched tree -> 250%+ CPU, 2+ GB RAM, crash --
+AND the worktree can be silently archived/deleted mid-session (observed twice:
+MYC-555, then again 2026-06-17 during a repo-evaluation). Work survives ONLY
+because the discipline (edit shared/canonical files at the MAIN vault path +
+commit) was followed; a less-careful session would lose worktree-only files.
 
-There is no documented config switch to stop the Desktop app creating the
-worktree, and a hook cannot un-create the worktree the session already started
-in. But it CAN make the bad state LOUD on the first turn so you abort and
-relaunch plain BEFORE the melt compounds and BEFORE anything is silently lost.
-A plain (non-worktree) vault session never trips this.
+The real fix is to stop the Desktop app creating the vault worktree at all
+(MYC-575, operator-gated: a Desktop toggle / settings lever / upstream request).
+A hook can't un-create the worktree the session already started in -- but it CAN
+make the bad state LOUD on the first turn so the human aborts and relaunches
+plain BEFORE the melt compounds and BEFORE anything is silently lost. This is the
+enforcement/tripwire layer; it self-quiets to a no-op once the source fix holds
+(a plain vault session never trips it).
 
 Detection reads THREE independent channels; first hit wins. The `.obsidian/`
-gate distinguishes a vault from a code repo in ALL THREE, so a code-repo worktree
-(Desktop `.claude/worktrees/` on a code repo, or a sibling-dir `<repo>-<slug>/`
-worktree) never fires.
-  - Channel A (payload cwd): cwd is under a `.claude/worktrees/` segment. This is
-    the terminal/CLI shape and the tool-time payloads (where the worktree cwd is
-    reliably present).
+gate (applied in main()) distinguishes vault from code repo in ALL THREE, so a
+code-repo worktree (Desktop `.claude/worktrees/` on a ~/dev repo, or the
+sibling-dir `claude-dev-worktree` `~/dev/<repo>-<slug>/`) never fires.
+  - Channel A (payload cwd): cwd is under a `.claude/worktrees/` segment. This
+    is the terminal/CLI shape AND every tool-time payload (PreToolUse/UPS reliably
+    carry the worktree cwd -- proven: check-cd-outside-worktree fires correctly there).
   - Channel B (transcript marker): cwd is the main root; the worktree id is in
     transcript_path as `--claude-worktrees-<slug>` (Desktop SessionStart, when the
     marker is present).
-  - Channel C (git ground truth, payload-INDEPENDENT): ask git -- from the hook's
-    OWN process cwd AND the payload cwd -- for the working-tree root
-    (`rev-parse --show-toplevel`). A linked worktree's toplevel carries the
-    `/.claude/worktrees/` segment regardless of what the harness reported in the
-    payload. This is the channel that catches the Desktop-SessionStart case where
-    the harness delivers cwd=main AND a transcript_path with no marker, so A and B
-    both go silent while git knows the truth.
+  - Channel C (process-cwd ground truth, payload-INDEPENDENT, ZERO subprocess): the
+    melt happens because the SESSION RUNS INSIDE the worktree, so the hook's own
+    `os.getcwd()` (the resolved physical path) carries the `/.claude/worktrees/`
+    segment even when the harness reported cwd=main at SessionStart (A) with no
+    transcript marker (B) -- exactly the 2026-06-17 miss. A linked worktree's git
+    toplevel is always a PREFIX of os.getcwd(), so a literal segment match here is a
+    complete superset of what `git rev-parse --show-toplevel` would reveal -- git
+    was strictly redundant. It was ALSO a subprocess that fired on EVERY plain
+    (non-worktree) UserPromptSubmit + PreToolUse(Bash) call -- the 99% case -- a
+    fleet-wide hot-path tax (MYC-1176). C is now a pure string test: zero git, zero
+    cost on the plain path. Skipped entirely at PreToolUse (the highest-fan-out
+    event) where Channel A is authoritative (payload cwd reliably = the worktree).
 
-Wiring (scripts/install-hooks-user-level.py + hooks.json): SessionStart (early)
-PLUS UserPromptSubmit + PreToolUse(Bash) -- the tool-time events where the
-worktree cwd is reliably present, so Channel A/C catch the Desktop-SessionStart
-miss. A once-per-worktree-slug dedup sentinel means it warns ONCE per session,
-not on every prompt/tool. Slugs are unique per Desktop worktree, so once-per-slug
-== once-per-session.
+Wiring: SessionStart (catches terminal launches + Desktop-with-marker early) PLUS
+UserPromptSubmit + PreToolUse(Bash) (the tool-time events where the worktree cwd
+is reliably present, so Channel A catches the Desktop-SessionStart-miss case; C
+backstops SessionStart + UPS via os.getcwd()). A once-per-worktree-slug dedup
+sentinel means it warns ONCE per session, not on every prompt/tool. Slugs are
+unique per Desktop worktree, so once-per-slug == once-per-session.
 
 Fail-open: any error -> silent continue (a nudge must never block a session).
+Telemetry: emits one guard-fire record (_lib/guard_telemetry.log_fire) on the WARN
+path only -- never the silent/plain hot path -- so guard-fleet-telemetry classifies
+it FIRING not UNINSTRUMENTED (MYC-1176 item 6). Defensive import: no-op if the rail
+is absent, so a stripped install never breaks.
 Bypass: VAULT_WORKTREE_WARN_BYPASS=1.
 Test knobs: VAULT_WORKTREE_WARN_NODEDUP=1 (skip dedup), VAULT_WORKTREE_WARN_STATE_DIR
-(redirect the sentinel dir).
+(redirect the sentinel dir), GUARD_FIRES_LOG (redirect the telemetry sink).
 
-Canonical: ai-brain-starter/hooks/ (installed to ~/.claude/skills/ai-brain-starter/
-hooks/ and wired into ~/.claude/settings.json by scripts/install-hooks-user-level.py).
-Negative-control test: warn-vault-session-in-worktree.test.sh.
+Canonical: ~/dev/adelaida-skills/hooks/ (deployed as a copy to ~/.claude/hooks/
+via install.sh). Negative-control test: warn-vault-session-in-worktree.test.sh.
+Ports to ai-brain-starter (MYC-576 -- every installed vault hits the same melt);
+guard_telemetry.py ports with it (MYC-809 -- port the rails, not just the pattern).
 """
 from __future__ import annotations
 
 import json
 import os
-import subprocess
 import sys
 import tempfile
 from pathlib import Path
+
+# Telemetry rail (MYC-1176 item 6): emit a guard-fire on the WARN path so
+# guard-fleet-telemetry classifies this hook FIRING, not UNINSTRUMENTED. Defensive
+# import -- a missing rail must NEVER break this fail-open hook.
+try:
+    sys.path.insert(0, str(Path(__file__).resolve().parent / "_lib"))
+    from guard_telemetry import log_fire as _log_fire
+except Exception:  # pragma: no cover - rail absent on a stripped install
+    def _log_fire(*_a, **_k):
+        return False
 
 WORKTREE_SEGMENT = "/.claude/worktrees/"
 # Claude Code encodes the session cwd into the ~/.claude/projects/<dir> name by
@@ -71,10 +93,12 @@ def _silent() -> int:
     return 0
 
 
-def _read_payload() -> tuple[str, str]:
-    """Hook stdin provides `cwd` + `transcript_path`. Returns ("", "") on anything odd."""
+def _read_payload() -> tuple[str, str, str]:
+    """Hook stdin provides `cwd` + `transcript_path` + `hook_event_name`.
+    Returns ("", "", "") on anything odd."""
     cwd = ""
     transcript = ""
+    event = ""
     try:
         raw = sys.stdin.read()
         if raw.strip():
@@ -82,38 +106,35 @@ def _read_payload() -> tuple[str, str]:
             if isinstance(data, dict):
                 cwd = data.get("cwd") or data.get("workingDirectory") or ""
                 transcript = data.get("transcript_path") or data.get("transcriptPath") or ""
+                event = data.get("hook_event_name") or data.get("hookEventName") or ""
     except Exception:
         pass
-    return cwd, transcript
+    return cwd, transcript, event
 
 
-def _git_toplevel(cwd: str) -> str:
-    """`git rev-parse --show-toplevel` from `cwd`; "" on any failure. Bounded (2s)."""
-    if not cwd:
-        return ""
-    try:
-        out = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
-            cwd=cwd,
-            capture_output=True,
-            text=True,
-            timeout=2,
-        )
-        if out.returncode == 0:
-            return out.stdout.strip()
-    except Exception:
-        pass
-    return ""
+def _split_segment(path: str) -> tuple[str, Path]:
+    """(worktree_root, main_root) from a path carrying WORKTREE_SEGMENT.
+
+    Normalizes a deep cwd (a worktree subdir) back to the worktree ROOT so the
+    dedup slug stays stable regardless of how far inside the session sits.
+    """
+    idx = path.index(WORKTREE_SEGMENT)
+    main_root = path[:idx]
+    slug = path[idx + len(WORKTREE_SEGMENT):].split("/", 1)[0]
+    return str(Path(main_root) / ".claude" / "worktrees" / slug), Path(main_root)
 
 
-def _detect(payload_cwd: str, transcript: str) -> tuple[str, Path] | tuple[None, None]:
+def _detect(payload_cwd: str, transcript: str, event: str) -> tuple[str, Path] | tuple[None, None]:
     """(worktree_path, main_root) if a worktree session on any channel, else (None, None).
 
+    ZERO subprocess -- every channel is a string/stat test (MYC-1176: the prior
+    git-subprocess Channel C ran on every plain-session hot-path call, fleet-wide).
     The `.obsidian/` vault gate is applied by the caller, not here.
     """
-    # Channel A -- any payload cwd that contains the worktree segment.
+    # Channel A -- any payload cwd that contains the worktree segment (terminal +
+    # tool-time payloads; the reliable signal at UserPromptSubmit + PreToolUse).
     if payload_cwd and WORKTREE_SEGMENT in payload_cwd:
-        return payload_cwd, Path(payload_cwd[: payload_cwd.index(WORKTREE_SEGMENT)])
+        return _split_segment(payload_cwd)
 
     # Channel B -- transcript marker (Desktop mode, when the marker is present).
     if payload_cwd and transcript and PROJECTS_WORKTREE_MARKER in transcript:
@@ -121,26 +142,29 @@ def _detect(payload_cwd: str, transcript: str) -> tuple[str, Path] | tuple[None,
         if slug:
             return str(Path(payload_cwd) / ".claude" / "worktrees" / slug), Path(payload_cwd)
 
-    # Channel C -- git ground truth, payload-INDEPENDENT. Ask git from the hook's
-    # own process cwd AND the payload cwd (either may be the worktree even when the
-    # other is reported as main). Catches the Desktop-SessionStart miss.
-    try:
-        proc_cwd = os.getcwd()
-    except OSError:
-        proc_cwd = ""
-    for gcwd in dict.fromkeys([proc_cwd, payload_cwd]):  # de-dup, preserve order
-        toplevel = _git_toplevel(gcwd)
-        if toplevel and WORKTREE_SEGMENT in toplevel:
-            return toplevel, Path(toplevel[: toplevel.index(WORKTREE_SEGMENT)])
+    # Channel C -- the hook's OWN process cwd is inside a .claude/worktrees/ checkout.
+    # The melt's ground truth: the session RUNS inside the worktree, so os.getcwd()
+    # (resolved physical path) carries the segment even when the harness reported
+    # cwd=main at SessionStart (A) with no marker (B) -- the 2026-06-17 miss. A
+    # worktree's git toplevel is always a PREFIX of os.getcwd(), so this literal
+    # match is a complete superset of `git rev-parse --show-toplevel` -- no
+    # subprocess. Skipped at PreToolUse (highest-fan-out event) where Channel A is
+    # authoritative (payload cwd reliably = the worktree there).
+    if event != "PreToolUse":
+        try:
+            proc_cwd = os.getcwd()
+        except OSError:
+            proc_cwd = ""
+        if proc_cwd and WORKTREE_SEGMENT in proc_cwd:
+            return _split_segment(proc_cwd)
 
     return None, None
 
 
 def _already_warned(slug: str) -> bool:
-    """Once-per-worktree-slug dedup so the re-firing events (UserPromptSubmit each
-    turn / every Bash) warn ONCE. Slugs are unique per Desktop worktree, so
-    once-per-slug == once-per-session. Stale sentinels for archived worktrees are
-    harmless (a slug never recurs)."""
+    """Once-per-worktree-slug dedup so the re-firing events (UPS each turn / every Bash)
+    warn ONCE. Slugs are unique per Desktop worktree, so once-per-slug == once-per-session.
+    Stale sentinels for archived worktrees are harmless (a slug never recurs)."""
     if os.environ.get("VAULT_WORKTREE_WARN_NODEDUP") == "1":
         return False
     state_dir = os.environ.get("VAULT_WORKTREE_WARN_STATE_DIR") or tempfile.gettempdir()
@@ -159,8 +183,8 @@ def main() -> int:
     if os.environ.get("VAULT_WORKTREE_WARN_BYPASS") == "1":
         return _silent()
 
-    payload_cwd, transcript = _read_payload()
-    worktree_path, main_root = _detect(payload_cwd, transcript)
+    payload_cwd, transcript, event = _read_payload()
+    worktree_path, main_root = _detect(payload_cwd, transcript, event)
     if worktree_path is None:
         return _silent()  # not a worktree session on any channel
 
@@ -179,21 +203,24 @@ def main() -> int:
         "SURFACE THIS TO THE USER IMMEDIATELY, before any other work:\n\n"
         "🛑 [vault-worktree] This vault session is running INSIDE a git worktree:\n"
         f"    {worktree_path}\n\n"
-        "An Obsidian vault must NEVER run in worktree mode. The Desktop app's\n"
+        "The vault must NEVER run in worktree mode (MYC-575). The Desktop app's\n"
         "per-session worktree checkbox created a multi-thousand-file checkout inside\n"
-        "Obsidian's watched tree → runaway CPU / RAM / crash, AND this worktree can\n"
-        "be SILENTLY DELETED mid-session, taking any worktree-only files with it.\n\n"
+        "Obsidian's watched tree → 250%+ CPU / 2+ GB RAM melt, AND this worktree can\n"
+        "be SILENTLY DELETED mid-session (that is exactly what happened in the\n"
+        "sessions that prompted this guard).\n\n"
         "DO THIS NOW:\n"
         "  1. Close this session.\n"
         f"  2. Relaunch the vault PLAIN: `cd {main_root} && claude`\n"
         "     (or, in the Desktop app, open the vault with the worktree box UNCHECKED).\n\n"
         "UNTIL YOU DO: any file created that lives ONLY in this worktree is discarded\n"
         f"when the worktree is archived. Edit shared/canonical files at the MAIN vault\n"
-        f"path ({main_root}/...) and commit them there — never the worktree path. The\n"
-        "Stop-hook snapshot net backstops divergent files, but the only safe state is a\n"
-        "plain (non-worktree) vault session.\n\n"
-        "Bypass this warning: VAULT_WORKTREE_WARN_BYPASS=1"
+        f"path ({main_root}/...) and commit via vault-safe-commit.sh — never the\n"
+        "worktree path. The Stop-hook snapshot net backstops divergent files, but the\n"
+        "only safe state is a plain (non-worktree) vault session.\n\n"
+        "Source fix tracked: MYC-575. Bypass this warning: VAULT_WORKTREE_WARN_BYPASS=1"
     )
+    # Telemetry on the WARN path ONLY (never the silent/plain hot path) -- MYC-1176 item 6.
+    _log_fire("warn-vault-session-in-worktree", status="warned", slug=slug, event=event or "?")
     print(json.dumps({"continue": True, "additionalContext": body}))
     return 0
 

--- a/hooks/warn-vault-session-in-worktree.test.sh
+++ b/hooks/warn-vault-session-in-worktree.test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Negative-control test for warn-vault-session-in-worktree.py.
+# Negative-control test for warn-vault-session-in-worktree.py (MYC-575 tripwire).
 #
 # A guard earns trust only by failing on the thing it catches. This proves:
 #   Channel A (payload cwd inside the worktree — terminal launch + tool-time payloads):
@@ -11,14 +11,23 @@
 #     5. FIRES   cwd=vault main root + transcript_path carries the marker  <- the catch
 #     6. SILENT  cwd=code-repo main root + marker present (no .obsidian/)   <- no over-fire
 #     7. SILENT  plain vault session (transcript_path has NO marker)
-#   Channel C (git ground truth — payload-INDEPENDENT; the Desktop-SessionStart miss):
+#   Channel C (process-cwd ground truth — payload-INDEPENDENT, ZERO subprocess; the
+#   2026-06-17 melt repro). MYC-1176: os.getcwd() carries the worktree segment, so a
+#   string match replaces the per-call `git rev-parse` that taxed every plain session:
 #     8. FIRES   payload cwd=MAIN + NO marker, but the PROCESS runs in a real git
-#                worktree -> git reveals the truth A+B both missed   <- THE FIX
+#                worktree -> os.getcwd() reveals the truth A+B both missed   <- THE FIX
 #     9. SILENT  same shape but a CODE repo (no .obsidian/ at main root) <- no over-fire
 #    10. SILENT  process in the real MAIN vault checkout (not a worktree) <- no over-fire
 #   Dedup (warn once per worktree slug, not every turn/tool):
 #    11. FIRES   first call for a slug
 #    12. SILENT  second call for the same slug (sentinel written)
+#   MYC-1176 (zero-cost on the plain path + PreToolUse skip + instrumentation):
+#    13. SILENT  PreToolUse skips Channel C (Channel A is authoritative at tool time)
+#    14. FIRES   PreToolUse: Channel A still catches a worktree PAYLOAD cwd
+#    15. ZERO git subprocess on a plain (99%) session  <- THE FIX (git-shim trace)
+#    16. worktree catch still FIRES via string-match with ZERO git
+#    17. guard-fire telemetry emitted on the WARN path (log_fire)
+#    18. ZERO telemetry on the silent/plain path (off the hot path)
 #
 # Exit 0 = all pass. Non-zero = regression (or git fixture setup failed — loud, never skipped).
 set -u
@@ -51,7 +60,7 @@ run() { # $1=payload-cwd  $2=extra-env  $3=transcript(opt)  $4=process-cwd(opt, 
   if [ -n "${3:-}" ]; then payload="{\"cwd\":\"$1\",\"transcript_path\":\"$3\"}"
   else payload="{\"cwd\":\"$1\"}"; fi
   # NODEDUP on so detection asserts are not silenced by a prior fire of the same slug;
-  # STATE_DIR isolated. cd sets os.getcwd() for Channel C.
+  # STATE_DIR isolated from the real ~/tmp sentinels. cd sets os.getcwd() for Channel C.
   ( cd "$pcwd" && printf '%s' "$payload" \
       | env VAULT_WORKTREE_WARN_NODEDUP=1 VAULT_WORKTREE_WARN_STATE_DIR="$TMP/state" $2 python3 "$HOOK" )
 }
@@ -65,18 +74,18 @@ assert_silent() { # $1=label $2=stdout
   else echo "FAIL: $1 — expected SILENT, got: $2"; fail=1; fi
 }
 
-# --- Channel A ---
+# --- Channel A: payload cwd inside the worktree ---
 assert_fires  "A1 vault worktree cwd"      "$(run "$TMP/vaultmain/.claude/worktrees/slug" "")"
 assert_silent "A2 plain vault cwd"         "$(run "$TMP/vaultmain" "")"
 assert_silent "A3 code-repo worktree cwd"  "$(run "$TMP/devrepo/.claude/worktrees/slug" "")"
 assert_silent "A4 bypass set"              "$(run "$TMP/vaultmain/.claude/worktrees/slug" "VAULT_WORKTREE_WARN_BYPASS=1")"
 
-# --- Channel B ---
+# --- Channel B: Desktop mode, cwd=MAIN ROOT, worktree id only in transcript_path ---
 assert_fires  "B5 vault main + marker"     "$(run "$TMP/vaultmain" "" "$WT_TRANSCRIPT")"
 assert_silent "B6 code main + marker"      "$(run "$TMP/devrepo" "" "$WT_TRANSCRIPT")"
 assert_silent "B7 plain vault, no marker"  "$(run "$TMP/vaultmain" "" "$PLAIN_TRANSCRIPT")"
 
-# --- Channel C: git ground truth (payload=main, NO marker, process in a real worktree) ---
+# --- Channel C: git ground truth (the 2026-06-17 melt repro: payload=main, NO marker) ---
 assert_fires  "C8 vault: payload=main+no-marker, PROCESS in real git worktree" \
               "$(run "$TMP/gitvault" "" "" "$TMP/gitvault/.claude/worktrees/wt")"
 assert_silent "C9 code-repo: same shape, no .obsidian"   \
@@ -90,6 +99,61 @@ ded() { ( cd "$TMP/gitvault/.claude/worktrees/wt" && printf '{"cwd":"%s"}' "$TMP
             | env VAULT_WORKTREE_WARN_STATE_DIR="$DSTATE" python3 "$HOOK" ); }
 assert_fires  "D11 dedup first call"   "$(ded)"
 assert_silent "D12 dedup second call"  "$(ded)"
+
+# --- MYC-1176: Channel C skipped at PreToolUse (Channel A is authoritative there) ---
+# 13. proc in a worktree + payload=main + event=PreToolUse -> C must NOT run -> silent.
+#     (A real PreToolUse payload carries the worktree cwd, so A catches; this artificial
+#      proc=worktree/payload=main shape is still covered at UPS + SessionStart.)
+out_pre_skip="$( cd "$TMP/gitvault/.claude/worktrees/wt" && printf '{"cwd":"%s","hook_event_name":"PreToolUse"}' "$TMP/gitvault" \
+    | env VAULT_WORKTREE_WARN_NODEDUP=1 VAULT_WORKTREE_WARN_STATE_DIR="$TMP/state" python3 "$HOOK" )"
+assert_silent "C13 PreToolUse skips Channel C (proc=worktree, payload=main)" "$out_pre_skip"
+# 14. Channel A still catches a worktree PAYLOAD cwd at PreToolUse (the real tool-time shape).
+out_pre_a="$( printf '{"cwd":"%s","hook_event_name":"PreToolUse"}' "$TMP/vaultmain/.claude/worktrees/slug" \
+    | env VAULT_WORKTREE_WARN_NODEDUP=1 VAULT_WORKTREE_WARN_STATE_DIR="$TMP/state" python3 "$HOOK" )"
+assert_fires  "C14 PreToolUse: Channel A still catches worktree payload cwd" "$out_pre_a"
+
+# --- MYC-1176 THE FIX: ZERO git subprocess on the hot path (git-shim trace) ---
+# A `git` shim records every invocation; the plain 99% session must spawn NONE.
+REALGIT="$(command -v git)"
+mkdir -p "$TMP/shim"
+cat > "$TMP/shim/git" <<EOF
+#!/usr/bin/env bash
+echo "git \$*" >> "$TMP/gitcalls"
+exec "$REALGIT" "\$@"
+EOF
+chmod +x "$TMP/shim/git"
+mkdir -p "$TMP/plainvault/.obsidian"   # a plain vault: .obsidian present, NO .claude/worktrees
+: > "$TMP/gitcalls"
+# 15. plain session (payload=main, proc=main, no marker, UPS) -> SILENT + ZERO git.
+out_plain="$( cd "$TMP/plainvault" && printf '{"cwd":"%s","hook_event_name":"UserPromptSubmit"}' "$TMP/plainvault" \
+    | env PATH="$TMP/shim:$PATH" VAULT_WORKTREE_WARN_NODEDUP=1 VAULT_WORKTREE_WARN_STATE_DIR="$TMP/state" python3 "$HOOK" )"
+assert_silent "C15 plain vault session (the 99% case)" "$out_plain"
+if [ -s "$TMP/gitcalls" ]; then echo "FAIL: C15 plain session spawned git ($(tr '\n' ';' <"$TMP/gitcalls"))"; fail=1
+else echo "PASS: C15 plain session spawned ZERO git subprocess (MYC-1176)"; fi
+# 16. the worktree CATCH path is ALSO git-free now (Channel C is a pure string match).
+: > "$TMP/gitcalls"
+out_wtcatch="$( cd "$TMP/gitvault/.claude/worktrees/wt" && printf '{"cwd":"%s","hook_event_name":"UserPromptSubmit"}' "$TMP/gitvault" \
+    | env PATH="$TMP/shim:$PATH" VAULT_WORKTREE_WARN_NODEDUP=1 VAULT_WORKTREE_WARN_STATE_DIR="$TMP/state" python3 "$HOOK" )"
+assert_fires "C16 worktree catch still FIRES with zero git" "$out_wtcatch"
+if [ -s "$TMP/gitcalls" ]; then echo "FAIL: C16 worktree-catch path spawned git ($(tr '\n' ';' <"$TMP/gitcalls"))"; fail=1
+else echo "PASS: C16 worktree catch fires via string-match, ZERO git"; fi
+
+# --- MYC-1176 item 6: guard-fire telemetry on the WARN path, never the silent path ---
+TFIRE="$TMP/fires.jsonl"; : > "$TFIRE"
+# 17. a FIRE emits a guard-fire record (name + status=warned) to GUARD_FIRES_LOG.
+out_t1="$( printf '{"cwd":"%s","hook_event_name":"UserPromptSubmit"}' "$TMP/vaultmain/.claude/worktrees/slug" \
+    | env VAULT_WORKTREE_WARN_NODEDUP=1 VAULT_WORKTREE_WARN_STATE_DIR="$TMP/state" GUARD_FIRES_LOG="$TFIRE" python3 "$HOOK" )"
+assert_fires "T17 warn path emits" "$out_t1"
+if grep -q "warn-vault-session-in-worktree" "$TFIRE" && grep -q "warned" "$TFIRE"; then
+  echo "PASS: T17 telemetry recorded a guard-fire on the WARN path (item 6)"
+else echo "FAIL: T17 no guard-fire on warn path — got: $(cat "$TFIRE")"; fail=1; fi
+# 18. a SILENT/plain run writes NOTHING (telemetry stays off the hot path).
+: > "$TFIRE"
+out_t2="$( cd "$TMP/plainvault" && printf '{"cwd":"%s","hook_event_name":"UserPromptSubmit"}' "$TMP/plainvault" \
+    | env VAULT_WORKTREE_WARN_NODEDUP=1 VAULT_WORKTREE_WARN_STATE_DIR="$TMP/state" GUARD_FIRES_LOG="$TFIRE" python3 "$HOOK" )"
+assert_silent "T18 silent path stays silent" "$out_t2"
+if [ -s "$TFIRE" ]; then echo "FAIL: T18 telemetry fired on the silent/plain path: $(cat "$TFIRE")"; fail=1
+else echo "PASS: T18 ZERO telemetry on the silent/plain path (off the hot path)"; fi
 
 if [ "$fail" -eq 0 ]; then echo "ALL GREEN"; else echo "HAS FAILURES"; fi
 exit $fail


### PR DESCRIPTION
Follow-on to MYC-576 (PR #206). `warn-vault-session-in-worktree.py` Channel C spawned `git rev-parse --show-toplevel` on every plain (non-worktree) UserPromptSubmit + PreToolUse(Bash) call — the 99% case, for every installed vault.

Channel C is now a pure `WORKTREE_SEGMENT in os.getcwd()` string match (a worktree's git toplevel is always a PREFIX of os.getcwd() → complete superset of what git revealed): ZERO subprocess on all paths. Skipped at PreToolUse (Channel A authoritative). 18/18 tests green incl. the C8 melt repro + a git-shim trace proving ZERO git on the plain path. Ports `guard_telemetry.py` (log_fire rail) into hooks/_lib (defensive import). Byte-reconciled with the private canonical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)