### PR TITLE
feat(guard): public-template-purity structural plane (MYC-1765)

### DIFF
--- a/.github/workflows/template-purity.yml
+++ b/.github/workflows/template-purity.yml
@@ -1,0 +1,33 @@
+name: template-purity
+#
+# Fails any PR/push that lands POPULATED personal data (a real floor / deal /
+# counterparty / amount / tenant-id) in a public-bound skill file. The STRUCTURAL
+# isolation plane (MYC-1765 — Jackie's 2nd veto plane), complementary to
+# personal-pii-scrub.yml: that workflow catches NAMES + vault paths; this one
+# catches populated typed-category SHAPES that carry no name.
+#
+# Repo-native guard (NOT auto-managed by gh-harden-repos.sh). The logic lives in
+# scripts/check-template-purity.py + hooks/_lib/template_purity.py so the identical
+# check runs locally pre-push, in the write-time hook, and here in CI — one source
+# of truth (the open-core-boundary.yml pattern). No untrusted input is referenced
+# in any run: command.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  purity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: "3.9"
+      - name: Check public-template-purity (MYC-1765)
+        run: python3 scripts/check-template-purity.py --skills

--- a/hooks.json
+++ b/hooks.json
@@ -150,6 +150,11 @@
           },
           {
             "type": "command",
+            "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/block-populated-public-skill.py 2>/dev/null || echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"allow\"}}'",
+            "statusMessage": "Checking template purity (populated data in a public skill)..."
+          },
+          {
+            "type": "command",
             "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/warn-learning-to-tool-private-memory.py 2>/dev/null || echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"allow\"}}'",
             "statusMessage": "Checking memory routing (team learning vs tool-private)..."
           }

