### PR TITLE
MYC-1893: dev-hub-refresh + stale-hub guard → substrate

### DIFF
--- a/hooks.json
+++ b/hooks.json
@@ -1,8 +1,6 @@
 {
   "_comment": "AI Brain Starter — Hook Templates. Run /setup-brain to install these, or apply manually via: claude config edit --add hooks <paste contents here>. After git pull, re-run setup or re-apply to get updated hooks.",
-
   "_paths_note": "The [VAULT_PATH] placeholder gets substituted with the user's actual vault path by /setup-brain. All Meta references use '⚙️ Meta/' with the emoji prefix, matching Phase 3's canonical folder structure. Do NOT remove the emoji — the bash scripts and hook contexts look for that exact folder name.",
-
   "hooks": {
     "UserPromptSubmit": [
       {
@@ -68,7 +66,6 @@
         ]
       }
     ],
-
     "Stop": [
       {
         "hooks": [
@@ -96,7 +93,6 @@
         ]
       }
     ],
-
     "PreCompact": [
       {
         "hooks": [
@@ -108,7 +104,6 @@
         ]
       }
     ],
-
     "PreToolUse": [
       {
         "matcher": "Bash",
@@ -177,9 +172,17 @@
             "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/observe-tool-calls.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'"
           }
         ]
+      },
+      {
+        "matcher": "Read|Edit|Write|MultiEdit|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/warn-stale-dev-checkout.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'"
+          }
+        ]
       }
     ],
-
     "SessionStart": [
       {
         "hooks": [
@@ -262,11 +265,14 @@
             "type": "command",
             "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/relocate-watch-surface.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'",
             "statusMessage": "Checking for vault-relocation drift (old-path recreators)..."
+          },
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/dev-hub-refresh-on-session-start.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'"
           }
         ]
       }
     ],
-
     "SessionEnd": [
       {
         "hooks": [
@@ -278,7 +284,6 @@
         ]
       }
     ],
-
     "PostToolUse": [
       {
         "matcher": "Write",
@@ -301,6 +306,5 @@
       }
     ]
   },
-
   "_how_to_update": "After running git pull on this repo, the auto-update hook (first UserPromptSubmit entry) automatically invokes scripts/sync-skills.sh (skill content backup + overwrite) and then prompts Claude to run scripts/install-hooks-user-level.py to rewire ~/.claude/settings.json. If the hook auto-update path is bypassed (network failure, hook disabled), re-run scripts/install-hooks-user-level.py manually or re-run bootstrap.sh — both call the installer with --fail-on-missing so divergent-fork strands surface loudly instead of silently."
 }

