### PR TITLE
feat(footprint): unconditional cloud-sync auto-detect + relocate offer (MYC-2360)

### DIFF
--- a/hooks/_lib/worktree_safety.py
+++ b/hooks/_lib/worktree_safety.py
@@ -556,6 +556,67 @@ def detect_cloud_sync(path: Path, *, _drivefs_db: str | Path | None = None) -> s
     return None
 
 
+def _obsidian_config_path(explicit: str | Path | None = None) -> Path | None:
+    """Locate Obsidian's obsidian.json: explicit arg > $OBSIDIAN_CONFIG > per-OS
+    default. Returns the explicit/env path verbatim (caller guards is_file); for
+    the defaults, the first that exists, else None."""
+    if explicit is not None:
+        return Path(explicit)
+    env = os.environ.get("OBSIDIAN_CONFIG")
+    if env:
+        return Path(env)
+    home = Path.home()
+    candidates = [
+        home / "Library/Application Support/obsidian/obsidian.json",  # macOS
+        home / ".config/obsidian/obsidian.json",                      # Linux
+    ]
+    appdata = os.environ.get("APPDATA")
+    if appdata:
+        candidates.append(Path(appdata) / "obsidian" / "obsidian.json")  # Windows
+    candidates.append(home / "AppData/Roaming/obsidian/obsidian.json")
+    for c in candidates:
+        try:
+            if c.is_file():
+                return c
+        except OSError:
+            continue
+    return None
+
+
+def obsidian_vault_paths(config_path: str | Path | None = None) -> list[Path]:
+    """Absolute paths of every vault Obsidian has registered, from obsidian.json.
+
+    Lets the cloud-sync offer find a pre-existing Obsidian vault that was never
+    pasted into guided setup — the "user already had an iCloud vault (Obsidian's
+    common default)" case the SessionStart footprint signal otherwise misses (it
+    only sees the vault you are cwd'd inside). Bounded + fail-open by construction:
+    one small JSON read, never a filesystem walk, and [] on any missing /
+    malformed / unreadable config — a registry hiccup must never break a hook.
+
+    Schema: {"vaults": {"<id>": {"path": "<abs>", "open": bool, ...}, ...}}.
+    """
+    cfg = _obsidian_config_path(config_path)
+    if cfg is None or not cfg.is_file():
+        return []
+    try:
+        data = json.loads(cfg.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    vaults = data.get("vaults") if isinstance(data, dict) else None
+    if not isinstance(vaults, dict):
+        return []
+    out: list[Path] = []
+    seen: set[str] = set()
+    for entry in vaults.values():
+        if not isinstance(entry, dict):
+            continue
+        p = entry.get("path")
+        if isinstance(p, str) and p and p not in seen:
+            seen.add(p)
+            out.append(Path(p))
+    return out
+
+
 # Optional session-liveness file written by session-lock.py (a sibling hook).
 # Reading it lets the cap reaper distinguish "this scratch worktree belongs to a
 # session that is still running" from "its session is gone" — so a crashed

--- a/hooks/worktree-footprint-signal.py
+++ b/hooks/worktree-footprint-signal.py
@@ -11,9 +11,13 @@ Surfaces (only when something warrants attention — silent when healthy):
   * worktree count over the soft threshold (WORKTREE_WARN, default 8)
   * on-disk worktree dirs git no longer tracks (orphans)
   * low free disk on the vault's volume
-  * THE DANGEROUS COMBO: vault sitting inside a consumer cloud-sync folder
+  * THE DANGEROUS COMBO: an AI-brain vault inside a consumer cloud-sync folder
     (iCloud / OneDrive / Dropbox / Google Drive / Box) — worktree/.git churn
-    there is what melts the sync daemon. Flagged loudly with the remedy.
+    there is what melts the sync daemon. Detected for ANY such vault — the one
+    cwd is in, $CLAUDE_PROJECT_DIR, OR any vault in Obsidian's registry, so a
+    pre-existing iCloud vault is caught even outside guided onboarding — and the
+    auto-capable relocate is OFFERED in plain language (move-local OR machinery-
+    sidecar), self-silencing once relocated. (MYC-2360)
 
 Bypass: WORKTREE_FOOTPRINT_BYPASS=1.
 
@@ -42,10 +46,14 @@ from _lib.worktree_safety import (  # noqa: E402
     find_main_repo,
     is_scratch_worktree,
     list_worktrees,
+    obsidian_vault_paths,
 )
 
 DEFAULT_WARN = 8
 DEFAULT_FREE_GB = 5.0
+# Scripts dir of the installed skill — where the auto-capable relocate helpers
+# live. The offer prints ready-to-run commands against this canonical path.
+SKILL_SCRIPTS = "~/.claude/skills/ai-brain-starter/scripts"
 
 
 def _emit(ctx: str | None) -> int:
@@ -56,78 +64,233 @@ def _emit(ctx: str | None) -> int:
     return 0
 
 
+# ── cloud-sync auto-detect + relocate OFFER (MYC-2360) ───────────────────────
+# Fires UNCONDITIONALLY at SessionStart — independent of guided onboarding and
+# of whether cwd is inside the vault. The freeze class (a git-backed brain inside
+# iCloud/Drive/Dropbox/Box) is detected for ANY such vault and the auto-capable
+# relocate scripts are OFFERED in plain language, rather than left as a passive
+# "see docs" warning the user must act on. Self-silences once relocated:
+# Shape A (relocate-vault.sh: move-local + symlink) resolves clean through
+# detect_cloud_sync; Shape B (relocate-machinery-sidecar.sh: machinery out, notes
+# stay) is suppressed by its sidecar manifest. Bounded by construction: a small
+# JSON read + a few stats + a tiny manifest glob, never a corpus walk.
+
+
+def _cwd_git_root() -> Path | None:
+    """The git checkout cwd sits in — bounded upward `.git` search, so a vault
+    that is git-backed but has no `.claude/worktrees/` yet (find_main_repo only
+    resolves worktree-owners) is still discovered when you're cwd'd in it."""
+    try:
+        cwd = Path.cwd().resolve()
+    except OSError:
+        return None
+    for d in (cwd, *cwd.parents):
+        try:
+            if (d / ".git").exists():
+                return d
+        except OSError:
+            continue
+    return None
+
+
+def _candidate_vaults(main_repo: Path | None) -> list[Path]:
+    """Every vault to consider, INDEPENDENT of guided onboarding: the worktree-
+    owning repo (find_main_repo, collapses an in-worktree cwd to its main vault)
+    ∪ $CLAUDE_PROJECT_DIR ∪ the git checkout cwd is in ∪ the Obsidian registry
+    ∪ $VAULT_ROOT. De-duped by resolved path, order preserved."""
+    cands: list[Path] = []
+    if main_repo is not None:
+        cands.append(main_repo)
+    pd = os.environ.get("CLAUDE_PROJECT_DIR")
+    if pd:
+        p = Path(pd)
+        try:
+            if p.is_dir():
+                cands.append(p)
+        except OSError:
+            pass
+    cwd_root = _cwd_git_root()
+    if cwd_root is not None:
+        cands.append(cwd_root)
+    cands.extend(obsidian_vault_paths())
+    vr = os.environ.get("VAULT_ROOT")
+    if vr:
+        cands.append(Path(vr).expanduser())
+    out: list[Path] = []
+    seen: set[str] = set()
+    for c in cands:
+        try:
+            key = str(c.resolve())
+        except OSError:
+            key = str(c)
+        if key not in seen:
+            seen.add(key)
+            out.append(c)
+    return out
+
+
+def _is_brain_vault(vault: Path) -> bool:
+    """Offer only for an actual AI brain — git-backed or carrying substrate
+    machinery — never a pristine markdown folder (markdown alone is low-churn,
+    not the freeze class). Mirrors surface-backup-status.py's _is_brain."""
+    try:
+        if (vault / ".git").exists() or (vault / "CLAUDE.md").is_file():
+            return True
+        for c in vault.iterdir():
+            if c.is_dir() and (c.name.endswith("Meta")
+                               or c.name in (".smart-env", ".codegraph")):
+                return True
+    except OSError:
+        return False
+    return False
+
+
+def _sidecar_roots() -> list[Path]:
+    roots: list[Path] = []
+    for env in ("BRAIN_SIDECAR", "MYCELIUM_SIDECAR"):
+        v = os.environ.get(env)
+        if v:
+            roots.append(Path(v).expanduser())
+    roots.append(Path.home() / ".brain-sidecar")
+    return roots
+
+
+def _machinery_relocated(vault: Path) -> bool:
+    """True if a machinery-sidecar manifest names this vault (Shape B already
+    applied: the vault may still sit in the cloud folder, but its churn is out,
+    so the offer must go quiet — an existing user must not be nagged forever)."""
+    try:
+        vkey = str(vault.resolve())
+    except OSError:
+        vkey = str(vault)
+    for root in _sidecar_roots():
+        try:
+            manifests = list((root / "manifests").glob("*.json"))
+        except OSError:
+            continue
+        for man in manifests:
+            try:
+                doc = json.loads(man.read_text(encoding="utf-8"))
+            except (OSError, ValueError):
+                continue
+            mv = doc.get("vault") if isinstance(doc, dict) else None
+            if not isinstance(mv, str):
+                continue
+            try:
+                if str(Path(mv).resolve()) == vkey:
+                    return True
+            except OSError:
+                if mv == vkey:
+                    return True
+    return False
+
+
+def _suggest_local_dest(vault: Path) -> Path:
+    """A safe local destination to pre-fill the move-local command with."""
+    name = vault.name or "brain"
+    home = Path.home()
+    cand = home / name
+    try:
+        if cand.exists():
+            return home / "vaults" / name
+    except OSError:
+        pass
+    return cand
+
+
+def _offer_block(vault: Path, service: str, dest: Path) -> str:
+    return (
+        f"🟡 [cloud-sync] Your vault `{vault}` is inside **{service}**. A git-backed "
+        f"AI brain in a consumer cloud-sync folder is the #1 cause of the "
+        f"\"whole machine froze\" failure: the sync daemon tries to upload millions "
+        f"of `.git`/index file-events and pegs the CPU. I can move it out for you — "
+        f"safely, backup-first, reversible, idempotent (each script previews with "
+        f"`--dry-run` and leaves a symlink so nothing breaks). Tell me which and "
+        f"I'll run it (I'll stand up a verified backup first):\n"
+        f"  • Simplest (recommended) — move the vault to a local disk, keep a symlink, "
+        f"migrate your Claude history:\n"
+        f"      bash {SKILL_SCRIPTS}/relocate-vault.sh \"{vault}\" \"{dest}\"\n"
+        f"  • Keep it on your iPhone — leave the notes in {service}, move only the "
+        f"churning machinery (`.git`, worktrees, caches) to a local sidecar:\n"
+        f"      bash {SKILL_SCRIPTS}/relocate-machinery-sidecar.sh \"{vault}\"\n"
+        f"This repeats each session until the vault is out of the sync path. "
+        f"Details: docs/CLOUD_SYNC.md."
+    )
+
+
+def cloud_sync_offer(main_repo: Path | None) -> list[str]:
+    """One plain-language offer block per cloud-resident, not-yet-relocated brain."""
+    lines: list[str] = []
+    for vault in _candidate_vaults(main_repo):
+        try:
+            if not _is_brain_vault(vault):
+                continue
+            service = detect_cloud_sync(vault)
+            if not service:
+                continue  # local disk, or Shape A symlink->local resolved clean
+            if _machinery_relocated(vault):
+                continue  # Shape B already applied
+        except OSError:
+            continue
+        lines.append(_offer_block(vault, service, _suggest_local_dest(vault)))
+    return lines
+
+
 def main() -> int:
     if os.environ.get("WORKTREE_FOOTPRINT_BYPASS") == "1":
         return _emit(None)
 
     main_repo = find_main_repo()
-    if main_repo is None:
-        return _emit(None)
-
-    try:
-        warn_at = max(1, int(os.environ.get("WORKTREE_WARN", DEFAULT_WARN)))
-    except ValueError:
-        warn_at = DEFAULT_WARN
-    try:
-        free_floor = float(os.environ.get("WORKTREE_FREE_GB", DEFAULT_FREE_GB))
-    except ValueError:
-        free_floor = DEFAULT_FREE_GB
-
-    # Count only scratch worktrees for the cap warning; deliberate sibling
-    # worktrees (~/dev/<repo>-<slug>) are not part of the pileup problem.
-    registered = sum(1 for w in list_worktrees(main_repo) if is_scratch_worktree(w))
-
-    wt_dir = main_repo / WORKTREES_SEG
-    on_disk = 0
-    if wt_dir.is_dir():
-        try:
-            on_disk = sum(1 for c in wt_dir.iterdir() if c.is_dir())
-        except OSError:
-            on_disk = 0
-    orphans = max(0, on_disk - registered)
-
-    free_gb = None
-    try:
-        free_gb = shutil.disk_usage(main_repo).free / 1024 ** 3
-    except OSError:
-        pass
-
-    cloud = detect_cloud_sync(main_repo)
 
     lines: list[str] = []
 
-    # Fire on ANY git-backed vault inside cloud sync — not only once worktrees
-    # exist. A fresh iCloud install with zero worktrees is ALREADY dangerous: the
-    # `.git/` rewrites on every commit and the sync daemon chokes on that alone
-    # (the .git-in-mirror variant). Catching it at first SessionStart beats
-    # catching it after the machine is already churning.
-    has_git = (main_repo / ".git").exists()
-    if cloud and (has_git or registered or on_disk):
-        if on_disk:
-            wt_note = f"it has {on_disk} worktree checkout(s); "
-        else:
-            wt_note = "even with zero worktrees its `.git/` rewrites on every commit; "
-        lines.append(
-            f"⚠️  [footprint] This vault is inside **{cloud}** — {wt_note}"
-            f"consumer cloud-sync + git churn = the sync-storm failure mode "
-            f"(millions of file events, pegged CPU, frozen machine). The vault "
-            f"belongs on a local disk; the index belongs server-side. Move it out "
-            f"of the sync folder (see docs/CLOUD_SYNC.md), or at minimum keep "
-            f"`.claude/`, `.git/`, `.smart-env/` out of sync scope."
-        )
+    # Cloud-sync relocate OFFER — runs even when cwd is NOT inside a vault, so a
+    # pre-existing iCloud Obsidian vault (Obsidian's common default) or a skipped
+    # onboarding is still caught and the fix is OFFERED, not just documented.
+    # (MYC-2360) Replaces the old passive "move it out, see docs" warning.
+    lines.extend(cloud_sync_offer(main_repo))
 
-    if registered > warn_at or orphans > 0:
-        bits = [f"{registered} registered worktree(s) (soft cap {warn_at})"]
-        if orphans:
-            bits.append(f"{orphans} orphan dir(s) git no longer tracks")
-        lines.append(
-            f"[footprint] {'; '.join(bits)}. Each worktree is ~a full checkout. "
-            f"They auto-trim at SessionEnd + via the cap; force now with "
-            f"`python3 scripts/worktree-prune.sh` or the reclaim tool."
-        )
+    # Footprint observability needs a repo to measure — gated on main_repo.
+    if main_repo is not None:
+        try:
+            warn_at = max(1, int(os.environ.get("WORKTREE_WARN", DEFAULT_WARN)))
+        except ValueError:
+            warn_at = DEFAULT_WARN
+        try:
+            free_floor = float(os.environ.get("WORKTREE_FREE_GB", DEFAULT_FREE_GB))
+        except ValueError:
+            free_floor = DEFAULT_FREE_GB
 
-    if free_gb is not None and free_gb < free_floor:
-        lines.append(f"⚠️  [footprint] Low free disk: {free_gb:.1f} GB on the vault volume.")
+        # Count only scratch worktrees for the cap warning; deliberate sibling
+        # worktrees (~/dev/<repo>-<slug>) are not part of the pileup problem.
+        registered = sum(1 for w in list_worktrees(main_repo) if is_scratch_worktree(w))
+
+        wt_dir = main_repo / WORKTREES_SEG
+        on_disk = 0
+        if wt_dir.is_dir():
+            try:
+                on_disk = sum(1 for c in wt_dir.iterdir() if c.is_dir())
+            except OSError:
+                on_disk = 0
+        orphans = max(0, on_disk - registered)
+
+        if registered > warn_at or orphans > 0:
+            bits = [f"{registered} registered worktree(s) (soft cap {warn_at})"]
+            if orphans:
+                bits.append(f"{orphans} orphan dir(s) git no longer tracks")
+            lines.append(
+                f"[footprint] {'; '.join(bits)}. Each worktree is ~a full checkout. "
+                f"They auto-trim at SessionEnd + via the cap; force now with "
+                f"`python3 scripts/worktree-prune.sh` or the reclaim tool."
+            )
+
+        free_gb = None
+        try:
+            free_gb = shutil.disk_usage(main_repo).free / 1024 ** 3
+        except OSError:
+            pass
+        if free_gb is not None and free_gb < free_floor:
+            lines.append(f"⚠️  [footprint] Low free disk: {free_gb:.1f} GB on the vault volume.")
 
     return _emit("\n".join(lines) if lines else None)
 

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -126,6 +126,7 @@ INTEGRATION_TESTS=(
   test_vault_safety_guards
   test_resource_aware_session_close
   test_cloud_sync_guard
+  test_cloud_sync_offer
   test_worktree_on_vault_guard
   test_machinery_sidecar
   test_relocate_vault

--- a/scripts/test-cloud-sync-offer.sh
+++ b/scripts/test-cloud-sync-offer.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Negative-controlled test for the UNCONDITIONAL cloud-sync relocate OFFER
+# (worktree-footprint-signal.py cloud branch, MYC-2360).
+#
+# The offer must fire for ANY AI-brain vault inside a consumer cloud-sync folder,
+# discovered INDEPENDENT of guided onboarding:
+#   * via the Obsidian registry (obsidian.json) when cwd is NOT in the vault
+#     (the "user already had an iCloud Obsidian vault" gap), AND
+#   * via the current git repo (find_main_repo) when cwd IS the vault.
+# It must present BOTH remediation shapes (relocate-vault.sh + relocate-machinery-
+# sidecar.sh), name the vault + the service, and then go SILENT once relocated
+# (Shape A symlink->local resolves clean; Shape B is suppressed by a machinery-
+# sidecar manifest), for a plain local vault, for a pristine non-git Obsidian
+# vault (markdown alone is not the freeze class), and under bypass.
+#
+# A guard earns trust only by failing on the thing it catches: every positive
+# is paired with a negative control. Stdlib python3 + bash + git only.
+# Run: bash scripts/test-cloud-sync-offer.sh
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+HOOK="$ROOT/hooks/worktree-footprint-signal.py"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+fails=0
+
+ICLOUD="Library/Mobile Documents/com~apple~CloudDocs"   # detect_cloud_sync marker
+NEUTRAL="$TMP/neutral"; mkdir -p "$NEUTRAL"              # a non-vault, non-git cwd
+NONE="$TMP/no-such-obsidian.json"                       # empty registry sentinel
+
+# Extract additionalContext from the hook's JSON stdout; "" when suppressed.
+emit_ctx() {
+  python3 -c 'import json,sys
+try:
+    d=json.load(sys.stdin)
+except (ValueError, OSError):   # hook stdout was not valid JSON -> treat as silent
+    print(""); sys.exit(0)
+print(d.get("additionalContext","") if isinstance(d,dict) else "")'
+}
+
+# Build an obsidian.json registry fixture listing the given vault path(s).
+write_obsidian_conf() {  # $1=config-path  $2..=vault paths
+  local cfg="$1"; shift
+  mkdir -p "$(dirname "$cfg")"
+  python3 - "$cfg" "$@" <<'PY'
+import json, sys
+cfg, paths = sys.argv[1], sys.argv[2:]
+vaults = {f"id{i}": {"path": p, "ts": 1700000000000, "open": True}
+          for i, p in enumerate(paths)}
+json.dump({"vaults": vaults}, open(cfg, "w"))
+PY
+}
+
+# Invoke the hook with a clean, deterministic footprint env (only the cloud
+# branch under test can speak; worktree-count / low-disk noise is silenced).
+run_hook() {  # $1=cwd  rest=VAR=VAL env assignments
+  local cwd="$1"; shift
+  ( cd "$cwd" && env WORKTREE_FREE_GB=0 WORKTREE_WARN=9999 "$@" \
+      python3 "$HOOK" </dev/null ) | emit_ctx
+}
+
+want_contains() {  # label  needle  haystack
+  case "$3" in *"$2"*) echo "PASS  $1";;
+    *) echo "FAIL  $1  (missing: $2)"; fails=$((fails+1));; esac
+}
+want_silent() {  # label  haystack
+  if [ -z "$2" ]; then echo "PASS  $1 (silent)"
+  else echo "FAIL  $1  expected silent, got: ${2:0:90}"; fails=$((fails+1)); fi
+}
+
+# ── 1. THE CORE GAP: registry discovery, cwd NOT in the vault ────────────────
+V1="$TMP/$ICLOUD/MyBrain"; mkdir -p "$V1"; : > "$V1/CLAUDE.md"
+CONF1="$TMP/ob1.json"; write_obsidian_conf "$CONF1" "$V1"
+ctx="$(run_hook "$NEUTRAL" OBSIDIAN_CONFIG="$CONF1")"
+want_contains "registry: offers move-local shape"   "relocate-vault.sh"            "$ctx"
+want_contains "registry: offers sidecar shape"       "relocate-machinery-sidecar.sh" "$ctx"
+want_contains "registry: names the vault path"       "$V1"                          "$ctx"
+want_contains "registry: names the cloud service"    "iCloud"                       "$ctx"
+
+# ── 2. cwd IS the git vault; empty registry (proves find_main_repo path) ─────
+V2="$TMP/$ICLOUD/GitBrain"; mkdir -p "$V2"; : > "$V2/CLAUDE.md"; git -C "$V2" init -q
+ctx="$(run_hook "$V2" OBSIDIAN_CONFIG="$NONE")"
+want_contains "cwd-in-vault: offer fires via find_main_repo" "relocate-vault.sh" "$ctx"
+
+# ── 3. Shape A relocated (symlink -> local): registry lists the OLD path ─────
+#       which resolves to a local disk -> SILENT (existing user not nagged).
+V3OLD="$TMP/$ICLOUD/MovedBrain"; mkdir -p "$V3OLD"; : > "$V3OLD/CLAUDE.md"
+V3NEW="$TMP/localdisk/MovedBrain"; mkdir -p "$TMP/localdisk"
+mv "$V3OLD" "$V3NEW"; ln -s "$V3NEW" "$V3OLD"   # what relocate-vault.sh leaves
+CONF3="$TMP/ob3.json"; write_obsidian_conf "$CONF3" "$V3OLD"
+ctx="$(run_hook "$NEUTRAL" OBSIDIAN_CONFIG="$CONF3")"
+want_silent "shape A: symlink->local resolves clean" "$ctx"
+
+# ── 4. Shape B (machinery-sidecar): vault STILL in iCloud but a sidecar ──────
+#       manifest names it -> SILENT. Paired negative control: drop the manifest
+#       (point BRAIN_SIDECAR elsewhere) and the SAME vault must offer again.
+V4="$TMP/$ICLOUD/SidecarBrain"; mkdir -p "$V4"; : > "$V4/CLAUDE.md"
+CONF4="$TMP/ob4.json"; write_obsidian_conf "$CONF4" "$V4"
+SIDE="$TMP/sidecar"; mkdir -p "$SIDE/manifests"
+python3 -c 'import json,sys; json.dump({"schema":"machinery-sidecar/1","vault":sys.argv[1]}, open(sys.argv[2],"w"))' \
+  "$V4" "$SIDE/manifests/sidecarbrain.json"
+ctx="$(run_hook "$NEUTRAL" OBSIDIAN_CONFIG="$CONF4" BRAIN_SIDECAR="$SIDE")"
+want_silent "shape B: sidecar manifest suppresses" "$ctx"
+ctx="$(run_hook "$NEUTRAL" OBSIDIAN_CONFIG="$CONF4" BRAIN_SIDECAR="$TMP/empty-sidecar")"
+want_contains "shape B neg-control: no manifest -> offer fires" "relocate-machinery-sidecar.sh" "$ctx"
+
+# ── 5. NEGATIVE CONTROL: plain local vault -> SILENT ─────────────────────────
+V5="$TMP/plainlocal/Brain"; mkdir -p "$V5"; : > "$V5/CLAUDE.md"; git -C "$V5" init -q
+ctx="$(run_hook "$V5" OBSIDIAN_CONFIG="$NONE")"
+want_silent "local vault: not the freeze class" "$ctx"
+
+# ── 6. NEGATIVE CONTROL: pristine non-git iCloud Obsidian vault -> SILENT ────
+#       (markdown alone is low-churn; don't nag every Obsidian user).
+V6="$TMP/$ICLOUD/JustNotes"; mkdir -p "$V6"; echo "# note" > "$V6/note.md"
+CONF6="$TMP/ob6.json"; write_obsidian_conf "$CONF6" "$V6"
+ctx="$(run_hook "$NEUTRAL" OBSIDIAN_CONFIG="$CONF6")"
+want_silent "pristine non-git iCloud vault: no false nag" "$ctx"
+
+# ── 7. bypass -> SILENT (same vault as case 1, which otherwise fires) ────────
+ctx="$(run_hook "$NEUTRAL" OBSIDIAN_CONFIG="$CONF1" WORKTREE_FOOTPRINT_BYPASS=1)"
+want_silent "WORKTREE_FOOTPRINT_BYPASS suppresses" "$ctx"
+
+# ── 8. fail-open: a malformed obsidian.json must not crash SessionStart ──────
+BAD="$TMP/bad-obsidian.json"; printf 'not json{{' > "$BAD"
+ctx="$(run_hook "$NEUTRAL" OBSIDIAN_CONFIG="$BAD")"
+want_silent "malformed obsidian.json: fail-open, no crash" "$ctx"
+
+echo
+if [ "$fails" -gt 0 ]; then echo "FAILED: $fails"; exit 1; fi
+echo "ALL TESTS PASSED"

