### PR TITLE
perf(hooks): bound orphan-branch git fan-out to 2 calls (MYC-2361)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,16 @@ description: What's new in AI Brain Starter — plain English, no jargon
 
 ---
 
+## 2026-06-30: faster session startup on big vaults
+
+One of the startup checks counts how many leftover `claude/*` work branches are sitting around (so it can remind you to clean them up). The old version asked git about each branch one at a time. On a small vault that's instant, but on a large vault with a hundred-plus branches it meant a hundred-plus separate git calls every time you opened a session — several seconds of lag before you could do anything, and it got slower the more branches piled up.
+
+It now does the same count in two git calls total, no matter how many branches you have. The reminder is identical; it just arrives instantly. A new test locks this in, so the slow per-branch version can't sneak back.
+
+You don't need to do anything — this applies automatically on update.
+
+---
+
 ## 2026-06-22: Granola sync now uses Granola's official API
 
 If you connected Granola for meeting transcripts, the old sync read Granola's local cache file on your Mac. Granola encrypted and moved that cache in mid-May 2026, so the old script silently stopped finding anything — it exited cleanly and exported nothing, with no error to tell you it had broken.

--- a/hooks/surface-orphan-claude-branches.py
+++ b/hooks/surface-orphan-claude-branches.py
@@ -17,7 +17,9 @@ six months later when something else breaks."
 Output: silent if no orphans. Single-line systemMessage if any exist,
 pointing at `scripts/recover-orphan-claude-branches.py` for recovery.
 