--- a/hooks/_lib/template_purity.py
+++ b/hooks/_lib/template_purity.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Public-template-purity detection — the STRUCTURAL isolation plane (MYC-1765).
+
+Companion to `.github/workflows/personal-pii-scrub.yml`. That workflow blocks
+personal NAME tokens + vault paths from public source. This module blocks the
+OTHER leak class: POPULATED typed-category content that carries no name and so
+slips a name-scrub entirely — a real floor entry, a real deal / counterparty /
+amount, a real tenant/entity id sealed into a public-bound skill template.
+
+Two-layer property (CLAUDE.md "two isolation planes"; MYC-1733 Jackie veto):
+this module is STRUCTURAL. It detects the SHAPE of populated personal data — a
+typed frontmatter field whose value is *real* rather than a placeholder —
+WITHOUT embedding any person's name, deal, or floor vocabulary. It ships in the
+public substrate so every client's data is protected the same way; the
+name-specific scrub stays in the private layer (personal-pii-scrub.yml). The
+two planes are non-overlapping: names → that workflow; populated shapes → here.
+
+Used by (single source of truth — adding a detector here covers both surfaces):
+- `scripts/check-template-purity.py`        — CLI / CI / pre-push gate
+- `hooks/block-populated-public-skill.py`   — PreToolUse write-time guard
+
+Python 3.9 compatible (hooks run via the system /usr/bin/python3).
+
+Threat model + limitations: this plane defends against ACCIDENTAL commits of real
+personal data into public templates, not a crafted bypass. It parses markdown
+`key: value` frontmatter/body lines (incl. YAML list items). Known v1 gaps,
+covered by defense-in-depth (personal-pii-scrub.yml name-scrub + human review):
+inline-JSON-embedded values (`{"floor": "Courage"}`), >8-space deep nesting, and
+a value deliberately prefixed with a placeholder wrapper (`<x>Courage`). Widen
+the parser when a real leak shape demands it; do not pre-harden against crafted
+evasion at the cost of false positives that self-DoS public pushes.
+
+Self-test: `python3 hooks/_lib/template_purity.py --selftest` (exit 0 = green).
+"""
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Violation:
+    """One populated typed-category leak found in a scanned text.
+
+    `rule` names the detector; `field` is the schema key (or "entity_id" for the
+    standalone id detector); `excerpt` is a short, safe slice for the report;
+    `line` is 1-based.
+    """
+
+    rule: str
+    field: str
+    excerpt: str
+    line: int
+
+
+# Typed frontmatter/body keys whose POPULATED value is per-person private data.
+# These are SCHEMA field names (every client's journal has a `floor:`; every
+# tenant record has an `entity_id:`), NOT any individual's data — so listing them
+# here embeds no one's private content. A populated value of one of these in a
+# public-bound template IS the leak this plane exists to stop.
+TYPED_FIELDS = frozenset({
+    # personal-scope journal schema (daily-journal / rise / coaching / insights)
+    "floor", "floor_level", "floor_name",
+    # deal / sales / investor schema (sales-pipeline / investor-draft / finance)
+    "counterparty", "deal", "deal_name", "investor", "investors",
+    "amount", "valuation", "arr", "mrr", "check_size",
+    # governance / legal schema
+    "board", "board_members", "advisor", "advisors",
+    # runtime tenancy schema (the sealed-corpus identity keys)
+    "entity_id", "tid", "tenant_id", "personal_owner_user_id",
+    # advisory-panel schema
+    "panel", "advisory_panel", "panelists",
+})
+
+# A value is a PLACEHOLDER (template-pure) if empty or one of these literal
+# tokens (exact match or leading token), case-insensitive.
+_PLACEHOLDER_TOKENS = (
+    "example", "placeholder", "todo", "fixme", "tbd", "xxx", "fill in",
+    "fill-in", "fill_in", "n/a", "na", "none", "null", "sample", "redacted",
+    "your value here", "your floor", "your reflection here", "lorem ipsum",
+    "foo", "bar", "baz",
+)
+
+# Floor-family schema slot-descriptors. In a `floor:` field these are
+# documentation of the SHAPE ("the primary floor", "the secondary floor"), never
+# a real floor name (Courage / Peace / Willingness / ...). Scoped to floor fields
+# ONLY: a real `counterparty: Primary Health Inc` must still flag. Generic English
+# slot words — embeds no personal floor vocabulary (two-layer principle holds).
+_FLOOR_FIELDS = frozenset({"floor", "floor_level", "floor_name"})
+_FLOOR_META_LABELS = ("primary", "secondary", "tertiary")
+
+# Structural placeholder shapes: <angle>, {{mustache}}, {brace}, [bracket]
+# wrappers; $X / $<amount> / $0 money placeholders; tnt_EXAMPLE-style ids; the
+# bare `Low|Middle|High` enum that documents the floor_level field itself.
+_PLACEHOLDER_RE = re.compile(
+    r"""^\s*(?:
+        <[^>]*>                                   # <placeholder>
+      | \{\{[^}]*\}\}                             # {{mustache}}
+      | \{[^}]*\}                                 # {brace}
+      | \[[^\]]*\]                                # [bracket]
+      | \$<[^>]*>                                 # $<amount>
+      | \$x+                                      # $X / $XX
+      | \$n+(?:[,.]?n{2,3})*                       # $N / $NNN / $N,NNN
+      | \$0+(?:[.,]0+)?                            # $0 / $0.00
+      | \$_+                                       # $___
+      | _+                                        # ___
+      | -{2,}                                      # ---
+      | \.{3,}                                     # ...
+      | (?:tnt|usr|tid)_(?:example|x+|placeholder|id|abc+|0+)  # id placeholders
+      | low\s*\|\s*middle\s*\|\s*high              # the floor_level enum doc
+    )\s*$""",
+    re.IGNORECASE | re.VERBOSE,
+)
+
+# A real tenant/entity/user id token, wherever it appears (frontmatter OR body
+# prose). `tnt_a1b2c3` leaks even under a non-schema key or in a sentence.
+_ENTITY_ID_RE = re.compile(r"\b(?:tnt|usr|tid)_[A-Za-z0-9]{4,}\b")
+_ENTITY_ID_PLACEHOLDER_RE = re.compile(
+    r"^(?:tnt|usr|tid)_(?:example|x+|placeholder|id|abc+|0+|nnn+)$", re.IGNORECASE)
+
+# `key: value`, with an optional leading YAML list marker so list-item typed
+# fields (`  - floor: Courage`) are caught, not just top-level keys.
+_FIELD_RE = re.compile(r"^\s{0,8}(?:-\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.*?)\s*$")
+
+
+def _strip_inline_comment(value: str) -> str:
+    """Drop a YAML-style inline ` # ...` comment. A documented schema line
+    (`floor: Primary  # single floor name`) classifies on the bare value, so the
+    comment text never makes a value look real — but a real value with a comment
+    (`floor: Courage  # felt brave`) still classifies on `Courage` and flags."""
+    idx = value.find(" #")
+    return value[:idx].rstrip() if idx != -1 else value
+
+
+def is_placeholder(value: str, field: str = "") -> bool:
+    """True if `value` is empty or a template placeholder (not real data).
+
+    `field` (a lowercased schema key) enables field-scoped placeholder rules:
+    floor-family slot-descriptors count as placeholders only under a floor field.
+    """
+    v = _strip_inline_comment(value).strip().strip("\"'").strip()
+    if not v:
+        return True
+    if _PLACEHOLDER_RE.match(v):
+        return True
+    if v[0] in "<{[":  # any wrapped placeholder, even with trailing prose
+        return True
+    low = v.lower()
+    for tok in _PLACEHOLDER_TOKENS:
+        if low == tok or low.startswith(tok + " ") or low.startswith(tok + "-"):
+            return True
+    if field in _FLOOR_FIELDS:
+        for tok in _FLOOR_META_LABELS:
+            if low == tok or low.startswith(tok + " ") or low.startswith(tok + "/"):
+                return True
+    return False
+
+
+def _entity_id_is_placeholder(token: str) -> bool:
+    return bool(_ENTITY_ID_PLACEHOLDER_RE.match(token))
+
+
+def scan_text(text: str) -> list[Violation]:
+    """Return every template-purity violation in `text`. Empty list = pure."""
+    out: list[Violation] = []
+    for i, line in enumerate(text.splitlines(), start=1):
+        m = _FIELD_RE.match(line)
+        if m:
+            key, value = m.group(1).lower(), m.group(2)
+            if key in TYPED_FIELDS and not is_placeholder(value, key):
+                out.append(Violation(
+                    rule="populated-typed-field", field=key,
+                    excerpt=("%s: %s" % (key, value))[:120], line=i))
+                continue  # one finding per line; skip the id-anywhere pass
+        for mm in _ENTITY_ID_RE.finditer(line):
+            tok = mm.group(0)
+            if not _entity_id_is_placeholder(tok):
+                out.append(Violation(
+                    rule="real-entity-id", field="entity_id",
+                    excerpt=tok, line=i))
+    return out
+
+
+def scan_file(path: str) -> list[Violation]:
+    """Scan a file's text. Unreadable file → a fail-closed sentinel violation."""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return scan_text(f.read())
+    except (OSError, UnicodeDecodeError) as e:
+        return [Violation(rule="unreadable", field="-",
+                          excerpt="cannot read (%s)" % e.__class__.__name__, line=0)]
+
+
+# ── self-test (gates regressions; mirrors _lib/secret_patterns.py discipline) ──
+# Each case: (label, text, expect_violation). A populated shape MUST flag; a
+# placeholder shape MUST NOT. This is the negative-control corpus in code form.
+_SELFTEST_CASES = (
+    # POPULATED — must flag
+    ("floor populated", "floor: Courage", True),
+    ("floor_level populated", "floor_level: High", True),
+    ("counterparty populated", "counterparty: Northwind Logistics LLC", True),
+    ("amount populated", "amount: $36,000", True),
+    ("valuation populated", "valuation: $1,200,000", True),
+    ("entity_id populated (frontmatter)", "entity_id: tnt_a1b2c3d4", True),
+    ("tenant id in prose", "the tenant tnt_9f8e7d6c signed today", True),
+    ("investor populated", "investor: Acme Ventures", True),
+    ("panel populated", "panel: a named real advisor", True),
+    # PLACEHOLDER / template — must NOT flag
+    ("floor angle ph", "floor: <floor-name>", False),
+    ("floor_level enum doc", "floor_level: <Low|Middle|High>", False),
+    ("floor_level bare enum", "floor_level: Low|Middle|High", False),
+    ("amount dollar-angle ph", "amount: $<amount>", False),
+    ("amount $X ph", "amount: $X", False),
+    ("amount zero ph", "amount: $0", False),
+    ("counterparty angle ph", "counterparty: <counterparty-name>", False),
+    ("entity_id angle ph", "entity_id: <tid>", False),
+    ("entity_id example ph", "entity_id: tnt_EXAMPLE", False),
+    ("entity_id xxx ph", "entity_id: tnt_xxxx", False),
+    ("empty value", "floor:", False),
+    ("EXAMPLE token", "counterparty: EXAMPLE", False),
+    ("TODO token", "amount: TODO", False),
+    ("floor schema-doc slot-label", "floor: Primary  # single floor name (or [Primary, Secondary])", False),
+    ("floor real WITH comment still flags", "floor: Courage  # felt brave today", True),
+    ("counterparty starting Primary still flags", "counterparty: Primary Health Inc", True),
+    ("yaml list-item typed field flags", "  - floor: Courage", True),
+    ("yaml list-item placeholder passes", "  - floor: <floor-name>", False),
+    ("non-typed key ignored", "stage: signed", False),
+    ("non-typed key with $ ignored", "price: $1,500", False),  # pricing is public
+    ("prose dollar not gated", "Plans start at $1,200,000 for enterprise.", False),
+    ("brace mustache ph", "investor: {{investor_name}}", False),
+)
+
+
+def _selftest() -> int:
+    failures = []
+    for label, text, expect in _SELFTEST_CASES:
+        got = bool(scan_text(text))
+        if got != expect:
+            failures.append("  [%s] %r expected violation=%s got=%s"
+                            % (label, text, expect, got))
+    if failures:
+        print("template_purity self-test FAILED (%d):" % len(failures))
+        print("\n".join(failures))
+        return 1
+    print("template_purity self-test OK (%d cases)" % len(_SELFTEST_CASES))
+    return 0
+
+
+if __name__ == "__main__":
+    if "--selftest" in sys.argv:
+        sys.exit(_selftest())
+    # bare invocation scans files named on argv (convenience)
+    rc = 0
+    for arg in sys.argv[1:]:
+        vs = scan_file(arg)
+        for v in vs:
+            print("%s:%d  %s  %s" % (arg, v.line, v.rule, v.excerpt))
+            rc = 1
+    sys.exit(rc)

