### PR TITLE
Windows/PowerShell parity for cloud-sync relocate scripts (MYC-2383)

### DIFF
--- a/docs/CLOUD_SYNC.md
+++ b/docs/CLOUD_SYNC.md
@@ -54,6 +54,20 @@ bash scripts/relocate-vault.sh ~/Desktop/MyVault ~/MyVault --dry-run
 bash scripts/relocate-vault.sh ~/Desktop/MyVault ~/MyVault
 ```
 
+**On Windows (PowerShell)** use the `.ps1` parity script — same behavior, same
+Claude-history migration, but it leaves a **junction** at the old path (needs no
+admin or Developer Mode, and OneDrive does not sync through it):
+
+```powershell
+# preview first (changes nothing)
+powershell -ExecutionPolicy Bypass -File scripts\relocate-vault.ps1 "$env:USERPROFILE\OneDrive\MyVault" "$env:USERPROFILE\MyVault" -DryRun
+# do it (quit Obsidian + close Claude sessions first; -Force overrides the soft gates)
+powershell -ExecutionPolicy Bypass -File scripts\relocate-vault.ps1 "$env:USERPROFILE\OneDrive\MyVault" "$env:USERPROFILE\MyVault"
+```
+
+The SessionStart cloud-sync offer auto-detects your OS and prints whichever of
+these you can actually run, so you usually do not type this by hand.
+
 Already moved it with a plain `mv` and lost your session picker? Re-home just the
 Claude Code state, no second move:
 
@@ -134,6 +148,20 @@ bash scripts/relocate-machinery-sidecar.sh "/path/to/vault"
 # fully reversible — restores a normal local repo
 bash scripts/relocate-machinery-sidecar.sh "/path/to/vault" --rollback
 ```
