### PR TITLE
feat(relocate): vault-relocation watchdog as substrate (MYC-1749)

### DIFF
--- a/hooks.json
+++ b/hooks.json
@@ -252,6 +252,11 @@
             "type": "command",
             "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/surface-connector-liveness.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'",
             "statusMessage": "Checking connectors for the silent-empty (0-vs-0) gap..."
+          },
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/relocate-watch-surface.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'",
+            "statusMessage": "Checking for vault-relocation drift (old-path recreators)..."
           }
         ]
       }

--- a/hooks/relocate-watch-surface.py
+++ b/hooks/relocate-watch-surface.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""SessionStart hook: surface vault-relocation drift back to an old path (the visible half).
+
+The every-session canary for the relocation watchdog. After a vault is moved off a
+cloud-sync folder (scripts/relocate-vault.sh), tooling that still hardcodes the OLD
+path silently `mkdir`s a phantom folder there / breaks every run. scripts/relocate-
+sweep.py --watch is the tested detection core (it reads the install's recorded move(s)
+from the manifest and classifies residual references); this hook names the drift at
+the NEXT session start so a re-introduced hardcode surfaces fast instead of riding a
+symlink unseen for days.
+
+WALK-FREE BY CONSTRUCTION: it reads two small JSON files (the relocation manifest +
+the cached watch verdict) and does ONE stat() per recorded move. It never walks a
+corpus, so it stays bounded under concurrency (the SessionStart freeze class, the
+incident scripts/audit-sessionstart-boundedness.py guards). The heavy residual scan
+lives in relocate-sweep.py --watch, run by the daily-maintenance cron AND by a
+cooldown-gated, single-spawn, DETACHED refresh fired here when the cache is stale —
+never inline.
+
+Output: silent when nothing was ever relocated, or when every recorded move is clean.
+One systemMessage block when an old path was recreated as a real directory, the
+relocated vault root is missing, or the last full scan found executed residual refs.
+
+Bypass: RELOCATE_WATCH_SURFACE_BYPASS=1 in env.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+CONFIG_DIR = Path(os.environ.get("CLAUDE_CONFIG_DIR") or (Path.home() / ".claude"))
+MANIFEST = CONFIG_DIR / "relocations.json"
+CACHE = CONFIG_DIR / "relocate-watch-state.json"
+REFRESH_STAMP = CONFIG_DIR / ".relocate-watch-refresh.stamp"
+REFRESH_COOLDOWN_S = 20 * 3600  # refresh the heavy scan at most ~once/day
+# The watch engine ships alongside this hook: hooks/ and scripts/ are siblings under
+# the installed skill dir. Resolve relative to __file__ so it works at any install path.
+SWEEP = Path(__file__).resolve().parent.parent / "scripts" / "relocate-sweep.py"
+
+
+def _quiet() -> int:
+    print(json.dumps({"continue": True, "suppressOutput": True}))
+    return 0
+
+
+def _load(path: Path):
+    try:
+        return json.loads(path.read_text())
+    except (OSError, ValueError):
+        return None
+
+
+def _recreated(old: str) -> bool:
+    """A REAL directory at the old path (not the post-relocation symlink, not absent)
+    means a tool that still hardcodes it mkdir'd a phantom folder."""
+    try:
+        return os.path.exists(old) and not os.path.islink(old) and os.path.isdir(old)
+    except OSError:
+        return False
+
+
+def _refresh_started_at() -> float:
+    try:
+        return float(REFRESH_STAMP.read_text().strip())
+    except (OSError, ValueError):
+        return 0.0
+
+
+def _maybe_spawn_refresh(cache) -> None:
+    """Cooldown-gated, single-spawn, DETACHED refresh of the heavy scan. The cooldown is
+    claimed AT START (the stamp is written BEFORE the spawn) so a session that starts
+    mid-refresh sees the fresh stamp and skips — preventing the N-concurrent-walks
+    freeze class. The spawned process writes the cache this hook reads next session."""
+    if os.environ.get("RELOCATE_WATCH_SURFACE_NO_REFRESH"):
+        return  # test seam: surface from the cache without firing a real background scan
+    if not SWEEP.is_file():
+        return
+    last = max(float((cache or {}).get("ts", 0) or 0), _refresh_started_at())
+    if time.time() - last < REFRESH_COOLDOWN_S:
+        return  # a recent scan or a recent refresh already covers it
+    try:
+        REFRESH_STAMP.write_text(str(time.time()))  # claim the cooldown BEFORE spawning
+    except OSError:
+        return
+    try:
+        devnull = open(os.devnull, "w")
+        subprocess.Popen(
+            [sys.executable, str(SWEEP), "--watch", "--config-dir", str(CONFIG_DIR)],
+            stdout=devnull, stderr=devnull, stdin=subprocess.DEVNULL, start_new_session=True,
+        )
+    except Exception:
+        pass
+
+
+def main() -> int:
+    if os.environ.get("RELOCATE_WATCH_SURFACE_BYPASS"):
+        return _quiet()
+
+    # SessionStart payload arrives on stdin (JSON). Drain so we never block.
+    try:
+        sys.stdin.read()
+    except Exception:
+        pass
+
+    # Fail silent on ANY error: a watchdog must never break session start.
+    try:
+        manifest = _load(MANIFEST)
+        if not isinstance(manifest, list) or not manifest:
+            return _quiet()  # nothing was ever relocated → nothing to watch
+        cache = _load(CACHE)
+        cache = cache if isinstance(cache, dict) else None
+        recreated = [
+            e for e in manifest
+            if isinstance(e, dict) and e.get("old") and _recreated(os.path.expanduser(e["old"]))
+        ]
+        cached_alarm = cache if (cache and cache.get("verdict") == "ALARM") else None
+        _maybe_spawn_refresh(cache)
+    except Exception:
+        return _quiet()
+
+    if not recreated and not cached_alarm:
+        return _quiet()
+
+    lines = []
+    for e in recreated:
+        lines.append(
+            f"  - RECREATED: a real directory reappeared at the old vault path "
+            f"{e['old']} — a tool that still hardcodes it ran. Repoint it to {e.get('new', '<new>')}."
+        )
+    if cached_alarm:
+        for p in cached_alarm.get("missing_roots") or []:
+            lines.append(f"  - VAULT ROOT MISSING: {p} — the relocated vault is not where the manifest says.")
+        findings = cached_alarm.get("findings") or []
+        for loc in findings[:8]:
+            lines.append(f"  - EXECUTED REF still resolves an old path: {loc}")
+        extra = (cached_alarm.get("executed", 0) or 0) - min(8, len(findings))
+        if extra > 0:
+            lines.append(f"  - … and {extra} more executed reference(s).")
+
+    if not lines:
+        return _quiet()
+
+    msg = (
+        "[relocate-watch] vault-relocation drift detected — a hardcoded OLD vault path "
+        "is back (it mkdir's a phantom folder / breaks tooling every run):\n"
+        + "\n".join(lines)
+        + "\n\nRepoint each reference to the relocated vault, or remove the recreated folder. "
+        "Full scan: scripts/relocate-sweep.py --watch (also runs in daily maintenance)."
+    )
+    print(json.dumps({"systemMessage": msg}))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -127,6 +127,7 @@ INTEGRATION_TESTS=(
   test_machinery_sidecar
   test_relocate_vault
   test_relocate_sweep
+  test_relocate_watch
   test_renderer_crash_guard
   test_install_api_canonical_base
   test_cd_worktree_inline_bypass

--- a/scripts/relocate-sweep.py
+++ b/scripts/relocate-sweep.py
@@ -43,20 +43,40 @@ This script NEVER edits anything. It classifies and reports. The repoint is your
 the symlink drop is `relocate-vault.sh --drop-symlink`, which runs this sweep and
 obeys its verdict.
 
+TWO MODES, ONE ENGINE
+---------------------
+  mode 1 (default, --old):  the one-shot SWEEP above — go/no-go on dropping a symlink.
+  mode 2 (--watch):         the ongoing WATCHDOG. Reads the install's OWN move(s) from
+                            the manifest relocate-vault.sh writes (never a hardcoded
+                            literal), reuses the SAME discovery + classification to ask
+                            "has anything drifted back to the old path?", and ALARMS
+                            (exit 1 + a verdict cache) on an executed residual, a
+                            recreated old directory, or a missing relocated vault root
+                            (fail-loud). The SessionStart surfacer + the daily-
+                            maintenance cron read its cache. Bug class:
+                            DESKTOP-PATH-RECREATOR (a hardcoded old path that mkdir's a
+                            phantom folder / breaks tooling every run).
+
 Usage:
-  relocate-sweep.py --old <old-vault-path> [--new <new-vault-path>] [options]
+  relocate-sweep.py --old <old-vault-path> [--new <new-vault-path>] [options]   # mode 1
+  relocate-sweep.py --watch [--config-dir <dir>] [scope options]                # mode 2
+  relocate-sweep.py --watch-selftest                                            # mode 2 controls
 
 Options:
   --root <dir>          add a scan root (repeatable). Combined with auto-discovery
                         unless --no-auto-discover.
   --dev-root <dir>      parent dir of code repos to auto-scan (default: ~/dev)
-  --config-dir <dir>    Claude Code config dir (default: $CLAUDE_CONFIG_DIR or ~/.claude)
+  --config-dir <dir>    Claude Code config dir (default: $CLAUDE_CONFIG_DIR or ~/.claude).
+                        Mode 2 reads relocations.json + writes relocate-watch-state.json here.
   --claude-json <file>  the big per-host config to characterize (default: ~/.claude.json)
   --no-auto-discover    scan only the explicit --root paths (+ --claude-json if given)
+  --watch               mode 2: watch the manifest's recorded move(s) for drift
+  --watch-selftest      mode 2 negative/positive controls (planted recreator/residual/
+                        missing-root must alarm; a clean tree must not), then exit
   --json                emit a machine-readable report on stdout
   -h, --help            this help
 
-Exit codes: 0 GO (no executed residuals) · 1 NO-GO (executed residuals remain) · 2 usage
+Exit codes: 0 GO / watch-clean · 1 NO-GO / watch-ALARM · 2 usage
 """
 from __future__ import annotations
 
@@ -69,9 +89,11 @@ import re
 import subprocess
 import sys
 import threading
+import time
 import tokenize
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from types import SimpleNamespace
 
 HOME = Path.home()
 
@@ -81,8 +103,11 @@ HOME = Path.home()
 READ_TIMEOUT = 5.0
 
 # File suffixes worth scanning on a filesystem walk. Everything else is skipped.
+# `.env`/`.envrc` are in scope: an `export VAULT=<oldpath>` or a `cd <oldpath>` in a
+# config-env file (e.g. an apprise.env) recreates/breaks tooling exactly like an
+# in-script default does (file-type parity with the watchdog's lessons).
 SCAN_EXTS = {".py", ".sh", ".bash", ".zsh", ".md", ".compressed", ".txt",
-             ".json", ".plist", ".yaml", ".yml", ".toml", ""}
+             ".json", ".plist", ".yaml", ".yml", ".toml", ".env", ".envrc", ""}
 # Path fragments that are never executable config (caches, vcs internals, logs).
 SKIP_SUB = ("/.git/", "/.venv/", "/node_modules/", "/.claude/worktrees/",
             ".jsonl", ".log", ".bak", ".pyc", "/.smart-env/", "/graphify-out/")
@@ -781,10 +806,215 @@ def print_human(rep):
         print("    relocate-vault.sh --drop-symlink " + abbrev(rep["old"]))
 
 
+# --------------------------------------------------------------------------- #
+# watch — mode 2 of the SAME engine (no second engine, no hand-kept root list)  #
+# --------------------------------------------------------------------------- #
+def manifest_path(config_dir):
+    return os.path.join(config_dir, "relocations.json")
+
+
+def watch_cache_path(config_dir):
+    return os.path.join(config_dir, "relocate-watch-state.json")
+
+
+def read_manifest(config_dir):
+    """The install's OWN relocation record, written by relocate-vault.sh: a list of
+    {old, new, symlink, at}. Missing → [] (a never-relocated install has nothing to
+    watch — clean no-op). Unparseable / wrong-shape → [] + a LOUD warning, never a
+    silent blind spot."""
+    path = manifest_path(config_dir)
+    if not os.path.isfile(path):
+        return []
+    try:
+        data = json.loads(Path(path).read_text())
+    except (OSError, ValueError):
+        WARNINGS.append("relocation manifest did not parse: " + abbrev(path)
+                        + " — the watchdog is blind until it is fixed or removed")
+        return []
+    if not isinstance(data, list):
+        WARNINGS.append("relocation manifest is not a JSON list: " + abbrev(path))
+        return []
+    return [e for e in data if isinstance(e, dict) and e.get("old") and e.get("new")]
+
+
+def old_path_recreated(old_abs):
+    """True when a REAL directory sits at the old path. Post-relocation the old path
+    is either the symlink relocate-vault.sh leaves (fine) or absent once the symlink
+    is dropped (fine). A real directory there means a tool that still hardcodes the
+    old path mkdir'd a phantom folder — the recreator bug, caught the instant it
+    happens with one stat (no walk)."""
+    return os.path.exists(old_abs) and not os.path.islink(old_abs) and os.path.isdir(old_abs)
+
+
+def _watch_args_for(base, old_abs, new_abs):
+    """A build_report() args object for ONE recorded move, inheriting the scan-scope
+    knobs (root / dev_root / no_auto_discover / config_dir / claude_json) from the CLI
+    so the watch auto-discovers in production yet is hermetically scopeable in tests."""
+    return SimpleNamespace(
+        old=old_abs, new=new_abs,
+        root=list(getattr(base, "root", []) or []),
+        dev_root=getattr(base, "dev_root", None) or str(HOME / "dev"),
+        config_dir=getattr(base, "config_dir", None) or str(HOME / ".claude"),
+        no_auto_discover=getattr(base, "no_auto_discover", False),
+        include_worktrees=getattr(base, "include_worktrees", False),
+        claude_json=getattr(base, "claude_json", None),
+    )
+
+
+def _dedupe(seq):
+    out, seen = [], set()
+    for x in seq:
+        if x not in seen:
+            seen.add(x)
+            out.append(x)
+    return out
+
+
+def _write_watch_cache(config_dir, payload):
+    """Atomically write the verdict the SessionStart surfacer + the cron read."""
+    try:
+        os.makedirs(config_dir, exist_ok=True)
+        path = watch_cache_path(config_dir)
+        tmp = path + ".tmp"
+        Path(tmp).write_text(json.dumps(payload, indent=2))
+        os.replace(tmp, path)
+    except OSError as ex:
+        WARNINGS.append("could not write watch cache: " + str(ex))
+
+
+def run_watch(args):
+    """Mode 2: scan the install's OWN recorded move(s) for drift back to an old path,
+    write a verdict cache, return the payload. ALARM (verdict='ALARM') when ANY move
+    has an executed residual reference, a recreated old directory, or a missing
+    new/vault root (fail-loud). Reuses build_report() — no second engine."""
+    config_dir = args.config_dir
+    entries = read_manifest(config_dir)
+    executed_findings, recreated, missing_roots = [], [], []
+
+    for e in entries:
+        old_abs = os.path.abspath(os.path.expanduser(e["old"]))
+        new_abs = os.path.abspath(os.path.expanduser(e["new"]))
+        # fail-loud: the relocated vault is supposed to live at `new`. If it does not,
+        # the move is broken (vault gone / moved again) — the watch must surface it.
+        if not os.path.exists(new_abs):
+            missing_roots.append(abbrev(new_abs))
+        if old_path_recreated(old_abs):
+            recreated.append(abbrev(old_abs))
+        # residual scan via the SAME engine (mode 1). new=None when absent so discovery
+        # never tries to walk a path that is not there.
+        rep = build_report(_watch_args_for(args, old_abs, new_abs if os.path.isdir(new_abs) else None))
+        for f in rep["findings"]:
+            if f["klass"] == "executed":
+                loc = f["path"] + ((":" + str(f["line"])) if f["line"] else "")
+                executed_findings.append(loc + ("  " + f["snippet"] if f["snippet"] else ""))
+
+    executed_findings = _dedupe(executed_findings)
+    alarm = bool(executed_findings or recreated or missing_roots)
+    payload = {
+        "ts": time.time(),
+        "verdict": "ALARM" if alarm else "OK",
+        "entries": len(entries),
+        "executed": len(executed_findings),
+        "findings": executed_findings[:50],
+        "recreated": _dedupe(recreated),
+        "missing_roots": _dedupe(missing_roots),
+        "warnings": _dedupe(list(WARNINGS)),
+    }
+    _write_watch_cache(config_dir, payload)
+    return payload
+
+
+def print_watch(payload):
+    print("relocate-watch")
+    print("  recorded moves watched: %d" % payload["entries"])
+    if payload["entries"] == 0:
+        print("  (no relocations recorded in the manifest — nothing to watch)")
+    for w in payload.get("warnings", []):
+        print("  WARN: " + w)
+    if payload["recreated"]:
+        print("\nRECREATED old path(s) — a real directory reappeared (a hardcoded old path mkdir'd it):")
+        for p in payload["recreated"]:
+            print("  - " + p)
+    if payload["missing_roots"]:
+        print("\nMISSING relocated vault root(s) — not where the manifest says (FAIL-LOUD):")
+        for p in payload["missing_roots"]:
+            print("  - " + p)
+    print("\nEXECUTED residual reference(s) to an old path (%d):" % payload["executed"])
+    if not payload["findings"]:
+        print("  (none)")
+    for loc in payload["findings"]:
+        print("  - " + loc)
+    print("\nVERDICT: " + payload["verdict"])
+    if payload["verdict"] == "ALARM":
+        print("  Drift detected. Repoint the executed references / remove the recreated folder, then re-run.")
+    else:
+        print("  No drift — every recorded move is clean.")
+
+
+def run_watch_selftest():
+    """Negative + positive controls for mode 2 (a guard earns trust only by failing on
+    the thing it catches): a planted recreated dir, a planted executed residual, and a
+    missing vault root MUST each alarm; a clean tree MUST NOT. Hermetic — temp dirs
+    only, fictional paths, no network, no real ~/dev."""
+    import shutil
+    import tempfile
+    global WARNINGS
+    failures = []
+
+    def _case(name, setup, expect_alarm):
+        tmp = tempfile.mkdtemp(prefix="relocate-watch-selftest-")
+        try:
+            cfg = os.path.join(tmp, "config")
+            scan = os.path.join(tmp, "scan")
+            old = os.path.join(tmp, "old-vault")
+            new = os.path.join(tmp, "new-vault")
+            os.makedirs(cfg)
+            os.makedirs(scan)
+            os.makedirs(new)
+            setup(old, new, scan)
+            manifest = [{"old": old, "new": new, "symlink": os.path.islink(old), "at": "selftest"}]
+            Path(os.path.join(cfg, "relocations.json")).write_text(json.dumps(manifest))
+            WARNINGS = []
+            args = SimpleNamespace(config_dir=cfg, root=[scan], dev_root=os.path.join(tmp, "nodev"),
+                                   no_auto_discover=True, include_worktrees=False, claude_json=None)
+            payload = run_watch(args)
+            got = payload["verdict"] == "ALARM"
+            ok = got == expect_alarm
+            print("  [%s] %s: alarm=%s expected=%s" % ("ok" if ok else "FAIL", name, got, expect_alarm))
+            if not ok:
+                failures.append(name)
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def _recreate(old, new, scan):
+        os.makedirs(old)  # a real directory at the old path = a recreator ran
+
+    def _residual(old, new, scan):
+        Path(os.path.join(scan, "recreator.sh")).write_text('#!/bin/bash\nmkdir -p "%s/sub"\n' % old)
+
+    def _missing(old, new, scan):
+        shutil.rmtree(new)  # the relocated vault root is gone
+
+    _case("clean tree (must NOT alarm)", lambda old, new, scan: None, False)
+    _case("recreated old dir (MUST alarm)", _recreate, True)
+    _case("executed residual ref (MUST alarm)", _residual, True)
+    _case("missing vault root (MUST alarm, fail-loud)", _missing, True)
+
+    if failures:
+        print("WATCH SELF-TEST FAILED (%d): %s" % (len(failures), ", ".join(failures)))
+        return 1
+    print("WATCH SELF-TEST OK: alarms fire on recreator/residual/missing-root; clean tree stays green.")
+    return 0
+
+
 def main(argv=None):
-    ap = argparse.ArgumentParser(add_help=True, description="code-repo-aware vault-relocation residual sweep")
-    ap.add_argument("--old", required=True)
+    ap = argparse.ArgumentParser(add_help=True, description="code-repo-aware vault-relocation residual sweep + watchdog")
+    ap.add_argument("--old", default=None)
     ap.add_argument("--new", default=None)
+    ap.add_argument("--watch", action="store_true",
+                    help="mode 2: watch the manifest's recorded move(s) for drift; alarm + write a verdict cache")
+    ap.add_argument("--watch-selftest", action="store_true",
+                    help="run the mode-2 negative/positive controls (planted recreator/residual/missing-root), then exit")
     ap.add_argument("--root", action="append", default=[])
     ap.add_argument("--dev-root", default=str(HOME / "dev"))
     ap.add_argument("--config-dir", default=os.environ.get("CLAUDE_CONFIG_DIR", str(HOME / ".claude")))
@@ -800,6 +1030,20 @@ def main(argv=None):
     global READ_TIMEOUT
     READ_TIMEOUT = args.read_timeout
 
+    # mode 2: the ongoing watchdog (manifest-driven, no --old).
+    if args.watch_selftest:
+        return run_watch_selftest()
+    if args.watch:
+        payload = run_watch(args)
+        if args.json:
+            print(json.dumps(payload, indent=2))
+        else:
+            print_watch(payload)
+        return 1 if payload["verdict"] == "ALARM" else 0
+
+    # mode 1: the one-shot sweep.
+    if not args.old:
+        ap.error("--old is required for the sweep (or use --watch / --watch-selftest)")
     rep = build_report(args)
     if args.json:
         print(json.dumps(rep, indent=2))

--- a/scripts/relocate-vault.sh
+++ b/scripts/relocate-vault.sh
@@ -165,6 +165,44 @@ migrate_claude_state() {  # $1=old-abs  $2=new-abs
   fi
 }
 
+# ---- record the move in the relocation manifest (the watchdog's source of truth) ---
+# scripts/relocate-sweep.py --watch reads $CONFIG_DIR/relocations.json to learn which
+# (old,new) move(s) to watch for drift back to the old path — NEVER a hardcoded literal,
+# so a paying install passes its own move and this one passes ours. Upsert keyed on
+# `old`. Non-fatal by construction: a manifest hiccup must never fail a real relocation.
+record_relocation() {  # $1=old-abs  $2=new-abs  $3=symlink(0|1)
+  local old="$1" new="$2" symlink="$3"
+  local manifest="$CONFIG_DIR/relocations.json"
+  if [ "$DRYRUN" = 1 ]; then
+    say "  · would record the move in $manifest (the watchdog reads this)"
+    return 0
+  fi
+  mkdir -p "$CONFIG_DIR" 2>/dev/null || true
+  if python3 - "$manifest" "$old" "$new" "$symlink" <<'PY'
+import json, os, sys, tempfile, time
+manifest, old, new, symlink = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4] == "1"
+try:
+    data = json.load(open(manifest)) if os.path.isfile(manifest) else []
+    if not isinstance(data, list):
+        data = []
+except (OSError, ValueError):
+    data = []
+data = [e for e in data if not (isinstance(e, dict) and e.get("old") == old)]  # upsert by old
+data.append({"old": old, "new": new, "symlink": symlink,
+             "at": time.strftime("%Y-%m-%dT%H:%M:%S%z")})
+d = os.path.dirname(manifest) or "."
+fd, tmp = tempfile.mkstemp(dir=d, prefix=".relocations.")
+with os.fdopen(fd, "w") as f:
+    json.dump(data, f, indent=2)
+os.replace(tmp, manifest)
+PY
+  then
+    say "  · recorded the move in $manifest (scripts/relocate-sweep.py --watch reads this)"
+  else
+    warn "could not record the move in $manifest (the watchdog will not see it until recorded)"
+  fi
+}
+
 # =============================================================================
 # state-only mode: the vault is already at the new path; just fix Claude history
 # =============================================================================
@@ -177,6 +215,8 @@ if [ "$MIGRATE_ONLY" = 1 ]; then
   NEW_ABS="$(abspath "$NEW")"
   say "relocate-vault: migrating Claude Code state only ($OLD_ABS -> $NEW_ABS)"
   migrate_claude_state "$OLD_ABS" "$NEW_ABS"
+  SYM=0; if [ -L "$OLD_ABS" ]; then SYM=1; fi
+  record_relocation "$OLD_ABS" "$NEW_ABS" "$SYM"
   exit 0
 fi
 
@@ -219,6 +259,7 @@ if [ "$DROP" = 1 ]; then
     exit 0
   fi
   rm "$OLD"
+  record_relocation "$OLD" "$NEW" 0
   say "relocate-vault: retired the symlink '$OLD' — sweep returned GO (zero executed references)."
   exit 0
 fi
@@ -262,6 +303,8 @@ if [ "$DRYRUN" = 1 ]; then
   say "DRY  would: mv '$OLD_ABS' -> '$NEW_ABS'"
   [ "$NOSYMLINK" = 1 ] || say "DRY  would: ln -s '$NEW_ABS' '$OLD_ABS'"
   migrate_claude_state "$OLD_ABS" "$NEW_ABS"
+  SYM=1; if [ "$NOSYMLINK" = 1 ]; then SYM=0; fi
+  record_relocation "$OLD_ABS" "$NEW_ABS" "$SYM"
   say "DRY-RUN complete — no changes made."
   exit 0
 fi
@@ -282,6 +325,9 @@ fi
 
 say "relocate-vault: migrating Claude Code session history + agent memory ..."
 migrate_claude_state "$OLD_ABS" "$NEW_ABS"
+
+SYM=1; if [ "$NOSYMLINK" = 1 ]; then SYM=0; fi
+record_relocation "$OLD_ABS" "$NEW_ABS" "$SYM"
 
 say ""
 say "relocate-vault: DONE."

--- a/scripts/test-relocate-watch.py
+++ b/scripts/test-relocate-watch.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""Integration + negative-control suite for the vault-relocation WATCHDOG (mode 2).
+
+Exercises the whole delivery chain end to end, hermetically (temp dirs, fictional
+paths, no network, no real ~/dev, no real ~/.claude):
+
+  - relocate-vault.sh records the move in the manifest; relocate-sweep.py --watch reads it
+  - ALARM fires on: a recreated old directory, an executed residual reference, a missing
+    relocated vault root (fail-loud), and an old-path ref in a `.env` file (SCAN_EXTS parity)
+  - a clean tree stays green (no false alarm)
+  - hooks/relocate-watch-surface.py surfaces a systemMessage on drift, stays quiet otherwise,
+    and is WALK-FREE (passes audit-sessionstart-boundedness.py --check)
+  - the engine's own --watch-selftest controls pass
+
+A guard earns trust only by failing on the thing it catches — every ALARM case here is
+a planted defect the watch MUST flag. Run: python3 scripts/test-relocate-watch.py
+(also wired into scripts/ci.sh as the named integration test `test_relocate_watch`).
+"""
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SWEEP = ROOT / "scripts" / "relocate-sweep.py"
+VAULT_SH = ROOT / "scripts" / "relocate-vault.sh"
+SURFACE = ROOT / "hooks" / "relocate-watch-surface.py"
+AUDIT = ROOT / "scripts" / "audit-sessionstart-boundedness.py"
+
+PASS = 0
+FAIL = 0
+
+
+def ok(msg):
+    global PASS
+    PASS += 1
+    print(f"PASS  {msg}")
+
+
+def bad(msg, detail=""):
+    global FAIL
+    FAIL += 1
+    print(f"FAIL  {msg} :: {detail}")
+
+
+def _run(cmd, **kw):
+    return subprocess.run(cmd, capture_output=True, text=True, **kw)
+
+
+def _watch(cfg, *extra):
+    return _run([sys.executable, str(SWEEP), "--watch", "--config-dir", cfg, *extra])
+
+
+def _write_manifest(cfg, old, new, symlink=False):
+    Path(cfg, "relocations.json").write_text(
+        json.dumps([{"old": old, "new": new, "symlink": symlink, "at": "test"}])
+    )
+
+
+def _cache(cfg):
+    try:
+        return json.loads(Path(cfg, "relocate-watch-state.json").read_text())
+    except (OSError, ValueError):
+        return None
+
+
+def _surfacer(cfg):
+    env = dict(os.environ, CLAUDE_CONFIG_DIR=cfg, RELOCATE_WATCH_SURFACE_NO_REFRESH="1")
+    return _run([sys.executable, str(SURFACE)], input="{}", env=env)
+
+
+def _tmp():
+    return tempfile.mkdtemp(prefix="test-relocate-watch-")
+
+
+# --------------------------------------------------------------------------- #
+# 1. engine in-script controls
+# --------------------------------------------------------------------------- #
+def case_engine_selftest():
+    r = _run([sys.executable, str(SWEEP), "--watch-selftest"])
+    if r.returncode == 0 and "WATCH SELF-TEST OK" in r.stdout:
+        ok("engine --watch-selftest controls pass")
+    else:
+        bad("engine --watch-selftest", r.stdout + r.stderr)
+
+
+# --------------------------------------------------------------------------- #
+# 2. no manifest → clean no-op
+# --------------------------------------------------------------------------- #
+def case_no_manifest():
+    t = _tmp()
+    try:
+        cfg = os.path.join(t, "cfg")
+        os.makedirs(cfg)
+        r = _watch(cfg, "--no-auto-discover")
+        if r.returncode == 0 and "nothing to watch" in r.stdout:
+            ok("no manifest → clean no-op (exit 0)")
+        else:
+            bad("no manifest no-op", f"rc={r.returncode} {r.stdout}")
+    finally:
+        shutil.rmtree(t, ignore_errors=True)
+
+
+# --------------------------------------------------------------------------- #
+# 3. relocate-vault.sh writes the manifest; watch reads it CLEAN
+# --------------------------------------------------------------------------- #
+def case_relocate_roundtrip():
+    t = _tmp()
+    try:
+        cfg = os.path.join(t, "cfg")
+        old = os.path.join(t, "Old Vault")
+        new = os.path.join(t, "NewVault")
+        os.makedirs(os.path.join(old, "sub"))
+        Path(old, "sub", "a.md").write_text("x")
+        r = _run(["bash", str(VAULT_SH), old, new, "--force", "--config-dir", cfg])
+        manifest = os.path.join(cfg, "relocations.json")
+        if r.returncode != 0 or not os.path.isfile(manifest):
+            bad("relocate-vault writes manifest", f"rc={r.returncode} {r.stdout} {r.stderr}")
+            return
+        data = json.loads(Path(manifest).read_text())
+        if not (data and data[0]["new"] == os.path.abspath(new) and data[0]["symlink"] is True):
+            bad("manifest content", json.dumps(data))
+            return
+        ok("relocate-vault.sh records the move in relocations.json")
+        # old is now the symlink relocate-vault left; new exists → CLEAN
+        w = _watch(cfg, "--no-auto-discover")
+        if w.returncode == 0 and "VERDICT: OK" in w.stdout:
+            ok("watch reads manifest → CLEAN after a real relocation (old=symlink, new exists)")
+        else:
+            bad("watch clean after relocate", f"rc={w.returncode} {w.stdout}")
+    finally:
+        shutil.rmtree(t, ignore_errors=True)
+
+
+# --------------------------------------------------------------------------- #
+# 4. NEG: a recreated old directory → ALARM
+# --------------------------------------------------------------------------- #
+def case_recreated_alarms():
+    t = _tmp()
+    try:
+        cfg = os.path.join(t, "cfg")
+        old = os.path.join(t, "old-vault")
+        new = os.path.join(t, "new-vault")
+        os.makedirs(cfg)
+        os.makedirs(new)
+        os.makedirs(old)  # a REAL directory at the old path = a recreator ran
+        _write_manifest(cfg, old, new)
+        w = _watch(cfg, "--no-auto-discover")
+        c = _cache(cfg)
+        if w.returncode == 1 and c and c["verdict"] == "ALARM" and c["recreated"]:
+            ok("NEG control: recreated old dir → ALARM (exit 1) + cache records it")
+        else:
+            bad("recreated alarm", f"rc={w.returncode} cache={c}")
+    finally:
+        shutil.rmtree(t, ignore_errors=True)
+
+
+# --------------------------------------------------------------------------- #
+# 5. NEG: an executed residual reference under a scan root → ALARM
+# --------------------------------------------------------------------------- #
+def case_executed_residual_alarms():
+    t = _tmp()
+    try:
+        cfg = os.path.join(t, "cfg")
+        scan = os.path.join(t, "scan")
+        old = os.path.join(t, "old-vault")
+        new = os.path.join(t, "new-vault")
+        os.makedirs(cfg)
+        os.makedirs(scan)
+        os.makedirs(new)
+        # old absent (symlink dropped); a shell command still hardcodes it = recreator-in-waiting
+        Path(scan, "recreator.sh").write_text('#!/bin/bash\nmkdir -p "%s/sub"\n' % old)
+        _write_manifest(cfg, old, new)
+        w = _watch(cfg, "--no-auto-discover", "--root", scan)
+        c = _cache(cfg)
+        if w.returncode == 1 and c and c["verdict"] == "ALARM" and c["executed"] >= 1:
+            ok("NEG control: executed residual ref → ALARM (exit 1)")
+        else:
+            bad("executed residual alarm", f"rc={w.returncode} cache={c}")
+    finally:
+        shutil.rmtree(t, ignore_errors=True)
+
+
+# --------------------------------------------------------------------------- #
+# 6. .env / .envrc SCAN_EXTS parity — an old-path ref in a config-env file
+# --------------------------------------------------------------------------- #
+def case_env_parity_alarms():
+    t = _tmp()
+    try:
+        cfg = os.path.join(t, "cfg")
+        scan = os.path.join(t, "scan")
+        old = os.path.join(t, "old-vault")
+        new = os.path.join(t, "new-vault")
+        os.makedirs(cfg)
+        os.makedirs(scan)
+        os.makedirs(new)
+        Path(scan, "app.env").write_text('VAULT_ROOT="%s"\n' % old)   # .env in scope now
+        Path(scan, ".envrc").write_text('export VAULT="%s"\n' % old)  # .envrc too
+        _write_manifest(cfg, old, new)
+        w = _watch(cfg, "--no-auto-discover", "--root", scan)
+        c = _cache(cfg)
+        if w.returncode == 1 and c and c["executed"] >= 1:
+            ok("file-type parity: old-path ref in a .env/.envrc → ALARM")
+        else:
+            bad(".env parity alarm", f"rc={w.returncode} cache={c}")
+    finally:
+        shutil.rmtree(t, ignore_errors=True)
+
+
+# --------------------------------------------------------------------------- #
+# 7. fail-loud: a missing relocated vault root → ALARM
+# --------------------------------------------------------------------------- #
+def case_missing_root_failloud():
+    t = _tmp()
+    try:
+        cfg = os.path.join(t, "cfg")
+        old = os.path.join(t, "old-vault")
+        new = os.path.join(t, "gone-vault")  # never created
+        os.makedirs(cfg)
+        _write_manifest(cfg, old, new)
+        w = _watch(cfg, "--no-auto-discover")
+        c = _cache(cfg)
+        if w.returncode == 1 and c and c["missing_roots"]:
+            ok("fail-loud: missing relocated vault root → ALARM")
+        else:
+            bad("missing-root fail-loud", f"rc={w.returncode} cache={c}")
+    finally:
+        shutil.rmtree(t, ignore_errors=True)
+
+
+# --------------------------------------------------------------------------- #
+# 8. SessionStart surfacer behaviour
+# --------------------------------------------------------------------------- #
+def case_surfacer():
+    # 8a. no manifest → quiet
+    t = _tmp()
+    try:
+        cfg = os.path.join(t, "cfg")
+        os.makedirs(cfg)
+        r = _surfacer(cfg)
+        if '"suppressOutput": true' in r.stdout and "systemMessage" not in r.stdout:
+            ok("surfacer: no manifest → quiet")
+        else:
+            bad("surfacer quiet (no manifest)", r.stdout)
+    finally:
+        shutil.rmtree(t, ignore_errors=True)
+
+    # 8b. recreated old dir → systemMessage
+    t = _tmp()
+    try:
+        cfg = os.path.join(t, "cfg")
+        old = os.path.join(t, "old-vault")
+        new = os.path.join(t, "new-vault")
+        os.makedirs(cfg)
+        os.makedirs(new)
+        os.makedirs(old)
+        _write_manifest(cfg, old, new)
+        r = _surfacer(cfg)
+        if "systemMessage" in r.stdout and "RECREATED" in r.stdout:
+            ok("surfacer: recreated old dir → systemMessage")
+        else:
+            bad("surfacer systemMessage (recreated)", r.stdout)
+    finally:
+        shutil.rmtree(t, ignore_errors=True)
+
+    # 8c. clean (old absent) + fresh OK cache → quiet
+    t = _tmp()
+    try:
+        cfg = os.path.join(t, "cfg")
+        old = os.path.join(t, "old-vault")  # never created
+        new = os.path.join(t, "new-vault")
+        os.makedirs(cfg)
+        os.makedirs(new)
+        _write_manifest(cfg, old, new)
+        Path(cfg, "relocate-watch-state.json").write_text(
+            json.dumps({"ts": 9999999999, "verdict": "OK", "executed": 0,
+                        "findings": [], "recreated": [], "missing_roots": []})
+        )
+        r = _surfacer(cfg)
+        if '"suppressOutput": true' in r.stdout and "systemMessage" not in r.stdout:
+            ok("surfacer: clean tree + OK cache → quiet")
+        else:
+            bad("surfacer quiet (clean)", r.stdout)
+    finally:
+        shutil.rmtree(t, ignore_errors=True)
+
+
+# --------------------------------------------------------------------------- #
+# 9. the surfacer is WALK-FREE (bounded for SessionStart)
+# --------------------------------------------------------------------------- #
+def case_surfacer_bounded():
+    if not AUDIT.is_file():
+        ok("boundedness audit absent — skipped (CI enforces)")
+        return
+    r = _run([sys.executable, str(AUDIT), "--check", str(SURFACE)])
+    if r.returncode == 0:
+        ok("surfacer passes audit-sessionstart-boundedness --check (walk-free)")
+    else:
+        bad("surfacer boundedness", r.stdout + r.stderr)
+
+
+def main():
+    case_engine_selftest()
+    case_no_manifest()
+    case_relocate_roundtrip()
+    case_recreated_alarms()
+    case_executed_residual_alarms()
+    case_env_parity_alarms()
+    case_missing_root_failloud()
+    case_surfacer()
+    case_surfacer_bounded()
+    print(f"\n{PASS} passed, {FAIL} failed")
+    return 1 if FAIL else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/vault-daily-maintenance.sh
+++ b/scripts/vault-daily-maintenance.sh
@@ -170,6 +170,14 @@ RULECONF="$SCRIPT_DIR/check-rule-conflicts.py"
 PASSIVE="$SCRIPT_DIR/passive-capture.py"
 [ -f "$PASSIVE" ] && VAULT_ROOT="$VAULT" run "passive-capture" /usr/bin/env python3 "$PASSIVE" --scan-today
 
+# Vault-relocation watchdog (mode 2): scan the install's recorded move(s) for drift
+# back to an old path (executed residuals / recreated old dir / missing vault root).
+# Heavy (auto-discovers ~/dev + the vault at canonical ref) so it lives here, not on
+# SessionStart. Writes the verdict cache the SessionStart surfacer reads; a no-op when
+# no relocation was ever recorded. rc=1 (ALARM) is logged, never fatal (set +e + run).
+RELOCWATCH="$SCRIPT_DIR/relocate-sweep.py"
+[ -f "$RELOCWATCH" ] && run "relocate-watch" /usr/bin/env python3 "$RELOCWATCH" --watch
+
 close_mutex_release
 log "=== vault-daily-maintenance COMPLETE @ $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
 exit 0

--- a/tests/integration/test_relocate_watch.sh
+++ b/tests/integration/test_relocate_watch.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# CI integration wrapper — runs the relocate-WATCH (mode 2) integration + negative-
+# control suite (scripts/test-relocate-watch.py) as part of scripts/ci.sh. Thin: the
+# logic lives next to the engine it exercises. python3 (not bash) because the watch,
+# the manifest, the surfacer hook, and the boundedness check are Python — JSON,
+# subprocess-driving the bash relocate-vault.sh, and exit-code assertions.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+exec python3 "$ROOT/scripts/test-relocate-watch.py"


### PR DESCRIPTION
Productizes the personal vault-relocation recreator guard into the open substrate (SUBSTRATE-IS-PRODUCT). One engine, two modes — no second engine, no hand-kept root list.

**What ships**
- `relocate-sweep.py` gains `--watch` (mode 2): reads the install's own move(s) from a manifest, reuses the existing discovery + classification, and ALARMS on an executed residual reference, a recreated old directory, or a missing relocated vault root (fail-loud). Writes a verdict cache.
- `relocate-vault.sh` records every move (relocate / state-migrate / drop-symlink) in `relocations.json` under the config dir — never a hardcoded literal, so each install passes its own move.
- `relocate-watch-surface.py` (new SessionStart hook, wired in `hooks.json`) is the visible half: WALK-FREE by construction (one stat per move + cached verdict + a cooldown-stamped, single-spawn, detached refresh), so it passes `audit-sessionstart-boundedness`.
- `vault-daily-maintenance.sh` runs the heavy `--watch` scan in its resource-gated cron.
- `.env`/`.envrc` added to `SCAN_EXTS` (file-type parity).

**Negative control** — `relocate-sweep.py --watch-selftest` and the new `test_relocate_watch` suite plant a recreated dir, an executed residual, a `.env` ref, and a missing root: each MUST alarm, a clean tree MUST stay green, and the surfacer MUST be bounded. Full `ci.sh` green (py_compile 265 + 48 integration tests + shellcheck 129).

`[scope-overlap-check: overlap]` siblings: MYC-605 #1 (scope self-discovery) absorbed; MYC-713 (vault-root SSOT) parallel; MYC-1743 (MCP-repo cleanup) separated.
`[umbrella-route: shipping-code]`

Generated with [Claude Code](https://claude.com/claude-code) for MYC-1749.
