### PR TITLE
fix(vault-backup): surface the real gpg/openssl/tar error on failure + negative-control the fail-loud (MYC-1804)

### DIFF
--- a/scripts/test-vault-backup-roundtrip.sh
+++ b/scripts/test-vault-backup-roundtrip.sh
@@ -93,6 +93,25 @@ if command -v gpg >/dev/null 2>&1 || command -v openssl >/dev/null 2>&1; then
   if grep -qa "secret journal" "$enc" 2>/dev/null; then fail "plaintext leaked into encrypted archive"; else pass "ciphertext does not contain plaintext"; fi
   vout="$(bash "$BACKUP" verify --vault "$V2" 2>&1)"
   echo "$vout" | grep -q "Restore verified" && pass "encrypted backup restores" || fail "encrypted restore failed: $vout"
+
+  # ---- 7b. NEGATIVE CONTROL: setup --encrypt must FAIL LOUD when the passphrase
+  #          store cannot be written (the silent-success bug fixed in MYC-1804).
+  #          Point VAULT_BACKUP_PASS_DIR at a path whose parent is a regular file so
+  #          mkdir -p fails; setup must abort non-zero, produce NO archive, and name
+  #          the real cause — never echo a false "Passphrase stored".
+  V3="$ROOT/Brain3"; DEST3="$ROOT/dest3"
+  mkdir -p "$V3"; printf '# CLAUDE.md\n' > "$V3/CLAUDE.md"
+  : > "$ROOT/not-a-dir"
+  neg_out="$(printf 'pw\npw\n' | VAULT_BACKUP_PASS_DIR="$ROOT/not-a-dir/sub" \
+    bash "$BACKUP" setup --vault "$V3" --dest "$DEST3" --encrypt --schedule none 2>&1)"; neg_rc=$?
+  if [ "$neg_rc" -ne 0 ] && [ -z "$(ls -1 "$DEST3"/vault-backup-* 2>/dev/null)" ]; then
+    pass "setup --encrypt fails loud on an unwritable passphrase store (rc=$neg_rc, no archive)"
+  else
+    fail "setup --encrypt did NOT fail loud on an unwritable store (rc=$neg_rc): $neg_out"
+  fi
+  printf '%s\n' "$neg_out" | grep -q "could not store backup passphrase\|could not create passphrase store dir\|could not write passphrase file" \
+    && pass "the failure names the real cause (passphrase store)" \
+    || fail "fail-loud message did not name the passphrase store: $neg_out"
 else
   echo "SKIP  encrypted round-trip (no gpg/openssl)"
 fi

--- a/scripts/vault-backup.sh
+++ b/scripts/vault-backup.sh
@@ -167,29 +167,37 @@ make_archive() { # <vault> <out-base-no-ext> <encrypt 0|1> <slug> <store-kind> -
   # Always exclude any prior archives that happen to live under the vault.
   excl+=("--exclude=./*.tar.gz" "--exclude=./*.tar.gz.gpg" "--exclude=./*.tar.gz.enc")
 
+  # Capture the encryption tool's stderr to a temp file so a failure surfaces the
+  # REAL error (gpg/openssl/tar) instead of dying with a bare "encryption failed".
+  # This is a BACKUP tool: a silent failure here is the difference between "I have
+  # backups" and data loss, so the failure path must be diagnosable for a real user,
+  # not just in the self-test. The passphrase is never written to stderr. (MYC-1804)
+  local errf; errf="$(mktemp)"
+  err_tail() { tr '\n' ' ' < "$errf" 2>/dev/null | sed 's/  */ /g; s/ *$//'; rm -f "$errf"; }
+
   if [ "$enc" = "1" ]; then
     local pass; pass="$(get_passphrase "$acct" "$kind")"
-    [ -n "$pass" ] || die "could not read backup passphrase from $kind"
+    [ -n "$pass" ] || { rm -f "$errf"; die "could not read backup passphrase from $kind"; }
     if command -v gpg >/dev/null 2>&1; then
       local out="$outbase.tar.gz.gpg"
       tar -cz "${excl[@]}" -C "$vault" . 2>/dev/null \
         | gpg --batch --yes --pinentry-mode loopback --passphrase "$pass" \
-              -c --cipher-algo AES256 -o "$out" 2>/dev/null \
-        && { echo "$out"; return 0; }
-      die "gpg encryption failed"
+              -c --cipher-algo AES256 -o "$out" 2>"$errf" \
+        && { rm -f "$errf"; echo "$out"; return 0; }
+      die "gpg encryption failed: $(err_tail)"
     elif command -v openssl >/dev/null 2>&1; then
       local out="$outbase.tar.gz.enc"
       tar -cz "${excl[@]}" -C "$vault" . 2>/dev/null \
-        | openssl enc -aes-256-cbc -pbkdf2 -salt -pass "pass:$pass" -out "$out" 2>/dev/null \
-        && { echo "$out"; return 0; }
-      die "openssl encryption failed"
+        | openssl enc -aes-256-cbc -pbkdf2 -salt -pass "pass:$pass" -out "$out" 2>"$errf" \
+        && { rm -f "$errf"; echo "$out"; return 0; }
+      die "openssl encryption failed: $(err_tail)"
     else
-      die "--encrypt needs gpg or openssl; neither found"
+      rm -f "$errf"; die "--encrypt needs gpg or openssl; neither found"
     fi
   else
     local out="$outbase.tar.gz"
-    tar -czf "$out" "${excl[@]}" -C "$vault" . 2>/dev/null && { echo "$out"; return 0; }
-    die "tar failed"
+    tar -czf "$out" "${excl[@]}" -C "$vault" . 2>"$errf" && { rm -f "$errf"; echo "$out"; return 0; }
+    die "tar failed: $(err_tail)"
   fi
 }
 


### PR DESCRIPTION
Follow-up to #246 (MYC-1804). Closes the same swallowed-error class one layer down, in the production encryption path, and adds the negative control the new fail-loud behavior was missing in-repo.

## Why

#246 fixed the silent failure at the test layer (capture-on-failure). But `make_archive` itself still piped gpg/openssl/tar to `2>/dev/null`, so a real user whose `setup --encrypt` failed for any reason (agent issue, disk full, bad cipher) got a bare `gpg encryption failed` with no cause. For a backup tool, an opaque failure is the difference between "I have backups" and data loss.

## Change

- `make_archive` captures the encryption tool's stderr to a temp file and includes it in the `die` message on all three paths (gpg, openssl, plain tar). The success path behavior is unchanged; the passphrase is never written to stderr.
- `test-vault-backup-roundtrip.sh` adds negative control `7b`: `setup --encrypt` with an unwritable `VAULT_BACKUP_PASS_DIR` must abort non-zero, produce no archive, and name the cause, proving the fail-loud from #246 actually fires (a guard earns trust only by failing on the thing it catches).

## Proof

Verified in `ubuntu:24.04` (the CI OS): full round-trip + `7b` pass; a sabotaged gpg now dies with `gpg encryption failed: SABOTAGE-gpg-boom: agent refused` instead of a bare message. `shellcheck.sh` clean; green on Linux and macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
