### PR TITLE
fix(onboarding): ask fewer install questions — defer Granola, auto-default cloud-sync fix

### DIFF
--- a/phases/phase-00-install.md
+++ b/phases/phase-00-install.md
@@ -100,21 +100,16 @@ Do NOT try to install Homebrew yourself, do NOT "work around" it by skipping Obs
 
 ---
 
-### Step 0.2. Granola setup check (conversational)
+### Step 0.2. Granola (DEFERRED — do NOT ask during install)
 
-Ask:
+**Do NOT ask "Do you use Granola?" during setup.** Meeting-notes tooling is an optional integration, not an install question. Asking it cold, mid-install, is exactly the kind of friction a non-technical user abandons over — the same reason nano-banana (0.4) and GitHub (0.5) are deferred. Default the meeting workflow to MANUAL mode (store `NO_GRANOLA=true`) and move on silently. Don't mention Granola.
 
-> "Do you use Granola for meeting notes?"
+Surface it later ONLY if the user brings up meetings themselves ("pull my meeting notes", "I use Granola", "process this transcript"). At that moment, walk them through it:
 
-**If YES:**
-1. **Check plan access first — Granola's API needs a paid Granola plan.** Have them open Granola → Settings → Connectors. If there is no **API keys** section, their plan does not include API access, so the script cannot sync. Route them to Google Meet + Gemini, Otter, or manual notes instead (same options as the "If NO" branch) and skip the rest of this step.
-2. If they have API access: "Generate an API key (Settings > Connectors > API keys), save it to `~/.config/granola/api-key` (chmod 600), then run `python3 scripts/granola_sync.py --health` to verify the key and `python3 scripts/granola_sync.py --dry-run` to preview what would export."
-3. For auto-export every 2 hours, offer to install the LaunchAgent: "Set the script path + log path in `scripts/com.granola-export.plist`, copy it to `~/Library/LaunchAgents/`, then run `launchctl load ~/Library/LaunchAgents/com.granola-export.plist`."
-4. Store `GRANOLA=api` so the meeting workflow rule knows to Glob for `*- Transcript.md` files.
-
-**If NO / "I don't use Granola":**
-- Store `NO_GRANOLA=true` so the meeting workflow rule installs in 'manual' mode.
-- "No problem. If you ever want Granola auto-sync later, the script is at `scripts/granola_sync.py`."
+1. **Check plan access first — Granola's API needs a paid Granola plan.** Have them open Granola → Settings → Connectors. If there is no **API keys** section, their plan has no API access; route them to Google Meet + Gemini, Otter, or manual notes instead.
+2. With API access: "Generate an API key (Settings > Connectors > API keys), save it to `~/.config/granola/api-key` (chmod 600), then `python3 scripts/granola_sync.py --health` to verify and `--dry-run` to preview."
+3. For auto-export every 2 hours, offer the LaunchAgent: set the script + log paths in `scripts/com.granola-export.plist`, copy to `~/Library/LaunchAgents/`, then `launchctl load ~/Library/LaunchAgents/com.granola-export.plist`.
+4. Store `GRANOLA=api` so the meeting workflow rule Globs for `*- Transcript.md` files.
 
 ---
 