+
+**On Windows (PowerShell)** the `.ps1` parity script does the same — `.git` via
+`git init --separate-git-dir` (a static pointer file) and each cache/worktree dir
+as a **junction** to the sidecar:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts\relocate-machinery-sidecar.ps1 "C:\path\to\vault" -DryRun
+powershell -ExecutionPolicy Bypass -File scripts\relocate-machinery-sidecar.ps1 "C:\path\to\vault"
+powershell -ExecutionPolicy Bypass -File scripts\relocate-machinery-sidecar.ps1 "C:\path\to\vault" -Rollback
+```
+
+(The bash `--nosync` flag is intentionally not ported: the `.nosync` suffix is an
+iCloud-only convention OneDrive ignores, so on Windows the sidecar relocation is
+the supported path.)
 
 Then turn on iCloud Drive (or Desktop & Documents) for that folder. The docs
 sync to every device; the machinery never leaves your Mac. Verify the calm

--- a/hooks/worktree-footprint-signal.py
+++ b/hooks/worktree-footprint-signal.py
@@ -200,7 +200,41 @@ def _suggest_local_dest(vault: Path) -> Path:
     return cand
 
 
+def _offer_os() -> str:
+    """Command flavor to print: 'windows' (PowerShell .ps1) or 'posix' (bash .sh).
+
+    Keys on the running OS so a Windows/OneDrive user gets commands they can
+    actually run (MYC-2383: the bash scripts are not natively runnable on
+    Windows). WORKTREE_FOOTPRINT_OS={nt|posix} forces the branch so both can be
+    covered on a single-OS CI runner; it changes ONLY which command strings
+    render, never whether the offer fires.
+    """
+    forced = os.environ.get("WORKTREE_FOOTPRINT_OS", "").strip().lower()
+    if forced in ("nt", "win", "windows"):
+        return "windows"
+    if forced in ("posix", "unix", "mac", "linux"):
+        return "posix"
+    return "windows" if os.name == "nt" else "posix"
+
+
 def _offer_block(vault: Path, service: str, dest: Path) -> str:
+    if _offer_os() == "windows":
+        # Windows PowerShell 5.1 is always present; -ExecutionPolicy Bypass lets
+        # an unsigned local script run. The .ps1 leaves a junction (no admin /
+        # Developer Mode needed), which OneDrive does not sync through.
+        move_cmd = (
+            f'powershell -ExecutionPolicy Bypass -File '
+            f'"{SKILL_SCRIPTS}/relocate-vault.ps1" "{vault}" "{dest}"'
+        )
+        sidecar_cmd = (
+            f'powershell -ExecutionPolicy Bypass -File '
+            f'"{SKILL_SCRIPTS}/relocate-machinery-sidecar.ps1" "{vault}"'
+        )
+        rb = "-Rollback"
+    else:
+        move_cmd = f'bash {SKILL_SCRIPTS}/relocate-vault.sh "{vault}" "{dest}"'
+        sidecar_cmd = f'bash {SKILL_SCRIPTS}/relocate-machinery-sidecar.sh "{vault}"'
+        rb = "--rollback"
     return (
         f"🟡 [cloud-sync] The user's brain `{vault}` is inside **{service}** — the "
         f"#1 cause of the \"whole machine froze\" failure (the sync daemon chokes on "
@@ -212,11 +246,11 @@ def _offer_block(vault: Path, service: str, dest: Path) -> str:
         f"  DEFAULT FIX — run THIS one. It leaves their notes exactly where they are "
         f"(still synced, still on their phone) and just moves the noisy hidden "
         f"machinery (`.git`, worktrees, caches) out of the sync folder so the computer "
-        f"stops choking. Reversible (`--rollback`), deletes nothing:\n"
-        f"      bash {SKILL_SCRIPTS}/relocate-machinery-sidecar.sh \"{vault}\"\n"
+        f"stops choking. Reversible (`{rb}`), deletes nothing:\n"
+        f"      {sidecar_cmd}\n"
         f"  Fallback — ONLY if they explicitly say they don't want {service} at all: "
-        f"move the whole vault to a local disk (leaves a symlink so nothing breaks):\n"
-        f"      bash {SKILL_SCRIPTS}/relocate-vault.sh \"{vault}\" \"{dest}\"\n"
+        f"move the whole vault to a local disk (leaves a link so nothing breaks):\n"
+        f"      {move_cmd}\n"
         f"Say it to them roughly like: \"Your notes are in {service}, and that combo "
         f"can freeze your computer. I can fix it safely in the background — your notes "
         f"don't move and nothing gets deleted. Want me to?\" Don't list both commands "

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -132,6 +132,7 @@ INTEGRATION_TESTS=(
   test_relocate_vault
   test_relocate_sweep
   test_relocate_watch
+  test_relocate_ps1
   test_renderer_crash_guard
   test_install_api_canonical_base
   test_cd_worktree_inline_bypass

--- a/scripts/relocate-machinery-sidecar.ps1
+++ b/scripts/relocate-machinery-sidecar.ps1
@@ -1,0 +1,467 @@
+﻿#Requires -Version 5.1
+<#
+  relocate-machinery-sidecar.ps1 - make a vault SAFE to keep inside OneDrive / a
+  cloud-sync folder by moving every churning machinery dir OUT of the synced
+  tree into a local sidecar, leaving only tiny static pointers/links behind.
+
+  Windows parity of relocate-machinery-sidecar.sh (MYC-2383). Same contract,
+  same manifest schema (machinery-sidecar/1), same --separate-git-dir + worktree
+  repair sequencing. Two platform differences: (1) the link is a JUNCTION on
+  Windows (privilege-free, not synced through by OneDrive), a symbolic link on
+  macOS/Linux PowerShell; (2) the .sh '--nosync' mode is intentionally NOT ported
+  - the '.nosync' suffix is an iCloud-only convention OneDrive ignores, so
+  exposing it on Windows would be a silent no-op. Windows relocates to the
+  sidecar (and is reversible with -Rollback).
+
+  WHY
+  ---
+  A git-backed Obsidian vault inside OneDrive / iCloud melts the OS sync daemon -
+  NOT the notes (markdown is tiny + low-churn) but the MACHINERY: a .git
+  rewritten wholesale on 'git gc', per-session worktree checkouts (thousands of
+  files each), and search/index caches. The fix is not "turn the cloud off". The
+  fix is: the vault MAY be synced; the machinery NEVER is. This relocates the
+  machinery and leaves the docs.
+
+  WHAT IT MOVES
+    .git              -> <sidecar>/git      via 'git init --separate-git-dir'
+                         (leaves a one-line .git POINTER FILE - static, safe)
+    .claude/worktrees -> <sidecar>/worktrees   (relocate + link)
+    caches            -> <sidecar>/cache/<name> (relocate + link)
+
+  SEQUENCING GOTCHA: 'git init --separate-git-dir' ORPHANS existing linked
+  worktrees. So this REFUSES to run while any linked worktree or live Claude
+  session exists, unless -Force. After relocation it runs 'git worktree repair'.
+
+  SAFETY: idempotent (re-run = no-op report), reversible (-Rollback reads the
+  manifest and puts everything back), -DryRun changes nothing, and it never
+  deletes content - only moves it and leaves a link/pointer.
+
+  Usage:
+    relocate-machinery-sidecar.ps1 <vault-path> [options]
+    relocate-machinery-sidecar.ps1 <vault-path> -Rollback
+
+  Options:
+    -Sidecar <dir>   sidecar root (default: $env:BRAIN_SIDECAR or ~/.brain-sidecar)
+    -DryRun          print intended actions, change nothing
+    -Rollback        reverse a previous relocation using the manifest
+    -Force           proceed even if linked worktrees / live sessions exist
+                     (DANGEROUS: separate-git-dir orphans live worktrees)
+    -Quiet           only print warnings/errors + the final summary line
+    -Help            this help
+
+  Exit codes: 0 ok / no-op . 1 refused (live worktree/session) . 2 usage .
+              3 not a git vault and could not init . 4 partial failure
+#>
+[CmdletBinding()]
+param(
+  [Parameter(Position = 0)][string]$Vault,
+  [string]$Sidecar,
+  [switch]$DryRun,
+  [switch]$Rollback,
+  [switch]$Force,
+  [switch]$Quiet,
+  [switch]$Help
+)
+
+$ErrorActionPreference = "Stop"
+$ScriptDir = $PSScriptRoot
+$script:OnWindows = if ($null -eq $IsWindows) { $true } else { [bool]$IsWindows }
+
+# ---- machinery the script relocates (relative to the vault root) -------------
+$CacheDirs = @(
+  ".smart-env",
+  ".codegraph",
+  "$([char]0x2699)$([char]0xFE0F) Meta/graphify-out",
+  "graphify-out",
+  "$([char]0x2699)$([char]0xFE0F) Meta/Sessions",
+  "$([char]0x2699)$([char]0xFE0F) Meta/Worktree Snapshots",
+  "$([char]0x2699)$([char]0xFE0F) Meta/logs",
+  ".obsidian/.smart-env"
+)
+$WorktreesRel = ".claude/worktrees"
+
+function Say  { param([string]$m) if (-not $Quiet) { Write-Host $m } }
+function Warn { param([string]$m) Write-Host "WARN  $m" -ForegroundColor Yellow }
+function Err  { param([string]$m) [Console]::Error.WriteLine("ERROR $m") }
+function Invoke-OrDry { param([string]$What, [scriptblock]$Action)
+  if ($DryRun) { Write-Host "DRY   $What" } else { & $Action }
+}
+
+# ---- python (manifest + live-session probe) ---------------------------------
+$script:PyExe = $null
+function Get-PyExe {
+  if ($script:PyExe) { return $script:PyExe }
+  foreach ($n in @("python3", "python")) {
+    $c = Get-Command $n -ErrorAction SilentlyContinue
+    if ($c) {
+      try {
+        $v = (& $c.Source -c "import sys;print(sys.version_info[0])" 2>$null)
+        if ("$v".Trim() -eq "3") { $script:PyExe = $c.Source; return $script:PyExe }
+      } catch { }
+    }
+  }
+  Err "python 3 required for the manifest"; exit 4
+}
+function Invoke-Py { param([string]$Code, [object[]]$PyArgs = @())
+  $py = Get-PyExe
+  return (& $py -c $Code @PyArgs)
+}
+function Get-AbsPath { param([string]$p)
+  return (Invoke-Py 'import os,sys; print(os.path.abspath(os.path.expanduser(sys.argv[1])))' @($p))
+}
+function Get-PhysicalPath { param([string]$p)
+  return (Invoke-Py 'import os,sys; print(os.path.realpath(os.path.expanduser(sys.argv[1])))' @($p))
+}
+
+function Get-HomeBase { if ($env:USERPROFILE) { return $env:USERPROFILE } else { return $HOME } }
+
+function Test-ReparsePoint { param([string]$p)
+  $it = Get-Item -LiteralPath $p -Force -ErrorAction SilentlyContinue
+  if (-not $it) { return $false }
+  return (($it.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)
+}
+
+# Remove ONLY the reparse point (junction/symlink), never the target's contents.
+# Remove-Item on a directory link can recurse into the target on Windows PS 5.1;
+# DirectoryInfo.Delete() severs the link and leaves the target intact.
+function Remove-DirLink { param([string]$p)
+  $it = Get-Item -LiteralPath $p -Force -ErrorAction SilentlyContinue
+  if ($it) { $it.Delete() }
+}
+
+# Cross-platform directory link. Windows: JUNCTION (no privilege, OneDrive does
+# not sync through it), symlink fallback. Elsewhere: symbolic link.
+function New-DirLink { param([string]$Link, [string]$Target)
+  if ($script:OnWindows) {
+    try {
+      New-Item -ItemType Junction -Path $Link -Target $Target -ErrorAction Stop | Out-Null
+      return
+    } catch {
+      try {
+        New-Item -ItemType SymbolicLink -Path $Link -Target $Target -ErrorAction Stop | Out-Null
+        return
+      } catch {
+        Err "could not create a directory link at '$Link' -> '$Target'. A junction needs no special rights; a symbolic link needs Developer Mode or an elevated shell."
+        throw
+      }
+    }
+  } else {
+    New-Item -ItemType SymbolicLink -Path $Link -Target $Target -ErrorAction Stop | Out-Null
+  }
+}
+
+function Get-VaultPath { param([string]$rel)
+  $relNative = $rel -replace '/', [System.IO.Path]::DirectorySeparatorChar
+  return (Join-Path $VaultAbs $relNative)
+}
+
+function Get-Slug { param([string]$p)
+  $base  = Split-Path -Leaf $p
+  $clean = ($base -replace '[^A-Za-z0-9._-]', '-') -replace '-{2,}', '-'
+  $clean = $clean.Trim('-')
+  if (-not $clean) { $clean = "vault" }
+  $sha   = [System.Security.Cryptography.SHA1]::Create()
+  $bytes = [System.Text.Encoding]::UTF8.GetBytes($p)
+  $hex   = ($sha.ComputeHash($bytes) | ForEach-Object { $_.ToString("x2") }) -join ""
+  return "$clean-$($hex.Substring(0, 8))"
+}
+
+# ---- manifest staging (TSV -> python JSON, dodges the PS single-element-array
+#      JSON quirk and matches the .sh writer byte-for-byte) --------------------
+$script:RecFile = $null
+function Add-Record { param([string]$Type, [string]$Rel, [string]$Target, [string]$Mode)
+  if (-not $script:RecFile) { $script:RecFile = [System.IO.Path]::GetTempFileName() }
+  ("{0}`t{1}`t{2}`t{3}" -f $Type, $Rel, $Target, $Mode) |
+    Out-File -LiteralPath $script:RecFile -Encoding UTF8 -Append
+}
+function Write-Manifest {
+  if ($DryRun) { return }
+  # An idempotent re-run (everything already relocated) records ZERO new moves.
+  # Do NOT clobber a prior valid manifest with an empty one - that silently
+  # breaks -Rollback. Only write when there is something to record, or when no
+  # manifest exists yet.
+  $hasRecords = $script:RecFile -and (Test-Path -LiteralPath $script:RecFile) -and ((Get-Item -LiteralPath $script:RecFile).Length -gt 0)
+  if (-not $hasRecords -and (Test-Path -LiteralPath $Manifest)) {
+    Say "  . no new moves; keeping existing manifest $Manifest"
+    return
+  }
+  New-Item -ItemType Directory -Force -Path (Split-Path -Parent $Manifest) | Out-Null
+  $rec = if ($script:RecFile) { $script:RecFile } else { "" }
+  $code = @'
+import json, os, sys
+rec, man, vault, sidecar, slug, nosync = sys.argv[1:7]
+recs = []
+if rec and os.path.isfile(rec):
+    with open(rec, encoding="utf-8") as f:
+        for line in f:
+            line = line.rstrip("\n")
+            if not line:
+                continue
+            parts = line.split("\t")
+            while len(parts) < 4:
+                parts.append("")
+            recs.append({"type": parts[0], "vault_rel": parts[1],
+                         "target": parts[2], "mode": parts[3]})
+doc = {"schema": "machinery-sidecar/1", "vault": vault, "sidecar": sidecar,
+       "slug": slug, "nosync": nosync == "1", "moves": recs}
+os.makedirs(os.path.dirname(man), exist_ok=True)
+with open(man, "w", encoding="utf-8") as f:
+    json.dump(doc, f, ensure_ascii=False, indent=2)
+    f.write("\n")
+'@
+  Invoke-Py $code @($rec, $Manifest, $VaultAbs, $Sidecar, $Slug, "0") | Out-Null
+}
+
+# ---- live-worktree / live-session guard -------------------------------------
+function Get-LinkedWorktrees {
+  $out = & git -C $VaultAbs worktree list --porcelain 2>$null
+  if ($LASTEXITCODE -ne 0) { return @() }
+  $n = 0; $res = @()
+  foreach ($line in @($out)) {
+    if ($line -like 'worktree *') { $n++; if ($n -gt 1) { $res += $line.Substring(9) } }
+  }
+  return $res
+}
+function Get-LiveSessions {
+  $lock = Join-Path $VaultAbs ".claude/.session-lock.json"
+  if (-not (Test-Path -LiteralPath $lock)) { return 0 }
+  $code = @'
+import json, os, sys, time
+lock = sys.argv[1]
+try:
+    data = json.load(open(lock, encoding="utf-8"))
+except Exception:
+    raise SystemExit(0)
+sessions = data.get("sessions", {}) if isinstance(data, dict) else {}
+cut = time.time() - 35 * 60
+self_pid = int(sys.argv[2] or 0)
+n = 0
+for s in sessions.values():
+    if not isinstance(s, dict):
+        continue
+    pid = s.get("pid")
+    la = s.get("last_activity_at")
+    alive = False
+    if isinstance(pid, int) and pid > 0 and pid != self_pid:
+        try:
+            os.kill(pid, 0); alive = True
+        except ProcessLookupError:
+            alive = False
+        except Exception:
+            alive = True
+    recent = isinstance(la, (int, float)) and la >= cut
+    if alive or recent:
+        n += 1
+print(n)
+'@
+  $out = Invoke-Py $code @($lock, "$PID")
+  $val = 0; [int]::TryParse("$out".Trim(), [ref]$val) | Out-Null
+  return $val
+}
+function Test-NoLive {
+  $wts  = @(Get-LinkedWorktrees)
+  $sess = Get-LiveSessions
+  if ($wts.Count -gt 0 -or $sess -gt 0) {
+    if ($Force) {
+      Warn "linked worktrees and/or $sess live session(s) present - proceeding under -Force (separate-git-dir will orphan live worktrees)"
+      return $true
+    }
+    Err "refusing: relocation must run in a no-live-worktree window."
+    if ($wts.Count -gt 0) { Err "  linked worktrees still registered:"; $wts | ForEach-Object { [Console]::Error.WriteLine("    $_") } }
+    if ($sess -gt 0) { Err "  $sess live Claude session(s) in $VaultAbs/.claude/.session-lock.json" }
+    Err "  close all sessions + 'git worktree remove' scratch trees, then re-run. Override: -Force"
+    return $false
+  }
+  return $true
+}
+
+# =============================================================================
+# RELOCATE one cache/worktree dir (relocate + link)
+# =============================================================================
+function Move-CacheDir { param([string]$Rel, [string]$Dst, [string]$RType)
+  $src = Get-VaultPath $Rel
+  if (Test-ReparsePoint $src) { Say "  . $Rel already a link - skip"; return }
+  if (-not (Test-Path -LiteralPath $src)) { return }   # absent -> nothing to do
+  if (Test-Path -LiteralPath $Dst) {
+    $bak = "$Dst.bak-$((Get-Date).ToString('yyyyMMddHHmmss'))"
+    Invoke-OrDry "move existing $Dst -> $bak" { Move-Item -LiteralPath $Dst -Destination $bak }
+    Warn "  . prior sidecar copy at $Dst backed up"
+  }
+  Invoke-OrDry "move $src -> $Dst + link" {
+    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $Dst) | Out-Null
+    Move-Item -LiteralPath $src -Destination $Dst
+    New-DirLink -Link $src -Target $Dst
+  }
+  Add-Record $RType $Rel $Dst "relocate"
+  Say "  . $Rel -> $Dst + link"
+}
+
+# =============================================================================
+# RELOCATE .git via --separate-git-dir
+# =============================================================================
+function Move-GitDir {
+  $gitpath = Join-Path $VaultAbs ".git"
+  if (Test-Path -LiteralPath $gitpath -PathType Leaf) {
+    $cur = ""
+    $first = Get-Content -LiteralPath $gitpath -TotalCount 1 -ErrorAction SilentlyContinue
+    if ("$first" -match '^gitdir:\s*(.+)$') { $cur = $Matches[1] }
+    Say "  . .git already a pointer (-> $cur) - skip"
+    return $true
+  }
+  if (Test-Path -LiteralPath $gitpath -PathType Container) {
+    Invoke-OrDry "git init --separate-git-dir $SideGit" {
+      New-Item -ItemType Directory -Force -Path (Split-Path -Parent $SideGit) | Out-Null
+      & git -C $VaultAbs init --separate-git-dir $SideGit | Out-Null
+    }
+    if (-not $DryRun -and -not (Test-Path -LiteralPath $gitpath -PathType Leaf)) {
+      Err "  separate-git-dir did not produce a .git pointer file"; return $false
+    }
+    Invoke-OrDry "git worktree repair" { & git -C $VaultAbs worktree repair *> $null }
+    Add-Record "git" ".git" $SideGit "separated"
+    Say "  . .git -> $SideGit (pointer file left in vault)"
+    return $true
+  }
+  # no .git at all -> fresh repo with a separated gitdir
+  Invoke-OrDry "git init --separate-git-dir $SideGit (fresh)" {
+    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $SideGit) | Out-Null
+    & git -C $VaultAbs init --separate-git-dir $SideGit | Out-Null
+  }
+  Add-Record "git" ".git" $SideGit "fresh-init"
+  Say "  . initialized fresh repo with gitdir at $SideGit"
+  return $true
+}
+
+# =============================================================================
+# ROLLBACK
+# =============================================================================
+function Invoke-Rollback {
+  if (-not (Test-Path -LiteralPath $Manifest)) { Err "no manifest at $Manifest - nothing to roll back"; exit 2 }
+  Say "Rolling back machinery sidecar for: $VaultAbs"
+  Say "  manifest: $Manifest"
+  $code = @'
+import json, os, sys
+man = sys.argv[1]
+doc = json.load(open(man, encoding="utf-8"))
+for m in reversed(doc.get("moves", [])):
+    print("\t".join([m.get("type",""), m.get("vault_rel",""),
+                     m.get("target",""), m.get("mode","")]))
+'@
+  $rows = Invoke-Py $code @($Manifest)
+  foreach ($row in @($rows)) {
+    if (-not "$row") { continue }
+    $parts = "$row" -split "`t"
+    while ($parts.Count -lt 4) { $parts += "" }
+    $typ = $parts[0]; $rel = $parts[1]; $target = $parts[2]
+    if (-not $typ) { continue }
+    switch ($typ) {
+      "git" {
+        $ptr = Join-Path $VaultAbs ".git"
+        if ((Test-Path -LiteralPath $ptr -PathType Leaf) -and (Test-Path -LiteralPath $target -PathType Container)) {
+          Invoke-OrDry "restore .git dir from $target" {
+            Remove-Item -LiteralPath $ptr -Force
+            Move-Item -LiteralPath $target -Destination $ptr
+            & git -C $VaultAbs config --unset core.worktree 2>$null | Out-Null
+            & git -C $VaultAbs worktree repair *> $null
+          }
+          Say "  restored .git (dir) from $target"
+        } else {
+          Warn "  git rollback skipped (pointer or gitdir missing)"
+        }
+      }
+      default {
+        if ($typ -eq "cache" -or $typ -eq "worktrees") {
+          $link = Get-VaultPath $rel
+          if (Test-ReparsePoint $link) { Invoke-OrDry "remove link $link" { Remove-DirLink $link } }
+          if (Test-Path -LiteralPath $target) {
+            Invoke-OrDry "restore $rel from $target" {
+              New-Item -ItemType Directory -Force -Path (Split-Path -Parent $link) | Out-Null
+              Move-Item -LiteralPath $target -Destination $link
+            }
+          } else {
+            Warn "  missing sidecar source: $target"
+          }
+          Say "  restored $rel"
+        }
+      }
+    }
+  }
+  if (-not $DryRun) { Remove-Item -LiteralPath $Manifest -Force -ErrorAction SilentlyContinue }
+  Say "Rollback complete."
+}
+
+# =============================================================================
+# MAIN
+# =============================================================================
+if ($Help) {
+  $inBlock = $false
+  foreach ($line in (Get-Content -LiteralPath $PSCommandPath)) {
+    if ($line -match '^\s*<#') { $inBlock = $true; continue }
+    if ($line -match '^\s*#>') { break }
+    if ($inBlock) { Write-Host $line }
+  }
+  exit 0
+}
+
+if (-not $Vault) { [Console]::Error.WriteLine("usage: relocate-machinery-sidecar.ps1 <vault-path> [options]"); exit 2 }
+if (-not (Test-Path -LiteralPath $Vault -PathType Container)) { [Console]::Error.WriteLine("not a directory: $Vault"); exit 2 }
+
+$VaultAbs = "$(Get-PhysicalPath $Vault)".Trim()
+
+if (-not $Sidecar) {
+  $Sidecar = if ($env:BRAIN_SIDECAR) { $env:BRAIN_SIDECAR }
+             elseif ($env:MYCELIUM_SIDECAR) { $env:MYCELIUM_SIDECAR }
+             else { Join-Path (Get-HomeBase) ".brain-sidecar" }
+}
+$Sidecar = "$(Get-AbsPath $Sidecar)".Trim()
+
+$Slug     = Get-Slug $VaultAbs
+$SideGit  = Join-Path (Join-Path $Sidecar "git") $Slug
+$SideCache = Join-Path (Join-Path $Sidecar "cache") $Slug
+$SideWt   = Join-Path (Join-Path $Sidecar "worktrees") $Slug
+$Manifest = Join-Path (Join-Path $Sidecar "manifests") "$Slug.json"
+
+if ($Rollback) { Invoke-Rollback; exit 0 }
+
+# informational cloud detect (the whole point is the cloud is ALLOWED)
+$cloud = ""
+$ccs = Join-Path $ScriptDir "check-cloud-sync.py"
+if (Test-Path -LiteralPath $ccs) {
+  try {
+    $py = Get-PyExe
+    $cloud = "$(& $py $ccs --porcelain $VaultAbs 2>$null)".Trim()
+  } catch { $cloud = "" }
+}
+
+Say "Machinery-sidecar relocation"
+Say "  vault   : $VaultAbs"
+Say "  sidecar : $Sidecar  (slug: $Slug)"
+if ($cloud -like 'CLOUD_SYNC_RISK*') {
+  Say "  cloud   : $($cloud -replace '^CLOUD_SYNC_RISK:?\s*','') - relocating machinery so the docs can sync safely"
+} elseif ($cloud -eq 'OK_LOCAL') {
+  Say "  cloud   : local disk (machinery relocation still valid; reduces in-tree churn)"
+}
+if ($DryRun) { Say "  mode    : -DryRun (no changes)" }
+
+if (-not (Test-NoLive)) { exit 1 }
+
+Say "Relocating .git ..."
+if (-not (Move-GitDir)) { exit 4 }
+
+Say "Relocating worktrees ..."
+Move-CacheDir -Rel $WorktreesRel -Dst $SideWt -RType "worktrees"
+
+Say "Relocating caches ..."
+foreach ($rel in $CacheDirs) {
+  Move-CacheDir -Rel $rel -Dst (Join-Path $SideCache ($rel -replace '/', [System.IO.Path]::DirectorySeparatorChar)) -RType "cache"
+}
+
+Write-Manifest
+if ($script:RecFile -and (Test-Path -LiteralPath $script:RecFile)) { Remove-Item -LiteralPath $script:RecFile -Force -ErrorAction SilentlyContinue }
+
+if ($DryRun) {
+  Say "DRY-RUN complete - no changes made. Manifest would be: $Manifest"
+} else {
+  Say "Done. Manifest: $Manifest"
+  Say "Reverse anytime: relocate-machinery-sidecar.ps1 `"$VaultAbs`" -Rollback"
+}
+exit 0

--- a/scripts/relocate-machinery-sidecar.sh
+++ b/scripts/relocate-machinery-sidecar.sh
@@ -118,6 +118,14 @@ record() { printf '%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" >> "$_manifest_records"
 
 write_manifest() {
   [ "$DRYRUN" = 1 ] && return 0
+  # An idempotent re-run (everything already relocated) records ZERO new moves.
+  # Do NOT clobber a prior valid manifest with an empty one - that silently
+  # breaks --rollback. Only write when there is something to record, or when no
+  # manifest exists yet. (Parity with relocate-machinery-sidecar.ps1, MYC-2383.)
+  if [ ! -s "$_manifest_records" ] && [ -f "$MANIFEST" ]; then
+    say "  · no new moves; keeping existing manifest $MANIFEST"
+    return 0
+  fi
   mkdir -p "$(dirname "$MANIFEST")"
   VAULT="$VAULT" SIDECAR="$SIDECAR" SLUG="$SLUG" NOSYNC="$NOSYNC" \
   REC="$_manifest_records" MAN="$MANIFEST" "$PYBIN" - <<'PY'

--- a/scripts/relocate-vault.ps1
+++ b/scripts/relocate-vault.ps1
@@ -1,0 +1,396 @@
+﻿#Requires -Version 5.1
+<#
+  relocate-vault.ps1 - move a vault OUT of a consumer cloud-sync folder onto a
+  local disk, leave a directory link so existing references keep resolving, AND
+  migrate Claude Code's path-keyed state (session transcripts + the agent-memory
+  link) so prior session history survives the move.
+
+  Windows parity of relocate-vault.sh (MYC-2383). Same contract, same Claude
+  path-key transform (shelled out to python for byte-identical semantics), same
+  relocations.json manifest the watchdog reads. The one platform difference is
+  the LINK: on Windows the old path is left as a JUNCTION (privilege-free, app-
+  transparent, and NOT followed/synced by OneDrive - which is the whole point),
+  falling back to a symbolic link only if a junction cannot be created. On
+  macOS/Linux PowerShell (used by the test harness) it leaves a symbolic link,
+  matching the .sh.
+
+  WHY
+  ---
+  A git-backed Obsidian/AI-brain vault inside OneDrive / iCloud / Dropbox /
+  Google Drive / Box melts the OS sync daemon - the high-churn .git plus per-
+  session worktree checkouts generate millions of file events. The supported fix
+  (Shape A in docs/CLOUD_SYNC.md) is to move the vault onto a local disk and
+  leave a link. A RAW move does the move but SILENTLY ORPHANS Claude Code
+  history: Claude stores per-project state under <config>/projects/<key>, where
+  <key> is the absolute cwd with every non-alphanumeric character replaced by
+  '-'. Moving the vault changes the key, so prior transcripts read "Session
+  history unavailable" and the agent-memory link dangles. This helper does the
+  move AND re-homes that state (copy, never move - old keys stay as a backup).
+
+  Usage:
+    relocate-vault.ps1 <old-vault-path> <new-vault-path> [options]
+    relocate-vault.ps1 -MigrateClaudeState <old-abs-path> <new-abs-path>
+      (state-only: the vault is already at the new path; just fix Claude history)
+    relocate-vault.ps1 -Sweep <old-path> [<new-path>]
+      (report residual references to the old path - classified - with a go/no-go)
+    relocate-vault.ps1 -DropSymlink <old-path> [<new-path>]
+      (retire the old-path link, but ONLY when the sweep finds zero executed refs)
+
+  Options:
+    -DryRun              print intended actions, change nothing
+    -NoSymlink           do NOT leave a link at the old path (default leaves one)
+    -Force               skip the soft gates (Obsidian-running, active-session).
+                         target-exists and source-already-a-link stay FATAL.
+    -ConfigDir <dir>     Claude Code config dir (default: $env:CLAUDE_CONFIG_DIR
+                         or ~/.claude)
+    -Help                this help
+
+  -Sweep / -DropSymlink shell out to scripts/relocate-sweep.py (same dir).
+
+  Exit codes: 0 ok / no-op / GO . 1 refused (gate) / NO-GO . 2 usage . 4 partial failure
+#>
+[CmdletBinding()]
+param(
+  [Parameter(Position = 0)][string]$Old,
+  [Parameter(Position = 1)][string]$New,
+  [switch]$DryRun,
+  [switch]$NoSymlink,
+  [switch]$Force,
+  [string]$ConfigDir,
+  [switch]$MigrateClaudeState,
+  [switch]$Sweep,
+  [switch]$DropSymlink,
+  [Parameter(ValueFromRemainingArguments = $true)][string[]]$SweepExtra,
+  [switch]$Help
+)
+
+$ErrorActionPreference = "Stop"
+$ScriptDir = $PSScriptRoot
+
+# On Windows PowerShell 5.1, $IsWindows does not exist (-> $null), and that shell
+# only ever runs on Windows; on pwsh 6+ $IsWindows is the real automatic var.
+$script:OnWindows = if ($null -eq $IsWindows) { $true } else { [bool]$IsWindows }
+
+if (-not $ConfigDir) {
+  if ($env:CLAUDE_CONFIG_DIR) {
+    $ConfigDir = $env:CLAUDE_CONFIG_DIR
+  } else {
+    $base = if ($env:USERPROFILE) { $env:USERPROFILE } else { $HOME }
+    $ConfigDir = Join-Path $base ".claude"
+  }
+}
+
+function Say  { param([string]$m) Write-Host $m }
+function Warn { param([string]$m) Write-Host "WARN  $m" -ForegroundColor Yellow }
+function Die  { param([string]$m, [int]$code = 1) Write-Host "relocate-vault: REFUSE - $m" -ForegroundColor Red; exit $code }
+
+# ---- python (path-key transform + manifest, for byte-identical semantics) -----
+$script:PyExe = $null
+function Get-PyExe {
+  if ($script:PyExe) { return $script:PyExe }
+  foreach ($n in @("python3", "python")) {
+    $c = Get-Command $n -ErrorAction SilentlyContinue
+    if ($c) {
+      try {
+        $v = (& $c.Source -c "import sys;print(sys.version_info[0])" 2>$null)
+        if ("$v".Trim() -eq "3") { $script:PyExe = $c.Source; return $script:PyExe }
+      } catch { }
+    }
+  }
+  Die "python 3 is required (path-key transform + manifest) and was not found on PATH. Install it (e.g. 'winget install Python.Python.3.12') and re-run." 4
+}
+function Invoke-Py {
+  param([string]$Code, [object[]]$PyArgs = @())
+  $py = Get-PyExe
+  return (& $py -c $Code @PyArgs)
+}
+
+function Get-AbsPath { param([string]$p)
+  return (Invoke-Py 'import os,sys; print(os.path.abspath(os.path.expanduser(sys.argv[1])))' @($p))
+}
+function Get-PhysicalPath { param([string]$p)
+  return (Invoke-Py 'import os,sys; print(os.path.realpath(os.path.expanduser(sys.argv[1])))' @($p))
+}
+# Claude Code's per-project dir name = the absolute cwd run through
+# replace(/[^A-Za-z0-9]/g, "-"). Resolve the ANCESTRY but NEVER follow a leaf
+# link: post-move the old leaf IS the link we leave behind. Matches the .sh.
+function Get-ProjKey { param([string]$p)
+  $code = @'
+import os,re,sys
+p = os.path.abspath(os.path.expanduser(sys.argv[1]))
+resolved = os.path.join(os.path.realpath(os.path.dirname(p)), os.path.basename(p))
+print(re.sub(r"[^a-zA-Z0-9]", "-", resolved))
+'@
+  return (Invoke-Py $code @($p))
+}
+
+function Test-ReparsePoint { param([string]$p)
+  $it = Get-Item -LiteralPath $p -Force -ErrorAction SilentlyContinue
+  if (-not $it) { return $false }
+  return (($it.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)
+}
+
+# Remove ONLY the reparse point (junction/symlink), never the target's contents.
+# Remove-Item on a directory link can recurse into the target on Windows PS 5.1.
+function Remove-DirLink { param([string]$p)
+  $it = Get-Item -LiteralPath $p -Force -ErrorAction SilentlyContinue
+  if ($it) { $it.Delete() }
+}
+
+# Cross-platform directory link. Windows: JUNCTION (no privilege, OneDrive does
+# not sync through it), symlink fallback. Elsewhere: symbolic link.
+function New-DirLink { param([string]$Link, [string]$Target)
+  if ($script:OnWindows) {
+    try {
+      New-Item -ItemType Junction -Path $Link -Target $Target -ErrorAction Stop | Out-Null
+      return
+    } catch {
+      try {
+        New-Item -ItemType SymbolicLink -Path $Link -Target $Target -ErrorAction Stop | Out-Null
+        return
+      } catch {
+        Die "could not create a directory link at '$Link' -> '$Target'. A junction needs no special rights; a symbolic link needs Developer Mode or an elevated shell. Enable Developer Mode (Settings > Privacy and security > For developers) and re-run." 4
+      }
+    }
+  } else {
+    New-Item -ItemType SymbolicLink -Path $Link -Target $Target -ErrorAction Stop | Out-Null
+  }
+}
+
+# ---- migrate Claude Code path-keyed state (sessions + agent memory) -----------
+function Move-ClaudeState { param([string]$OldAbs, [string]$NewAbs)
+  $projdir = Join-Path $ConfigDir "projects"
+  if (-not (Test-Path -LiteralPath $projdir)) {
+    Say "  . no Claude Code projects dir ($projdir) - nothing to migrate"; return
+  }
+  $oldkey = "$(Get-ProjKey $OldAbs)".Trim()
+  $newkey = "$(Get-ProjKey $NewAbs)".Trim()
+  if ($oldkey -eq $newkey) {
+    Say "  . old and new path keys are identical - nothing to migrate"; return
+  }
+
+  $matched = 0; $keys = 0; $files = 0
+  Get-ChildItem -LiteralPath $projdir -Directory -Force -ErrorAction SilentlyContinue |
+    Where-Object { $_.Name.StartsWith($oldkey) } | ForEach-Object {
+      $matched++
+      $nb = $newkey + $_.Name.Substring($oldkey.Length)
+      $nd = Join-Path $projdir $nb
+      if ($DryRun) { Say "  . would migrate $($_.Name) -> $nb"; $keys++; return }
+      New-Item -ItemType Directory -Force -Path $nd | Out-Null
+      $before = (Get-ChildItem -LiteralPath $nd -Filter *.jsonl -File -ErrorAction SilentlyContinue | Measure-Object).Count
+      Get-ChildItem -LiteralPath $_.FullName -Filter *.jsonl -File -ErrorAction SilentlyContinue | ForEach-Object {
+        $dest = Join-Path $nd $_.Name
+        if (-not (Test-Path -LiteralPath $dest)) { Copy-Item -LiteralPath $_.FullName -Destination $dest }
+      }
+      $after = (Get-ChildItem -LiteralPath $nd -Filter *.jsonl -File -ErrorAction SilentlyContinue | Measure-Object).Count
+      $keys++; $files += ($after - $before)
+    }
+
+  if ($matched -eq 0) {
+    Warn "  . no Claude Code session history found under old key '$oldkey*' in $projdir."
+    Warn "    Nothing to migrate, OR the path-key encoding differs from what was expected -"
+    Warn "    inspect $projdir if you expected prior sessions here."
+    return
+  }
+  if ($DryRun) { Say "  . would migrate transcripts across $keys project key(s) -> new path key" }
+  else { Say "  . migrated $files transcript(s) across $keys project key(s) -> new path key" }
+
+  # Re-home the agent-memory link under the new base key. Prefer repointing an
+  # existing old-key link; fall back to the ai-brain-starter memory convention.
+  $oldmem = Join-Path (Join-Path $projdir $oldkey) "memory"
+  $newmem = Join-Path (Join-Path $projdir $newkey) "memory"
+  if (-not (Test-Path -LiteralPath $newmem)) {
+    $target = $null
+    if (Test-ReparsePoint $oldmem) {
+      $t = @((Get-Item -LiteralPath $oldmem -Force).Target)[0]
+      if ($t) {
+        if ($t -eq $OldAbs) {
+          $target = $NewAbs
+        } elseif ($t.StartsWith($OldAbs + [System.IO.Path]::DirectorySeparatorChar) -or $t.StartsWith($OldAbs + "/")) {
+          $target = $NewAbs + $t.Substring($OldAbs.Length)
+        } else {
+          $target = $t
+        }
+      }
+    } else {
+      # ai-brain-starter memory convention: "<gear> Meta/Agent Memory". Build the
+      # gear + variation-selector from char codes so the source stays ASCII-clean
+      # (no literal emoji byte to depend on the editor's encoding).
+      $gear = [string][char]0x2699 + [string][char]0xFE0F
+      $target = Join-Path $NewAbs (Join-Path "$gear Meta" "Agent Memory")
+    }
+    if ($target -and (Test-Path -LiteralPath $target -PathType Container)) {
+      if ($DryRun) {
+        Say "  . would re-link agent-memory -> $target"
+      } else {
+        New-Item -ItemType Directory -Force -Path (Join-Path $projdir $newkey) | Out-Null
+        New-DirLink -Link $newmem -Target $target
+        Say "  . agent-memory re-linked -> $target"
+      }
+    }
+  }
+}
+
+# ---- record the move in the relocation manifest (the watchdog's source of truth) ---
+function Write-RelocationRecord { param([string]$OldAbs, [string]$NewAbs, [bool]$Symlink)
+  $manifest = Join-Path $ConfigDir "relocations.json"
+  if ($DryRun) { Say "  . would record the move in $manifest (the watchdog reads this)"; return }
+  New-Item -ItemType Directory -Force -Path $ConfigDir -ErrorAction SilentlyContinue | Out-Null
+  $code = @'
+import json, os, sys, tempfile, time
+manifest, old, new, symlink = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4] == "1"
+try:
+    data = json.load(open(manifest)) if os.path.isfile(manifest) else []
+    if not isinstance(data, list):
+        data = []
+except (OSError, ValueError):
+    data = []
+data = [e for e in data if not (isinstance(e, dict) and e.get("old") == old)]
+data.append({"old": old, "new": new, "symlink": symlink,
+             "at": time.strftime("%Y-%m-%dT%H:%M:%S%z")})
+d = os.path.dirname(manifest) or "."
+fd, tmp = tempfile.mkstemp(dir=d, prefix=".relocations.")
+with os.fdopen(fd, "w") as f:
+    json.dump(data, f, indent=2)
+os.replace(tmp, manifest)
+'@
+  $sym = if ($Symlink) { "1" } else { "0" }
+  try {
+    Invoke-Py $code @($manifest, $OldAbs, $NewAbs, $sym) | Out-Null
+    Say "  . recorded the move in $manifest (scripts/relocate-sweep.py --watch reads this)"
+  } catch {
+    Warn "could not record the move in $manifest (the watchdog will not see it until recorded)"
+  }
+}
+
+function Invoke-Sweep { param([string]$OldP, [string]$NewP, [string[]]$Extra)
+  $sweepPy = Join-Path $ScriptDir "relocate-sweep.py"
+  if (-not (Test-Path -LiteralPath $sweepPy)) { Die "relocate-sweep.py not found next to this script ($sweepPy)" }
+  $py = Get-PyExe
+  $a = @($sweepPy, "--old", $OldP)
+  if ($NewP) { $a += @("--new", $NewP) }
+  if ($Extra) { $a += $Extra }
+  & $py @a
+  return $LASTEXITCODE
+}
+
+# =============================================================================
+if ($Help) {
+  # Print the file's leading block-comment (the usage doc) between <# and #>.
+  $inBlock = $false
+  foreach ($line in (Get-Content -LiteralPath $PSCommandPath)) {
+    if ($line -match '^\s*<#') { $inBlock = $true; continue }
+    if ($line -match '^\s*#>') { break }
+    if ($inBlock) { Say $line }
+  }
+  exit 0
+}
+
+# state-only mode -------------------------------------------------------------
+if ($MigrateClaudeState) {
+  if (-not $Old -or -not $New) {
+    [Console]::Error.WriteLine("usage: relocate-vault.ps1 -MigrateClaudeState <old-abs-path> <new-abs-path>"); exit 2
+  }
+  $OldA = "$(Get-AbsPath $Old)".Trim()
+  $NewA = "$(Get-AbsPath $New)".Trim()
+  Say "relocate-vault: migrating Claude Code state only ($OldA -> $NewA)"
+  Move-ClaudeState -OldAbs $OldA -NewAbs $NewA
+  $sym = Test-ReparsePoint $OldA
+  Write-RelocationRecord -OldAbs $OldA -NewAbs $NewA -Symlink $sym
+  exit 0
+}
+
+# sweep mode ------------------------------------------------------------------
+if ($Sweep) {
+  if (-not $Old) { [Console]::Error.WriteLine("usage: relocate-vault.ps1 -Sweep <old-path> [<new-path>]"); exit 2 }
+  $rc = Invoke-Sweep -OldP $Old -NewP $New -Extra $SweepExtra
+  exit $rc
+}
+
+# drop-symlink mode -----------------------------------------------------------
+if ($DropSymlink) {
+  if (-not $Old) { [Console]::Error.WriteLine("usage: relocate-vault.ps1 -DropSymlink <old-path> [<new-path>]"); exit 2 }
+  if (-not (Test-ReparsePoint $Old)) { Die "old path '$Old' is not a link - nothing to drop (relocate first, or it is already gone)" }
+  if (-not $New) { $New = @((Get-Item -LiteralPath $Old -Force).Target)[0] }
+  Say "relocate-vault: sweeping for residual references before retiring the link at '$Old' ..."
+  $rc = Invoke-Sweep -OldP $Old -NewP $New -Extra $SweepExtra
+  if ($rc -ne 0) {
+    Die "NO-GO - executed references still resolve the old path (see report above). Repoint them, then re-run -DropSymlink." 1
+  }
+  if ($DryRun) { Say "DRY  would: remove '$Old' (link) - sweep returned GO (zero executed references)."; exit 0 }
+  Remove-DirLink $Old
+  Write-RelocationRecord -OldAbs $Old -NewAbs $New -Symlink $false
+  Say "relocate-vault: retired the link '$Old' - sweep returned GO (zero executed references)."
+  exit 0
+}
+
+# full relocate ---------------------------------------------------------------
+if (-not $Old -or -not $New) {
+  [Console]::Error.WriteLine("usage: relocate-vault.ps1 <old-vault-path> <new-vault-path> [-DryRun] [-Force] [-NoSymlink]"); exit 2
+}
+if (-not (Test-Path -LiteralPath $Old)) { Die "source '$Old' not found (already moved?)" }
+if (Test-ReparsePoint $Old) { Die "source '$Old' is already a link (already relocated?)" }
+if (-not (Test-Path -LiteralPath $Old -PathType Container)) { Die "source '$Old' is not a directory" }
+
+$OldAbs = "$(Get-PhysicalPath $Old)".Trim()
+$NewAbs = "$(Get-AbsPath $New)".Trim()
+if ($OldAbs -eq $NewAbs) { Die "source and target are the same path" }
+if (Test-Path -LiteralPath $NewAbs) { Die "target '$NewAbs' already exists (will not overwrite)" }
+
+# Soft gates - skippable with -Force.
+if (-not $Force) {
+  if (Get-Process -Name Obsidian -ErrorAction SilentlyContinue) {
+    Die "Obsidian is running - quit it first (moving an open vault is unsafe), or pass -Force"
+  }
+  $wt = Join-Path $OldAbs ".claude/worktrees"
+  if (Test-Path -LiteralPath $wt -PathType Container) {
+    $cut = (Get-Date).AddMinutes(-10)
+    $active = Get-ChildItem -LiteralPath $wt -Recurse -File -Force -ErrorAction SilentlyContinue |
+      Where-Object { $_.LastWriteTime -gt $cut } | Select-Object -First 1
+    if ($active) { Die "an active Claude session is writing under .claude/worktrees (touched <10 min) - close it, or pass -Force" }
+  }
+}
+
+Say ""
+Say "relocate-vault: BACK UP FIRST. A vault is often your one irreplaceable asset."
+Say "  Stand up + VERIFY an off-machine backup before moving:"
+Say "    pwsh -File scripts/vault-backup.ps1 setup ; pwsh -File scripts/vault-backup.ps1 verify"
+Say ""
+
+if ($DryRun) {
+  Say "DRY  would: move '$OldAbs' -> '$NewAbs'"
+  if (-not $NoSymlink) { Say "DRY  would: link '$OldAbs' -> '$NewAbs' (junction on Windows)" }
+  Move-ClaudeState -OldAbs $OldAbs -NewAbs $NewAbs
+  Write-RelocationRecord -OldAbs $OldAbs -NewAbs $NewAbs -Symlink (-not $NoSymlink)
+  Say "DRY-RUN complete - no changes made."
+  exit 0
+}
+
+Say "relocate-vault: moving '$OldAbs' -> '$NewAbs'"
+New-Item -ItemType Directory -Force -Path (Split-Path -Parent $NewAbs) | Out-Null
+Move-Item -LiteralPath $OldAbs -Destination $NewAbs
+if (-not (Test-Path -LiteralPath $NewAbs -PathType Container)) { Die "POST: '$NewAbs' missing after move" 4 }
+
+if (-not $NoSymlink) {
+  New-DirLink -Link $OldAbs -Target $NewAbs
+  if ((Test-ReparsePoint $OldAbs)) {
+    Say "relocate-vault: left a link '$OldAbs' -> '$NewAbs' (old references keep resolving; the sync daemon sees a tiny reparse point, not the churn)"
+  } else {
+    Warn "POST: expected link not in place at $OldAbs"
+  }
+}
+
+Say "relocate-vault: migrating Claude Code session history + agent memory ..."
+Move-ClaudeState -OldAbs $OldAbs -NewAbs $NewAbs
+
+Write-RelocationRecord -OldAbs $OldAbs -NewAbs $NewAbs -Symlink (-not $NoSymlink)
+
+Say ""
+Say "relocate-vault: DONE."
+Say "  - Vault now lives at:  $NewAbs   (outside the sync folder)"
+if (-not $NoSymlink) { Say "  - Old path is a link:  $OldAbs -> $NewAbs   (scripts/hooks/CLAUDE.md keep working)" }
+Say "  - Reopen Obsidian; if it lost the vault, open $NewAbs"
+Say "  - Reopen Claude Code in the vault - prior sessions appear in the picker"
+Say "    (history was re-homed to the new path key; the old keys are kept as a backup)"
+Say "  - Re-run a backup against the new path:  `$env:VAULT_PATH=`"$NewAbs`"; pwsh -File scripts/vault-backup.ps1 run"
+exit 0

--- a/scripts/test-cloud-sync-offer.sh
+++ b/scripts/test-cloud-sync-offer.sh
@@ -134,6 +134,25 @@ BAD="$TMP/bad-obsidian.json"; printf 'not json{{' > "$BAD"
 ctx="$(run_hook "$NEUTRAL" OBSIDIAN_CONFIG="$BAD")"
 want_silent "malformed obsidian.json: fail-open, no crash" "$ctx"
 
+# ── 9. OS-AWARE COMMAND SURFACE (MYC-2383) ──────────────────────────────────
+#       A Windows/OneDrive user must get .ps1 commands they can actually run,
+#       NOT the bash scripts (which do not run natively on Windows). The offer
+#       branches on the running OS; WORKTREE_FOOTPRINT_OS forces each branch so
+#       both are coverable on this Linux CI runner. Paired negative control: the
+#       Windows offer must never leak a bash .sh command.
+ctx_posix="$(run_hook "$NEUTRAL" OBSIDIAN_CONFIG="$CONF1" WORKTREE_FOOTPRINT_OS=posix)"
+want_contains "posix branch: bash invocation"        "bash "                          "$ctx_posix"
+want_contains "posix branch: .sh relocate script"    "relocate-vault.sh"              "$ctx_posix"
+
+ctx_win="$(run_hook "$NEUTRAL" OBSIDIAN_CONFIG="$CONF1" WORKTREE_FOOTPRINT_OS=nt)"
+want_contains "windows branch: .ps1 relocate script" "relocate-vault.ps1"             "$ctx_win"
+want_contains "windows branch: .ps1 sidecar script"  "relocate-machinery-sidecar.ps1" "$ctx_win"
+want_contains "windows branch: powershell invocation" "powershell"                    "$ctx_win"
+case "$ctx_win" in
+  *"relocate-vault.sh"*) echo "FAIL  windows branch: leaked a bash .sh command"; fails=$((fails+1));;
+  *) echo "PASS  windows branch: no bash .sh command leaked (neg control)";;
+esac
+
 echo
 if [ "$fails" -gt 0 ]; then echo "FAILED: $fails"; exit 1; fi
 echo "ALL TESTS PASSED"

