### PR TITLE
TEST-FIRE (DO NOT MERGE): negative control for windows-install gate (MYC-2125)

### DIFF
--- a/scripts/install-hooks-user-level.py
+++ b/scripts/install-hooks-user-level.py
@@ -234,7 +234,7 @@ def normalize_path_substitutions(template: dict, vault_path: str | None) -> dict
         # JSON-escape the substituted path: on Windows it contains backslashes
         # (C:\Users\...) which are invalid JSON escapes when the string is
         # re-parsed by json.loads below, raising JSONDecodeError mid-install.
-        s = s.replace("[VAULT_PATH]", json.dumps(str(Path.home()), ensure_ascii=False)[1:-1])
+        s = s.replace("[VAULT_PATH]", str(Path.home()))  # NEGATIVE-CONTROL: reintroduced Bug 2 (raw backslash) - DO NOT MERGE
         return json.loads(s)
     s = json.dumps(template, ensure_ascii=False)
     s = s.replace("[VAULT_PATH]", json.dumps(str(Path(vault_path).resolve()), ensure_ascii=False)[1:-1])


### PR DESCRIPTION
Negative-control test-fire. Reverts the PR #254 JSON-escape fix to reintroduce Bug 2 (hook installer crashes on a Windows backslash path). Expectation: `windows-install` fails at the assert step with "expected >= 7 UserPromptSubmit hooks, found 0", proving the gate (and the skill-dir seed) is not a no-op. Closed without merging once confirmed.