### PR TITLE
fix(closed-loop): the episodic sink self-protects against git sync

### DIFF
--- a/hooks/post-tool-use-learnings.py
+++ b/hooks/post-tool-use-learnings.py
@@ -227,6 +227,29 @@ def render_frontmatter(frontmatter: dict) -> str:
     return "\n".join(lines) + "\n"
 
 
+SINK_GITIGNORE = (
+    "# Closed-loop episodic sink — local-only machinery, never synced.\n"
+    "# Captures can carry failure excerpts, internal paths, and (on subagent\n"
+    "# failures) untrusted third-party content. They must never enter a vault's\n"
+    "# git history. This .gitignore self-scopes the sink so protection does not\n"
+    "# depend on the vault's root .gitignore or the operator's git habits.\n"
+    "*\n"
+    "!.gitignore\n"
+)
+
+
+def ensure_sink_gitignore(directory: Path) -> None:
+    """Drop a self-scoping .gitignore into a machinery sink dir (idempotent +
+    self-healing). Safe-by-construction: the sink never syncs, regardless of the
+    vault's root .gitignore or the operator's git habits."""
+    gi = directory / ".gitignore"
+    if not gi.exists():
+        try:
+            gi.write_text(SINK_GITIGNORE, encoding="utf-8")
+        except OSError:
+            pass
+
+
 def write_learning(
     vault_root: Path,
     captured_at: str,
@@ -243,6 +266,7 @@ def write_learning(
         learnings_dir.mkdir(parents=True, exist_ok=True)
     except OSError:
         return None
+    ensure_sink_gitignore(learnings_dir)
 
     date_part = captured_at[:10]
     target = learnings_dir / f"{date_part}-{sha8}.md"

--- a/scripts/promote-episodic-to-procedural.py
+++ b/scripts/promote-episodic-to-procedural.py
@@ -341,6 +341,28 @@ def build_candidate(
     return sha8, frontmatter, "\n".join(body_parts)
 
 
+SINK_GITIGNORE = (
+    "# Closed-loop machinery sink — local-only, never synced.\n"
+    "# Episodic captures and derived candidates can carry failure excerpts,\n"
+    "# internal paths, and untrusted third-party content. They must never enter\n"
+    "# a vault's git history. This .gitignore self-scopes the sink so protection\n"
+    "# does not depend on the vault's root .gitignore or the operator's habits.\n"
+    "*\n"
+    "!.gitignore\n"
+)
+
+
+def ensure_sink_gitignore(directory: Path) -> None:
+    """Drop a self-scoping .gitignore into a machinery sink dir (idempotent +
+    self-healing). Safe-by-construction: the sink never syncs."""
+    gi = directory / ".gitignore"
+    if not gi.exists():
+        try:
+            gi.write_text(SINK_GITIGNORE, encoding="utf-8")
+        except OSError:
+            pass
+
+
 def load_learnings(learnings_dir: Path) -> list[dict]:
     items: list[dict] = []
     if not learnings_dir.is_dir():
@@ -456,6 +478,11 @@ def main(argv: list[str] | None = None) -> int:
     candidates_dir = vault_root / "Meta" / "Promotion-Candidates"
     state_path = vault_root / STATE_FILENAME
 
+    # Re-assert sink self-protection every run (self-heals older installs whose
+    # hook predates the safe-by-construction .gitignore).
+    if learnings_dir.is_dir():
+        ensure_sink_gitignore(learnings_dir)
+
     state = load_state(state_path)
     learning_count = count_learnings(learnings_dir)
     last_count = state.get("last_learning_count", -1)
@@ -516,6 +543,7 @@ def main(argv: list[str] | None = None) -> int:
                 continue
             try:
                 candidates_dir.mkdir(parents=True, exist_ok=True)
+                ensure_sink_gitignore(candidates_dir)
                 target.write_text(content, encoding="utf-8")
                 drafted_messages.append(
                     f"Wrote {target} ({len(cluster)} captures, tool={tool}, status={status})"

--- a/tests/integration/test_post_tool_use_learnings.sh
+++ b/tests/integration/test_post_tool_use_learnings.sh
@@ -91,6 +91,14 @@ if [ "$(count_md)" = "1" ]; then
   else
     bad "(d.3) redaction note missing"
   fi
+  # (e) sink self-protection: the episodic sink must carry a .gitignore that
+  # excludes everything, so captures never enter a vault's git history
+  # regardless of the vault's root .gitignore or the operator's git habits.
+  if [ -f "$LEARN/.gitignore" ] && grep -qx '\*' "$LEARN/.gitignore" && grep -qx '!.gitignore' "$LEARN/.gitignore"; then
+    pass "(e) sink self-protects with a .gitignore (machinery never syncs)"
+  else
+    bad "(e) sink .gitignore missing/incomplete — captures could be committed to a remote"
+  fi
 else
   bad "(c) genuine Agent isError failure was NOT captured ($(count_md) file(s)) — hook over-suppresses"
 fi


### PR DESCRIPTION
## Problem

The closed-loop episodic sink (`Meta/Learnings/`) and its derived candidate dir
(`Meta/Promotion-Candidates/`) are **local-only machinery**. Captures can carry
failure excerpts, internal paths, and — on subagent failures — untrusted
third-party content. Nothing in the substrate guaranteed they stayed out of a
vault's git history:

- the repo `.gitignore` ignores only `.promote-state.json`,
- the installer never gitignores the sink in a **user's** vault.

So a Mycelium client whose vault has a remote and runs a broad `git add` would
commit (and possibly push) their captures. Found while hardening the closed-loop
after the Agent-return false-positive fix (#238).

## Fix — safe by construction ("machinery never syncs")

The hook and the promote script drop a self-scoping `.gitignore` (`*` +
`!.gitignore`) into each sink dir when they create it. Protection no longer
depends on the vault's root `.gitignore` or the operator's git habits. The
promote script re-asserts it every run, **self-healing older installs** whose
hook predates this change.

## Proof

- `git add -A` in a vault with a populated sink stages **only** the `.gitignore`;
  the capture is `check-ignore`'d (verified in a temp git repo).
- The `.gitignore` itself is tracked, so protection travels with the repo.
- Integration test gains assertion **(e)**; full suite **7/7**, self-test **14/14**, shellcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