--- a/scripts/test-machinery-sidecar.sh
+++ b/scripts/test-machinery-sidecar.sh
@@ -150,6 +150,24 @@ rc=$?
 gitq "$VC" status && pass "D git functional after rollback" || fail "D git broke after rollback"
 
 # ---------------------------------------------------------------------------
+# D2. ROLLBACK SURVIVES AN IDEMPOTENT RE-RUN (manifest-clobber regression):
+#     relocate -> re-run (records zero new moves) -> rollback must STILL restore
+#     the repo. A re-run that overwrites the manifest with moves:[] silently
+#     breaks --rollback. This is the negative control for that fix (MYC-2383).
+# ---------------------------------------------------------------------------
+VG="$ROOT/G"
+make_vault "$VG"
+bash "$HELPER" "$VG" --sidecar "$SIDE" --quiet
+bash "$HELPER" "$VG" --sidecar "$SIDE" --quiet            # idempotent re-run
+bash "$HELPER" "$VG" --sidecar "$SIDE" --rollback --quiet
+rc=$?
+[ "$rc" = 0 ] && pass "D2 rollback after re-run exit 0" || fail "D2 rollback after re-run exit=$rc"
+[ -d "$VG/.git" ] && pass "D2 .git restored to a dir after re-run+rollback" \
+                  || fail "D2 .git NOT restored (manifest clobbered by re-run)"
+[ -d "$VG/.smart-env" ] && [ ! -L "$VG/.smart-env" ] && pass "D2 .smart-env restored after re-run+rollback" \
+                                                      || fail "D2 .smart-env NOT restored after re-run"
+
+# ---------------------------------------------------------------------------
 # E. LIVE-WORKTREE GUARD: refuse (exit 1) when a linked worktree exists
 # ---------------------------------------------------------------------------
 VD="$ROOT/D"

