### PR TITLE
fix(vault-backup): make encrypted setup work on a fresh box and surface the real error (MYC-1804)

### DIFF
--- a/scripts/test-vault-backup-roundtrip.sh
+++ b/scripts/test-vault-backup-roundtrip.sh
@@ -73,12 +73,21 @@ left=$(ls -1 "$DEST"/vault-backup-* 2>/dev/null | wc -l | tr -d ' ')
 if command -v gpg >/dev/null 2>&1 || command -v openssl >/dev/null 2>&1; then
   V2="$ROOT/Brain2"; DEST2="$ROOT/dest2"
   mkdir -p "$V2"; printf '# CLAUDE.md\n' > "$V2/CLAUDE.md"; printf 'secret journal\n' > "$V2/secret.md"
+  # Hermetic passphrase store: bypass the real OS keychain and keep the 0600 fallback
+  # file inside $ROOT, so the encrypted leg does not depend on a keychain service or
+  # on ~/.claude existing — the env-correlated flake fixed in MYC-1804.
+  export VAULT_BACKUP_PASS_DIR="$ROOT/passdir"; mkdir -p "$VAULT_BACKUP_PASS_DIR"
+  # Capture setup output: on failure, surface the REAL encryption error instead of an
+  # empty archive path (it used to be swallowed by >/dev/null 2>&1, undiagnosable in CI).
+  setup_log="$ROOT/encrypt-setup.log"
   # Feed the passphrase twice on stdin (setup reads it with read -rs).
-  printf 'pw-correct-horse\npw-correct-horse\n' | bash "$BACKUP" setup --vault "$V2" --dest "$DEST2" --encrypt --schedule none >/dev/null 2>&1
+  printf 'pw-correct-horse\npw-correct-horse\n' | bash "$BACKUP" setup --vault "$V2" --dest "$DEST2" --encrypt --schedule none >"$setup_log" 2>&1
   enc="$(ls -1 "$DEST2"/vault-backup-* 2>/dev/null | head -1)"
   case "$enc" in
     *.tar.gz.gpg|*.tar.gz.enc) pass "encrypted archive written ($(basename "$enc"))" ;;
-    *) fail "encrypted archive not produced: $enc" ;;
+    *) fail "encrypted archive not produced: $enc"
+       echo "      --- setup --encrypt output (the real error) ---"
+       sed 's/^/      /' "$setup_log" ;;
   esac
   # The encrypted blob must NOT contain the plaintext.
   if grep -qa "secret journal" "$enc" 2>/dev/null; then fail "plaintext leaked into encrypted archive"; else pass "ciphertext does not contain plaintext"; fi

--- a/scripts/vault-backup.sh
+++ b/scripts/vault-backup.sh
@@ -29,6 +29,9 @@
 #
 # Config:  ~/.claude/.vault-backup.conf  (JSON, keyed by resolved vault path)
 # Marker:  ~/.claude/.vault-backup-last  (ISO8601 of the last successful run)
+# Pass dir: VAULT_BACKUP_PASS_DIR overrides where the 0600 passphrase-fallback file
+#           lives AND bypasses the OS keychain. Used by the round-trip self-test to
+#           stay hermetic and not depend on ~/.claude existing. Defaults to ~/.claude.
 set -uo pipefail
 
 CONF="${VAULT_BACKUP_CONF:-$HOME/.claude/.vault-backup.conf}"
@@ -115,20 +118,33 @@ resolve_vault() { # echoes resolved vault path; dies if not a dir
 }
 
 # ---------- passphrase (keychain-backed) ----------
