### PR TITLE
chore(relocate-sweep): drop retired personal guard from KEEP_BASENAMES (MYC-1749 #7)

### DIFF
--- a/scripts/relocate-sweep.py
+++ b/scripts/relocate-sweep.py
@@ -128,8 +128,7 @@ def _under_cloud_sync(path):
 # Files whose OLD-path references are intentional — the relocate tooling itself
 # (migration sources, fixtures) and personal-data scrub token lists.
 KEEP_BASENAMES = {"relocate-vault.sh", "relocate-sweep.py", "relocate-machinery-sidecar.sh",
-                  "test-relocate-vault.sh", "test-relocate-sweep.py",
-                  "check-desktop-path-recreators.py"}
+                  "test-relocate-vault.sh", "test-relocate-sweep.py"}
 KEEP_PATH_TOKENS = ("scrub-or-die", "gh-harden-repos", "personal-pii-scrub", "/docs/superpowers/")
 # A line carrying one of these is an intentional KEEP regardless of file type:
 #   relocate-keep    → explicit marker;  OLD=/NEW= → a migration source assignment;


### PR DESCRIPTION
Final retire step for MYC-1749. The personal recreator guard `check-desktop-path-recreators.py` was retired in favor of this engine's `--watch` mode; its name no longer exists on any install, so its `KEEP_BASENAMES` entry is dead. Removing it leaves no trace of the retired personal guard in the substrate. The substrate's own relocate tooling stays in the set. No test depends on the removed entry.

Generated with [Claude Code](https://claude.com/claude-code) for MYC-1749.