--- a/hooks/block-populated-public-skill.py
+++ b/hooks/block-populated-public-skill.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Block writing POPULATED personal data into a public-bound skill file —
+PreToolUse(Write|Edit|MultiEdit). The write-time half of MYC-1765 (Jackie's 2nd
+isolation plane).
+
+personal-pii-scrub.yml catches NAMES + vault paths at commit time. This catches
+the OTHER class at WRITE time: a real floor / deal / counterparty / amount /
+tenant-id introduced into a public-repo skill template — content that carries no
+name and so slips the name-scrub. Detection logic is shared with the CI gate via
+hooks/_lib/template_purity.py (one source of truth, no drift).
+
+Scope: markdown skill files (`*/skills/*.md|.mdx|.markdown`) under a PUBLIC
+substrate root. Scoping is a POSITIVE allowlist of public roots (default: the
+public substrate repo's own name) — never an exclusion list of private paths,
+which would both leak a private name into public source and break the two-layer
+principle. Extend via TEMPLATE_PURITY_PUBLIC_ROOTS (colon-separated substrings)
+for other public Mycelium-HQ repos. Private/local skill repos legitimately hold
+real data and simply don't match a public root, so they're out of scope. The CI
+gate (--skills, run inside the public repo) is the authoritative backstop; this
+hook is the early, write-time convenience block.
+
+Only blocks data being INTRODUCED: for an Edit it scans the new text, so scrubbing
+real data OUT of a public skill is never blocked.
+
+Bypass: TEMPLATE_PURITY_BYPASS=1  (self-referential docs: this hook, the detector
+module, a doc quoting a populated example, CLAUDE.md).
+
+WIRING (PreToolUse, matcher "Write|Edit|MultiEdit"):
+  {"type": "command",
+   "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/block-populated-public-skill.py 2>/dev/null || echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"allow\"}}'"}
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+HOOK_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(HOOK_DIR))
+
+try:
+    from _lib.template_purity import scan_text
+except Exception:
+    scan_text = None  # fail-open below
+
+NOTE_EXTS = {".md", ".mdx", ".markdown"}
+# Public substrate root(s) whose skill markdown ships publicly. POSITIVE
+# allowlist by the public repo's own name (public, so naming it here leaks
+# nothing). Private/local skill repos simply don't match and are out of scope.
+_DEFAULT_PUBLIC_ROOTS = ("ai-brain-starter",)
+
+
+def _public_roots() -> tuple:
+    extra = os.environ.get("TEMPLATE_PURITY_PUBLIC_ROOTS", "")
+    return _DEFAULT_PUBLIC_ROOTS + tuple(r for r in extra.split(":") if r.strip())
+
+
+def _allow() -> int:
+    print(json.dumps({"hookSpecificOutput": {
+        "hookEventName": "PreToolUse", "permissionDecision": "allow"}}))
+    return 0
+
+
+def _deny(reason: str) -> int:
+    print(json.dumps({"hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": reason}}))
+    return 0
+
+
+def _is_public_skill_path(fp: str) -> bool:
+    if "/skills/" not in fp:
+        return False
+    if Path(fp).suffix.lower() not in NOTE_EXTS:
+        return False
+    return any(root in fp for root in _public_roots())
+
+
+def main() -> int:
+    if os.environ.get("TEMPLATE_PURITY_BYPASS") == "1" or scan_text is None:
+        return _allow()
+    try:
+        data = json.loads(sys.stdin.read() or "{}")
+    except json.JSONDecodeError:
+        return _allow()
+
+    ti = data.get("tool_input") or {}
+    fp = ti.get("file_path") or ti.get("path") or ""
+    if not _is_public_skill_path(fp):
+        return _allow()
+
+    # Only the text being INTRODUCED (Write.content / Edit new strings). Scanning
+    # new text means scrubbing real data OUT of a public skill is never blocked.
+    chunks: list[str] = []
+    if "content" in ti:
+        chunks.append(str(ti.get("content") or ""))
+    if "new_string" in ti:
+        chunks.append(str(ti.get("new_string") or ""))
+    for e in ti.get("edits") or []:
+        chunks.append(str((e or {}).get("new_string") or ""))
+    text = "\n".join(chunks)
+    if not text.strip():
+        return _allow()
+
+    violations = scan_text(text)
+    if violations:
+        v = violations[0]
+        more = (" (+%d more)" % (len(violations) - 1)) if len(violations) > 1 else ""
+        return _deny(
+            "Blocked: this write would put POPULATED personal data into the "
+            "public skill '%s' — %s '%s' (L%d)%s. Open artifacts must be empty "
+            "templates: use a placeholder (<floor-name>, $<amount>, tnt_<id>, "
+            "EXAMPLE). The name-scrub catches names; this catches populated "
+            "shapes (MYC-1765). If this is a self-referential doc/example, set "
+            "TEMPLATE_PURITY_BYPASS=1 for this write."
+            % (Path(fp).name, v.rule, v.excerpt, v.line, more)
+        )
+    return _allow()
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        # Fail OPEN: a write-time convenience guard must never block legitimate
+        # writing on a bug. The CI gate (--skills) is the real backstop.
+        print(json.dumps({"hookSpecificOutput": {
+            "hookEventName": "PreToolUse", "permissionDecision": "allow"}}))
+        sys.exit(0)