--- a/hooks/_lib/dev_repo_scan.py
+++ b/hooks/_lib/dev_repo_scan.py
@@ -1,0 +1,979 @@
+"""Shared scanner for in-flight builds across ~/dev/* repos.
+
+Used by:
+- block-branch-switch-with-untracked-build.py (PreToolUse)
+- nudge-checkpoint-after-pytest-pass.py (PostToolUse)
+- warn-uncommitted-builds-on-stop.py (Stop)
+- list-wip-stashes-on-session-start.py (SessionStart)
+
+Heuristic for "in-flight build":
+- A directory under <repo> contains 3+ untracked source files matching
+  one of: .py .ts .tsx .js .jsx .go .rs .java .rb .php .c .cpp .h
+- OR a new test file exists alongside a new module (tests/X/* + src/X/*)
+
+Heuristic for "active repo": modified within the last 60 minutes.
+Faster than scanning every ~/dev/* repo every session-start.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import NamedTuple, Optional
+
+
+SOURCE_EXT_RE = re.compile(
+    r"\.(py|ts|tsx|js|jsx|go|rs|java|rb|php|c|cpp|h|hpp|swift|kt|scala)$"
+)
+DEV_ROOT = Path.home() / "dev"
+ACTIVE_WINDOW_SECONDS = 60 * 60  # 60 minutes
+MIN_FILES_FOR_MODULE = 3
+
+
+class ModuleInFlight(NamedTuple):
+    repo: Path
+    module_dir: str  # relative to repo, e.g. "src/voice"
+    file_count: int
+    files: list[str]  # relative to repo
+
+
+class StashEntry(NamedTuple):
+    repo: Path
+    stash_ref: str  # e.g. "stash@{0}"
+    branch: str
+    message: str
+
+
+def find_active_repos(now_ts: Optional[float] = None) -> list[Path]:
+    """Return ~/dev/<repo> dirs whose .git or working tree was touched recently."""
+    if not DEV_ROOT.exists():
+        return []
+    now_ts = now_ts or time.time()
+    cutoff = now_ts - ACTIVE_WINDOW_SECONDS
+    out: list[Path] = []
+    try:
+        for child in DEV_ROOT.iterdir():
+            if not child.is_dir():
+                continue
+            git_dir = child / ".git"
+            if not git_dir.exists():
+                continue
+            # Cheap activity check: stat the .git/HEAD or working tree mtime
+            try:
+                head_mtime = (git_dir / "HEAD").stat().st_mtime
+                index_mtime = (git_dir / "index").stat().st_mtime if (
+                    git_dir / "index"
+                ).exists() else 0
+                # Also check working-tree top-level for recent edits
+                try:
+                    wt_mtime = max(
+                        (
+                            p.stat().st_mtime
+                            for p in child.iterdir()
+                            if p.name not in {".git", "node_modules", ".venv", "__pycache__"}
+                        ),
+                        default=0,
+                    )
+                except OSError:
+                    wt_mtime = 0
+                last_touch = max(head_mtime, index_mtime, wt_mtime)
+                if last_touch >= cutoff:
+                    out.append(child)
+            except OSError:
+                continue
+    except OSError:
+        return []
+    return out
+
+
+def find_modules_in_flight(repo: Path) -> list[ModuleInFlight]:
+    """Run git status -uall in <repo> and group untracked source files by directory.
+
+    Returns one ModuleInFlight per directory with 3+ untracked source files.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo), "status", "--porcelain=v1", "-uall"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return []
+    if result.returncode != 0:
+        return []
+
+    # Untracked entries start with "?? " in porcelain v1
+    untracked_sources: list[str] = []
+    for line in result.stdout.splitlines():
+        if not line.startswith("?? "):
+            continue
+        rel = line[3:].strip()
+        # git can emit quoted paths for unicode; strip surrounding quotes
+        if rel.startswith('"') and rel.endswith('"'):
+            try:
+                rel = rel[1:-1].encode("utf-8").decode("unicode_escape")
+            except Exception:
+                pass
+        if SOURCE_EXT_RE.search(rel):
+            untracked_sources.append(rel)
+
+    # Group by 2-segment directory prefix (e.g. "src/voice/" or "tests/voice/")
+    grouped: dict[str, list[str]] = {}
+    for rel in untracked_sources:
+        parts = rel.split("/")
+        if len(parts) < 2:
+            # Top-level untracked file; skip (not module-shaped)
+            continue
+        # 2-segment prefix; if file is deeper (e.g. src/voice/backends/x.py)
+        # we still group at the 2-segment level (src/voice/) because that
+        # captures the module identity. Subdirs roll up to the same module.
+        prefix = "/".join(parts[:2]) + "/"
+        grouped.setdefault(prefix, []).append(rel)
+
+    out: list[ModuleInFlight] = []
+    for prefix, files in grouped.items():
+        if len(files) >= MIN_FILES_FOR_MODULE:
+            out.append(
+                ModuleInFlight(
+                    repo=repo,
+                    module_dir=prefix,
+                    file_count=len(files),
+                    files=files,
+                )
+            )
+    return out
+
+
+def find_wip_stashes(repo: Path) -> list[StashEntry]:
+    """Return stash entries whose message hints at parking/WIP/incomplete work."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo), "stash", "list"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return []
+    if result.returncode != 0:
+        return []
+
+    pattern = re.compile(
+        r"(?i)\b(wip|parking|parked|incomplete|in[- ]flight|do not lose|preserve|recover)\b"
+    )
+    out: list[StashEntry] = []
+    for line in result.stdout.splitlines():
+        # Format: stash@{0}: On <branch>: <message>
+        m = re.match(r"^(stash@\{\d+\}):\s+(?:On|WIP on)\s+([^:]+):\s+(.*)$", line)
+        if not m:
+            continue
+        stash_ref, branch, message = m.group(1), m.group(2).strip(), m.group(3)
+        if pattern.search(message):
+            out.append(
+                StashEntry(
+                    repo=repo,
+                    stash_ref=stash_ref,
+                    branch=branch,
+                    message=message,
+                )
+            )
+    return out
+
+
+class UnpushedCommitEntry(NamedTuple):
+    repo: Path
+    branch: str  # local branch with the commits
+    commits: list[tuple[str, str, float]]  # (sha7, subject, committer_ts)
+    upstream: Optional[str]  # tracking ref, e.g. "origin/main", or None
+
+
+def find_unpushed_local_commits(
+    repo: Path,
+    min_age_minutes: int = 24 * 60,
+) -> list[UnpushedCommitEntry]:
+    """Return local branches with commits not on any remote ref.
+
+    Filters to commits older than `min_age_minutes` (default 24h) so a
+    just-committed change in active work doesn't get flagged as drift.
+
+    Bug class this surfaces: LOCAL-COMMITS-DRIFT-UNPUSHED. A chore commit
+    (e.g. a CI pin from an automated hardening pass) sitting on local main
+    unpushed for days blocks fast-forward pulls AND silently corrupts any
+    deploy that ships whatever is at local HEAD — the operator's local ends
+    up several commits behind origin while production serves the stale tree.
+    """
+    try:
+        # --branches restricts to commits reachable from local branches.
+        # --not --remotes excludes anything already on a remote ref.
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo),
+                "log",
+                "--branches",
+                "--not",
+                "--remotes",
+                "--format=%H%x09%s%x09%ct%x09%D",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return []
+    if result.returncode != 0 or not result.stdout.strip():
+        return []
+
+    cutoff_ts = time.time() - (min_age_minutes * 60)
+    by_branch: dict[str, list[tuple[str, str, float]]] = {}
+
+    for line in result.stdout.splitlines():
+        parts = line.split("\t", 3)
+        if len(parts) < 3:
+            continue
+        sha, subject, ct_str = parts[0], parts[1], parts[2]
+        refs = parts[3] if len(parts) > 3 else ""
+        try:
+            ct = float(ct_str)
+        except ValueError:
+            continue
+        if ct > cutoff_ts:
+            # Too fresh to nudge — operator may be mid-build.
+            continue
+        # `refs` is like "HEAD -> main, tag: v1, feature/x". Pull out
+        # local branch names; skip remote/tag/HEAD pointers.
+        branch_names: list[str] = []
+        for ref in refs.split(","):
+            ref = ref.strip()
+            if not ref or ref.startswith("tag:") or ref.startswith("HEAD"):
+                continue
+            if ref.startswith("HEAD -> "):
+                ref = ref[len("HEAD -> "):]
+            if ref.startswith("origin/") or ref.startswith("upstream/"):
+                continue
+            branch_names.append(ref)
+        if not branch_names:
+            branch_names = ["(detached)"]
+        for b in branch_names:
+            by_branch.setdefault(b, []).append((sha[:7], subject, ct))
+
+    out: list[UnpushedCommitEntry] = []
+    for branch, commits in by_branch.items():
+        upstream = _resolve_upstream(repo, branch)
+        out.append(
+            UnpushedCommitEntry(
+                repo=repo,
+                branch=branch,
+                commits=commits,
+                upstream=upstream,
+            )
+        )
+    return out
+
+
+def _resolve_upstream(repo: Path, branch: str) -> Optional[str]:
+    """Return the tracking ref for a local branch, or None if unset."""
+    if branch == "(detached)":
+        return None
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo),
+                "rev-parse",
+                "--abbrev-ref",
+                "--symbolic-full-name",
+                f"{branch}@{{u}}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    upstream = result.stdout.strip()
+    return upstream or None
+
+
+# ---------------------------------------------------------------------------
+# Branch lifecycle classifier (MYC-683) — the shared reap/surface primitive.
+#
+# The drift surfacer + the reaper both need to tell GENUINE-UNIQUE work (the
+# only real drift, the only thing worth surfacing/pushing) apart from
+# squash-merged-stale + relic branches (content is already on origin → safe to
+# reap, NOT drift). `merge-base --is-ancestor` alone CANNOT — a squash-merged
+# branch's commits are not ancestors of main (the squash is a new SHA) yet its
+# content IS on main. That false-positive is the ~25x cry-wolf the surfacer
+# showed (MYC-683 re-verification 2026-06-14). Five classes, evaluated in order:
+# ---------------------------------------------------------------------------
+
+
+class BranchClass:
+    """String enum (kept as plain constants for json/log friendliness)."""
+
+    RELIC = "relic"                          # no common ancestor with origin/main → obsolete
+    TRUE_MERGED = "true_merged"              # tip is an ancestor of origin/main
+    BACKED_UP = "backed_up"                  # pushed to its own origin/<branch>, not merged
+    SQUASH_MERGED_STALE = "squash_merged_stale"  # content ⊆ origin/main (squash artifact)
+    GENUINE_UNIQUE = "genuine_unique"        # real divergent work NOT on any remote → the only drift
+    UNKNOWN = "unknown"                      # can't classify safely → always preserve
+
+
+# Content is provably preserved on origin → the local branch ref is safe to delete.
+REAPABLE_CLASSES = frozenset({BranchClass.TRUE_MERGED, BranchClass.SQUASH_MERGED_STALE})
+# Real, un-backed-up state → surface for a human, NEVER auto-delete.
+SURFACE_CLASSES = frozenset({BranchClass.RELIC, BranchClass.GENUINE_UNIQUE})
+
+
+def _git(repo: Path, *args: str, timeout: int = 15):
+    """Run git, never raise. Returns (returncode, stdout, stderr) trimmed."""
+    try:
+        r = subprocess.run(
+            ["git", "-C", str(repo), *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        return r.returncode, r.stdout.strip(), r.stderr.strip()
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return 99, "", "git-exec-failed"
+
+
+def detect_default_branch(repo: Path) -> Optional[str]:
+    """The remote default branch name (no `origin/` prefix), or None.
+
+    Tries `origin/HEAD`, then verifies `origin/main` / `origin/master`.
+    """
+    rc, out, _ = _git(repo, "rev-parse", "--abbrev-ref", "origin/HEAD")
+    if rc == 0 and out and "/" in out:
+        cand = out.split("/", 1)[1]
+        rc2, _, _ = _git(repo, "rev-parse", "--verify", "--quiet", f"origin/{cand}")
+        if rc2 == 0:
+            return cand
+    for cand in ("main", "master"):
+        rc2, _, _ = _git(repo, "rev-parse", "--verify", "--quiet", f"origin/{cand}")
+        if rc2 == 0:
+            return cand
+    return None
+
+
+def _branch_adds_nothing(repo: Path, base_ref: str, branch: str) -> Optional[bool]:
+    """True if `branch` introduces no content `base_ref` lacks (tree ⊆ base).
+
+    Uses `git diff --numstat base..branch`: each line is `added<TAB>deleted<TAB>path`.
+    If the total ADDED lines across all files is 0 AND there is no binary change,
+    the branch adds nothing beyond base → its content is already absorbed
+    (the squash-merged-stale signal that survives main moving on with its own
+    unrelated commits). Returns None on any git error (caller preserves).
+    """
+    rc, out, _ = _git(repo, "diff", "--numstat", f"{base_ref}..{branch}")
+    if rc != 0:
+        return None
+    if not out:
+        return True  # identical trees → adds nothing
+    total_added = 0
+    for line in out.splitlines():
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+        added = parts[0]
+        if added == "-":
+            return False  # binary delta → can't prove ⊆; treat as genuine (preserve)
+        try:
+            total_added += int(added)
+        except ValueError:
+            return False
+    return total_added == 0
+
+
+def classify_branch(
+    repo: Path, branch: str, default_branch: Optional[str] = None
+) -> str:
+    """Classify a local branch into one of BranchClass. Fail-safe to UNKNOWN."""
+    default_branch = default_branch or detect_default_branch(repo)
+    if not default_branch:
+        return BranchClass.UNKNOWN
+    origin_main = f"origin/{default_branch}"
+    rc, _, _ = _git(repo, "rev-parse", "--verify", "--quiet", origin_main)
+    if rc != 0:
+        return BranchClass.UNKNOWN
+    rc, tip, _ = _git(repo, "rev-parse", "--verify", "--quiet", branch)
+    if rc != 0 or not tip:
+        return BranchClass.UNKNOWN
+
+    # 1. RELIC — no shared history with origin/main.
+    rc_mb, mb, _ = _git(repo, "merge-base", origin_main, branch)
+    if rc_mb != 0 or not mb:
+        return BranchClass.RELIC
+
+    # 2. TRUE_MERGED — tip already reachable from origin/main.
+    rc_anc, _, _ = _git(repo, "merge-base", "--is-ancestor", branch, origin_main)
+    if rc_anc == 0:
+        return BranchClass.TRUE_MERGED
+
+    # 3. BACKED_UP — pushed to its own upstream (tip == origin/<branch> or behind).
+    rc_ob, _, _ = _git(repo, "rev-parse", "--verify", "--quiet", f"origin/{branch}")
+    if rc_ob == 0:
+        rc_bup, _, _ = _git(
+            repo, "merge-base", "--is-ancestor", branch, f"origin/{branch}"
+        )
+        if rc_bup == 0:
+            return BranchClass.BACKED_UP
+
+    # 4. SQUASH_MERGED_STALE — content already on origin/main (squash artifact).
+    adds_nothing = _branch_adds_nothing(repo, origin_main, branch)
+    if adds_nothing is True:
+        return BranchClass.SQUASH_MERGED_STALE
+    if adds_nothing is None:
+        return BranchClass.UNKNOWN  # git error → preserve
+
+    # 5. GENUINE_UNIQUE — real divergent, un-backed-up work. The only real drift.
+    return BranchClass.GENUINE_UNIQUE
+
+
+# --- Reap planning ---------------------------------------------------------
+
+
+@dataclass
+class ReapTarget:
+    branch: str
+    cls: str
+    sha: str
+
+
+@dataclass
+class WorktreeTarget:
+    path: Path
+    branch: str
+    sha: str
+
+
+@dataclass
+class StashTarget:
+    ref: str
+    message: str
+    reason: str = ""
+
+
+@dataclass
+class ReapPlan:
+    repo: Path
+    reap_branches: list = field(default_factory=list)      # ReapTarget
+    reap_worktrees: list = field(default_factory=list)     # WorktreeTarget
+    reap_stashes: list = field(default_factory=list)       # StashTarget
+    surface_branches: list = field(default_factory=list)   # ReapTarget (human decision)
+    skipped: list = field(default_factory=list)            # (name, reason)
+
+
+def _list_worktrees(repo: Path) -> list[tuple[Path, Optional[str]]]:
+    """Return [(worktree_path, branch_or_None)] incl. the primary checkout."""
+    rc, out, _ = _git(repo, "worktree", "list", "--porcelain")
+    if rc != 0:
+        return []
+    res: list[tuple[Path, Optional[str]]] = []
+    cur_path: Optional[Path] = None
+    cur_branch: Optional[str] = None
+    for line in out.splitlines() + [""]:
+        if line.startswith("worktree "):
+            if cur_path is not None:
+                res.append((cur_path, cur_branch))
+            cur_path = Path(line[len("worktree "):])
+            cur_branch = None
+        elif line.startswith("branch "):
+            cur_branch = line[len("branch "):].replace("refs/heads/", "")
+        elif line == "" and cur_path is not None:
+            res.append((cur_path, cur_branch))
+            cur_path = None
+            cur_branch = None
+    return res
+
+
+def _is_dirty(path: Path) -> bool:
+    rc, out, _ = _git(path, "status", "--porcelain")
+    return rc != 0 or bool(out)  # treat git error as dirty (preserve)
+
+
+# A destructive tool errs toward PRESERVE: widen the system's own 300s "live"
+# window to 15 min so a session that paused briefly still shields its repo.
+SESSION_LOCK_LIVE_WINDOW_SEC = 900
+
+
+def _has_live_session_lock(repo: Path, now_ts: Optional[float] = None) -> bool:
+    """True if a Claude session was active in this repo within the live window.
+
+    Reads the REAL shared lock written by session-lock.py at
+    `<main_root>/.claude/.session-lock.json` — a multi-session map whose liveness
+    field is `last_activity_at` (NOT `.session-lock`, NOT `pid`). A STALE lock
+    (all sessions idle past the window) does NOT count, or the reaper would never
+    run on a repo that ever hosted a session. Worktrees share the main lock, so
+    checking the primary checkout covers the whole worktree set.
+    """
+    now_ts = now_ts or time.time()
+    lock = repo / ".claude" / ".session-lock.json"
+    try:
+        data = json.loads(lock.read_text())
+    except (OSError, ValueError):
+        return False
+    if not isinstance(data, dict):
+        return False
+    for s in data.get("sessions", []):
+        la = s.get("last_activity_at") if isinstance(s, dict) else None
+        if isinstance(la, (int, float)) and (now_ts - la) < SESSION_LOCK_LIVE_WINDOW_SEC:
+            return True
+    return False
+
+
+def _plan_stash_reap(
+    repo: Path, keep_k: int, ttl_days: float, now_ts: Optional[float] = None
+) -> list[StashTarget]:
+    """Reap claude-checkpoint stashes beyond keep-K OR older than TTL.
+
+    NEVER touches named (non-checkpoint) stashes — those are hand-parked work.
+    `git stash list` is newest-first, so we keep the first keep_k checkpoint
+    entries and reap the rest, plus any checkpoint older than TTL.
+    """
+    now_ts = now_ts or time.time()
+    rc, out, _ = _git(repo, "stash", "list", "--format=%gd%x09%ct%x09%gs")
+    if rc != 0 or not out:
+        return []
+    targets: list[StashTarget] = []
+    seen_checkpoints = 0
+    for line in out.splitlines():
+        parts = line.split("\t", 2)
+        if len(parts) < 3:
+            continue
+        ref, ts_str, msg = parts[0], parts[1], parts[2]
+        if PREFIX not in msg:  # PREFIX = "claude-checkpoint"
+            continue  # named/parked stash → never reap
+        try:
+            ts = float(ts_str)
+        except ValueError:
+            ts = now_ts  # unknown age → don't reap on age grounds
+        beyond_k = seen_checkpoints >= keep_k
+        too_old = (now_ts - ts) > ttl_days * 86400
+        seen_checkpoints += 1
+        if beyond_k or too_old:
+            reason = "beyond keep-K" if beyond_k else f"older than {ttl_days}d"
+            targets.append(StashTarget(ref=ref, message=msg, reason=reason))
+    return targets
+
+
+PREFIX = "claude-checkpoint"  # checkpoint stash message prefix (see create-dev-repo-checkpoint.py)
+
+
+def plan_repo_reap(
+    repo: Path,
+    keep_k: int = 10,
+    ttl_days: float = 14,
+    default_branch: Optional[str] = None,
+    now_ts: Optional[float] = None,
+) -> ReapPlan:
+    """Compute (do NOT execute) what is safe to reap in one repo.
+
+    Conservative by construction: reap only TRUE_MERGED + SQUASH_MERGED_STALE
+    branches that are not checked out, only CLEAN worktrees on reapable
+    branches, only surplus/old checkpoint stashes. Everything else is either
+    surfaced for a human (RELIC, GENUINE_UNIQUE) or left untouched (BACKED_UP).
+    A live .session-lock skips the whole repo.
+    """
+    repo = Path(repo)
+    plan = ReapPlan(repo=repo)
+
+    if _has_live_session_lock(repo, now_ts):
+        plan.skipped.append((repo.name, "live session-lock — repo skipped wholesale"))
+        return plan
+
+    default_branch = default_branch or detect_default_branch(repo)
+    if not default_branch:
+        plan.skipped.append((repo.name, "no origin default branch — repo skipped"))
+        return plan
+
+    worktrees = _list_worktrees(repo)
+    rc, primary, _ = _git(repo, "rev-parse", "--show-toplevel")
+    primary_path = Path(primary) if rc == 0 and primary else repo
+    checked_out = {b: p for (p, b) in worktrees if b}
+
+    rc, out, _ = _git(repo, "for-each-ref", "--format=%(refname:short)", "refs/heads/")
+    for branch in out.splitlines():
+        branch = branch.strip()
+        if not branch or branch == default_branch:
+            continue  # never touch the default branch
+        cls = classify_branch(repo, branch, default_branch)
+        rc_s, sha, _ = _git(repo, "rev-parse", "--short", branch)
+        tgt = ReapTarget(branch=branch, cls=cls, sha=sha)
+        if cls in REAPABLE_CLASSES:
+            if branch in checked_out:
+                plan.skipped.append(
+                    (branch, f"{cls} but checked out at {checked_out[branch]} — branch kept")
+                )
+            else:
+                plan.reap_branches.append(tgt)
+        elif cls in SURFACE_CLASSES:
+            plan.surface_branches.append(tgt)
+        # BACKED_UP / UNKNOWN → no-op
+
+    for wt_path, wt_branch in worktrees:
+        if wt_branch is None:
+            continue  # detached HEAD worktree → leave for human
+        if wt_path.resolve() == primary_path.resolve():
+            continue  # never reap the primary checkout
+        if wt_branch == default_branch:
+            continue
+        cls = classify_branch(repo, wt_branch, default_branch)
+        if cls not in REAPABLE_CLASSES:
+            continue
+        if _is_dirty(wt_path):
+            plan.skipped.append(
+                (str(wt_path), f"worktree on {cls} branch but DIRTY — never --force")
+            )
+            continue
+        rc_s, sha, _ = _git(repo, "rev-parse", "--short", wt_branch)
+        plan.reap_worktrees.append(WorktreeTarget(path=wt_path, branch=wt_branch, sha=sha))
+
+    plan.reap_stashes = _plan_stash_reap(repo, keep_k, ttl_days, now_ts)
+    return plan
+
+
+def _stash_index(ref: str) -> int:
+    m = re.search(r"\{(\d+)\}", ref)
+    return int(m.group(1)) if m else 0
+
+
+def execute_reap(plan: ReapPlan, apply: bool = False) -> dict:
+    """Build a recovery manifest and, only when apply=True, perform the reaps.
+
+    Order: worktrees first (frees their branch), then branches, then stashes
+    (highest index first so lower indices stay valid mid-drop). Branch delete is
+    `-D` — safe because the class proves the content is on origin. Worktree
+    remove is WITHOUT `--force` (git refuses if it somehow turned dirty between
+    plan and apply — fail safe). The manifest is ALWAYS returned (even dry-run)
+    so a caller can persist it before destruction.
+    """
+    manifest: dict = {
+        "repo": str(plan.repo),
+        "applied": apply,
+        "branches": [],
+        "worktrees": [],
+        "stashes": [],
+    }
+    for wt in plan.reap_worktrees:
+        manifest["worktrees"].append(
+            {"path": str(wt.path), "branch": wt.branch, "sha": wt.sha}
+        )
+        if apply:
+            _git(plan.repo, "worktree", "remove", str(wt.path))  # no --force
+    for t in plan.reap_branches:
+        manifest["branches"].append({"branch": t.branch, "cls": t.cls, "sha": t.sha})
+        if apply:
+            _git(plan.repo, "branch", "-D", t.branch)
+    for s in sorted(plan.reap_stashes, key=lambda x: _stash_index(x.ref), reverse=True):
+        manifest["stashes"].append(
+            {"ref": s.ref, "message": s.message, "reason": s.reason}
+        )
+        if apply:
+            _git(plan.repo, "stash", "drop", s.ref)
+    return manifest
+
+
+def has_recent_session_commits(repo: Path, minutes: int = 30) -> bool:
+    """True if at least one commit landed in the last <minutes>. Used to suppress
+    nudges right after the user has actually committed.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo),
+                "log",
+                f"--since={minutes}.minutes.ago",
+                "--oneline",
+                "-1",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return False
+    return result.returncode == 0 and bool(result.stdout.strip())
+
+
+def discover_hubs(dev_root: Optional[Path] = None) -> list[Path]:
+    """Enumerate the BARE hubs under ~/dev — one primary checkout per repo.
+
+    A bare hub's `.git` is a real DIRECTORY (it can rot). A linked worktree's
+    `.git` is a gitdir-pointer FILE (fresh off origin by construction) → excluded.
+    A bare ORIGIN mirror (`<name>.git`, no `.git` subdir) is excluded too. This is
+    deliberately simpler than the reaper's worktree-grouping discovery: hub-refresh
+    only ever ff's / surfaces bare hubs, never worktrees.
+    """
+    dev_root = Path(dev_root) if dev_root is not None else (Path.home() / "dev")
+    if not dev_root.exists():
+        return []
+    try:
+        children = sorted(p for p in dev_root.iterdir() if p.is_dir())
+    except OSError:
+        return []
+    return [c for c in children if (c / ".git").is_dir()]
+
+
+# ---------------------------------------------------------------------------
+# Hub-refresh classifier (MYC-1893) — keep bare ~/dev/<repo> hubs fresh.
+#
+# Bare hubs ROT: parked on stale feature branches, dirtied by edits, written
+# into by background jobs (STALE-BARE-CHECKOUT-READ, MYC-670 / MYC-1127). The
+# read-time guard warn-stale-dev-checkout.py DETECTS the rot; this is the
+# PREVENTION half. It has exactly ONE auto-action — fast-forward a hub that is
+# clean, on its default branch, behind, and carries no local commits (a
+# GUARANTEED ff, fully reversible via reflog). Everything else is SURFACED for a
+# human, NEVER auto-switched / auto-cleaned / auto-recovered (the over-engineered
+# version was cut). Fetch-first is the CALLER's job (a stale local ref misleads
+# in BOTH directions — MYC-1893 correction); this classifier reads refs only.
+# ---------------------------------------------------------------------------
+
+
+class HubAction:
+    """String enum (plain constants for json/log friendliness)."""
+
+    FF = "ff"                                  # clean + on default + behind>0 + ahead==0 → ff (only auto action)
+    SURFACE_DIRTY = "surface:dirty"            # uncommitted changes → never touch
+    SURFACE_OFF_DEFAULT = "surface:off-default"  # detached or on a feature branch → never switch
+    SURFACE_DIVERGED = "surface:diverged"      # on default but carries unpushed local commits
+    SKIP_CURRENT = "skip:current"              # already up to date with origin default
+    SKIP_NO_ORIGIN = "skip:no-origin"          # no origin default branch (local-only repo)
+    SKIP_SESSION_LOCK = "skip:session-lock"    # a live sibling session → don't fight it
+    SKIP_WORKTREE = "skip:worktree"            # a linked worktree, not a primary bare hub
+
+
+# A hub is only ever AUTO-advanced (ff); every other non-skip action is surfaced.
+HUB_AUTO_ACTIONS = frozenset({HubAction.FF})
+HUB_SURFACE_ACTIONS = frozenset({
+    HubAction.SURFACE_DIRTY,
+    HubAction.SURFACE_OFF_DEFAULT,
+    HubAction.SURFACE_DIVERGED,
+})
+
+
+@dataclass
+class HubState:
+    repo: Path
+    action: str
+    default_branch: Optional[str] = None
+    current_branch: Optional[str] = None  # None if HEAD is detached
+    behind: int = 0
+    ahead: int = 0
+    dirty: bool = False
+    head: str = ""
+
+
+def _current_branch(repo: Path) -> Optional[str]:
+    """The checked-out branch name, or None if HEAD is detached."""
+    rc, out, _ = _git(repo, "symbolic-ref", "--quiet", "--short", "HEAD")
+    return out if rc == 0 and out else None
+
+
+def _ahead_behind(repo: Path, upstream: str) -> tuple[int, int]:
+    """(ahead, behind) of HEAD vs `upstream` (e.g. 'origin/main'); (0, 0) on error.
+
+    `git rev-list --left-right --count upstream...HEAD` prints '<behind>\\t<ahead>'
+    (left = commits in upstream not in HEAD; right = commits in HEAD not in upstream).
+    """
+    rc, out, _ = _git(repo, "rev-list", "--left-right", "--count", f"{upstream}...HEAD")
+    if rc != 0 or not out:
+        return 0, 0
+    parts = out.split()
+    if len(parts) != 2:
+        return 0, 0
+    try:
+        behind, ahead = int(parts[0]), int(parts[1])
+    except ValueError:
+        return 0, 0
+    return ahead, behind
+
+
+def classify_hub_action(
+    repo: Path,
+    *,
+    default_branch: Optional[str] = None,
+    now_ts: Optional[float] = None,
+) -> HubState:
+    """Classify a bare hub into exactly one HubAction. Fail-safe: anything the
+    classifier cannot prove safe is SURFACEd or SKIPped, never auto-advanced.
+
+    Decision order (first match wins):
+      1. live .session-lock        → SKIP_SESSION_LOCK (don't fight a session)
+      2. no origin default branch  → SKIP_NO_ORIGIN
+      3. off the default branch    → SURFACE_OFF_DEFAULT (detached / feature branch)
+      4. dirty working tree        → SURFACE_DIRTY
+      5. unpushed local commits    → SURFACE_DIVERGED (ahead > 0)
+      6. clean, on default, behind → FF   (the only auto action; a guaranteed ff)
+         clean, on default, even   → SKIP_CURRENT
+    """
+    repo = Path(repo)
+    st = HubState(repo=repo, action=HubAction.SKIP_CURRENT)
+    rc, head, _ = _git(repo, "rev-parse", "--verify", "--quiet", "HEAD")
+    st.head = head if rc == 0 else ""
+
+    if _has_live_session_lock(repo, now_ts):
+        st.action = HubAction.SKIP_SESSION_LOCK
+        return st
+
+    default_branch = default_branch or detect_default_branch(repo)
+    st.default_branch = default_branch
+    if not default_branch:
+        st.action = HubAction.SKIP_NO_ORIGIN
+        return st
+    upstream = f"origin/{default_branch}"
+
+    st.current_branch = _current_branch(repo)
+    st.dirty = _is_dirty(repo)
+    st.ahead, st.behind = _ahead_behind(repo, upstream)
+
+    # Off the default branch (detached or a feature branch) → SURFACE, never
+    # auto-switch. ff-only is only meaningful while sitting on the default.
+    if st.current_branch != default_branch:
+        st.action = HubAction.SURFACE_OFF_DEFAULT
+        return st
+
+    # On the default branch from here down.
+    if st.dirty:
+        st.action = HubAction.SURFACE_DIRTY
+        return st
+
+    # Un-backed-up local commits (ahead of origin) → SURFACE; an ff-only into a
+    # branch carrying its own commits is either a no-op or impossible.
+    if st.ahead > 0:
+        st.action = HubAction.SURFACE_DIVERGED
+        return st
+
+    st.action = HubAction.FF if st.behind > 0 else HubAction.SKIP_CURRENT
+    return st
+
+
+def execute_hub_refresh(
+    state: HubState,
+    apply: bool = False,
+    now_ts: Optional[float] = None,
+) -> dict:
+    """Advance exactly the FF hubs by a fast-forward; everything else is a no-op.
+
+    apply=False is a dry-run that mutates nothing. apply=True re-classifies the
+    hub immediately before mutating (a read-then-act atomicity gate: a hub that
+    turned dirty / switched branch / diverged between plan and apply drops out of
+    the FF set), then runs `git merge --ff-only` — which itself fails closed if
+    the move is somehow no longer a fast-forward. A fast-forward only advances the
+    branch pointer, so it is fully reversible from the reflog.
+    """
+    res: dict = {
+        "repo": str(state.repo),
+        "action": state.action,
+        "applied": False,
+        "ff_to": None,
+        "ok": None,
+    }
+    if state.action != HubAction.FF:
+        return res
+    if not apply:
+        res["ff_to"] = f"origin/{state.default_branch}"
+        return res
+
+    fresh = classify_hub_action(state.repo, now_ts=now_ts)
+    if fresh.action != HubAction.FF:
+        res["action"] = fresh.action
+        res["skipped"] = "state-changed-since-plan"
+        return res
+
+    upstream = f"origin/{fresh.default_branch}"
+    rc, _out, err = _git(state.repo, "merge", "--ff-only", upstream)
+    res["ok"] = rc == 0
+    res["applied"] = rc == 0
+    if rc == 0:
+        rc2, head, _ = _git(state.repo, "rev-parse", "HEAD")
+        res["ff_to"] = head if rc2 == 0 else upstream
+    else:
+        res["error"] = err[:200]
+    return res
+
+
+def summarize_hub_states(states) -> dict:
+    """Roll a fleet of HubState into counts + worst offenders, for the cheap
+    SessionStart surfacer. 'offenders' = surfaced hubs + any hub still behind,
+    sorted by commits-behind descending."""
+    states = list(states)
+    ff = sum(1 for s in states if s.action == HubAction.FF)
+    surfaced = sum(1 for s in states if s.action in HUB_SURFACE_ACTIONS)
+    skipped = sum(1 for s in states if s.action.startswith("skip:"))
+    max_behind = max((s.behind for s in states), default=0)
+    offenders = sorted(
+        (
+            (s.repo.name, s.action, s.behind)
+            for s in states
+            if s.action in HUB_SURFACE_ACTIONS or s.behind > 0
+        ),
+        key=lambda t: t[2],
+        reverse=True,
+    )
+    return {
+        "ff": ff,
+        "surfaced": surfaced,
+        "skipped": skipped,
+        "max_behind": max_behind,
+        "offenders": offenders,
+    }
+
+
+_HUB_ACTION_LABEL = {
+    HubAction.SURFACE_DIRTY: "dirty working tree",
+    HubAction.SURFACE_OFF_DEFAULT: "off the default branch",
+    HubAction.SURFACE_DIVERGED: "unpushed local commits",
+    HubAction.FF: "behind (auto-ff pending)",
+}
+
+
+def format_hub_surface_line(
+    summary: dict, threshold: int = 50, limit: int = 6
+) -> Optional[str]:
+    """A one-line SessionStart nudge, or None when nothing is worth saying.
+
+    Speaks up when ANY hub needs a human (surfaced: dirty / off-default /
+    diverged) OR a hub is >= `threshold` commits behind origin (a sign the
+    launchd auto-refresh has stalled). A clean main only a little behind is
+    auto-fixable and stays silent."""
+    surfaced = summary.get("surfaced", 0)
+    max_behind = summary.get("max_behind", 0)
+    if surfaced == 0 and max_behind < threshold:
+        return None
+    offenders = summary.get("offenders", [])
+    parts = [
+        "[dev-hub-refresh]",
+        "",
+        (
+            f"{surfaced} bare ~/dev hub(s) need a human; worst is {max_behind} "
+            f"commit(s) behind origin. Auto-ff handles clean mains — these need you:"
+        ),
+    ]
+    for name, action, behind in offenders[:limit]:
+        label = _HUB_ACTION_LABEL.get(action, action)
+        parts.append(f"- `{name}` — {label} ({behind} behind)")
+    if len(offenders) > limit:
+        parts.append(f"- … and {len(offenders) - limit} more")
+    parts += [
+        "",
+        (
+            "Resolve in a worktree (`claude-dev-worktree start <repo> <slug>`) or run "
+            "`dev-hub-refresh.py` (dry-run) then `--apply`. "
+            "Bug class: STALE-BARE-CHECKOUT-READ (MYC-1893)."
+        ),
+    ]
+    return "\n".join(parts)

