### PR TITLE
fix(close-cascade): inject missing Phase 1.8 team broadcast

### DIFF
--- a/hooks/detect-closing-signal.py
+++ b/hooks/detect-closing-signal.py
@@ -806,6 +806,43 @@ your job before goodbye.
 Phases 0c/0d/0e and the Phase 3 audit are MODEL-SIDE. The post-Stop hook
 does NOT run them.
 
+PHASE 1.8 — TEAM BROADCAST (per workspace, MODEL-SIDE, OPT-IN; physically
+here in run order because broadcasts must follow Phase 2 writes — the
+"1.8" name matches the canonical reference in chief-of-staff/SKILL.md):
+SKIP this phase entirely unless the OPTIONAL companion skill is installed:
+  ~/.claude/skills/team-broadcast/scripts/auto-send.py
+If absent (the common case for solo / personal-vault users): do nothing,
+do not narrate, move on to Phase 3. The companion skill is install-it-
+yourself; ai-brain-starter does NOT auto-install it.
+
+If installed AND this session shipped, decided, or unblocked anything
+the team should know about, broadcast via:
+
+  python ~/.claude/skills/team-broadcast/scripts/auto-send.py \\
+    {{onde|mycelium}} --trigger session-close --body-file <file>
+
+Use --body-file with the plain 5th-grader recap THIS conversation already
+showed the user (do NOT re-derive or re-scan; --allow-rescan is an escape
+hatch, not the default). Body lives in scratchpad; the script consumes
++ removes it after posting.
+
+Per-workspace rule: post to EACH workspace where the work is materially
+relevant. A typical product-ticket ship -> that product's workspace only.
+A change to a shared substrate (an *-mcp, a public skill) -> the
+substrate's workspace. Cross-umbrella work -> both.
+
+SKIP conditions (broadcast nothing):
+  - Tiny / housekeeping session (close cascade alone, no substantive ship)
+  - Personal-only work (journaling, coaching, calendar, finance)
+  - Already broadcast earlier this session
+
+Dry-run first (--dry-run) when uncertain about content or audience; go
+live once the dry-run output reads clean. Audit log is automatic.
+
+If a workspace's Slack creds are missing, the script fails loud — do NOT
+silently swallow. Report the failure in Phase 4 + add a to-do to fix the
+creds.
+
 PHASE 3 — Functional audit (conditional, MODEL-SIDE):
 If this session shipped code or docs to a PUBLIC REPO that users download
 (ai-brain-starter, humanizer, mycelium-site, any *-mcp, etc.), run the
@@ -832,7 +869,8 @@ misleading copy, or unreferenced files. The audit catches what CI can't.
 
 PHASE 4 — Final summary (one line, after audit if Phase 3 fired):
 "Filed X seeds, Y to-dos (yours: A, delegations: B), Z decisions, checked
-off M items. Anything I missed?"
+off M items[, broadcast to <workspaces> if Phase 1.8 fired]. Anything I
+missed?"
 
 Then say goodbye in the user's primary language, warm, no machinery
 narration."""


### PR DESCRIPTION
## What

The close-cascade hook (`hooks/detect-closing-signal.py`) never injected a Phase 1.8 step, so models following the cascade as written would silently skip team broadcasts even with the optional `team-broadcast` companion skill installed. `chief-of-staff/SKILL.md` references "Phase 1.8 of the close cascade runs `team-broadcast/scripts/auto-send.py` per workspace" — so the doc and the hook were out of sync.

This adds the missing phase.

## Caught how

Live, by a real user. A product ship landed in the session, the close cascade ran clean, and the team was never told. The four-word user nudge "what about 1.8 the slack update?" exposed the gap.

## Design choices

- **Opt-in.** The phase explicitly tells the model to SKIP entirely (no narration, no error) if `~/.claude/skills/team-broadcast/scripts/auto-send.py` is absent. `ai-brain-starter` does not auto-install the companion skill, so solo / personal-vault users see no behavior change.
- **Placement: between Phase 2b (commit) and Phase 3 (audit).** The "1.8" name is preserved to match the chief-of-staff reference, with a comment in the section itself explaining the run-order vs naming tension: broadcasts must follow Phase 2 writes so they don't claim work that hasn't actually landed.
- **Workspace-neutral examples.** The cascade text uses generic placeholders (`{onde|mycelium}` is a literal example, not a hard-coded set) and tells the model to pick workspaces based on what was materially relevant in the session.
- **Phase 4 final-summary template** updated to optionally mention the broadcast count when Phase 1.8 fired.

## Verified

- `python -m py_compile` — clean.
- `_full_cascade_block(...)` rendered end-to-end via `importlib`: phases now read `0a, 0b, 0(ref), 1, 2, 2b, 1.8, 3, 4`. Phase 1.8 present, opt-in language present, no f-string brace bug (`{{onde|mycelium}}` correctly escaped).
- Single-file edit. No new files, no path/orphan/link audit items.

## Out of scope

The `team-broadcast` companion skill itself is not in this repo and not touched here. This PR only fixes the cascade-text gap; whether/how to bundle or document the companion is a separate question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)