### PR TITLE
test(install): scheduled live-probe guard for the 308 canonical-flip recurrence (MYC-1663)

### DIFF
--- a/.github/workflows/install-canon-live-probe.yml
+++ b/.github/workflows/install-canon-live-probe.yml
@@ -1,0 +1,28 @@
+name: install-api canonical live probe
+
+# Recurrence guard for the 308 canonical-flip class (MYC-419 -> MYC-1659, twice).
+# A FUTURE Vercel primary flip that makes the canonical install-API host
+# 308-redirect would silently break the urllib POST callers again; the offline
+# regression test cannot catch that. This probes the live host on a schedule and
+# fails (-> GitHub failure email) only when the host actually redirects.
+#
+# Scheduled + manual only. NEVER a merge gate (no pull_request trigger): a network
+# blip must not block a PR, and the probe's job is to catch infra drift, not code.
+# No untrusted input: the only run: step executes a static checked-in script with
+# no ${{ github.event.* }} interpolation (no command-injection surface).
+
+on:
+  schedule:
+    - cron: '0 13 * * *'   # daily 13:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - name: Probe canonical install-API host serves 2xx (not a redirect)
+        run: bash tests/integration/probe_install_api_live.sh

--- a/tests/integration/probe_install_api_live.sh
+++ b/tests/integration/probe_install_api_live.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# LIVE probe: the install-API host the installer actually targets must serve a
+# 2xx, NOT a redirect.
+#
+# Why this exists (and why the offline test is not enough): its sibling
+# test_install_api_canonical_base.sh pins a hardcoded canonical STRING and checks
+# the code matches it. That cannot catch a FUTURE Vercel primary flip where the
+# canonical host ITSELF starts 308-redirecting — the offline test stays green
+# because the string still equals itself, while the urllib POST callers (which do
+# not reliably follow 308 on Python 3.9/3.10, and are fail-open) silently drop
+# install emails/pings. That bug shipped twice: MYC-419, then MYC-1659 mirror-imaged.
+#
+# Runs on a SCHEDULE, never as a merge gate: a redirect fails the scheduled run
+# and GitHub emails the failure (the MYC-770 alert channel). A transient network
+# error does NOT fail — only a definitive 3xx does — so it never false-alarms.
+#
+# Exit 0 = OK (2xx) or transient network error. Exit 1 = host redirects (the
+# canonical moved; repoint the client per MYC-1659 or fix the Vercel primary).
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# Single source of truth: read the SAME default the installer uses, so this probe
+# can never drift from what bootstrap.sh actually targets. INSTALL_API_PROBE_BASE_OVERRIDE
+# is a test seam for the negative control (point it at a known-308 host to prove
+# the probe fails on the thing it catches).
+if [ -n "${INSTALL_API_PROBE_BASE_OVERRIDE:-}" ]; then
+  BASE="$INSTALL_API_PROBE_BASE_OVERRIDE"
+else
+  BASE="$(grep -oE 'MYCELIUM_INSTALL_API:-https?://[^}"]+' "$REPO_ROOT/bootstrap.sh" | head -1 | sed 's/^MYCELIUM_INSTALL_API:-//')"
+fi
+
+if [ -z "${BASE:-}" ]; then
+  echo "FAIL: could not read INSTALL_API_BASE default from bootstrap.sh" >&2
+  exit 1
+fi
+echo "Probing canonical install-API base: $BASE"
+
+FAILED=0
+probe() {
+  local path="$1"
+  local code
+  code="$(curl -sS -m 12 --retry 2 --retry-delay 2 -o /dev/null -w '%{http_code}' -X OPTIONS "$BASE$path" 2>/dev/null || echo 000)"
+  case "$code" in
+    2*) echo "  OK   $code  $path" ;;
+    3*) echo "  FAIL $code  $path  <-- REDIRECT: canonical host moved; urllib POST callers silently drop here" >&2; FAILED=1 ;;
+    000) echo "  WARN  --   $path  (network error reaching host; not failing — transient)" ;;
+    *)  echo "  WARN $code  $path  (unexpected; not a redirect; not failing)" ;;
+  esac
+}
+
+# The endpoints the fail-open urllib callers POST to (the silent-death surface).
+probe "/api/install/quick-mint"
+probe "/api/install"
+probe "/api/install/first-journal"
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "install-api live probe: canonical host is REDIRECTING. Repoint the client (MYC-1659) or fix the Vercel primary flip (MYC-1539)." >&2
+  exit 1
+fi
+echo "install-api live probe: PASS ($BASE serves 2xx, no redirect)"


### PR DESCRIPTION
## Why

The 308 canonical-flip bug bit **twice** — [MYC-419](https://linear.app/myceliumai/issue/MYC-419), then [MYC-1659](https://linear.app/myceliumai/issue/MYC-1659) mirror-imaged. The offline `test_install_api_canonical_base.sh` pins a hardcoded canonical string and checks the code matches it — it **cannot** catch a *future* Vercel primary flip where the canonical host itself starts 308-redirecting (the test stays green because the string still equals itself, while the urllib POST callers silently drop install emails/pings). This adds the missing live layer.

## What

- **`tests/integration/probe_install_api_live.sh`** — reads the *same* `INSTALL_API_BASE` default `bootstrap.sh` uses (so it can't drift from what the installer targets), OPTIONS-probes the install routes, and FAILs **only** on a 3xx redirect. Exit 0 on 2xx or a transient network error — so it never false-alarms. `INSTALL_API_PROBE_BASE_OVERRIDE` is the negative-control seam.
- **`.github/workflows/install-canon-live-probe.yml`** — daily + `workflow_dispatch`, `permissions: contents: read`, **never a merge gate** (no `pull_request` trigger). A redirect fails the scheduled run → GitHub failure email (the MYC-770 alert channel).

## Verify (run locally)

- Live run: **PASS** — apex returns 204 on `/api/install/quick-mint`, `/api/install`, `/api/install/first-journal`.
- Negative control: `INSTALL_API_PROBE_BASE_OVERRIDE=https://www.mycelium-ai.co` (the host that 308s) → **FAIL exit 1** on all three.
- Workflow YAML parses; no `github.event` interpolation; injection scanner clean.

Part of MYC-1663 (the recurrence-guard layer for the 2026-06-24 install-funnel incidents).

🤖 Generated with [Claude Code](https://claude.com/claude-code)