### PR TITLE
fix(session-lock): GIT_DIR= env in the coarse multi-line -m branch (MYC-323 parity)

### DIFF
--- a/hooks/session-lock.py
+++ b/hooks/session-lock.py
@@ -618,6 +618,22 @@ def _is_home_repo_git_mutation(command, cwd, main_root):
                     continue
                 if os.path.isabs(gpath) and not _in_home(os.path.normpath(gpath)):
                     continue  # explicit git-dir at a different repo → not this lock's business
+            # GIT_DIR= env form lands here too under a multi-line -m. ANCHOR it to the
+            # leading env-assignment block BEFORE `git` (env vars must precede the
+            # command) so a GIT_DIR= appearing only INSIDE the message can't
+            # false-ALLOW a real home commit — the worst failure for this gate.
+            mge = re.search(
+                r"^\s*(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*GIT_DIR=(\S+)"
+                r"(?:\s+[A-Za-z_][A-Za-z0-9_]*=\S+)*\s+"
+                r"(?:env\s+|command\s+|sudo\s+|exec\s+|nohup\s+|builtin\s+)*git\b",
+                seg,
+            )
+            if mge:
+                gpath = _expand(mge.group(1).strip("\"'"))
+                if "$" in gpath:
+                    continue  # unresolvable GIT_DIR ($VAR) → fail open
+                if os.path.isabs(gpath) and not _in_home(os.path.normpath(gpath)):
+                    continue  # GIT_DIR at a different repo → not this lock's business
             if cwd_known and _in_home(effective_cwd) and re.search(r"\bgit\b", seg) and re.search(
                 r"\b(commit|push|checkout|switch|merge|rebase|reset|cherry-pick|"
                 r"revert|pull|am|apply)\b", seg

--- a/hooks/test_session_lock_enforcement.py
+++ b/hooks/test_session_lock_enforcement.py
@@ -108,6 +108,15 @@ CASES = [
     ("multi-line -m commit in home -> block (coarse)", ML, HOME, HOME, True),
     ("multi-line -m + -C cross-repo -> allow (coarse -C escape)", ML_C, HOME, HOME, False),
     ("multi-line -m + $VAR -C -> allow (coarse $VAR escape)", ML_VAR_C, HOME, HOME, False),
+    # --- GIT_DIR= env form in the coarse multi-line -m branch ---
+    ("GIT_DIR= env + multi-line, cross-repo -> allow (coarse mge)",
+     'GIT_DIR=/home/other/.git git commit -m "l1\nl2"', HOME, HOME, False),
+    ("GIT_DIR= env + multi-line, home -> block (coarse)",
+     'GIT_DIR=/home/proj/.git git commit -m "l1\nl2"', HOME, HOME, True),
+    ("FOO=bar GIT_DIR= prefix + multi-line, cross-repo -> allow",
+     'FOO=bar GIT_DIR=/home/other/.git git commit -m "l1\nl2"', HOME, HOME, False),
+    ("GIT_DIR= only INSIDE the message -> still blocks home commit (no false-ALLOW)",
+     'git commit -m "ref GIT_DIR=/home/other/.git here\nl2"', HOME, HOME, True),
 ]
 
 for label, cmd, cwd, home, want in CASES:


### PR DESCRIPTION
## What
Follow-up to #245. Canonical `session-lock.py` advanced one commit (a `GIT_DIR=` env handler for the coarse multi-line `-m` branch) right after #245's resolver matched the prior canonical. This ports it so the public hook stays at **full parity** rather than lagging by one fix.

## Why
`GIT_DIR=/other/.git git commit -m "<multi-line>"` drops to the coarse unbalanced-quote branch (a multi-line message makes the newline-splitter emit an unbalanced-quote segment). That branch honored `--git-dir` but not the `GIT_DIR=` env form → false-block of a legitimate cross-repo commit while a sibling is live. Multi-line commit messages are the norm, so this fires routinely.

## Safety
The `GIT_DIR=` match is **anchored to the leading env-assignment block before `git`** (env vars must precede the command), so a `GIT_DIR=` appearing only *inside* the commit message can't false-ALLOW a real home commit — the worst failure mode for this gate. A negative-control assertion pins it.

## Verification
- Resolver unit suite: **50/50** (+4: GIT_DIR= multi-line cross-repo allow, home block, `FOO=bar GIT_DIR=` prefix allow, message-mention false-ALLOW guard).
- `test_session_coordination_guards.sh`: **33/33**. py_compile + scrub clean.
- `_is_home_repo_git_mutation` is now code-identical to canonical (scrubbed comments aside).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