--- a/scripts/check-template-purity.py
+++ b/scripts/check-template-purity.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""check-template-purity.py — public-template-purity gate (MYC-1765).
+
+The STRUCTURAL isolation plane: blocks POPULATED typed-category content (a real
+floor / deal / counterparty / amount / tenant-id) from public-bound skill files.
+Companion to personal-pii-scrub.yml (which catches NAMES + vault paths). The two
+planes are non-overlapping. Detection logic lives in hooks/_lib/template_purity.py
+so this CLI, CI, the local pre-push gate, and the write-time hook all share ONE
+source of truth and cannot drift (the open-core-boundary.sh / ci.sh pattern).
+
+Usage:
+  check-template-purity.py <file> [<file> ...]   # scan specific files
+  check-template-purity.py --skills              # scan all tracked skills/**/*.md (CI default)
+  check-template-purity.py --staged              # scan git-staged public-bound files (pre-push)
+
+Exit 0 = template-pure. Exit 1 = at least one populated file (each named with the
+offending line + reason). Exit 2 = usage / fail-closed error.
+
+Runs in: .github/workflows/template-purity.yml (CI) and locally pre-push.
+Python 3.9 compatible.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "hooks"))
+
+try:
+    from _lib.template_purity import Violation, scan_file
+except Exception as e:  # fail-closed: the guard must never silently no-op
+    print("TEMPLATE-PURITY ERROR: cannot import detector (%s)" % e, file=sys.stderr)
+    sys.exit(2)
+
+_SCAN_EXTS = (".md", ".mdx", ".markdown")
+
+
+def _git(args: list[str]) -> list[str]:
+    try:
+        out = subprocess.run(
+            ["git"] + args, cwd=str(REPO), capture_output=True, text=True, check=True
+        ).stdout
+    except (subprocess.CalledProcessError, OSError):
+        return []
+    return [ln for ln in out.splitlines() if ln.strip()]
+
+
+def _skills_files() -> list[str]:
+    files = _git(["ls-files", "--", "skills/"])
+    return [f for f in files if f.lower().endswith(_SCAN_EXTS)]
+
+
+def _staged_files() -> list[str]:
+    files = _git(["diff", "--cached", "--name-only", "--diff-filter=ACM", "--", "skills/"])
+    return [f for f in files if f.lower().endswith(_SCAN_EXTS)]
+
+
+def _report(findings: dict[str, list[Violation]]) -> None:
+    print("PUBLIC-TEMPLATE-PURITY VIOLATION (MYC-1765 — Jackie's 2nd isolation plane).",
+          file=sys.stderr)
+    print(file=sys.stderr)
+    print("These public-bound files carry POPULATED personal data where an empty",
+          file=sys.stderr)
+    print("template was required. Open artifacts must be templates, never real",
+          file=sys.stderr)
+    print("floors / deals / counterparties / amounts / tenant-ids:", file=sys.stderr)
+    print(file=sys.stderr)
+    for path in sorted(findings):
+        print("  %s" % path, file=sys.stderr)
+        for v in findings[path]:
+            loc = ("L%d" % v.line) if v.line else "-"
+            print("      %-5s %-22s %s" % (loc, v.rule, v.excerpt), file=sys.stderr)
+    print(file=sys.stderr)
+    print("Fix: replace the real value with a placeholder (<floor-name>, $<amount>,",
+          file=sys.stderr)
+    print("tnt_<id>, EXAMPLE, ...). The name-scrub (personal-pii-scrub.yml) covers",
+          file=sys.stderr)
+    print("names; this plane covers populated SHAPES. See docs / CLAUDE.md 'two",
+          file=sys.stderr)
+    print("isolation planes'.", file=sys.stderr)
+
+
+def main() -> int:
+    args = sys.argv[1:]
+    if not args:
+        print(__doc__.strip().splitlines()[0], file=sys.stderr)
+        print("usage: check-template-purity.py [--skills | --staged | <file> ...]",
+              file=sys.stderr)
+        return 2
+
+    if "--skills" in args:
+        targets = _skills_files()
+        # fail-closed: --skills must find a skills/ tree. An empty result means
+        # either no skills dir or a broken git invocation — never a silent pass.
+        if not targets and not (REPO / "skills").is_dir():
+            print("TEMPLATE-PURITY ERROR: --skills but no skills/ directory at %s" % REPO,
+                  file=sys.stderr)
+            return 2
+    elif "--staged" in args:
+        targets = _staged_files()
+    else:
+        targets = [a for a in args if not a.startswith("--")]
+        missing = [t for t in targets if not Path(t).exists()]
+        if missing:
+            for m in missing:
+                print("TEMPLATE-PURITY ERROR: file not found: %s" % m, file=sys.stderr)
+            return 2
+
+    findings: dict[str, list[Violation]] = {}
+    for path in targets:
+        vs = scan_file(path)
+        if vs:
+            findings[path] = vs
+
+    if findings:
+        _report(findings)
+        return 1
+
+    n = len(targets)
+    print("template-purity OK: %d public-bound file(s) are template-pure." % n)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as e:  # fail-closed
+        print("TEMPLATE-PURITY ERROR: %s" % e, file=sys.stderr)
+        sys.exit(2)

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -139,6 +139,7 @@ INTEGRATION_TESTS=(
   test_granola_core_shared
   test_agent_memory_link
   test_open_core_boundary
+  test_template_purity
   test_audited_content_injection_scan
   test_post_tool_use_learnings
 )

