### PR TITLE
fix(windows): JSON-escape [VAULT_PATH] so backslashes don't break hook install

### DIFF
--- a/scripts/install-hooks-user-level.py
+++ b/scripts/install-hooks-user-level.py
@@ -224,10 +224,13 @@ def normalize_path_substitutions(template: dict, vault_path: str | None) -> dict
                 # the now-empty event rather than leave a bare "Event": [].
                 del pruned["hooks"][event]
         s = json.dumps(pruned, ensure_ascii=False)
-        s = s.replace("[VAULT_PATH]", str(Path.home()))
+        # JSON-escape the substitution so Windows backslashes (C:\Users\...)
+        # don't break json.loads with invalid \U / \a escape sequences. (local fix)
+        s = s.replace("[VAULT_PATH]", json.dumps(str(Path.home()))[1:-1])
         return json.loads(s)
     s = json.dumps(template, ensure_ascii=False)
-    s = s.replace("[VAULT_PATH]", str(Path(vault_path).resolve()))
+    # JSON-escape the substitution so Windows backslashes don't break parsing. (local fix)
+    s = s.replace("[VAULT_PATH]", json.dumps(str(Path(vault_path).resolve()))[1:-1])
     return json.loads(s)
 
 


### PR DESCRIPTION
## Problem

On Windows, `scripts/install-hooks-user-level.py` substitutes `[VAULT_PATH]` with a path like `C:\Users\name\…` into a JSON string and then calls `json.loads()` on it. The unescaped backslashes form invalid JSON escape sequences (`\U`, `\n`, `\a`, …), so `json.loads` raises:

```
json.decoder.JSONDecodeError: Invalid \escape: line 1 column 249 (char 248)
```

The hook installer aborts with exit 1, so the meeting trigger and the `UserPromptSubmit` hooks **silently never get wired** on Windows. The bootstrap reports the hook step failed, but a non-technical user has no way to fix it.

## Fix

JSON-escape the substituted path with `json.dumps(path)[1:-1]` for both the home-dir and vault-path substitutions, so backslashes are emitted as `\` and `json.loads` parses cleanly.

```python
s = s.replace("[VAULT_PATH]", json.dumps(str(Path.home()))[1:-1])
...
s = s.replace("[VAULT_PATH]", json.dumps(str(Path(vault_path).resolve()))[1:-1])
```

No-op on macOS/Linux (forward slashes need no escaping).

## Why it matters

This bug has recurred across updates for Windows users carrying the fix as a local uncommitted change — every `bootstrap` stashes it and the bug returns. Landing it upstream makes it permanent.

## Test

`python install-hooks-user-level.py` on Windows: before → `JSONDecodeError`; after → hooks merged into `settings.json` (verified: 19 added, 23 updated).