-store_passphrase() { # <slug> <passphrase>
+store_passphrase() { # <slug> <passphrase>  -> store-kind on stdout; non-zero on failure
   local acct="$1" pass="$2"
-  if command -v security >/dev/null 2>&1; then        # macOS Keychain
-    security add-generic-password -a "$acct" -s "$KEYCHAIN_SERVICE" -w "$pass" -U >/dev/null 2>&1 \
-      && { echo "keychain"; return 0; }
+  # VAULT_BACKUP_PASS_DIR set => use a 0600 file in that dir and bypass the OS
+  # keychain entirely. Keeps the round-trip self-test hermetic (no real keychain
+  # write, no dependence on ~/.claude pre-existing) and exercises the same
+  # file-store path CI uses on Linux. (MYC-1804)
+  if [ -z "${VAULT_BACKUP_PASS_DIR:-}" ]; then
+    if command -v security >/dev/null 2>&1; then        # macOS Keychain
+      security add-generic-password -a "$acct" -s "$KEYCHAIN_SERVICE" -w "$pass" -U >/dev/null 2>&1 \
+        && { echo "keychain"; return 0; }
+    fi
+    if command -v secret-tool >/dev/null 2>&1; then      # Linux libsecret
+      printf '%s' "$pass" | secret-tool store --label="$KEYCHAIN_SERVICE" \
+        service "$KEYCHAIN_SERVICE" account "$acct" >/dev/null 2>&1 \
+        && { echo "secret-tool"; return 0; }
+    fi
   fi
-  if command -v secret-tool >/dev/null 2>&1; then      # Linux libsecret
-    printf '%s' "$pass" | secret-tool store --label="$KEYCHAIN_SERVICE" \
-      service "$KEYCHAIN_SERVICE" account "$acct" >/dev/null 2>&1 \
-      && { echo "secret-tool"; return 0; }
-  fi
-  # Fallback: 0600 file. Loud about it — this is weaker than a keychain.
-  local pf="$HOME/.claude/.vault-backup-pass-$acct"
-  ( umask 077; printf '%s' "$pass" > "$pf" )
+  # Fallback: 0600 file. Loud about it — this is weaker than a keychain. Ensure the
+  # parent dir exists and FAIL LOUD if the write does not land. Silently reporting
+  # success here (the old bug) made `setup --encrypt` produce no archive on a fresh
+  # box with no ~/.claude, and the real error got swallowed downstream. (MYC-1804)
+  local store_dir="${VAULT_BACKUP_PASS_DIR:-$HOME/.claude}"
+  local pf="$store_dir/.vault-backup-pass-$acct"
+  mkdir -p "$store_dir" 2>/dev/null \
+    || { warn "could not create passphrase store dir: $store_dir" >&2; return 1; }
+  ( umask 077; printf '%s' "$pass" > "$pf" ) \
+    || { warn "could not write passphrase file: $pf" >&2; return 1; }
   warn "No OS keychain found; passphrase stored in $pf (chmod 600). A keychain is safer." >&2
   echo "file:$pf"
 }
@@ -248,7 +264,9 @@ cmd_setup() {
     read -rs p2; echo
     [ -n "$p1" ] || die "empty passphrase"
     [ "$p1" = "$p2" ] || die "passphrases do not match"
-    store_kind="$(store_passphrase "$slug" "$p1")"
+    store_kind="$(store_passphrase "$slug" "$p1")" \
+      || die "could not store backup passphrase (see error above)"
+    [ -n "$store_kind" ] || die "could not store backup passphrase (empty store kind)"
     ok "Passphrase stored ($store_kind). Daily runs read it from there, no prompt."
   fi
 


### PR DESCRIPTION
Fixes the ci-gate flake in MYC-1804 where the encrypted round-trip in `test-vault-backup-roundtrip.sh` false-reds on PRs that never touch backup.

## Root cause

`store_passphrase`'s 0600 file fallback wrote to `$HOME/.claude/...` without creating `~/.claude` first, then reported success even when that write failed. On a CI runner with no `~/.claude` and no OS keychain, `setup --encrypt` therefore stored no passphrase, `make_archive` could not read one and `die`d, so no encrypted archive was produced. The real error was swallowed by three layers of `>/dev/null` (the test, `make_archive`'s gpg pipe, and `die`'s stderr), which is why it read as an undiagnosable flake.

It is env-correlated: it passes wherever `~/.claude` already exists (the maintainer's laptop, hence the green local `ci-test`) and fails where it does not (a fresh runner). The gpg `--pinentry-mode loopback` flag the ticket hypothesized was already present, so that was not the cause.

## Fix

- `store_passphrase` `mkdir -p`s the store dir and fails loud (returns non-zero) when the write does not land, rather than echoing a `file:` kind on a failed write.
- `cmd_setup` aborts with `die` when the passphrase store fails or returns empty.
- New `VAULT_BACKUP_PASS_DIR` env relocates the fallback file and bypasses the OS keychain, so the self-test is hermetic: no dependence on `~/.claude` existing, no real keychain write, no passphrase-file litter on dev machines. Default behavior is unchanged when it is unset.
- `test-vault-backup-roundtrip.sh` sets `VAULT_BACKUP_PASS_DIR` to a temp dir and captures the `setup --encrypt` output, printing it on failure so the real encryption error surfaces instead of an empty archive path.

## Proof

Reproduced and fixed in `ubuntu:24.04` (the CI OS) with no `~/.claude`:

- full round-trip passes deterministically (encrypted archive produced and restored);
- a negative control that sabotages `gpg` now fails with `gpg encryption failed` printed inside the captured block, instead of an empty path.

`scripts/shellcheck.sh` is clean across all tracked scripts; `test_vault_safety_guards` is green on both Linux and macOS.

Bug class: `REQUIRED-GATE-FLAKES-ON-UNRELATED-ENV-CORRELATED-TEST`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