--- a/tests/integration/test_cloud_sync_offer.sh
+++ b/tests/integration/test_cloud_sync_offer.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# CI integration wrapper — runs the unconditional cloud-sync relocate-OFFER
+# negative-control suite (scripts/test-cloud-sync-offer.sh, MYC-2360) as part of
+# scripts/ci.sh. Thin: the logic lives next to the hook it exercises.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+exec bash "$ROOT/scripts/test-cloud-sync-offer.sh"


### PR DESCRIPTION
Closes MYC-2360

A git-backed AI brain inside a consumer cloud-sync folder (iCloud / Drive / Dropbox / Box) is the #1 reproducible "whole machine froze" cause. `phase-01-welcome` handles it well, but only when the user pastes their vault path in guided setup. A user who already had an iCloud Obsidian vault (Obsidian's common default), or who skipped onboarding, previously got only a passive per-session warning, and only when cwd was inside the git vault.

## What changed

`worktree-footprint-signal.py` (already the designated SessionStart cloud-sync owner) now fires an unconditional auto-detect + relocate OFFER, independent of guided onboarding:

- **Discovery** spans `find_main_repo` (collapses an in-worktree cwd to its main vault), `$CLAUDE_PROJECT_DIR`, the git checkout cwd sits in, Obsidian's `obsidian.json` registry (so a pre-existing iCloud vault is caught even with no guided welcome and cwd elsewhere), and `$VAULT_ROOT`.
- **Action**: replaces the passive "move it out, see docs" warning with a plain-language OFFER presenting both auto-capable shapes — `relocate-vault.sh` (move-local + symlink) and `relocate-machinery-sidecar.sh` (notes keep syncing, machinery out) — framed for Claude to run on consent, backup-first, idempotent, reversible.
- **Existing users not broken**: self-silences once relocated. Shape A resolves clean through `detect_cloud_sync` (symlink to local); Shape B is suppressed by its machinery-sidecar manifest. Fires for an actual brain only (git-backed or substrate machinery), never a pristine markdown folder.
- **Footprint-safe**: extends the existing owner, so zero new SessionStart fan-out — the Footprint SLA gate stays green. Bounded by construction (one JSON read plus a few stats plus a tiny manifest glob, no corpus walk), so the SessionStart boundedness audit passes.

New shared fail-open helper `obsidian_vault_paths()` in `_lib/worktree_safety.py`.

## Verification

`scripts/ci.sh` green (py_compile + 53 integration tests + shellcheck). New `test-cloud-sync-offer.sh` is negative-controlled: registry discovery (cwd not in vault), cwd-in-vault, both relocation shapes self-silencing, local + pristine-non-git negative controls, bypass, and malformed-`obsidian.json` fail-open. The Footprint SLA gate and SessionStart boundedness audit both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
