### PR TITLE
fix(install): repoint install-API to apex mycelium-ai.co (www now 308s + silently drops on urllib) — MYC-1659

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -67,7 +67,7 @@ If Claude asks for permission to do something and you are not sure what it does,
 
 Local-first by default. Your vault, journals, notes, and files never leave your machine. The install does not require an email and does not phone home about your content.
 
-There is exactly one opt-in. At the end of setup you may choose to give an email (for occasional update notes and a free workflow audit). If you do, an install token is minted: `www.mycelium-ai.co/api/install/quick-mint` receives the email, name, and language you gave, plus a short OS label (e.g. `mac-arm`). That is the email submission you chose to make.
+There is exactly one opt-in. At the end of setup you may choose to give an email (for occasional update notes and a free workflow audit). If you do, an install token is minted: `mycelium-ai.co/api/install/quick-mint` receives the email, name, and language you gave, plus a short OS label (e.g. `mac-arm`). That is the email submission you chose to make.
 
 While that token exists on your machine, three best-effort, fail-open events may be sent. Each carries only the token and a coarse signal — never any content:
 

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -95,7 +95,7 @@ if ($CorporateProfile) {
 $emailMarker = "$env:USERPROFILE\.claude\.ai-brain-starter-email-on-file"
 # Canonical host: alternate domains 308-redirect and POST bodies are not
 # reliably re-sent on redirect by older PowerShell. Always call canonical.
-$installApiBase = if ($env:MYCELIUM_INSTALL_API) { $env:MYCELIUM_INSTALL_API } else { "https://www.mycelium-ai.co" }
+$installApiBase = if ($env:MYCELIUM_INSTALL_API) { $env:MYCELIUM_INSTALL_API } else { "https://mycelium-ai.co" }
 
 # Optional signup. This block only runs when the user already provided an
 # email - a web-form token or EMAIL/NAME env vars. With nothing provided it

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -286,7 +286,7 @@ if [[ "$CORPORATE_PROFILE" == "1" ]]; then
   export CORPORATE_PROFILE=1    # so the embedded python here-docs can read it
   export SKIP_VENDOR_SKILLS=1   # skip ALL third-party plugin marketplaces
   export EMAIL_GATE_BYPASS=1    # no email mint / no quick-mint network call
-  export MYCELIUM_NO_PING=1     # no install-ping to myceliumai.co (this run + children)
+  export MYCELIUM_NO_PING=1     # no install-ping to mycelium-ai.co (this run + children)
 fi
 
 # Tee subsequent output to the log (header + everything that follows)
@@ -553,7 +553,7 @@ EMAIL_MARKER="$HOME/.claude/.ai-brain-starter-email-on-file"
 # non-canonical base silently died for weeks (consumed/completed stayed 0
 # in the funnel while real installs ran). Keep the canonical host AND -L
 # on every call below — defense in depth against the next domain change.
-INSTALL_API_BASE="${MYCELIUM_INSTALL_API:-https://www.mycelium-ai.co}"
+INSTALL_API_BASE="${MYCELIUM_INSTALL_API:-https://mycelium-ai.co}"
 
 # Optional signup. This block only runs when the user already provided an
 # email -- a web-form token (TOKEN=) or EMAIL=/NAME= env vars. With nothing

--- a/hooks/install-ping.py
+++ b/hooks/install-ping.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""One-time install signal to myceliumai.co.
+"""One-time install signal to mycelium-ai.co.
 
 Idempotent (one sentinel per plugin per machine), silent, fire-and-forget.
 Sends ONLY plugin name + version. No PII, no IP storage post-dedup.
@@ -33,7 +33,7 @@ def main():
     try:
         data = json.dumps({"plugin": PLUGIN_NAME, "version": VERSION}).encode()
         req = urllib.request.Request(
-            "https://www.mycelium-ai.co/api/install",
+            "https://mycelium-ai.co/api/install",
             data=data,
             headers={"Content-Type": "application/json"},
         )

--- a/phases/phase-19-23-finish.md
+++ b/phases/phase-19-23-finish.md
@@ -123,7 +123,7 @@ try:
 except Exception:
     pass
 payload = json.dumps({"email": email, "name": name, "lang": lang, "stage": "post_install"}).encode()
-req = urllib.request.Request("https://www.mycelium-ai.co/api/install/quick-mint",
+req = urllib.request.Request("https://mycelium-ai.co/api/install/quick-mint",
     data=payload, headers={"content-type": "application/json"}, method="POST")
 try:
     with urllib.request.urlopen(req, timeout=12) as r:
@@ -516,7 +516,7 @@ if os.path.exists(pend):
         try:
             rec = json.loads(line)
             payload = json.dumps({**rec, "stage": "post_install"}).encode()
-            req = urllib.request.Request("https://www.mycelium-ai.co/api/install/quick-mint",
+            req = urllib.request.Request("https://mycelium-ai.co/api/install/quick-mint",
                 data=payload, headers={"content-type": "application/json"}, method="POST")
             urllib.request.urlopen(req, timeout=12).read()
         except Exception:

--- a/scripts/post-update-email-ask.py
+++ b/scripts/post-update-email-ask.py
@@ -185,7 +185,7 @@ payload = json.dumps({
     "stage": "post_install",
 }).encode()
 req = urllib.request.Request(
-    "https://www.mycelium-ai.co/api/install/quick-mint",
+    "https://mycelium-ai.co/api/install/quick-mint",
     data=payload, headers={"content-type": "application/json"}, method="POST")
 mp = os.path.expanduser("~/.claude/.ai-brain-starter-email-on-file")
 try:
@@ -230,7 +230,7 @@ payload = json.dumps({
     "stage": "post_install",
 }).encode()
 req = urllib.request.Request(
-    "https://www.mycelium-ai.co/api/install/quick-mint",
+    "https://mycelium-ai.co/api/install/quick-mint",
     data=payload, headers={"content-type": "application/json"}, method="POST")
 mp = os.path.expanduser("~/.claude/.ai-brain-starter-email-on-file")
 try:

--- a/skills/daily-journal/SKILL.md
+++ b/skills/daily-journal/SKILL.md
@@ -738,7 +738,7 @@ if [ -f "$TOKEN_FILE" ] && [ ! -f "$SENTINEL" ]; then
   # server returned no token). In those cases send nothing.
   if printf '%s' "$TOKEN" | grep -Eq '^[a-f0-9]{32}$'; then
     TODAY="$(date -u +%Y-%m-%d)"
-    curl -sSL -m 6 -X POST "https://www.mycelium-ai.co/api/install/first-journal" \
+    curl -sSL -m 6 -X POST "https://mycelium-ai.co/api/install/first-journal" \
       -H "content-type: application/json" \
       -d "{\"token\":\"$TOKEN\",\"journalDate\":\"$TODAY\"}" \
       >/dev/null 2>&1 \

--- a/tests/integration/test_install_api_canonical_base.sh
+++ b/tests/integration/test_install_api_canonical_base.sh
@@ -2,13 +2,21 @@
 # Regression test: every install-API call targets the CANONICAL host and
 # shell callers follow redirects.
 #
-# Bug class (caught 2026-06-10, MYC-419): alternate domains 308-redirect to
-# the canonical host. curl does NOT follow redirects without -L, and
-# Python 3.9's urllib does not follow 308 at all — so every install-API
-# call against a non-canonical base died silently (the reporters are
-# deliberately fail-open). The funnel showed signups but consumed=0 /
-# completed=0 for weeks while real installs ran: the mid-funnel zeros were
-# measurement failure, not user drop-off.
+# Bug class (caught 2026-06-10, MYC-419; recurred mirror-image 2026-06-24,
+# MYC-1659): alternate domains 308-redirect to the canonical host. curl does
+# NOT follow redirects without -L, and Python 3.9/3.10's urllib does not
+# follow 308 at all — so every install-API call against a non-canonical base
+# dies silently (the reporters are deliberately fail-open). The funnel showed
+# signups but consumed=0 / completed=0 for weeks while real installs ran: the
+# mid-funnel zeros were measurement failure, not user drop-off.
+#
+# Canonical host = bare apex https://mycelium-ai.co (NO www). The 2026-06-22
+# Vercel primary flip (MYC-1539) made the apex canonical; www.mycelium-ai.co
+# AND the no-hyphen myceliumai.co now BOTH 308 to it. This test pins the apex
+# so the next flip (either direction) fails loud instead of bleeding the funnel.
+# Live probe for humans (not in CI — keeps the test offline-deterministic):
+#   curl -s -o /dev/null -w '%{http_code}\n' -X OPTIONS https://mycelium-ai.co/api/install/quick-mint
+#   expect 2xx (route live, no redirect); a 308 means the apex moved again.
 #
 # Asserts:
 #   1. bootstrap.sh INSTALL_API_BASE default is the canonical host.
@@ -24,7 +32,7 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$REPO_ROOT"
 
-CANON="https://www.mycelium-ai.co"
+CANON="https://mycelium-ai.co"
 FAILED=0
 
 fail() { echo "FAIL: $1" >&2; FAILED=$((FAILED + 1)); }
@@ -44,11 +52,13 @@ while IFS= read -r line; do
   fi
 done < <(grep -E 'curl .*\$INSTALL_API_BASE/api' bootstrap.sh)
 
-# 4. no non-canonical API calls in install-facing files
-#    (myceliumai.co — no hyphen — 308s; so does bare mycelium-ai.co without www)
-#    -I skips binary files: a stray __pycache__/*.pyc (the URL compiled into a
-#    bytecode string constant) is an untracked local artifact, not source to audit.
-if matches=$(grep -rnEI '(myceliumai\.co|[^.w]mycelium-ai\.co)/api' \
+# 4. no non-canonical API calls in install-facing files. After the 2026-06-22
+#    apex flip the non-canonical hosts are www.mycelium-ai.co (www 308s to apex)
+#    and myceliumai.co (no hyphen, also 308s). The bare apex mycelium-ai.co is
+#    canonical and must NOT match (the hyphen means "myceliumai.co" is not a
+#    substring of it). -I skips binary files: a stray __pycache__/*.pyc (the URL
+#    compiled into a bytecode string constant) is an untracked local artifact.
+if matches=$(grep -rnEI '(www\.mycelium-ai\.co|myceliumai\.co)/api' \
     bootstrap.sh bootstrap.ps1 phases/ scripts/ hooks/ skills/ SECURITY.md 2>/dev/null); then
   fail "non-canonical install-API base found:"
   echo "$matches" | head -5 | sed 's|^|  |' >&2


### PR DESCRIPTION
## Why

The 2026-06-22 Vercel primary flip ([MYC-1539](https://linear.app/myceliumai/issue/MYC-1539)) made the bare apex `https://mycelium-ai.co` the canonical host; `www.mycelium-ai.co` and the no-hyphen `myceliumai.co` now **308-redirect** to it. mycelium-site's own URLs were repointed (PR #193) but this client repo was missed.

`bootstrap.sh` survives the 308 (`curl -L` follows it), but the **urllib POST callers** (`install-ping.py`, `post-update-email-ask.py`, the phase-19-23 inline python) do not reliably follow 308 on Python 3.9/3.10 and are deliberately fail-open (`except: pass`) — so the email/ping silently never arrives on those machines. This is [MYC-419](https://linear.app/myceliumai/issue/MYC-419) regressed in mirror-image (canonical flipped www↔apex).

Live-verified 2026-06-24: `www.mycelium-ai.co/api/install/quick-mint` → 308 → `mycelium-ai.co`; bare apex → **204** (route live, no redirect).

## What

- Repoint every install-API URL to the bare apex (no www): `bootstrap.sh`/`.ps1`, `install-ping.py`, `post-update-email-ask.py`, `phase-19-23-finish.md`, `daily-journal/SKILL.md`, `SECURITY.md`.
- Fix `test_install_api_canonical_base.sh`: it hardcoded the **old** www canonical (so it was green while the funnel bled) and treated the apex as non-canonical. Now pins `CANON` to the apex and flips the non-canonical patterns to catch `www.` + no-hyphen. Negative-control verified (catches all three bad forms, passes the canonical).

## Verify

- Regression test: **PASS** (`install-API calls all target https://mycelium-ai.co and follow redirects`).
- Zero residual `www.mycelium-ai.co` in install-facing files.
- `bash -n` + `py_compile` clean.
- Live apex probe: `OPTIONS → 204`.

Closes MYC-1659.

🤖 Generated with [Claude Code](https://claude.com/claude-code)