--- a/scripts/test-relocate-machinery-sidecar.ps1
+++ b/scripts/test-relocate-machinery-sidecar.ps1
@@ -1,0 +1,123 @@
+﻿#Requires -Version 5.1
+<#
+  Behavioral test for relocate-machinery-sidecar.ps1 (MYC-2383 - Windows parity
+  of relocate-machinery-sidecar.sh). Runs under pwsh on any OS. On Windows the
+  machinery links are junctions, elsewhere symbolic links; both carry the
+  ReparsePoint attribute, so the link assertions hold cross-platform. Proves:
+  .git -> pointer file via --separate-git-dir, caches -> links, manifest names
+  the vault (the offer-suppression key), idempotency, full rollback, dry-run
+  inertness, and the live-worktree refusal gate (paired negative control).
+
+  Run: pwsh -File scripts/test-relocate-machinery-sidecar.ps1
+#>
+$ErrorActionPreference = "Stop"
+$Here = $PSScriptRoot
+$MS   = Join-Path $Here "relocate-machinery-sidecar.ps1"
+$script:fails = 0
+$gear = [string][char]0x2699 + [string][char]0xFE0F   # keep this file ASCII-clean
+
+function Check { param([string]$Label, [bool]$Cond)
+  if ($Cond) { Write-Host "PASS  $Label" } else { Write-Host "FAIL  $Label"; $script:fails++ }
+}
+function Get-Py {
+  foreach ($n in @("python3", "python")) {
+    $c = Get-Command $n -ErrorAction SilentlyContinue
+    if ($c) { $v = (& $c.Source -c "import sys;print(sys.version_info[0])" 2>$null); if ("$v".Trim() -eq "3") { return $c.Source } }
+  }
+  throw "python 3 required for the test"
+}
+$Py = Get-Py
+function RealPath { param([string]$p) return ("$(& $Py -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' $p)").Trim() }
+function Is-Reparse { param([string]$p)
+  $it = Get-Item -LiteralPath $p -Force -ErrorAction SilentlyContinue
+  return ($it -and (($it.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0))
+}
+function Run-MS { param([string[]]$MsArgs)
+  $out = & pwsh -NoProfile -File $MS @MsArgs 2>&1
+  return [pscustomobject]@{ rc = $LASTEXITCODE; out = ("$out" -join "`n") }
+}
+function New-Vault { param([string]$Path)
+  New-Item -ItemType Directory -Force -Path $Path | Out-Null
+  Set-Content -LiteralPath (Join-Path $Path "CLAUDE.md") -Value "# brain"
+  & git -C $Path init -q | Out-Null
+  & git -C $Path config user.email "t@example.com" | Out-Null
+  & git -C $Path config user.name "t" | Out-Null
+  New-Item -ItemType Directory -Force -Path (Join-Path $Path ".smart-env") | Out-Null
+  New-Item -ItemType Directory -Force -Path (Join-Path $Path ".codegraph") | Out-Null
+  New-Item -ItemType Directory -Force -Path (Join-Path $Path "$gear Meta/Sessions") | Out-Null
+  New-Item -ItemType Directory -Force -Path (Join-Path $Path ".claude/worktrees") | Out-Null
+  Set-Content -LiteralPath (Join-Path $Path ".smart-env/cache.bin") -Value "x"
+}
+
+$TMP = Join-Path ([System.IO.Path]::GetTempPath()) ("ms-test-" + [Guid]::NewGuid().ToString("N").Substring(0, 10))
+New-Item -ItemType Directory -Force -Path $TMP | Out-Null
+try {
+  # ---- 1. REAL relocate: .git pointer + cache links + manifest --------------
+  $v1   = Join-Path $TMP "vault1"; New-Vault $v1
+  $side = Join-Path $TMP "sidecar"
+  $r = Run-MS -MsArgs @($v1, "-Sidecar", $side)
+  Check "relocate: rc 0"                       ($r.rc -eq 0)
+  $gitptr = Join-Path $v1 ".git"
+  $gitIsFile = (Test-Path -LiteralPath $gitptr -PathType Leaf)
+  Check "relocate: .git is now a pointer FILE" $gitIsFile
+  if ($gitIsFile) {
+    $first = Get-Content -LiteralPath $gitptr -TotalCount 1
+    Check "relocate: .git pointer says 'gitdir:'" ("$first" -match '^gitdir:')
+  }
+  Check "relocate: .smart-env is a link"       (Is-Reparse (Join-Path $v1 ".smart-env"))
+  Check "relocate: .codegraph is a link"       (Is-Reparse (Join-Path $v1 ".codegraph"))
+  Check "relocate: emoji-Meta/Sessions is a link" (Is-Reparse (Join-Path $v1 "$gear Meta/Sessions"))
+  Check "relocate: .claude/worktrees is a link" (Is-Reparse (Join-Path $v1 ".claude/worktrees"))
+  Check "relocate: cached file survived the move" (Test-Path -LiteralPath (Join-Path $v1 ".smart-env/cache.bin"))
+  $man = @(Get-ChildItem -LiteralPath (Join-Path $side "manifests") -Filter *.json -ErrorAction SilentlyContinue)
+  Check "relocate: manifest written"           ($man.Count -eq 1)
+  if ($man.Count -eq 1) {
+    $doc = Get-Content -Raw -LiteralPath $man[0].FullName | ConvertFrom-Json
+    Check "relocate: manifest 'vault' = resolved vault (suppression key)" ($doc.vault -eq (RealPath $v1))
+    Check "relocate: manifest schema tag"      ($doc.schema -eq "machinery-sidecar/1")
+  }
+
+  # ---- 2. idempotency: re-run is a no-op report -----------------------------
+  $r = Run-MS -MsArgs @($v1, "-Sidecar", $side)
+  Check "idempotent: rc 0"                     ($r.rc -eq 0)
+  Check "idempotent: .git already a pointer"   ($r.out -match "already a pointer")
+  Check "idempotent: a cache already a link"   ($r.out -match "already a link")
+
+  # ---- 3. rollback restores .git dir + caches, removes manifest -------------
+  $r = Run-MS -MsArgs @($v1, "-Sidecar", $side, "-Rollback")
+  Check "rollback: rc 0"                       ($r.rc -eq 0)
+  Check "rollback: .git is a real dir again"   (Test-Path -LiteralPath (Join-Path $v1 ".git") -PathType Container)
+  Check "rollback: .smart-env is a real dir again" ((Test-Path -LiteralPath (Join-Path $v1 ".smart-env") -PathType Container) -and -not (Is-Reparse (Join-Path $v1 ".smart-env")))
+  Check "rollback: cached file still present"  (Test-Path -LiteralPath (Join-Path $v1 ".smart-env/cache.bin"))
+  Check "rollback: manifest removed"           (-not (Test-Path -LiteralPath $man[0].FullName))
+
+  # ---- 4. dry-run inertness -------------------------------------------------
+  $v4 = Join-Path $TMP "vault4"; New-Vault $v4
+  $r = Run-MS -MsArgs @($v4, "-Sidecar", (Join-Path $TMP "sidecar4"), "-DryRun")
+  Check "dry-run: rc 0"                        ($r.rc -eq 0)
+  Check "dry-run: .git still a real dir"       (Test-Path -LiteralPath (Join-Path $v4 ".git") -PathType Container)
+  Check "dry-run: no sidecar manifest written" (-not (Test-Path -LiteralPath (Join-Path $TMP "sidecar4/manifests")))
+
+  # ---- 5. GUARD: a live linked worktree REFUSES (separate-git-dir orphans) --
+  $v5 = Join-Path $TMP "vault5"; New-Vault $v5
+  Set-Content -LiteralPath (Join-Path $v5 "f.txt") -Value "x"
+  & git -C $v5 add -A | Out-Null
+  & git -C $v5 commit -qm init | Out-Null
+  & git -C $v5 worktree add -q (Join-Path $TMP "wt5") -b scratch5 | Out-Null
+  $r = Run-MS -MsArgs @($v5, "-Sidecar", (Join-Path $TMP "sidecar5"))
+  Check "guard: linked worktree -> rc 1 (refuse)" ($r.rc -eq 1)
+  Check "guard: explains the refusal"          ($r.out -match "refusing")
+  Check "guard: .git untouched (still a dir)"   (Test-Path -LiteralPath (Join-Path $v5 ".git") -PathType Container)
+  # negative control: -Force proceeds past the same guard
+  $r = Run-MS -MsArgs @($v5, "-Sidecar", (Join-Path $TMP "sidecar5"), "-Force")
+  Check "guard neg-control: -Force proceeds (rc 0)" ($r.rc -eq 0)
+}
+finally {
+  # detach any worktree gitdir lock before cleanup
+  Remove-Item -LiteralPath $TMP -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host ""
+if ($script:fails -gt 0) { Write-Host "FAILED: $($script:fails)"; exit 1 }
+Write-Host "ALL TESTS PASSED"
+exit 0

--- a/scripts/test-relocate-vault.ps1
+++ b/scripts/test-relocate-vault.ps1
@@ -1,0 +1,135 @@
+﻿#Requires -Version 5.1
+<#
+  Behavioral test for relocate-vault.ps1 (MYC-2383 - Windows parity of
+  relocate-vault.sh). Runs under pwsh on any OS: on Windows the script leaves a
+  junction, elsewhere a symbolic link; .NET flags both with the ReparsePoint
+  attribute, so the link assertions hold cross-platform. The Junction-vs-symlink
+  CHOICE is the only Windows-runtime-specific line and is exercised by hand on a
+  Windows box; everything else (arg parse, move, Claude path-key migration,
+  manifest record, refusal gates) is proven here.
+
+  Every positive is paired with a negative control. Run: pwsh -File scripts/test-relocate-vault.ps1
+#>
+$ErrorActionPreference = "Stop"
+$Here = $PSScriptRoot
+$RV   = Join-Path $Here "relocate-vault.ps1"
+$script:fails = 0
+
+function Check { param([string]$Label, [bool]$Cond)
+  if ($Cond) { Write-Host "PASS  $Label" } else { Write-Host "FAIL  $Label"; $script:fails++ }
+}
+
+function Get-Py {
+  foreach ($n in @("python3", "python")) {
+    $c = Get-Command $n -ErrorAction SilentlyContinue
+    if ($c) {
+      $v = (& $c.Source -c "import sys;print(sys.version_info[0])" 2>$null)
+      if ("$v".Trim() -eq "3") { return $c.Source }
+    }
+  }
+  throw "python 3 required for the test"
+}
+$Py = Get-Py
+
+# The exact path-key transform the script uses, so the test seeds the right key.
+function Get-Key { param([string]$p)
+  $code = @'
+import os,re,sys
+p = os.path.abspath(os.path.expanduser(sys.argv[1]))
+resolved = os.path.join(os.path.realpath(os.path.dirname(p)), os.path.basename(p))
+print(re.sub(r"[^a-zA-Z0-9]", "-", resolved))
+'@
+  return ("$(& $Py -c $code $p)").Trim()
+}
+
+# Run relocate-vault.ps1 as a SEPARATE process so its `exit` cannot kill us.
+function Run-RV { param([string[]]$RvArgs, [string]$ConfigDir)
+  $prev = $env:CLAUDE_CONFIG_DIR
+  if ($ConfigDir) { $env:CLAUDE_CONFIG_DIR = $ConfigDir }
+  try {
+    $out = & pwsh -NoProfile -File $RV @RvArgs 2>&1
+    return [pscustomobject]@{ rc = $LASTEXITCODE; out = ("$out" -join "`n") }
+  } finally {
+    if ($null -eq $prev) { Remove-Item Env:CLAUDE_CONFIG_DIR -ErrorAction SilentlyContinue }
+    else { $env:CLAUDE_CONFIG_DIR = $prev }
+  }
+}
+
+$TMP = Join-Path ([System.IO.Path]::GetTempPath()) ("rv-test-" + [Guid]::NewGuid().ToString("N").Substring(0, 10))
+New-Item -ItemType Directory -Force -Path $TMP | Out-Null
+try {
+  # ---- 1. DRY-RUN changes nothing ------------------------------------------
+  $old1 = Join-Path $TMP "cloud1/Brain"; New-Item -ItemType Directory -Force -Path $old1 | Out-Null
+  Set-Content -LiteralPath (Join-Path $old1 "CLAUDE.md") -Value "# brain"
+  New-Item -ItemType Directory -Force -Path (Join-Path $TMP "local1") | Out-Null
+  $new1 = Join-Path $TMP "local1/Brain"
+  $cfg1 = Join-Path $TMP "cfg1"
+  $k1   = Get-Key $old1
+  New-Item -ItemType Directory -Force -Path (Join-Path $cfg1 "projects/$k1") | Out-Null
+  Set-Content -LiteralPath (Join-Path $cfg1 "projects/$k1/a.jsonl") -Value "{}"
+  $r = Run-RV -RvArgs @($old1, $new1, "-DryRun") -ConfigDir $cfg1
+  Check "dry-run: rc 0"                       ($r.rc -eq 0)
+  Check "dry-run: announces DRY"              ($r.out -match "DRY")
+  Check "dry-run: old still a real directory" ((Test-Path -LiteralPath $old1 -PathType Container) -and -not ((Get-Item -LiteralPath $old1 -Force).Attributes -band [IO.FileAttributes]::ReparsePoint))
+  Check "dry-run: new not created"            (-not (Test-Path -LiteralPath $new1))
+
+  # ---- 2. REAL relocate: move + link + Claude-state migration + manifest ----
+  $old2 = Join-Path $TMP "cloud2/Brain"; New-Item -ItemType Directory -Force -Path $old2 | Out-Null
+  Set-Content -LiteralPath (Join-Path $old2 "CLAUDE.md") -Value "# brain"
+  New-Item -ItemType Directory -Force -Path (Join-Path $TMP "local2") | Out-Null
+  $new2 = Join-Path $TMP "local2/Brain"
+  $cfg2 = Join-Path $TMP "cfg2"
+  $oldk = Get-Key $old2
+  $newk = Get-Key $new2
+  New-Item -ItemType Directory -Force -Path (Join-Path $cfg2 "projects/$oldk") | Out-Null
+  Set-Content -LiteralPath (Join-Path $cfg2 "projects/$oldk/session.jsonl") -Value "{}"
+  # Capture the physical old path BEFORE the move (after it, old2 is a link that
+  # realpath would follow to new2). The manifest records this pre-move path.
+  $physOld = ("$(& $Py -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' $old2)").Trim()
+  $r = Run-RV -RvArgs @($old2, $new2, "-Force") -ConfigDir $cfg2
+  Check "relocate: rc 0"                      ($r.rc -eq 0)
+  Check "relocate: new is a real dir w/ notes" ((Test-Path -LiteralPath (Join-Path $new2 "CLAUDE.md")))
+  $oldIsLink = (Test-Path -LiteralPath $old2) -and (((Get-Item -LiteralPath $old2 -Force).Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0)
+  Check "relocate: old path is now a link"    $oldIsLink
+  Check "relocate: transcript migrated to new key" (Test-Path -LiteralPath (Join-Path $cfg2 "projects/$newk/session.jsonl"))
+  Check "relocate: old-key transcript kept as backup" (Test-Path -LiteralPath (Join-Path $cfg2 "projects/$oldk/session.jsonl"))
+  $manifest = Join-Path $cfg2 "relocations.json"
+  Check "relocate: relocations.json written"  (Test-Path -LiteralPath $manifest)
+  if (Test-Path -LiteralPath $manifest) {
+    $doc = Get-Content -Raw -LiteralPath $manifest | ConvertFrom-Json
+    Check "relocate: manifest records the old path" (@($doc | ForEach-Object { $_.old }) -contains $physOld)
+  }
+
+  # ---- 3. NEGATIVE CONTROL: re-running on the now-linked old path REFUSES ----
+  $r = Run-RV -RvArgs @($old2, (Join-Path $TMP "local2/Brain2"), "-Force") -ConfigDir $cfg2
+  Check "refusal: source already a link -> rc 1" ($r.rc -eq 1)
+  Check "refusal: explains 'already a link'"     ($r.out -match "already a link")
+
+  # ---- 4. NEGATIVE CONTROL: target already exists REFUSES -------------------
+  $old4 = Join-Path $TMP "cloud4/Brain"; New-Item -ItemType Directory -Force -Path $old4 | Out-Null
+  Set-Content -LiteralPath (Join-Path $old4 "CLAUDE.md") -Value "# brain"
+  $new4 = Join-Path $TMP "local4/Brain"; New-Item -ItemType Directory -Force -Path $new4 | Out-Null
+  $r = Run-RV -RvArgs @($old4, $new4, "-Force") -ConfigDir (Join-Path $TMP "cfg4")
+  Check "refusal: target exists -> rc 1"      ($r.rc -eq 1)
+  Check "refusal: explains 'already exists'"  ($r.out -match "already exists")
+
+  # ---- 5. state-only migration (vault already at the new path) --------------
+  $old5 = Join-Path $TMP "cloud5/Brain"
+  $new5 = Join-Path $TMP "local5/Brain"; New-Item -ItemType Directory -Force -Path $new5 | Out-Null
+  $cfg5 = Join-Path $TMP "cfg5"
+  $ok5 = Get-Key $old5
+  $nk5 = Get-Key $new5
+  New-Item -ItemType Directory -Force -Path (Join-Path $cfg5 "projects/$ok5") | Out-Null
+  Set-Content -LiteralPath (Join-Path $cfg5 "projects/$ok5/t.jsonl") -Value "{}"
+  $r = Run-RV -RvArgs @("-MigrateClaudeState", $old5, $new5) -ConfigDir $cfg5
+  Check "state-only: rc 0"                    ($r.rc -eq 0)
+  Check "state-only: transcript at new key"   (Test-Path -LiteralPath (Join-Path $cfg5 "projects/$nk5/t.jsonl"))
+}
+finally {
+  Remove-Item -LiteralPath $TMP -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host ""
+if ($script:fails -gt 0) { Write-Host "FAILED: $($script:fails)"; exit 1 }
+Write-Host "ALL TESTS PASSED"
+exit 0

--- a/tests/integration/test_relocate_ps1.sh
+++ b/tests/integration/test_relocate_ps1.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# CI integration wrapper - runs the PowerShell relocate parity suites
+# (scripts/test-relocate-vault.ps1 + scripts/test-relocate-machinery-sidecar.ps1,
+# MYC-2383) as part of scripts/ci.sh. pwsh is preinstalled on GitHub's
+# ubuntu-latest runner, so CI always exercises them. If pwsh is absent locally we
+# LOUDLY skip (CI still enforces) rather than block a contributor's other gates -
+# the same graceful-degradation pattern ci.sh uses for shellcheck and ruff.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+
+if ! command -v pwsh >/dev/null 2>&1; then
+  echo "SKIP: pwsh not installed here; CI's ubuntu runner enforces the .ps1 behavioral tests."
+  echo "      install: brew install --cask powershell (macOS) / https://aka.ms/powershell (other)"
+  exit 0
+fi
+
+pwsh -NoProfile -File "$ROOT/scripts/test-relocate-vault.ps1"
+pwsh -NoProfile -File "$ROOT/scripts/test-relocate-machinery-sidecar.ps1"


### PR DESCRIPTION
## What

The MYC-2360 SessionStart cloud-sync offer already **detects** Windows/OneDrive vaults, but printed **bash-only** relocate commands a Windows user cannot run natively. This ships native `.ps1` parity for both relocate scripts and branches the offer on OS.

Closes MYC-2383.

## Decision

Native `.ps1` parity (the ticket's stated higher-fidelity path) over routing Windows users through WSL/Git-Bash. Git-Bash's `ln -s` silently *copies* on Windows, which would break the symlink premise the whole mechanism relies on, so the WSL route was not actually equivalent.

## New files

- `scripts/relocate-vault.ps1` — Shape A: move the vault out of the sync folder, leave a link, migrate Claude Code path-keyed state (transcripts + agent-memory link), record `relocations.json`. Modes: full relocate, `-MigrateClaudeState`, `-Sweep`, `-DropSymlink`.
- `scripts/relocate-machinery-sidecar.ps1` — Shape B: `.git` via `git init --separate-git-dir` (static pointer file) + worktrees/caches relocated to a sidecar behind links; `-Rollback`, idempotent, live-worktree refusal gate.
- `scripts/test-relocate-vault.ps1`, `scripts/test-relocate-machinery-sidecar.ps1` — behavioral suites, wired into `scripts/ci.sh` via `tests/integration/test_relocate_ps1.sh`.

## Key Windows design choices

- **Junction** for directory links (`New-Item -ItemType Junction`), symlink fallback. Junctions need no admin / Developer Mode (a symlink does), and OneDrive does not sync through them — so the offer stays *actionable* and the churn actually leaves the sync scope.
- Link teardown uses `DirectoryInfo.Delete()`, never `Remove-Item`, so removing a junction can't recurse into and delete the target's contents (a real PS 5.1 footgun).
- Parity-critical transforms (the Claude project-key regex, manifests) **shell out to python**, byte-identical to the `.sh`.
- `#Requires -Version 5.1`, UTF-8 BOM, ASCII-clean (the repo's `.ps1` CI gates).
- The bash `--nosync` mode is intentionally **not** ported: `.nosync` is an iCloud-only convention OneDrive ignores, so porting it would be a silent no-op.

## Offer

`hooks/worktree-footprint-signal.py` `_offer_block` branches on `os.name`: Windows prints `powershell -ExecutionPolicy Bypass -File ...relocate-*.ps1`, POSIX prints `bash`. `WORKTREE_FOOTPRINT_OS={nt|posix}` is a test seam so both branches are covered on one CI OS.

## Bug fixed in passing (both scripts)

An idempotent re-run records zero moves and previously **clobbered the manifest with `moves: []`**, silently breaking `-Rollback`/`--rollback`. Now a no-move run keeps the existing manifest. Backported to `relocate-machinery-sidecar.sh` with a `D2` negative-control regression test.

## Verification

- Full `scripts/ci.sh` green: py_compile (274) + 54 integration tests + shellcheck.
- All four `.ps1`: BOM present, no em dashes, `ParseFile` clean.
- Behavioral suites pass under pwsh 7.6 locally; the offer test covers both OS branches + a negative control (which caught a real `str`-vs-`Path` throw in the Windows branch before ship).
- **Not** executed on a real Windows box (this repo has no Windows runner). The junction-vs-symlink line is the only Windows-runtime-specific branch; everything else (arg parse, move, Claude-state migration, manifests, idempotency, rollback, refusal gates) is exercised here under pwsh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)