### PR TITLE
fix(relocate-sweep): KEEP anti-recreator assertions (MYC-1749 follow-up)

### DIFF
--- a/scripts/relocate-sweep.py
+++ b/scripts/relocate-sweep.py
@@ -132,9 +132,13 @@ KEEP_BASENAMES = {"relocate-vault.sh", "relocate-sweep.py", "relocate-machinery-
                   "check-desktop-path-recreators.py"}
 KEEP_PATH_TOKENS = ("scrub-or-die", "gh-harden-repos", "personal-pii-scrub", "/docs/superpowers/")
 # A line carrying one of these is an intentional KEEP regardless of file type:
-#   relocate-keep  → explicit marker;  OLD=/NEW= → a migration source assignment;
-#   .exists()/-e   → a guarded ref that no-ops once the path is gone.
-KEEP_LINE_RE = re.compile(r"relocate-keep|^\s*(OLD|NEW)=|\.exists\(\)|os\.path\.exists|\[\s+-[ed]\s")
+#   relocate-keep    → explicit marker;  OLD=/NEW= → a migration source assignment;
+#   .exists()/-e     → a guarded ref that no-ops once the path is gone;
+#   assert … not in  → an ANTI-recreator: a test asserting the old path is ABSENT from a
+#                      default/config is the OPPOSITE of a recreator, so flagging it would
+#                      teach bypass. Narrow by construction — a real recreator line is an
+#                      assignment / mkdir, never an `assert … not in`.
+KEEP_LINE_RE = re.compile(r"relocate-keep|^\s*(OLD|NEW)=|\.exists\(\)|os\.path\.exists|\[\s+-[ed]\s|\bassert\b.*\bnot in\b")
 # JSON keys whose subtree is an inert string-MATCHER list, not executable config.
 INERT_JSON_KEYS = {"permissions"}
 

--- a/scripts/test-relocate-sweep.py
+++ b/scripts/test-relocate-sweep.py
@@ -164,6 +164,12 @@ def main() -> int:
         "#!/usr/bin/env bash\n"
         'OLD="' + OLD + '"  # relocate-keep: migration source\n'
     )
+    # KEEP: an anti-recreator assertion (asserts the old path is ABSENT) is the
+    # OPPOSITE of a recreator — must not be flagged as executed.
+    (fsroot / "antiassert.py").write_text(
+        "def _default_root():\n    return '/somewhere/else'\n\n"
+        'assert "' + OLD + '" not in str(_default_root())\n'
+    )
 
     # ---------------------------------------------------------------------
     # Root 2: a git repo where origin/main CARRIES the ref but the checked-out
@@ -251,6 +257,8 @@ def main() -> int:
     # ---- CLASSIFY: KEEP --------------------------------------------------
     k = klass_of(obj, "keepme.sh")
     (pass_ if k == "keep" else fail)(f"KEEP: relocate-keep-marked line (keepme.sh) -> {k}")
+    ka = klass_of(obj, "antiassert.py")
+    (pass_ if ka == "keep" else fail)(f"KEEP: anti-recreator `assert ... not in` line (antiassert.py) -> {ka}")
     # The inert permissions matcher in .claude.json must be KEEP, not EXECUTED.
     # Match on the semantic `reason` field, NOT the snippet: a finding's snippet is
     # path-length-fragile (a compact one-line JSON or a long tmp path can push an


### PR DESCRIPTION
Precision fix surfaced by the MYC-1749 watchdog's first real dogfood run: it flagged a vault-root SSOT test's `assert "<oldpath>" not in default_root()` as an executed residual. That assertion asserts the old path is ABSENT — the opposite of a recreator — so alarming on it teaches bypass.

Adds `assert ... not in` to `KEEP_LINE_RE`. Narrow by construction: a real recreator line is an assignment / `mkdir`, never an `assert ... not in`. Negative control in `test-relocate-sweep.py`; verified a real recreator line still classifies EXECUTED.

Generated with [Claude Code](https://claude.com/claude-code) for MYC-1749.