--- a/hooks/dev-hub-refresh-on-session-start.py
+++ b/hooks/dev-hub-refresh-on-session-start.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""SessionStart hook (MYC-1893): surface bare ~/dev hubs that need a human.
+
+CHEAP by construction — reads the state file the launchd `dev-hub-refresh --apply`
+job writes (NO git, NO fetch on the interactive path). The launchd leg owns the
+expensive fetch + fast-forward; this leg is the human-visible backstop that says
+"these hubs are far behind / dirty / off-branch — the auto-ff couldn't touch them".
+
+Stays SILENT unless something genuinely needs attention (surfaced hub, or a hub
+>= THRESHOLD commits behind — a sign the launchd refresh has stalled). Fail-open:
+a missing / garbled state file prints nothing (a fresh install seeds it at login;
+daemon-liveness is surface-stale-automation-failures.py's job, not this hook's).
+
+Bug class: STALE-BARE-CHECKOUT-READ (MYC-670 / MYC-1127 / MYC-1893).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+STATE_PATH = Path(
+    os.environ.get("DEV_HUB_REFRESH_STATE")
+    or (Path.home() / ".claude" / ".dev-hub-refresh-state.json")
+)
+THRESHOLD = 50  # a hub >= this many commits behind is "loud" even though it is auto-fixable
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    from _lib.dev_repo_scan import format_hub_surface_line
+except Exception:
+    print(json.dumps({}))
+    sys.exit(0)
+
+
+def _emit(message: str | None = None) -> None:
+    if message:
+        print(json.dumps({
+            "hookSpecificOutput": {
+                "hookEventName": "SessionStart",
+                "additionalContext": message,
+            }
+        }))
+    else:
+        print(json.dumps({}))
+    sys.exit(0)
+
+
+def main() -> None:
+    try:
+        json.load(sys.stdin)
+    except Exception:
+        pass
+
+    try:
+        data = json.loads(STATE_PATH.read_text())
+    except (OSError, ValueError):
+        _emit()  # no state yet (fresh install / launchd not run) → silent
+
+    summary = data.get("summary") if isinstance(data, dict) else None
+    if not isinstance(summary, dict):
+        _emit()
+
+    _emit(format_hub_surface_line(summary, threshold=THRESHOLD))
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/warn-stale-dev-checkout.py
+++ b/hooks/warn-stale-dev-checkout.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""
+warn-stale-dev-checkout.py — PreToolUse guard.
+
+Bug class: STALE-BARE-CHECKOUT-READ (sibling of WRONG-ARTIFACT-VERIFIED).
+
+Incident 2026-06-08 (MYC-670): the ~/dev/mycelium-studio BARE checkout was 147
+commits / 2 weeks behind origin/main. A recon Read of its pr-build.yml returned a
+stale, JS-only workflow that contradicted the Linear issue. The miss was caught
+only by LUCK (the issue described jobs absent from the stale file). A subtler
+2-week drift (a 5-line change to an existing job) would have slipped through and
+produced a broken / conflicting edit.
+
+Recurrence 2026-06-21 (MYC-1127 re-audit): a `git grep` recon of the same bare
+checkout (282 behind) returned NOTHING for a dir that did not exist at the stale
+HEAD — nearly mis-concluding "the consumer doesn't exist". The Read tool warned;
+the Bash `git grep` did NOT, because this guard only covered Read/Edit/Write.
+Coverage now includes Bash read-class commands (git grep/log/show/diff without a
+ref, plus cat/grep/rg/sed/head/tail on a checkout path). A ref-qualified read
+(`origin/main`) IS the canonical remedy → stays silent.
+
+Root cause: bare ~/dev/<repo> checkouts ROT — all real work happens in per-session
+worktrees (which base on origin/main and are fresh by construction), so nobody
+ever pulls the bare checkout. Reading it as if it were "current" is the danger.
+
+Fix: when a file-touching tool OR a read-class Bash command targets a STALE bare
+~/dev/<repo> checkout, warn once (per session, per repo) with the canonical-state
+remedy. Worktrees (<repo>-<slug>, whose .git is a FILE pointer) are fresh by
+construction and are skipped. Fail-open, non-blocking.
+
+Discriminator (Julia Evans, panel 2026-06-08): a bare checkout's .git is a DIR
+(can rot); a worktree's .git is a FILE (gitdir pointer, fresh off origin/main).
+
+Noise budget (Charity Majors, panel 2026-06-08): fire ONCE per (session, repo),
+only on real drift (>= THRESHOLD behind), remedy copy-pasteable. A guard that
+cries wolf teaches its own bypass (over-strict-verification-teaches-bypass.md).
+Bash precision: a ref-qualified read (origin/main) is the remedy → never warned;
+a command merely MENTIONING a fresh repo never warns (gated on real staleness).
+
+Bypass: STALE_CHECKOUT_BYPASS=1
+"""
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+THRESHOLD = 5          # commits behind origin/main before we warn
+FETCH_TIMEOUT = 8      # seconds; fail-open past this
+STALE_FETCH_DAYS = 3.0 # if last fetch older than this, also flag knowledge-staleness
+# STALE_CHECKOUT_DEV_ROOT overrides the scanned root (tests point it at a tempdir).
+DEV = Path(os.environ.get("STALE_CHECKOUT_DEV_ROOT") or (Path.home() / "dev"))
+SEEN_DIR = Path.home() / ".claude" / ".stale-dev-checkout-seen"
+
+# Telemetry so this guard's fire-count is measurable — the precondition for
+# RETIRING it once MYC-427 (merge queue) stops bare checkouts from rotting.
+# Fail-open: a missing _lib must never break the guard (or its tests).
+try:
+    sys.path.insert(0, str(Path(__file__).resolve().parent / "_lib"))
+    from guard_telemetry import log_fire
+except Exception:
+    def log_fire(*_a, **_k):
+        return
+
+# Inline-bypass consult (MYC-772): a `STALE_CHECKOUT_BYPASS=1 <cmd>` prefix lives
+# ONLY in the command string, never the hook's os.environ — read both or the
+# advertised bypass can never fire (HOOK-READS-SESSION-ENV-NOT-COMMAND-ENV).
+try:
+    from cmd_env import inline_bypass
+except Exception:                          # fail-open: a missing _lib must never break the guard
+    def inline_bypass(command, var, value="1"):  # type: ignore
+        return False
+
+
+def _run(args, cwd=None, timeout=10):
+    try:
+        r = subprocess.run(
+            args, cwd=cwd, capture_output=True, text=True, timeout=timeout
+        )
+        return r.returncode, r.stdout.strip(), r.stderr.strip()
+    except Exception:
+        return 1, "", ""
+
+
+def _repo_root(path: Path):
+    """Walk up to the dir that contains a .git entry. Returns (root, git_is_dir)."""
+    for d in [path, *path.parents]:
+        g = d / ".git"
+        if g.exists():
+            return d, g.is_dir()
+    return None, False
+
+
+def _behind(root: Path):
+    """Commits HEAD is behind origin/main (or origin/master). None if no origin ref."""
+    for ref in ("origin/main", "origin/master"):
+        rc, out, _ = _run(["git", "-C", str(root), "rev-list", "--count", f"HEAD..{ref}"])
+        if rc == 0 and out.isdigit():
+            return int(out), ref
+    return None, None
+
+
+def _fetch_age_days(root: Path):
+    fh = root / ".git" / "FETCH_HEAD"
+    if fh.exists():
+        return (time.time() - fh.stat().st_mtime) / 86400.0
+    return None
+
+
+def _warn_for_root(root: Path, session_id: str):
+    """Once-per-(session,repo) staleness warning for a BARE checkout root.
+
+    Caller guarantees `root` is a bare checkout (.git is a DIR). Returns the
+    warning string, or None to stay silent.
+    """
+    # Fire once per (session, repo).
+    try:
+        SEEN_DIR.mkdir(parents=True, exist_ok=True)
+        marker = SEEN_DIR / f"{session_id}__{root.name}"
+        if marker.exists():
+            return None
+        marker.touch()
+    except Exception:
+        pass  # marker is best-effort; never block on it
+
+    # Refresh origin refs once (timeout-guarded, fail-open).
+    _run(["git", "-C", str(root), "fetch", "--quiet", "origin"], timeout=FETCH_TIMEOUT)
+
+    behind, ref = _behind(root)
+    if behind is None:
+        return None  # no origin/main to compare against (local-only repo)
+
+    age = _fetch_age_days(root)
+    stale_knowledge = age is not None and age > STALE_FETCH_DAYS
+
+    if behind < THRESHOLD and not stale_knowledge:
+        return None
+
+    _, head, _ = _run(["git", "-C", str(root), "log", "-1", "--format=%h %cs (%cr)"])
+    msg = (
+        f"⚠ STALE BARE CHECKOUT: {root} is {behind} commit(s) behind {ref} "
+        f"(HEAD {head}). This working tree is NOT current — reading its files as "
+        f"'the live state' is the STALE-BARE-CHECKOUT-READ class (MYC-670 near-miss).\n"
+        f"Before editing OR trusting any file here:\n"
+        f"  • work in a fresh worktree (bases on origin/main):\n"
+        f"      claude-dev-worktree start {root.name} <slug>\n"
+        f"  • or read canonical state directly:\n"
+        f"      git -C {root} show {ref}:<path>\n"
+        f"      git -C {root} grep <pat> {ref} -- <path>\n"
+        f"Do NOT treat {root.name}'s working tree as the canonical artifact. "
+        f"Bypass: STALE_CHECKOUT_BYPASS=1"
+    )
+    log_fire("warn-stale-dev-checkout", status="warned", repo=root.name, behind=behind)
+    return msg
+
+
+def evaluate(file_path: str, session_id: str):
+    """File-tool path (Read/Edit/Write/MultiEdit). Returns a warning or None."""
+    if os.environ.get("STALE_CHECKOUT_BYPASS") == "1":
+        return None
+    try:
+        p = Path(file_path).resolve()
+    except Exception:
+        return None
+
+    # Only ~/dev/<repo> paths.
+    try:
+        p.relative_to(DEV.resolve())
+    except (ValueError, OSError):
+        return None
+
+    root, git_is_dir = _repo_root(p)
+    if root is None:
+        return None
+    # Worktrees (.git is a FILE) are fresh off origin/main by construction → skip.
+    if not git_is_dir:
+        return None
+
+    return _warn_for_root(root, session_id)
+
+
+def _bash_dev_targets(command: str):
+    """Resolve the ~/dev/<repo> dirs a bash command references (best-effort).
+
+    Matches any of DEV's spellings — the resolved absolute path, `~/dev`,
+    `$HOME/dev` — followed by `/<repo>`. A literal path in the command string
+    (incl. a `R=~/dev/<repo>` assignment) is enough; unexpanded shell variables
+    are not chased (precision over completeness — the file-tool path still
+    covers Read/Edit/Write).
+    """
+    prefixes = set()
+    try:
+        prefixes.add(str(DEV))
+        prefixes.add(str(DEV.resolve()))
+    except Exception:
+        prefixes.add(str(DEV))
+    try:
+        rel = DEV.resolve().relative_to(Path.home().resolve())
+        prefixes.add(f"~/{rel}")
+        prefixes.add(f"$HOME/{rel}")
+    except Exception:
+        pass
+
+    cands = {}
+    for pfx in prefixes:
+        for m in re.finditer(re.escape(pfx) + r"/([A-Za-z0-9][A-Za-z0-9._-]*)", command):
+            cand = DEV / m.group(1)
+            cands[str(cand)] = cand
+    return list(cands.values())
+
+
+def evaluate_bash(command: str, session_id: str):
+    """Bash path. Warns on a read-class command against a STALE bare checkout.
+
+    A ref-qualified read (`origin/main` / `origin/master`) IS the canonical-state
+    remedy — stay silent. Otherwise, any referenced ~/dev/<repo> that is a bare,
+    stale checkout warns once. Worktrees / fresh / missing dirs are skipped.
+    """
+    if os.environ.get("STALE_CHECKOUT_BYPASS") == "1" or inline_bypass(command, "STALE_CHECKOUT_BYPASS"):
+        return None
+    if not command:
+        return None
+    # Already reading canonical state → never nag.
+    if re.search(r"\borigin/(main|master)\b", command):
+        return None
+
+    for cand in _bash_dev_targets(command):
+        try:
+            g = cand / ".git"
+            if not cand.is_dir() or not g.exists() or not g.is_dir():
+                continue  # missing, non-repo, or worktree (.git is a FILE) → skip
+        except OSError:
+            continue
+        warning = _warn_for_root(cand, session_id)
+        if warning:
+            return warning
+    return None
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
+    tool = payload.get("tool_name", "")
+    session_id = payload.get("session_id", "nosession")
+    ti = payload.get("tool_input") or {}
+    try:
+        if tool in ("Read", "Edit", "Write", "MultiEdit"):
+            fp = ti.get("file_path", "")
+            warning = evaluate(fp, session_id) if fp else None
+        elif tool == "Bash":
+            warning = evaluate_bash(ti.get("command", ""), session_id)
+        else:
+            sys.exit(0)
+    except Exception:
+        sys.exit(0)  # fail-open: a freshness nudge must never block a read/edit
+    if warning:
+        print(json.dumps({
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "additionalContext": warning,
+            }
+        }))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dev-hub-refresh.py
+++ b/scripts/dev-hub-refresh.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""dev-hub-refresh — keep bare ~/dev/<repo> hubs fresh (MYC-1893).
+
+Bare hubs ROT: parked on stale feature branches, dirtied by edits, written into
+by background jobs (STALE-BARE-CHECKOUT-READ, MYC-670 / MYC-1127). The read-time
+guard warn-stale-dev-checkout.py DETECTS the rot; this is the PREVENTION half.
+
+ONE auto-action: fast-forward a hub that is clean, on its default branch, behind,
+and carrying no local commits (a GUARANTEED ff, reversible via reflog). Everything
+else — dirty / on a feature branch / detached / diverged — is SURFACED, never
+auto-switched, auto-cleaned, or auto-recovered. Worktrees and any repo with a live
+.session-lock are skipped. The reap/surface decision lives in _lib/dev_repo_scan.py
+and is proven RED-then-green (incl. neg controls) by hooks/test_dev_hub_refresh.py.
+
+FETCH-FIRST: a stale local ref misleads in BOTH directions (MYC-1893 correction),
+so the scan `git fetch --quiet origin` each hub before judging. --no-fetch skips it.
+
+DRY-RUN BY DEFAULT. --apply performs the fast-forwards and writes the state file
+(~/.claude/.dev-hub-refresh-state.json) the SessionStart surfacer reads, plus a
+per-run log to ~/.claude/logs/dev-hub-refresh/. A fast-forward only advances the
+branch pointer, so every action is reversible from the reflog.
+
+Usage:
+  dev-hub-refresh.py                 # dry-run, fetch-first, whole ~/dev fleet
+  dev-hub-refresh.py --apply         # ff clean mains, surface the rest, write state
+  dev-hub-refresh.py --repo ~/dev/x  # one hub
+  dev-hub-refresh.py --no-fetch      # skip the pre-scan `git fetch origin`
+  dev-hub-refresh.py --json          # machine-readable plan
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+DEV_ROOT = Path(os.environ.get("DEV_HUB_REFRESH_ROOT") or (Path.home() / "dev"))
+STATE_PATH = Path(
+    os.environ.get("DEV_HUB_REFRESH_STATE")
+    or (Path.home() / ".claude" / ".dev-hub-refresh-state.json")
+)
+LOG_DIR = Path.home() / ".claude" / "logs" / "dev-hub-refresh"
+FETCH_TIMEOUT = 20
+
+
+def _add_lib_to_path() -> bool:
+    """Locate the deployed/in-repo _lib package and put it on sys.path."""
+    for c in (
+        os.environ.get("DEV_REPO_SCAN_DIR"),
+        str(Path.home() / ".claude" / "hooks"),            # deployed
+        str(Path(__file__).resolve().parent.parent / "hooks"),  # in-repo (bin/../hooks)
+    ):
+        if c and (Path(c) / "_lib" / "dev_repo_scan.py").exists():
+            sys.path.insert(0, c)
+            return True
+    return False
+
+
+if not _add_lib_to_path():
+    print(
+        "dev-hub-refresh: could not locate _lib/dev_repo_scan.py "
+        "(set DEV_REPO_SCAN_DIR).",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+from _lib.dev_repo_scan import (  # noqa: E402
+    HUB_SURFACE_ACTIONS,
+    classify_hub_action,
+    discover_hubs,
+    execute_hub_refresh,
+    summarize_hub_states,
+)
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _fetch(repo: Path) -> None:
+    """Read-only origin refresh, fail-open + bounded."""
+    try:
+        subprocess.run(
+            ["git", "-C", str(repo), "fetch", "--quiet", "origin"],
+            capture_output=True,
+            timeout=FETCH_TIMEOUT,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        pass
+
+
+def refresh_fleet(repos, *, apply: bool, fetch: bool):
+    """Fetch-first (optional), then classify + execute each hub.
+
+    Returns (states, results). States are the POST-action classification so an
+    ff'd hub reads as current in the state file (not perpetually "behind").
+    """
+    if fetch:
+        for r in repos:
+            _fetch(r)
+    states, results = [], []
+    for r in repos:
+        st = classify_hub_action(r)
+        res = execute_hub_refresh(st, apply=apply)
+        if res.get("applied"):
+            st = classify_hub_action(r)  # reflect the fast-forward
+        states.append(st)
+        results.append(res)
+    return states, results
+
+
+def _state_payload(states, results, applied: bool) -> dict:
+    return {
+        "generated_at": _utcnow(),
+        "applied": applied,
+        "hubs": [
+            {
+                "repo": s.repo.name,
+                "path": str(s.repo),
+                "action": s.action,
+                "behind": s.behind,
+                "ahead": s.ahead,
+                "dirty": s.dirty,
+                "current_branch": s.current_branch,
+                "default_branch": s.default_branch,
+            }
+            for s in states
+        ],
+        "summary": summarize_hub_states(states),
+        "ff_applied": [Path(r["repo"]).name for r in results if r.get("applied")],
+    }
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, indent=2))
+    except OSError:
+        pass
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Keep bare ~/dev hubs fresh: ff clean mains, surface the rest."
+    )
+    ap.add_argument("--apply", action="store_true",
+                    help="perform the fast-forwards (default: dry-run)")
+    ap.add_argument("--repo", help="limit to one hub path (default: whole ~/dev fleet)")
+    ap.add_argument("--no-fetch", action="store_true",
+                    help="skip the pre-scan `git fetch origin` freshness pass")
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    ap.add_argument("--quiet", action="store_true")
+    args = ap.parse_args()
+
+    repos = [Path(args.repo).expanduser()] if args.repo else discover_hubs(DEV_ROOT)
+    states, results = refresh_fleet(repos, apply=args.apply, fetch=not args.no_fetch)
+    payload = _state_payload(states, results, args.apply)
+
+    # The state file feeds the cheap SessionStart surfacer; refresh it every run
+    # (dry-run included) so the surface stays current between --apply cycles.
+    _write_json(STATE_PATH, payload)
+
+    ff_done = payload["ff_applied"]
+    summary = payload["summary"]
+
+    if args.json:
+        print(json.dumps(
+            {"applied": args.apply, "ff_applied": ff_done,
+             "results": results, "summary": summary}, indent=2))
+    elif not args.quiet:
+        mode = "APPLY" if args.apply else "DRY-RUN"
+        print(f"dev-hub-refresh {mode} — {len(repos)} hub(s) scanned")
+        print(f"  ff: {summary['ff']}  surfaced (need human): {summary['surfaced']}  "
+              f"max-behind: {summary['max_behind']}")
+        if ff_done:
+            print(f"  fast-forwarded: {', '.join(ff_done)}")
+        for s in states:
+            if s.action in HUB_SURFACE_ACTIONS:
+                br = s.current_branch or "DETACHED"
+                print(f"  SURFACE  {s.repo.name}  [{s.action}]  on {br}, "
+                      f"{s.behind} behind, {s.ahead} ahead")
+        if not args.apply and summary["ff"]:
+            print("\nRe-run with --apply to fast-forward the clean mains "
+                  "(SURFACE items are never auto-touched).")
+
+    if args.apply:
+        _write_json(
+            LOG_DIR / f"refresh-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}.json",
+            payload,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/install-dev-hub-refresh-daemon.sh
+++ b/scripts/install-dev-hub-refresh-daemon.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# install-dev-hub-refresh-daemon.sh
+#
+# One-shot installer for the bare-~/dev-hub freshness daemon on macOS (MYC-1893).
+# It does two things:
+#   1. Ensures the codegraph index dir (.codegraph/) is GLOBALLY git-ignored, so
+#      codegraph indexing can never dirty a bare ~/dev hub (a background-job write
+#      that otherwise blocks the hub's auto-fast-forward).
+#   2. Renders templates/launchd/com.abs.dev-hub-refresh.plist.template with this
+#      clone's path, installs it to ~/Library/LaunchAgents/, and loads it.
+#
+# The daemon runs scripts/dev-hub-refresh.py --apply every 6h (and once at load):
+# fetch-first, fast-forward CLEAN hubs sitting on their default branch (a
+# guaranteed, reflog-reversible fast-forward), and surface the rest. It NEVER
+# switches branches, cleans a dirty tree, or forces anything.
+#
+# Usage:
+#   ./scripts/install-dev-hub-refresh-daemon.sh
+#
+# Idempotent: re-running unloads the old plist first, and the global-ignore line
+# is added at most once.
+#
+# Requires: macOS, launchctl, /usr/bin/python3, git.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEMPLATE="$REPO_ROOT/templates/launchd/com.abs.dev-hub-refresh.plist.template"
+TARGET_DIR="$HOME/Library/LaunchAgents"
+TARGET_FILE="$TARGET_DIR/com.abs.dev-hub-refresh.plist"
+LOG_DIR="$HOME/.local/state/ai-brain-starter"
+
+if [[ ! -f "$TEMPLATE" ]]; then
+    echo "template missing at $TEMPLATE" >&2
+    exit 2
+fi
+
+# --- 1. ensure codegraph machinery is globally git-ignored (never dirties a hub) ---
+GLOBAL_IGNORE="$(git config --global core.excludesfile 2>/dev/null || true)"
+if [[ -z "$GLOBAL_IGNORE" ]]; then
+    GLOBAL_IGNORE="${XDG_CONFIG_HOME:-$HOME/.config}/git/ignore"
+fi
+# Expand a leading ~ that git may store literally.
+GLOBAL_IGNORE="${GLOBAL_IGNORE/#\~/$HOME}"
+mkdir -p "$(dirname "$GLOBAL_IGNORE")"
+touch "$GLOBAL_IGNORE"
+if ! grep -qxF '.codegraph/' "$GLOBAL_IGNORE"; then
+    {
+        echo ""
+        echo "# Codegraph knowledge-graph index (machine-local, rebuilt per-repo, never synced)."
+        echo "# Global-ignored so indexing a bare ~/dev hub cannot dirty its tree (MYC-1893)."
+        echo ".codegraph/"
+    } >> "$GLOBAL_IGNORE"
+    echo "[install-dev-hub-refresh-daemon] added .codegraph/ to $GLOBAL_IGNORE"
+fi
+
+# --- 2. install + load the launchd agent ---
+mkdir -p "$TARGET_DIR" "$LOG_DIR"
+if [[ -f "$TARGET_FILE" ]]; then
+    echo "[install-dev-hub-refresh-daemon] unloading existing plist..."
+    launchctl unload "$TARGET_FILE" 2>/dev/null || true
+fi
+
+# sed -i differs across macOS / GNU; render via a temp redirect.
+sed \
+    -e "s|{{REPO_ROOT}}|$REPO_ROOT|g" \
+    -e "s|{{LOG_DIR}}|$LOG_DIR|g" \
+    "$TEMPLATE" > "$TARGET_FILE"
+echo "[install-dev-hub-refresh-daemon] wrote $TARGET_FILE"
+launchctl load "$TARGET_FILE"
+echo "[install-dev-hub-refresh-daemon] loaded + scheduled (every 6h + at load)"
+echo
+echo "Logs:        $LOG_DIR/dev-hub-refresh.{out,err}.log"
+echo "Run now:     python3 $REPO_ROOT/scripts/dev-hub-refresh.py --apply"
+echo "Dry-run:     python3 $REPO_ROOT/scripts/dev-hub-refresh.py"
+echo "Stop:        launchctl unload $TARGET_FILE"

--- a/scripts/install-hooks-user-level.py
+++ b/scripts/install-hooks-user-level.py
@@ -91,6 +91,9 @@ ABS_FINGERPRINTS = [
     "ai-brain-starter/hooks/warn-vault-session-in-worktree.py",
     # Memory-routing nudge (team learning written to tool-private memory → shared brain):
     "ai-brain-starter/hooks/warn-learning-to-tool-private-memory.py",
+    # Bare ~/dev hub-rot guard (read-time detection) + surfacer (MYC-1893):
+    "ai-brain-starter/hooks/warn-stale-dev-checkout.py",
+    "ai-brain-starter/hooks/dev-hub-refresh-on-session-start.py",
 ]
 
 # Path-divergence-robust matching: an ai-brain-starter hook may be wired at the
@@ -111,6 +114,7 @@ ABS_OWNED_BASENAMES = {
     "block-secret-in-note.py", "context-budget-measure.py",
     "block-populated-public-skill.py",
     "warn-vault-session-in-worktree.py", "warn-learning-to-tool-private-memory.py",
+    "warn-stale-dev-checkout.py", "dev-hub-refresh-on-session-start.py",
 }
 
 # Hooks ai-brain-starter USED TO ship and has deliberately RETIRED. The

--- a/scripts/post-install-smoke-test.sh
+++ b/scripts/post-install-smoke-test.sh
@@ -35,10 +35,12 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-SKILL_DIR="$HOME/.claude/skills/ai-brain-starter"
-if [[ ! -d "$SKILL_DIR" ]]; then
-  # fallback to the maintainer location
-  SKILL_DIR="$HOME/Desktop/ai-brain-starter"
+# Honor an explicit SKILL_DIR (lets a maintainer smoke a checkout/worktree
+# pre-merge); otherwise auto-detect the installed clone, then the maintainer dir.
+SKILL_DIR="${SKILL_DIR:-}"
+if [[ -z "$SKILL_DIR" ]]; then
+  SKILL_DIR="$HOME/.claude/skills/ai-brain-starter"
+  [[ -d "$SKILL_DIR" ]] || SKILL_DIR="$HOME/Desktop/ai-brain-starter"
 fi
 
 PASS=0
@@ -120,6 +122,35 @@ if [[ -f "$LINTER" ]]; then
   else
     fail "lint-vault-frontmatter.py wrong response for Read tool"
   fi
+fi
+
+# === 4b. dev-hub-refresh guard + surfacer (MYC-1893) ===
+hdr "dev-hub-refresh (bare ~/dev hub-rot guard)"
+WARN_STALE="$SKILL_DIR/hooks/warn-stale-dev-checkout.py"
+if [[ -f "$WARN_STALE" ]]; then
+  resp=$(echo '{"tool_name":"Read","session_id":"smoke","tool_input":{"file_path":"/tmp/not-a-dev-repo"}}' | python3 "$WARN_STALE" 2>/dev/null)
+  if echo "$resp" | python3 -c "import json,sys; s=sys.stdin.read(); json.loads(s) if s.strip() else None" 2>/dev/null; then
+    ok "warn-stale-dev-checkout.py runs + emits valid JSON (silent on a non-~/dev path)"
+  else
+    fail "warn-stale-dev-checkout.py produced invalid output"
+  fi
+else
+  warn "warn-stale-dev-checkout.py not present"
+fi
+
+SURFACER="$SKILL_DIR/hooks/dev-hub-refresh-on-session-start.py"
+if [[ -f "$SURFACER" ]]; then
+  STATE_F=$(mktemp)
+  printf '%s' '{"summary":{"ff":0,"surfaced":1,"skipped":0,"max_behind":360,"offenders":[["studio","surface:off-default",360]]}}' > "$STATE_F"
+  resp=$(echo '{}' | DEV_HUB_REFRESH_STATE="$STATE_F" python3 "$SURFACER" 2>/dev/null)
+  if echo "$resp" | python3 -c "import json,sys; d=json.loads(sys.stdin.read()); assert 'studio' in d.get('hookSpecificOutput',{}).get('additionalContext','')" 2>/dev/null; then
+    ok "dev-hub-refresh surfacer emits a surface line from its state file"
+  else
+    fail "dev-hub-refresh surfacer did not surface the off-default hub"
+  fi
+  rm -f "$STATE_F"
+else
+  warn "dev-hub-refresh-on-session-start.py not present"
 fi
 
 # === 5. Aggregator smoke ===

--- a/templates/launchd/com.abs.dev-hub-refresh.plist.template
+++ b/templates/launchd/com.abs.dev-hub-refresh.plist.template
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  com.abs.dev-hub-refresh.plist.template
+
+  macOS launchd template for ai-brain-starter's bare-~/dev-hub freshness pass —
+  the PREVENTION half of STALE-BARE-CHECKOUT-READ (pairs with the read-time guard
+  hooks/warn-stale-dev-checkout.py, which DETECTS a stale bare hub).
+
+  Runs scripts/dev-hub-refresh.py --apply every 6h (and once at load): FETCH-FIRST,
+  then fast-forward any hub that is CLEAN, on its default branch, behind, with no
+  local commits (a GUARANTEED fast-forward, reflog-reversible), and SURFACE the rest
+  (dirty / feature-branch / detached / diverged) into
+  ~/.claude/.dev-hub-refresh-state.json for the SessionStart surfacer. It NEVER
+  auto-switches branches, cleans a dirty tree, or forces anything; it skips
+  worktrees and any repo with a live .session-lock.
+
+  scripts/install-dev-hub-refresh-daemon.sh does substitution + load in one step.
+
+  Placeholders:
+    {{REPO_ROOT}}   absolute path to the ai-brain-starter clone
+    {{LOG_DIR}}     absolute directory for stdout/stderr logs
+
+  After the file lands at ~/Library/LaunchAgents/, run:
+    launchctl load ~/Library/LaunchAgents/com.abs.dev-hub-refresh.plist
+  Stop with:
+    launchctl unload ~/Library/LaunchAgents/com.abs.dev-hub-refresh.plist
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.abs.dev-hub-refresh</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/bin/python3</string>
+        <string>{{REPO_ROOT}}/scripts/dev-hub-refresh.py</string>
+        <string>--apply</string>
+        <string>--quiet</string>
+    </array>
+
+    <key>StartInterval</key>
+    <integer>21600</integer>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>{{LOG_DIR}}/dev-hub-refresh.out.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>{{LOG_DIR}}/dev-hub-refresh.err.log</string>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+
+    <key>LowPriorityIO</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
## MYC-1893: dev-hub-refresh + stale-hub guard → substrate

Bare `~/dev/<repo>` hubs rot — parked on stale feature branches, dirtied by background jobs, written into. The read-time guard `warn-stale-dev-checkout` DETECTS this but was personal-only; this ships it plus the PREVENTION mechanism into the public substrate (Substrate Is Product).

**What ships**
- `dev_repo_scan` gains `classify_hub_action` / `execute_hub_refresh` / `discover_hubs` + the surfacer formatter. One auto-action: fast-forward a hub that is clean, on its default branch, behind, with no local commits (a guaranteed fast-forward, reflog-reversible). Dirty / feature-branch / detached / diverged hubs are surface-only. Worktrees and live-`session-lock` repos are skipped. Fetch-first (a stale local ref misleads in both directions).
- `warn-stale-dev-checkout` wired PreToolUse; `dev-hub-refresh-on-session-start` wired SessionStart (cheap, no-fetch, reads a state file, silent when nothing needs a human).
- `dev-hub-refresh` CLI + an opt-in every-6h daemon installer that also global-ignores `.codegraph/` (a background-write that otherwise dirties hubs).
- Shipping `dev_repo_scan` also activates the previously-dormant `list-wip-stashes-on-session-start` (its `_lib` import was unresolved on `main`).

**Verification**: `ci.sh` green — `py_compile` (273) + 50 integration tests + shellcheck. `post-install-smoke-test` gains behavioral checks for both hooks (green) and honors a `SKILL_DIR` override so a maintainer can smoke a checkout pre-merge. The negative-control suite (proves it refuses dirty / feature-branch / unpushed-WIP hubs) lives in the private source-of-truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
