### PR TITLE
feat(skills): public vault-system router + patterns/repurpose-talk gains (MYC-1955)

### DIFF
--- a/.github/free-tier-allowlist.txt
+++ b/.github/free-tier-allowlist.txt
@@ -58,3 +58,4 @@ skills/security-snapshot                   # lead-magnet
 skills/setup-vault-types                   # teaching
 skills/skillify-meta-loop                  # teaching
 skills/sunday-review                       # teaching
+skills/vault-system                        # teaching

--- a/skills/patterns/SKILL.md
+++ b/skills/patterns/SKILL.md
@@ -30,6 +30,23 @@ Save preferences. Don't ask again.
 
 ---
 
+## Pre-flight: institutional-knowledge check
+
+**Use BEFORE starting a non-trivial feature, bug-diagnosis, or refactor — not after.** This is the proactive sibling of the reactive auto-detection below. Pattern source: `EveryInc/compound-engineering-plugin` `ce-learnings-researcher` (MIT, reimplemented clean).
+
+**Trigger surface:** any session that opens with verbs like "fix", "debug", "diagnose", "implement", "build", "refactor", "extract", "consolidate" plus a named surface (a service, an MCP server, a runbook, a hook) — work where a similar problem might already have been solved.
+
+**What to do (silently, before the user's first task):**
+1. Search the prior-work sources from your prefs — the decision log, any `feedback_*` / memory files, prior `/patterns` captures, and a failure-inventory note if one exists (last ~60 days) — for keywords matching the surface the user just named.
+2. If 1+ match: surface a single 1-2 line nudge before the user starts — *"There's prior work on [X]: [link or path]. Worth reading before you start?"*
+3. If nothing found: stay silent. Pre-flight is value when it surfaces something, dead weight when it doesn't.
+
+**Why this matters:** the reactive auto-detection (below) catches drift AFTER the work is done. The pre-flight check catches it BEFORE you re-solve a problem you already solved — so you don't spend Tuesday rediscovering what you codified on Thursday.
+
+**Anti-pattern:** dumping a 5-link wall of "you might want to read these." ONE link, ONE sentence, the closest match. The user can ask for more.
+
+---
+
 ## Auto-Detection (session-end triggers)
 
 At the end of every session (before the session-close checklist), Claude should silently evaluate whether the current session hit any of these four triggers. If one or more fires, surface it as a suggestion before closing.
@@ -118,7 +135,7 @@ After the user confirms, execute all approved captures in one pass:
 - **CLAUDE.md rule** → add to the relevant section, sync to any other CLAUDE.md files
 - **Concept note** → create in the concept folder, add wikilinks
 - **Skill improvement** → note it clearly: "This should be baked into [skill name] — flag for next update"
-- **Confidence update (self-improving memory)** → when this run confirms an existing instinct held (it fired again, uncorrected), run `python3 ~/.claude/skills/ai-brain-starter/scripts/instinct.py reinforce <slug>`. When the user corrected one, run `... correct <slug>`. That bidirectional update is what makes the library self-improving instead of append-only. See `docs/instinct-engine.md`.
+- **Confidence update (self-improving memory)** → when this run confirms an existing instinct held (it fired again, uncorrected), run `python3 ~/.claude/skills/ai-brain-starter/scripts/instinct.py reinforce <slug>`. When the user corrected one, run `... correct <slug>`. That bidirectional update is what makes the library self-improving instead of append-only. See `docs/instinct-engine.md`. When a domain accumulates many high-confidence instincts, run `/evolve` to propose promoting the cluster into a dedicated skill.
 
 ---
 

--- a/skills/repurpose-talk/SKILL.md
+++ b/skills/repurpose-talk/SKILL.md
@@ -32,6 +32,23 @@ Pull out:
 - **Audience questions** that came up (each question is a content seed)
 - **The main thesis** of the talk in one sentence
 
+### Phase 1.5: Score clip candidates against the virality framework
+
+For each candidate moment (one-liner, story beat, question, insight), tag which virality category it hits. Cherry-picked from SamurAIGPT/Generative-Media-Skills `ai-clipping` SKILL.md (MIT) — 8 categories that explain WHY short-form clips travel:
+
+- **Hook moments** — strong opening line that stops the scroll
+- **Emotional peaks** — laughter, anger, vulnerability, awe
+- **Opinion bombs** — spicy, contrarian, debate-bait takes
+- **Revelation moments** — "wait, what?" reframes
+- **Conflict** — disagreement, tension, callouts
+- **Quotable lines** — tight, screenshot-worthy phrasing
+- **Story peaks** — climax of a narrative arc
+- **Practical value** — actionable insight a viewer will save
+
+A clip that hits 2+ categories is a stronger pick than one that hits 1. A clip that hits 0 isn't worth packaging — drop it.
+
+The taxonomy is FOR RANKING + EXPLAINING, not for inventing content. Every clip still has to come from the actual talk; never confabulate a "spicy take" the speaker didn't make.
+
 ### Phase 2: Generate Content Package
 
 Create all of the following:

--- a/skills/vault-system/SKILL.md
+++ b/skills/vault-system/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: vault-system
+description: Use for VAULT META-MAINTENANCE — the second brain itself as a system. Knowledge-graph build + query, second-brain metadata mapping, vault self-diagnose, drift detection, rule extraction, journal backfill, vault type setup, memory consolidation, Obsidian tooling (CLI / Bases / Markdown / JSON Canvas). Triggers include "rebuild the knowledge graph", "second-brain map", "diagnose the vault", "vault audit", "drift detection", "extract rules from vault", "backfill journals", "setup vault types", "consolidate memory", "obsidian cli", "vault hygiene". For QUERYING the vault to answer a question, use the graph-query tools directly. For daily journaling / coaching / pattern detection, use those skills, not this one.
+trigger: /vault-system
+---
+
+# Vault system
+
+Routes **vault meta-maintenance** — the vault AS a system (its markdown corpus, knowledge graph, drift monitors, rule extraction, substrate sync). Not the content; the substrate that makes the content queryable and auditable.
+
+**Distinct from:**
+- Querying the vault to answer a question (use the knowledge-graph query tools)
+- Bringing external data INTO the vault (use the ingest skills)
+- Daily journal + coaching + pattern detection (those operate inside the substrate)
+
+This is the SUBSTRATE layer. It maintains what every other skill uses.
+
+## Step 1. Identify the maintenance moment
+
+| Trigger | Skill / tool |
+|---|---|
+| Knowledge graph stale or never built for a corpus | `graphify` |
+| Existing graph query (find concept / path / cluster) | your graph-query tool, or Obsidian graph view |
+| Typed-file metadata extraction (books, meetings, people, articles, goals) | `second-brain-mapping` |
+| Vault self-check (CLAUDE.md / Meta folder / skills / hooks / MCPs / journal index) | `diagnose` |
+| Files edited many times in a short window (drift hotspot) | a drift-detection pass → a Drift Audit note |
+| Recurring corruption pattern needs codification | `extract-rules-from-vault` → new rule file |
+| Journals missing body / frontmatter context | `backfill-journal-body-context` |
+| Vault types not yet set up (new vault or refresh) | `setup-vault-types` |
+| Memory index getting long (truncation cliff) | `consolidate-memory` |
+| Obsidian Bases / JSON Canvas / Markdown / CLI work | the matching `obsidian:*` skill |
+
+If unclear → ask ONE question. Don't guess.
+
+## Step 2. Pre-flight
+
+1. **Vault location:** resolve the vault root (a `VAULT_PATH` / `VAULT_ROOT` env var, or the current directory).
+2. **Graph state:** check whether a graph report exists and how fresh it is before answering graph questions.
+3. **Drift state:** check the latest drift-audit output.
+4. **Rules state:** list the rules directory.
+5. **Memory state:** check the memory index length (keep it under the truncation cliff).
+6. **Git in a large vault:** NEVER `git add -A` / `.` / unscoped `git status` on a big vault — full-tree walks are slow and lock-contending. Use explicit paths.
+
+## Step 3. Route by work-type
+
+### Knowledge graph
+- Build a new graph from a corpus (code / docs / papers / images) → `graphify`
+- Query an existing graph (search nodes / neighbors / path) → your graph-query tool
+- Coverage audit (which corpus chunks were processed) → graphify's coverage audit
+
+### Second-brain mapping
+- Extract structured metadata from every typed file → `second-brain-mapping`
+- Apply wikilinks from detected entities → `second-brain-mapping` (wikilink phase)
+- Cross-type insights (patterns no single file shows) → `second-brain-mapping` (insights phase)
+
+### Diagnostics + drift
+- Vault self-check → `diagnose`
+- Drift detection (files edited many times in 30d) → a drift-detection pass → a Drift Audit note
+
+### Rule extraction + memory
+- Extract recurring patterns into a CLAUDE.md rule / rules file → `extract-rules-from-vault`
+- Consolidate memory files (merge duplicates, prune the index) → `consolidate-memory`
+
+### Journal hygiene
+- Backfill journal body / frontmatter context → `backfill-journal-body-context`
+- Tag / taxonomy consistency check → manual against your canonical tag list
+
+### Vault setup + onboarding
+- Setup vault types (frontmatter taxonomy) → `setup-vault-types`
+- Setup the substrate on a new vault → the bootstrap flow
+
+### Obsidian tooling
+- CLI (backlinks, search, unresolved, orphans, properties) → `obsidian:obsidian-cli`
+- Bases queries (typed views) → `obsidian:obsidian-bases`
+- JSON Canvas creation / edit → `obsidian:json-canvas`
+- Markdown specifics (callouts, wikilinks, embeds) → `obsidian:obsidian-markdown`
+
+## Step 4. Post-flight (gates "done")
+
+1. Graph rebuilt + report regenerated if graphify ran.
+2. Memory index under the truncation cliff post-consolidation.
+3. Drift hotspots resolved if the Drift Audit surfaced any.
+4. New rules indexed in the rules directory.
+5. Vault committed with explicit paths (never raw `git add -A` in a large vault).
+
+## Common mistakes
+
+- **`git add -A` in a large vault.** Long walks + lock contention. Use explicit paths.
+- **Editing aggregator outputs directly** (e.g. a "Last Session" or "Decision Log" roll-up). Edit the per-entry source files; let the aggregator rebuild.
+- **Hand-editing symlinked skill copies.** Edit the source repo + re-sync.
+- **Re-reading the memory index when it is already in context.**
+- **Routing daily journal / coaching / pattern detection here.** Those are their own skills; this umbrella maintains the substrate, not the content.


### PR DESCRIPTION
## What

Public-substrate side of **MYC-1955** (closes the MYC-1832 done-predicate gap, bug class FALSE-CLOSE-ON-PARTIAL-PREDICATE).

- **`skills/vault-system/`** — NEW genericized public thin-router (the *public-starter* half of the public-starter / private-superset split). Routes only public substrate vault skills (graphify, second-brain-mapping, diagnose, setup-vault-types, backfill-journal-body-context, consolidate-memory, obsidian tooling). No personal scripts / MCPs / runtime moat. Added to `free-tier-allowlist.txt` (`teaching`).
- **`skills/patterns/`** — ported two generic capability gains from the diverged private copy: the **pre-flight institutional-knowledge check** + the **`/evolve` promotion mention**.
- **`skills/repurpose-talk/`** — ported the **virality-framework clip-scoring taxonomy** (MIT, SamurAIGPT/Generative-Media-Skills).

## Reconciliation finding

The public copies of the 8 personal-scope skills are genericized **supersets** (genericized *from* the private copies), so the OPEN-leg dedup is **repoint-to-public + fold-nothing**, except these two additive ports. **Personal data folds NOTHING into public.**

## Free-tier decision

Per **MYC-1832** + the 2026-06-25 productization decision: open *mechanism* markdown ships in the public substrate; per-tenant computation stays in the paid runtime. `vault-system` is `teaching` (existing category, no ADR-0001 change).

## Gates (local, pre-push)

- personal-data scrub: clean (word-boundary, case-sensitive)
- `template-purity`: 6/6
- `open-core-boundary`: 4/4
- `ci.sh`: green — py_compile (269) + 49 integration tests + shellcheck