--- a/phases/phase-01-welcome.md
+++ b/phases/phase-01-welcome.md
@@ -261,17 +261,16 @@ python3 ~/.claude/skills/ai-brain-starter/scripts/check-cloud-sync.py --porcelai
 ```
 
 - Output starts with `OK_LOCAL` → good, continue.
-- Output starts with `CLOUD_SYNC_RISK:` → the path is inside `<service>`. This is **supported, but only with the machinery out of the synced tree** — never proceed with a raw synced vault (that is the freeze class). Offer BOTH supported shapes and pick by the user's answer to "do you want these notes on your iPhone?":
-
-  - **Shape A — move it local (simplest; default if they don't need phone sync):** *"That folder is inside <service>. The simplest fix is a local path like `~/Brain`. Paste a new path and I'll re-check."* Re-run the check until it returns `OK_LOCAL`, then continue. (Large vault already there → `docs/CLOUD_SYNC.md` for how to move it out safely.)
-  - **Shape B — keep it synced, notes on every device:** *"I'll keep the vault in <service> and move just the machinery (git + caches) to a local sidecar so the notes sync to your iPhone without the storm."* With all other Claude sessions closed (separating the git dir orphans live worktrees — the script refuses otherwise), run:
+- Output starts with `CLOUD_SYNC_RISK:` → the path is inside `<service>`. **Do NOT make them choose between options or explain the internals, and do NOT ask "do you want these notes on your iPhone?"** — a non-technical user won't know what to answer. Apply the one safe default yourself: keep their notes exactly where they are (still synced, still on their phone) and move only the churning machinery (git + caches) out to a local sidecar. With all other Claude sessions closed (separating the git dir orphans live worktrees — the script refuses otherwise), run:
 
     ```bash
     bash ~/.claude/skills/ai-brain-starter/scripts/relocate-machinery-sidecar.sh "<VAULT_PATH>" --dry-run   # preview
     bash ~/.claude/skills/ai-brain-starter/scripts/relocate-machinery-sidecar.sh "<VAULT_PATH>"             # apply
     ```
 
-    Then confirm `<VAULT_PATH>/.git` is now a one-line pointer file (`cat "<VAULT_PATH>/.git"` shows `gitdir: ...`) and continue. The helper is **idempotent and safe to re-run** — run it once more after your first working session to sweep any caches (`.smart-env`, `.codegraph`) that get created later. Fully reversible with `--rollback`. Details: `docs/CLOUD_SYNC.md` Shape B.
+  Say it simply, in their language: *"That folder syncs to the cloud, which can freeze your computer. I'm moving the noisy hidden part out so it's safe — your notes don't move and nothing gets deleted."* Then confirm `<VAULT_PATH>/.git` is now a one-line pointer (`cat "<VAULT_PATH>/.git"` shows `gitdir: ...`) and continue. Idempotent + safe to re-run (sweep new caches after the first session), fully reversible with `--rollback`. Details: `docs/CLOUD_SYNC.md` Shape B.
+
+  - **Fallback — ONLY if the user explicitly says they don't want the vault in `<service>` at all:** move it fully local instead. *"No problem — paste a local path like `~/Brain` and I'll re-check."* Re-run the check until it returns `OK_LOCAL`, then continue. (Large vault already there → `docs/CLOUD_SYNC.md` for how to move it out safely.)
 
 ### Step 8.6 — Establish an off-machine backup (or explicitly defer, with a warning) — BEFORE declaring setup complete
 


### PR DESCRIPTION
Audited the ai-brain-starter install flow for questions tossed at non-technical users. The installer itself (`bootstrap.sh`) is already non-interactive (its only `read` is the *uninstall* confirmation). Two avoidable questions remained in the front of the funnel; both are removed here so the install just installs and lands the user at the interview.

## What changed

- **phase-00 Step 0.2** stopped asking *"Do you use Granola for meeting notes?"* mid-install (with its paid-plan + API-key branch). Granola is an optional integration, not an install question — and it was the odd one out: nano-banana (0.4) and GitHub (0.5) are already *deferred* ("do NOT mention proactively"). Now Granola defers the same way: default the meeting workflow to manual mode, surface it only if the user brings up meetings themselves. All the setup detail is preserved, just moved behind that trigger.
- **phase-01 Step 8.5** no longer presents a Shape A vs Shape B menu keyed on *"do you want these notes on your iPhone?"* A non-technical user can't answer that. It now applies the one safe default — `relocate-machinery-sidecar.sh` (keep the notes exactly where they are, still synced + on the phone, move only the churning git/caches out) — matching the SessionStart offer simplification in #267. The full local move stays a quiet fallback, only if the user explicitly says they don't want the cloud sync at all.

## Verification

`scripts/ci.sh` green (py_compile + 53 integration tests + shellcheck), including `test_onboarding_wrong_surface_and_nudge`, `test_personal_brain_not_optional`, and the "phase docs reference real repo files" check. Net −6 lines (fewer questions, less prose).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