--- a/scripts/install-hooks-user-level.py
+++ b/scripts/install-hooks-user-level.py
@@ -83,6 +83,8 @@ ABS_FINGERPRINTS = [
     "ai-brain-starter/hooks/remediate-runaway-procs.py",
     # Write-time secret guard:
     "ai-brain-starter/hooks/block-secret-in-note.py",
+    # Write-time template-purity guard (MYC-1765, structural isolation plane):
+    "ai-brain-starter/hooks/block-populated-public-skill.py",
     # Context-budget measurer (always-loaded text layer; MYC-619):
     "ai-brain-starter/hooks/context-budget-measure.py",
     # Vault-in-worktree melt tripwire (3-channel detect; SessionStart + tool-time + dedup):
@@ -107,6 +109,7 @@ ABS_OWNED_BASENAMES = {
     "remove-ended-worktree.py", "enforce-worktree-cap.py",
     "worktree-footprint-signal.py", "remediate-runaway-procs.py",
     "block-secret-in-note.py", "context-budget-measure.py",
+    "block-populated-public-skill.py",
     "warn-vault-session-in-worktree.py", "warn-learning-to-tool-private-memory.py",
 }
 

--- a/tests/integration/test_template_purity.sh
+++ b/tests/integration/test_template_purity.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# tests/integration/test_template_purity.sh
+#
+# Verifies the public-template-purity guard (MYC-1765 — Jackie's 2nd isolation
+# plane). The guard is the STRUCTURAL complement to personal-pii-scrub.yml: that
+# workflow catches personal NAME tokens + vault paths; this one catches POPULATED
+# typed-category content (a real floor entry, a real deal/counterparty/amount, a
+# real entity_id) that carries NO name and so slips the name-scrub entirely.
+#
+# Three surfaces, one shared detection module (hooks/_lib/template_purity.py):
+#   1. scripts/check-template-purity.py  — CLI / CI / pre-push gate
+#   2. hooks/block-populated-public-skill.py — PreToolUse(Write|Edit) write-time guard
+#   3. the module self-test                — unit coverage for each detector
+#
+# Negative-control requirement (the guard earns trust only by failing on the
+# exact harm it prevents): a POPULATED example is blocked + named; an EMPTY
+# TEMPLATE passes. Structural detection only — no personal-name list lives here.
+#
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+CLI="scripts/check-template-purity.py"
+LIB="hooks/_lib/template_purity.py"
+HOOK="hooks/block-populated-public-skill.py"
+PASS=0
+FAIL=0
+_ok()   { echo "  [PASS] $1"; PASS=$((PASS+1)); }
+_fail() { echo "  [FAIL] $1"; FAIL=$((FAIL+1)); }
+
+echo "==> test_template_purity"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# A POPULATED skill example — real typed-category data, NO personal name token
+# (proves the structural layer catches what the name-scrub cannot). Fully
+# synthetic ("Northwind" is a classic sample-DB name) so the fixture itself
+# carries no real private data.
+POPULATED="$TMP/populated-example.md"
+cat > "$POPULATED" <<'EOF'
+---
+type: deal
+counterparty: Northwind Logistics LLC
+amount: $36,000
+stage: signed
+entity_id: tnt_a1b2c3d4
+---
+
+# Pilot close
+
+floor: Courage
+floor_level: High
+
+Closed the pilot today. Valuation discussion landed at $1,200,000.
+EOF
+
+# An EMPTY TEMPLATE — same schema, every value a placeholder. Must pass.
+EMPTY="$TMP/empty-template.md"
+cat > "$EMPTY" <<'EOF'
+---
+type: deal
+counterparty: <counterparty-name>
+amount: $<amount>
+stage: <stage>
+entity_id: <tid>
+---
+
+# <title>
+
+floor: <floor-name>
+floor_level: <Low|Middle|High>
+
+<your reflection here>
+EOF
+
+# ── Test 1: NEGATIVE — populated example blocks + names the file ──────────────
+out="$(python3 "$CLI" "$POPULATED" 2>&1)" && rc=0 || rc=$?
+if [ "$rc" -ne 0 ] && echo "$out" | grep -q "populated-example.md"; then
+  _ok "populated example → guard exits non-zero AND names the offending file"
+else
+  _fail "populated example → expected non-zero exit naming the file (rc=$rc)"
+fi
+
+# ── Test 2: POSITIVE — empty template passes ─────────────────────────────────
+if python3 "$CLI" "$EMPTY" >/dev/null 2>&1; then
+  _ok "empty template → guard exits 0"
+else
+  _fail "empty template → guard exited non-zero (false positive on a pure template)"
+fi
+
+# ── Test 3: module self-test (per-detector unit coverage) ────────────────────
+if python3 "$LIB" --selftest >/dev/null 2>&1; then
+  _ok "template_purity.py --selftest → exit 0"
+else
+  _fail "template_purity.py --selftest → non-zero (a structural detector regressed)"
+fi
+
+# ── Test 4: write-time hook DENIES introducing populated data ────────────────
+deny_in="$(printf '{"tool_input":{"file_path":"%s/ai-brain-starter/skills/vertical-finance/EXAMPLE.md","content":%s}}' \
+  "$TMP" "$(python3 -c 'import json,sys; print(json.dumps(open(sys.argv[1]).read()))' "$POPULATED")")"
+hook_out="$(printf '%s' "$deny_in" | python3 "$HOOK" 2>/dev/null || true)"
+if echo "$hook_out" | grep -q '"permissionDecision": *"deny"'; then
+  _ok "write-time hook → DENY on populated content into a public skill path"
+else
+  _fail "write-time hook → expected deny (got: $hook_out)"
+fi
+
+# ── Test 5: write-time hook ALLOWS an empty template ─────────────────────────
+allow_in="$(printf '{"tool_input":{"file_path":"%s/ai-brain-starter/skills/vertical-finance/EXAMPLE.md","content":%s}}' \
+  "$TMP" "$(python3 -c 'import json,sys; print(json.dumps(open(sys.argv[1]).read()))' "$EMPTY")")"
+hook_out2="$(printf '%s' "$allow_in" | python3 "$HOOK" 2>/dev/null || true)"
+if echo "$hook_out2" | grep -q '"permissionDecision": *"allow"'; then
+  _ok "write-time hook → ALLOW on a pure template"
+else
+  _fail "write-time hook → expected allow (got: $hook_out2)"
+fi
+
+# ── Test 6: the real public skills/ tree passes the guard (no self-DoS) ───────
+# The committed public substrate must already be template-pure. If this fails,
+# the named files are REAL pre-existing leaks to fix — not a guard bug.
+if python3 "$CLI" --skills >/dev/null 2>&1; then
+  _ok "public skills/ tree → guard exits 0 (substrate is template-pure)"
+else
+  _fail "public skills/ tree → guard flagged committed files (see: python3 $CLI --skills)"
+fi
+
+echo
+echo "  template_purity: ${PASS} passed, ${FAIL} failed"
+if [ "${FAIL}" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
Closes MYC-1765 — the public-template-purity guard (the second isolation plane from the open-core boundary review).

## What
A STRUCTURAL complement to `personal-pii-scrub.yml`. That workflow blocks personal **names + vault paths** from public source. This blocks the *other* leak class: **POPULATED typed-category content that carries no name** — a real floor entry, a real deal / counterparty / amount, a real tenant/entity id — sealed into a public-bound skill template. The two planes are non-overlapping.

## Surfaces (one shared detector, no drift)
- `hooks/_lib/template_purity.py` — structural detector + 31-case self-test (Python 3.9). Populated typed frontmatter (incl. YAML list items) + real `tnt_/usr_/tid_` ids flag; placeholders (`<x>`, `$<amount>`, `EXAMPLE`, …) and floor-scoped slot-descriptors pass.
- `scripts/check-template-purity.py` — CLI / CI / pre-push gate (`--skills`, `--staged`, files). **Fail-closed** on import/read error (never silent-pass).
- `hooks/block-populated-public-skill.py` — PreToolUse write-time guard (fail-open; the CI gate is the backstop).
- `.github/workflows/template-purity.yml` — CI gate on push + PR.
- `tests/integration/test_template_purity.sh` — negative control (populated example fails **and is named**; empty template passes), wired into `scripts/ci.sh`.
- registered in `install-hooks-user-level.py` (active on fresh installs).

## Two-layer property
This plane embeds **no** personal name or floor vocabulary — it detects populated *shapes*. The name-specific scrub stays the private layer. The write-time hook scopes by a **positive** public-root allowlist (no private path hardcoded).

## Verification
- `bash scripts/ci.sh` green: py_compile 269 files + 49 integration tests + shellcheck.
- The real public `skills/` tree scans **template-pure** (no pre-existing leaks; guard's job is to keep it that way).
- Personal-data scrub run on the diff: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)