### PR TITLE
fix(relocate-sweep): single-instance lock on --watch (freeze-class blind spot)

### DIFF
--- a/scripts/relocate-sweep.py
+++ b/scripts/relocate-sweep.py
@@ -821,6 +821,31 @@ def watch_cache_path(config_dir):
     return os.path.join(config_dir, "relocate-watch-state.json")
 
 
+def acquire_watch_lock(config_dir):
+    """Single-instance lock for --watch. The SessionStart surfacer spawns --watch
+    detached when its cache is stale; several sessions starting at once (3 panes in
+    the morning) would otherwise launch N concurrent ~/dev+vault CORPUS WALKS — the
+    MYC-570 freeze class (4 concurrent walks pegged a Mac to load 36). The cooldown
+    stamp narrows the window but has a read-then-write race; this flock closes it at
+    the engine, covering EVERY caller (surfacer spawn + cron) at once.
+
+    Returns (handle, should_run): keep `handle` open for the process lifetime (the OS
+    releases it on exit). should_run False = another --watch already holds it → skip
+    cleanly. On a platform without fcntl (Windows) there is no lock — run anyway and
+    lean on the cooldown stamp, so the watch is never silently dead there."""
+    try:
+        import fcntl
+    except ImportError:
+        return None, True
+    try:
+        os.makedirs(config_dir, exist_ok=True)
+        fh = open(os.path.join(config_dir, ".relocate-watch.lock"), "w")
+        fcntl.flock(fh, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return fh, True
+    except OSError:
+        return None, False
+
+
 def read_manifest(config_dir):
     """The install's OWN relocation record, written by relocate-vault.sh: a list of
     {old, new, symlink, at}. Missing → [] (a never-relocated install has nothing to
@@ -1038,6 +1063,12 @@ def main(argv=None):
     if args.watch_selftest:
         return run_watch_selftest()
     if args.watch:
+        _lock, should_run = acquire_watch_lock(args.config_dir)
+        if not should_run:
+            # Another --watch is already scanning — skip rather than stack a second
+            # concurrent corpus walk (the MYC-570 freeze class). Not an alarm; exit 0.
+            print("relocate-watch: another scan is already running — skipping this one.")
+            return 0
         payload = run_watch(args)
         if args.json:
             print(json.dumps(payload, indent=2))

--- a/scripts/test-relocate-watch.py
+++ b/scripts/test-relocate-watch.py
@@ -302,8 +302,43 @@ def case_surfacer_bounded():
         bad("surfacer boundedness", r.stdout + r.stderr)
 
 
+def case_single_instance_lock():
+    # The surfacer spawns --watch detached; several sessions starting at once must NOT
+    # stack N concurrent corpus walks (the MYC-570 freeze class). A held lock → skip.
+    try:
+        import fcntl
+    except ImportError:
+        ok("single-instance lock — skipped (no fcntl on this platform)")
+        return
+    t = _tmp()
+    try:
+        cfg = os.path.join(t, "cfg")
+        old = os.path.join(t, "old-vault")
+        new = os.path.join(t, "new-vault")
+        os.makedirs(cfg)
+        os.makedirs(new)
+        _write_manifest(cfg, old, new)
+        lock = open(os.path.join(cfg, ".relocate-watch.lock"), "w")
+        fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)  # hold it
+        r = _watch(cfg, "--no-auto-discover")
+        if r.returncode == 0 and "skipping" in r.stdout:
+            ok("single-instance lock: a concurrent --watch skips (no stacked corpus walk)")
+        else:
+            bad("single-instance lock skip", f"rc={r.returncode} {r.stdout}")
+        fcntl.flock(lock, fcntl.LOCK_UN)
+        lock.close()
+        r2 = _watch(cfg, "--no-auto-discover")  # released → next run proceeds
+        if r2.returncode == 0 and "recorded moves watched" in r2.stdout and "skipping" not in r2.stdout:
+            ok("single-instance lock: released → the next --watch runs")
+        else:
+            bad("single-instance lock release", f"rc={r2.returncode} {r2.stdout}")
+    finally:
+        shutil.rmtree(t, ignore_errors=True)
+
+
 def main():
     case_engine_selftest()
+    case_single_instance_lock()
     case_no_manifest()
     case_relocate_roundtrip()
     case_recreated_alarms()


### PR DESCRIPTION
Closes a freeze-class blind spot in the watchdog shipped in #242. The SessionStart surfacer spawns `relocate-sweep.py --watch` detached when its cache is stale. The cooldown stamp narrows but does not close a **read-then-write race**: several sessions starting at once read the stale stamp before any writes it, and each spawns a full `~/dev`+vault corpus walk — N concurrent walks, the MYC-570 freeze class (4 walks → load 36 → Mac freeze). `audit-sessionstart-boundedness.py` can't catch it because it scans the hook's own source for `os.walk`, not what the hook spawns.

Fix at the engine: a `flock` single-instance lock so N concurrent `--watch` invocations collapse to 1 (the rest exit 0, "skipping") — covering the surfacer spawn AND the cron. Windows (no `fcntl`) runs unlocked so the watch is never silently dead there. Deterministic concurrency test added.

Generated with [Claude Code](https://claude.com/claude-code) for MYC-1749.
