### PR TITLE
fix(closed-loop): a successful subagent return is not a failure signal

### DIFF
--- a/hooks/post-tool-use-learnings.py
+++ b/hooks/post-tool-use-learnings.py
@@ -5,7 +5,10 @@ Learnings as episodic memory.
 
 Fires after every Bash, Edit, Write, or Agent tool call. Two trigger conditions:
 
-  1. Tool result indicates failure (non-zero exit, error string, exception).
+  1. Tool result indicates failure via an AUTHORITATIVE signal: a non-zero
+     Bash exitCode, or an isError flag. A subagent's (Agent/Task) free-form
+     product and a Write/Edit's file content are NEVER substring-scanned for
+     error keywords — that text is the tool's OUTPUT, not a failure signal.
   2. Tool result contains an explicit `<learning>...</learning>` annotation.
 
 When either fires, the hook appends one Learning file to:
@@ -143,7 +146,20 @@ def detect_failure(tool_response: dict, source_tool: str = "") -> tuple[bool, st
         if tool_response.get("filePath") or tool_response.get("file_path"):
             return False, ""
 
-    # Generic content scan (Bash, Agent, Task without exitCode/isError)
+    # Agent/Task success short-circuit. A subagent's return is its PRODUCT —
+    # free-form prose/code that routinely contains "error", "exception",
+    # "failed", "fatal" because it is DISCUSSING or AUDITING code, exactly like
+    # a Write's file content. The only sound failure signal for a subagent is an
+    # authoritative isError / non-zero exitCode, both checked above; if neither
+    # fired, the subagent SUCCEEDED. Substring-scanning the product was the
+    # false-positive bug that flooded Meta/Learnings/ with successful
+    # repo-evaluation transcripts — and leaked audited third-party content into
+    # error_excerpt — until 2026-06-25 (46 false captures across two vaults).
+    # Mirror the Write/Edit fix: never scan an agent's product for error tokens.
+    if source_tool in ("Agent", "Task"):
+        return False, ""
+
+    # Generic content scan (Bash without an explicit exitCode)
     content = tool_response.get("content") or tool_response.get("output") or ""
     if isinstance(content, list):
         joined = " ".join(str(c.get("text", c)) if isinstance(c, dict) else str(c) for c in content)
@@ -249,6 +265,14 @@ def write_learning(
     if error_excerpt:
         frontmatter["error_excerpt"] = error_excerpt[:500]
 
+    # Agent/Task captures reach here only on a genuine isError failure or an
+    # explicit <learning> annotation (detect_failure short-circuits successful
+    # subagent returns). Even then, do NOT persist the raw subagent
+    # input/output body: a subagent's prompt + product can carry UNTRUSTED
+    # THIRD-PARTY CONTENT (audited repos, fetched URLs). Keep only the bounded
+    # signal (error_excerpt / learning_text) already rendered above.
+    redact_subagent_body = source_tool in ("Agent", "Task")
+
     body_parts = ["---", render_frontmatter(frontmatter).rstrip(), "---", ""]
 
     if learning_text:
@@ -265,25 +289,35 @@ def write_learning(
         body_parts.append("```")
         body_parts.append("")
 
-    body_parts.append("## Tool input")
-    body_parts.append("")
-    body_parts.append("```json")
-    try:
-        body_parts.append(json.dumps(tool_input, indent=2, ensure_ascii=False)[:1500])
-    except (TypeError, ValueError):
-        body_parts.append(str(tool_input)[:1500])
-    body_parts.append("```")
-    body_parts.append("")
+    if redact_subagent_body:
+        body_parts.append("## Tool input + response")
+        body_parts.append("")
+        body_parts.append(
+            "_Omitted for Agent/Task captures: a subagent's prompt and product "
+            "can contain untrusted third-party content (audited repos, fetched "
+            "URLs). Only the bounded signal above is persisted._"
+        )
+        body_parts.append("")
+    else:
+        body_parts.append("## Tool input")
+        body_parts.append("")
+        body_parts.append("```json")
+        try:
+            body_parts.append(json.dumps(tool_input, indent=2, ensure_ascii=False)[:1500])
+        except (TypeError, ValueError):
+            body_parts.append(str(tool_input)[:1500])
+        body_parts.append("```")
+        body_parts.append("")
 
-    body_parts.append("## Tool response (excerpt)")
-    body_parts.append("")
-    body_parts.append("```")
-    try:
-        body_parts.append(json.dumps(tool_response, indent=2, ensure_ascii=False)[:1500])
-    except (TypeError, ValueError):
-        body_parts.append(str(tool_response)[:1500])
-    body_parts.append("```")
-    body_parts.append("")
+        body_parts.append("## Tool response (excerpt)")
+        body_parts.append("")
+        body_parts.append("```")
+        try:
+            body_parts.append(json.dumps(tool_response, indent=2, ensure_ascii=False)[:1500])
+        except (TypeError, ValueError):
+            body_parts.append(str(tool_response)[:1500])
+        body_parts.append("```")
+        body_parts.append("")
 
     try:
         target.write_text("\n".join(body_parts), encoding="utf-8")
@@ -368,8 +402,21 @@ def _self_test() -> int:
          {"type": "update", "filePath": "/tmp/d.py",
           "content": "auto-yes wikilink application is unsafe"},
          "Write", False),
-        ("Agent isError true → failure",
+        ("Agent isError true → failure (genuine subagent failure, positive control)",
          {"isError": True, "error": "agent crashed"}, "Agent", True),
+        ("Agent successful audit return mentioning error/exception/failed → not failure (regression-agent-fp1)",
+         {"status": "completed",
+          "content": "Here is the candidate list. The code handles errors via try/except, "
+                     "fails gracefully on exception, and logs fatal conditions."},
+         "Agent", False),
+        ("Task successful return, error vocabulary, no literal success token → not failure (regression-agent-fp2)",
+         {"content": "Pattern: a defensive guard wraps the call; on error it raises a typed exception."},
+         "Task", False),
+        ("Agent product is pure error-vocab with no authoritative signal → not failure (regression-agent-fp3)",
+         {"output": "error handling, exception safety, failure modes, fatal-path coverage"},
+         "Agent", False),
+        ("Task with non-zero exitCode is still authoritative → failure (positive control)",
+         {"exitCode": 2, "stderr": "boom"}, "Task", True),
         ("Bash with traceback in stdout → failure",
          {"content": "Traceback (most recent call last):\n  File 'x.py'"},
          "Bash", True),

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -139,6 +139,7 @@ INTEGRATION_TESTS=(
   test_agent_memory_link
   test_open_core_boundary
   test_audited_content_injection_scan
+  test_post_tool_use_learnings
 )
 echo "==> (b) Shell integration: ${#INTEGRATION_TESTS[@]} tests"
 for t in "${INTEGRATION_TESTS[@]}"; do

--- a/tests/integration/test_post_tool_use_learnings.sh
+++ b/tests/integration/test_post_tool_use_learnings.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Regression guard for hooks/post-tool-use-learnings.py — the closed-loop
+# episodic-capture PostToolUse hook.
+#
+# Proves the 2026-06-25 fix: a SUCCESSFUL subagent (Agent/Task) return is the
+# tool's PRODUCT (free-form prose/code that routinely contains "error",
+# "exception", "failed"), NOT a failure signal. Before the fix the generic
+# substring scan misclassified successful repo-evaluation transcripts as
+# failures and stuffed them — plus the audited third-party content — into an
+# error_excerpt Learning. 46 false captures landed across two vaults.
+#
+# Four assertions (negative + positive controls, per "a guard earns trust only
+# by failing on the thing it catches"):
+#   (a) the inline unit self-test passes (detect_failure cases),
+#   (b) NEGATIVE CONTROL: a successful Agent return with error vocabulary writes
+#       NO Learning file,
+#   (c) POSITIVE CONTROL: a genuine Agent isError failure DOES write a file
+#       (the hook still captures real failures — the fix is not "ignore Agent"),
+#   (d) LEAK CONTROL: that genuine-failure file carries the bounded error signal
+#       but NOT the raw subagent prompt body (untrusted third-party content).
+#
+# Bash-script test per the tests/integration/ convention; wired into scripts/ci.sh.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOK="$ROOT/hooks/post-tool-use-learnings.py"
+
+fail=0
+pass() { echo "  PASS  $1"; }
+bad() { echo "  FAIL  $1"; fail=1; }
+
+[ -f "$HOOK" ] || { echo "::error::hook not found at $HOOK"; exit 1; }
+
+# --- (a) inline unit self-test --------------------------------------------
+if python3 "$HOOK" --self-test >/dev/null 2>&1; then
+  pass "(a) detect_failure self-test exits 0"
+else
+  bad "(a) detect_failure self-test FAILED (run: python3 $HOOK --self-test)"
+fi
+
+# Scratch vault: a directory whose child folder is named 'Meta' so the hook's
+# find_vault_root resolves it on the first iteration (no walk-up ambiguity).
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+VAULT="$TMP/vault"
+mkdir -p "$VAULT/Meta"
+LEARN="$VAULT/Meta/Learnings"
+
+run_hook() { printf '%s' "$1" | python3 "$HOOK" >/dev/null 2>&1 || true; }
+count_md() { find "$LEARN" -name '*.md' 2>/dev/null | wc -l | tr -d ' '; }
+
+# --- (b) NEGATIVE CONTROL: successful Agent return must NOT be captured -----
+rm -rf "$LEARN"
+run_hook "$(cat <<JSON
+{"tool_name":"Agent","cwd":"$VAULT","session_id":"s","tool_call_id":"neg1",
+ "tool_input":{"description":"audit","prompt":"read /tmp/thirdparty/foo.py"},
+ "tool_response":{"status":"completed","content":"Candidate list: the code handles errors via try/except, fails gracefully on exception, logs fatal conditions."}}
+JSON
+)"
+if [ "$(count_md)" = "0" ]; then
+  pass "(b) successful Agent return wrote NO Learning file"
+else
+  bad "(b) successful Agent return WAS captured ($(count_md) file(s)) — false-positive bug is back"
+fi
+
+# --- (c)+(d) POSITIVE + LEAK CONTROL: genuine isError failure --------------
+SENTINEL="SENTINEL_THIRDPARTY_a1b2c3d4"
+rm -rf "$LEARN"
+run_hook "$(cat <<JSON
+{"tool_name":"Agent","cwd":"$VAULT","session_id":"s","tool_call_id":"pos1",
+ "tool_input":{"description":"audit","prompt":"$SENTINEL untrusted audited repo content"},
+ "tool_response":{"isError":true,"error":"agent crashed: API error after 3 retries"}}
+JSON
+)"
+if [ "$(count_md)" = "1" ]; then
+  pass "(c) genuine Agent isError failure DID write a Learning file"
+  CAP="$(find "$LEARN" -name '*.md' | head -1)"
+  if grep -q "agent crashed" "$CAP"; then
+    pass "(d.1) capture carries the bounded error signal"
+  else
+    bad "(d.1) capture is missing the error signal"
+  fi
+  if grep -q "$SENTINEL" "$CAP"; then
+    bad "(d.2) LEAK: raw subagent prompt body persisted ($SENTINEL found in capture)"
+  else
+    pass "(d.2) raw subagent prompt body NOT persisted (no third-party leak)"
+  fi
+  if grep -q "Omitted for Agent/Task captures" "$CAP"; then
+    pass "(d.3) redaction note present"
+  else
+    bad "(d.3) redaction note missing"
+  fi
+else
+  bad "(c) genuine Agent isError failure was NOT captured ($(count_md) file(s)) — hook over-suppresses"
+fi
+
+echo
+if [ "$fail" = "0" ]; then
+  echo "test_post_tool_use_learnings: all assertions passed"
+else
+  echo "::error::test_post_tool_use_learnings: one or more assertions failed"
+fi
+exit "$fail"


### PR DESCRIPTION
## Problem

The closed-loop PostToolUse hook (`hooks/post-tool-use-learnings.py`) was
misclassifying **successful** subagent (Agent/Task) returns as error-captured
episodic Learnings.

`detect_failure()` ran a generic substring scan over Agent/Task tool responses,
flagging any output containing `error`/`exception`/`failed`/`fatal` (with no
literal success token) as a failure. But a subagent's successful return is its
**product** — free-form prose/code that routinely contains that vocabulary
because it is auditing or discussing code. So repo-evaluation transcripts were:

1. mislabeled as errors (`error_excerpt:` populated on a clean success),
2. dumped whole into `Meta/Learnings/`, polluting the episodic sink that feeds
   the promote/cluster job, and
3. leaking audited **third-party** repo content into the learnings corpus.

Observed: **46 false captures across two vaults** (a real repo-evaluation audit
on 2026-06-24, e.g. `Meta/Learnings/2026-06-25-bb88925b.md`).

This is the exact false-positive class already fixed for Write/Edit (the
2026-05-08 "169-capture flood"), which short-circuits before the substring scan
because a Write's response carries file content, not a failure signal.

## Fix

- **`detect_failure`**: Agent/Task failure is determined **only** by
  authoritative signals (`isError` / non-zero `exitCode`), never the substring
  scan — mirroring the Write/Edit short-circuit. Successful subagent returns are
  no longer captured.
- **`write_learning`**: even a genuine Agent/Task failure no longer persists the
  raw subagent input/output body (untrusted third-party content). Only the
  bounded `error_excerpt` / `<learning>` annotation is kept.

## Guard (negative + positive controls)

- New `_self_test` cases (the exact bug shapes → not a failure; genuine
  `isError`/`exitCode` → still a failure).
- New `tests/integration/test_post_tool_use_learnings.sh`, wired into
  `scripts/ci.sh`:
  - **negative control** — a successful Agent return with error vocabulary
    writes **no** Learning file,
  - **positive control** — a genuine `isError` failure **does** write one,
  - **leak control** — that file carries the error signal but **not** the raw
    subagent prompt (no third-party leak).

Verified: old hook writes 1 file for the success payload (bug reproduced); new
hook writes 0. Full self-test 14/14, integration test 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