-Performance: <100ms even with hundreds of branches.
+Performance: TWO git calls total, independent of branch count (MYC-2361).
+Reintroducing a per-branch git loop is the SLOW-INSTALL-FROM-LAZY-PLUMBING
+regression that tests/integration/test_orphan_branch_bounded_git.sh locks out.
 
 Bypass: ORPHAN_SURFACE_BYPASS=1 in env.
 """
@@ -70,30 +72,49 @@ def detect_base_branch(vault: Path) -> str | None:
 
 
 def count_orphans(vault: Path, base: str) -> tuple[int, int]:
-    """Return (branch_count, total_unmerged_commit_count)."""
+    """Return (branch_count, total_unmerged_commit_count).
+
+    Bounded git fan-out: TWO git calls, independent of branch count.
+
+    `for-each-ref --no-merged <base>` returns, in ONE call, exactly the claude/*
+    branches that carry at least one commit not reachable from <base> (equivalent
+    to the old per-branch ``rev-list --count <base>..<branch> > 0`` test — a branch
+    is "not merged" into base iff base lacks its tip). A single
+    ``rev-list --count <branches...> ^<base>`` then counts the DISTINCT unmerged
+    commits across them.
+
+    The previous implementation ran one ``rev-list`` per branch — O(branches)
+    subprocesses. On a large vault (~150 claude/* branches against a 60K-file
+    index) that cost ~2.7s at EVERY SessionStart; the per-branch git fan-out, not
+    a filesystem walk, was the cost. Two calls makes the docstring's "<100ms even
+    with hundreds of branches" actually true. See MYC-2348 / MYC-2361.
+
+    Note: total_commits is now the count of DISTINCT unmerged commits (union). The
+    old loop summed per-branch counts, double-counting a commit shared by two
+    orphan branches; for the typical case (each branch owns its commits) the two
+    are identical, and the distinct count is the truer recovery workload.
+    """
     out = subprocess.run(
-        ["git", "-C", str(vault), "for-each-ref", "--format=%(refname:short)", "refs/heads/claude/"],
+        ["git", "-C", str(vault), "for-each-ref", "--no-merged", base,
+         "--format=%(refname:short)", "refs/heads/claude/"],
         capture_output=True,
         text=True,
     )
     if out.returncode != 0:
         return (0, 0)
     branches = [b.strip() for b in out.stdout.split() if b.strip()]
-    n_branches = 0
-    total_commits = 0
-    for b in branches:
-        r = subprocess.run(
-            ["git", "-C", str(vault), "rev-list", "--count", f"{base}..{b}"],
-            capture_output=True,
-            text=True,
-        )
-        try:
-            c = int(r.stdout.strip())
-        except (ValueError, AttributeError):
-            c = 0
-        if c > 0:
-            n_branches += 1
-            total_commits += c
+    n_branches = len(branches)
+    if n_branches == 0:
+        return (0, 0)
+    r = subprocess.run(
+        ["git", "-C", str(vault), "rev-list", "--count", *branches, f"^{base}"],
+        capture_output=True,
+        text=True,
+    )
+    try:
+        total_commits = int(r.stdout.strip())
+    except (ValueError, AttributeError):
+        total_commits = 0
     return (n_branches, total_commits)
 
 

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -121,6 +121,7 @@ INTEGRATION_TESTS=(
   test_scan_prior_failclosed_scrub
   test_sessionstart_freeze_class_excluded
   test_sessionstart_boundedness
+  test_orphan_branch_bounded_git
   test_vault_safety_guards
   test_resource_aware_session_close
   test_cloud_sync_guard

--- a/tests/integration/test_orphan_branch_bounded_git.sh
+++ b/tests/integration/test_orphan_branch_bounded_git.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Regression test for hooks/surface-orphan-claude-branches.py (MYC-2348 / MYC-2361).
+#
+# Locks the bounded git fan-out fix. The hook surfaces, at SessionStart, the count
+# of orphan claude/* branches. The pre-fix implementation ran one `git rev-list`
+# per branch -- O(branches) subprocesses -- which on a large vault (~150 branches
+# against a 60K-file index) cost ~2.7s at EVERY session open (SLOW-INSTALL-FROM-
+# LAZY-PLUMBING). The fix uses TWO git calls total, independent of branch count.
+#
+# This is the deterministic class guard the static audit-sessionstart-boundedness
+# gate CANNOT catch: that gate checks filesystem-walk boundedness (flock + cooldown
+# + deadline); a per-branch SUBPROCESS fan-out is bounded-by-construction to it yet
+# still O(branches) in cost. Here we count actual git invocations via a PATH shim
+# and assert the count does not scale with branch count. Reintroduce the per-branch
+# loop and the git-call count jumps from a small constant to O(branches): red.
+#
+# Also asserts CORRECTNESS: only branches with commits not reachable from base are
+# counted; fully-merged claude/* branches are excluded.
+#
+# Stdlib python3 + bash + git only. No network. One owned temp root; the real vault
+# and ~/.claude are never touched.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HOOK="$REPO_ROOT/hooks/surface-orphan-claude-branches.py"
+
+PASS=0
+FAIL=0
+ROOT="$(mktemp -d)"
+cleanup() { rm -rf "$ROOT"; }
+trap cleanup EXIT
+
+ok()  { PASS=$((PASS+1)); echo "PASS  $1"; }
+bad() { FAIL=$((FAIL+1)); echo "FAIL  $1 :: $2"; }
+
+REAL_GIT="$(command -v git)"
+if [ -z "$REAL_GIT" ]; then echo "FAIL  git not found on PATH"; exit 1; fi
+
+SN=0   # shim/run counter (run_hook runs in the parent shell, so this persists)
+
+# build_vault <n_orphan> <n_merged> -- a vault-shaped repo (has .git + a *Meta dir,
+# base branch 'main') with n_orphan claude/* branches each carrying one unmerged
+# commit and n_merged claude/* branches fully reachable from main. Echoes the path.
+# Arithmetic for-loops (not `seq`): BSD `seq 1 0` prints "1 0", GNU prints nothing.
+build_vault() {
+  local n_orphan="$1" n_merged="$2" repo i
+  # mktemp -d for a unique dir: build_vault runs inside $(...) (a subshell), so a
+  # parent-scoped counter would not persist and every vault would collide.
+  repo="$(mktemp -d "$ROOT/vault.XXXXXX")"
+  mkdir -p "$repo/Meta"
+  git init -q -b main "$repo"
+  git -C "$repo" config user.email t@t.t
+  git -C "$repo" config user.name t
+  git -C "$repo" commit -q --allow-empty -m base
+  for (( i=1; i<=n_orphan; i++ )); do
+    git -C "$repo" checkout -q -b "claude/orphan$i" main
+    git -C "$repo" commit -q --allow-empty -m "orphan work $i"
+  done
+  for (( i=1; i<=n_merged; i++ )); do
+    git -C "$repo" branch "claude/merged$i" main   # at main, no new commits -> merged
+  done
+  git -C "$repo" checkout -q main
+  echo "$repo"
+}
+
+# run_hook <repo> -- run the hook with cwd=repo under a git-counting PATH shim.
+# Sets OUT (stdout), RC, NGIT (number of git invocations).
+run_hook() {
+  local repo="$1" shimdir counter
+  SN=$((SN+1)); shimdir="$ROOT/shim$SN"; counter="$ROOT/cnt$SN"
+  mkdir -p "$shimdir"; : > "$counter"
+  cat > "$shimdir/git" <<SHIM
+#!/usr/bin/env bash
+printf 'x' >> "$counter"
+exec "$REAL_GIT" "\$@"
+SHIM
+  chmod +x "$shimdir/git"
+  # cd binds before the pipe (| is higher precedence than &&), so printf and
+  # python3 both run with cwd=repo; shimdir is first on python3's PATH so the
+  # hook's child `git` calls route through the counter.
+  OUT="$(cd "$repo" && printf '{}' | PATH="$shimdir:$PATH" python3 "$HOOK" 2>/dev/null)"
+  RC=$?
+  NGIT="$(wc -c < "$counter" | tr -d ' ')"
+}
+
+# --- Scenario A: correctness -- 5 orphan + 3 merged => reports 5 ----------------
+run_hook "$(build_vault 5 3)"
+case "$OUT" in
+  *'"systemMessage"'*'[orphan-branches] 5 '*'branch(es)'*) ok "correctness: 5 orphan, 3 merged -> reports 5" ;;
+  *) bad "correctness: reports 5 orphans" "out=${OUT:0:160}" ;;
+esac
+
+# --- Scenario B: merged-only => silent (no systemMessage, rc 0) -----------------
+run_hook "$(build_vault 0 4)"
+if [ "$RC" = 0 ] && [ -z "$OUT" ]; then
+  ok "merged-only vault is silent"
+else
+  bad "merged-only vault is silent" "rc=$RC out=${OUT:0:120}"
+fi
+
+# --- Scenario C: BOUNDED fan-out -- git calls do NOT scale with branch count ----
+# 8 vs 40 orphan branches must cost the SAME (small) git-call count. The pre-fix
+# loop would be ~ (3 + N): 11 vs 43. Assert both <= 6 AND the 40-branch count does
+# not exceed the 8-branch count -- the precise O(branches) signature.
+run_hook "$(build_vault 8 0)";  N8="$NGIT"
+run_hook "$(build_vault 40 0)"; N40="$NGIT"
+if [ "$N8" -le 6 ] && [ "$N40" -le 6 ]; then
+  ok "bounded git fan-out: 8-branch=$N8 calls, 40-branch=$N40 calls (both <= 6)"
+else
+  bad "bounded git fan-out" "8-branch=$N8 calls, 40-branch=$N40 calls (want both <= 6; O(branches) regression?)"
+fi
+if [ "$N40" -le "$N8" ]; then
+  ok "git-call count does not grow with branch count (8->$N8, 40->$N40)"
+else
+  bad "git-call count grows with branch count" "8->$N8 but 40->$N40 (O(branches) fan-out reintroduced)"
+fi
+
+# --- Scenario D: NEGATIVE CONTROL -- prove the shim+counter actually detects the
+# O(branches) fan-out it is meant to catch. Run the PRE-FIX shape (one rev-list
+# per branch) by hand over the 40-branch vault under the shim; the git-call count
+# MUST blow past the bounded ceiling. If it does not, the bounded assertion above
+# is vacuous (a broken counter would pass everything).
+NEG_VAULT="$(build_vault 40 0)"
+SN=$((SN+1)); negshim="$ROOT/shim$SN"; negcnt="$ROOT/cnt$SN"
+mkdir -p "$negshim"; : > "$negcnt"
+cat > "$negshim/git" <<SHIM
+#!/usr/bin/env bash
+printf 'x' >> "$negcnt"
+exec "$REAL_GIT" "\$@"
+SHIM
+chmod +x "$negshim/git"
+(
+  cd "$NEG_VAULT" || exit 1
+  export PATH="$negshim:$PATH"
+  for b in $(git for-each-ref --format='%(refname:short)' refs/heads/claude/); do
+    git rev-list --count "main..$b" >/dev/null
+  done
+)
+NEG="$(wc -c < "$negcnt" | tr -d ' ')"
+if [ "$NEG" -gt 6 ]; then
+  ok "negative control: pre-fix per-branch loop trips the ceiling ($NEG git calls > 6)"
+else
+  bad "negative control" "per-branch loop made only $NEG git calls (counter mechanism broken?)"
+fi
+
+echo "----"
+echo "orphan-branch bounded-git: PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## What

`surface-orphan-claude-branches.py` (a SessionStart hook) counted orphan `claude/*` branches by running one `git rev-list` **per branch** — O(branches) subprocesses. On a large vault (~150 branches against a 60K-file index) that cost ~2.7s at **every** session open, and got worse as branches accumulated (SLOW-INSTALL-FROM-LAZY-PLUMBING).

Now it uses **two git calls total**, independent of branch count:
- `git for-each-ref --no-merged <base> refs/heads/claude/` → the orphan branches (equivalent to the old per-branch `<base>..<branch> > 0` test: a branch is "not merged" into base iff base lacks its tip)
- one `git rev-list --count <branches...> ^<base>` → distinct unmerged commits

Same output, same `n_branches` semantics. `total_commits` is now the distinct (union) count rather than double-counting a commit shared by two orphan branches (typically identical; the distinct count is the truer recovery workload).

## Why it isn't caught today

The static `audit-sessionstart-boundedness` gate checks **filesystem-walk** boundedness (flock + cooldown + deadline). A per-branch **subprocess** fan-out is bounded-by-construction to that gate yet still O(branches) in cost — a real gap this closes.

## Test (new, wired into `scripts/ci.sh`)

`tests/integration/test_orphan_branch_bounded_git.sh`:
- **correctness**: 5 orphan + 3 merged → reports 5; merged-only → silent
- **bounded fan-out**: counts actual `git` invocations via a PATH shim; asserts the 8-branch and 40-branch runs cost the same small constant (≤6)
- **negative control**: the pre-fix per-branch loop trips the ceiling (41 calls > 6), proving the counter actually detects the regression class

## Verification
- `bash scripts/ci.sh` GREEN: py_compile (273 files) + 51 integration tests + shellcheck `-S warning`
- personal-data scrub: clean
- measured: 8-branch = 4 git calls, 40-branch = 4 git calls (was 1+N)

Closes MYC-2361. Part of MYC-2348 (substrate footprint epic; Stage 0 report posted on the epic).
