### PR TITLE
feat(relocate-vault): REFUSE to move a backup-less vault without --force (MYC-2382)

### DIFF
--- a/docs/CLOUD_SYNC.md
+++ b/docs/CLOUD_SYNC.md
@@ -50,7 +50,8 @@ re-homes that Claude state (copying it, so the old location stays a backup):
 ```bash
 # preview first (changes nothing)
 bash scripts/relocate-vault.sh ~/Desktop/MyVault ~/MyVault --dry-run
-# do it (quit Obsidian + close Claude sessions first; --force overrides the soft gates)
+# do it (quit Obsidian + close Claude sessions + have a verified off-machine backup first;
+# it REFUSES to move a backup-less vault. --force overrides the soft gates.)
 bash scripts/relocate-vault.sh ~/Desktop/MyVault ~/MyVault
 ```
 

--- a/scripts/relocate-vault.sh
+++ b/scripts/relocate-vault.sh
@@ -281,6 +281,7 @@ NEW_ABS="$(abspath "$NEW")"
 if [ -e "$NEW_ABS" ]; then die "target '$NEW_ABS' already exists (will not overwrite)"; fi
 
 # Soft gates — skippable with --force.
+BACKUP_TOKEN=""
 if [ "$FORCE" != 1 ]; then
   if command -v pgrep >/dev/null 2>&1 && pgrep -x Obsidian >/dev/null 2>&1; then
     die "Obsidian is running — quit it first (moving an open vault is unsafe), or pass --force"
@@ -291,12 +292,37 @@ if [ "$FORCE" != 1 ]; then
       die "an active Claude session is writing under .claude/worktrees (touched <10 min) — close it, or pass --force"
     fi
   fi
+  # Backup-first ENFORCEMENT (MYC-2382). A vault is often the one irreplaceable
+  # asset; moving it with no off-machine backup is the one move you cannot undo
+  # if the disk dies mid-flight. Route through the SINGLE source of truth
+  # (check-vault-backup.py) and REFUSE on NO_BACKUP. The whole block is skipped
+  # under --force, so --force IS the documented escape hatch — by construction.
+  backup_guard="$SCRIPT_DIR/check-vault-backup.py"
+  if [ -f "$backup_guard" ]; then
+    set +e
+    BACKUP_TOKEN="$(python3 "$backup_guard" --porcelain "$OLD_ABS" 2>/dev/null)"
+    brc=$?
+    set -e
+    if [ "$brc" != 0 ]; then
+      die "no verified off-machine backup of '$OLD_ABS' (${BACKUP_TOKEN:-backup check failed}).
+  Moving a vault with no backup is the one move you cannot undo if the disk dies mid-flight.
+  Stand up + verify a backup first (one command), then re-run:
+    bash \"$SCRIPT_DIR/vault-backup.sh\" setup && bash \"$SCRIPT_DIR/vault-backup.sh\" verify
+  Or move anyway, accepting the risk: re-run with --force."
+    fi
+  else
+    die "cannot verify a backup — the guard is missing ($backup_guard). Restore it, or re-run with --force to move without the check."
+  fi
 fi
 
 say ""
-say "relocate-vault: BACK UP FIRST. A vault is often your one irreplaceable asset."
-say "  Stand up + VERIFY an off-machine backup before moving:"
-say "    bash scripts/vault-backup.sh setup && bash scripts/vault-backup.sh verify"
+if [ "$FORCE" = 1 ]; then
+  warn "relocate-vault: --force — skipping the backup check. A vault is often your one"
+  warn "  irreplaceable asset; stand up + verify an off-machine backup as soon as the move lands:"
+  warn "    bash \"$SCRIPT_DIR/vault-backup.sh\" setup && bash \"$SCRIPT_DIR/vault-backup.sh\" verify"
+else
+  say "relocate-vault: verified off-machine backup present (${BACKUP_TOKEN}) — proceeding."
+fi
 say ""
 
 if [ "$DRYRUN" = 1 ]; then

--- a/scripts/test-relocate-vault.sh
+++ b/scripts/test-relocate-vault.sh
@@ -13,6 +13,9 @@
 #     is already a symlink (both fatal even under --force).
 #   - HAPPY PATH: a full move relocates the dir, leaves the symlink, migrates
 #     history; --no-symlink omits the symlink.
+#   - BACKUP GATE (MYC-2382): a backup-less full relocate REFUSES (vault not
+#     moved, remedy named); a verified off-machine backup lets it PROCEED;
+#     --force overrides the gate on the same no-backup condition.
 # Hermetic: a temp HOME-like sandbox + an isolated --config-dir; the real
 # ~/.claude is never touched.
 # Run: bash scripts/test-relocate-vault.sh
@@ -101,6 +104,47 @@ hh="$(jsonl_count "$PROJ/$NK")"
 nsv="$TMP/Desktop/NoSym Vault" ; nsn="$TMP/nosym-brain" ; mkdir -p "$nsv"
 CLAUDE_CONFIG_DIR="$CFG" bash "$SCRIPT" "$nsv" "$nsn" --force --no-symlink >/dev/null 2>&1
 { [ -d "$nsn" ] && [ ! -e "$nsv" ]; } && pass "--no-symlink leaves nothing at the old path" || fail "--no-symlink left something at old path"
+
+# --- 7. BACKUP-FIRST GATE (MYC-2382): refuse a backup-less full relocate -------
+# Moving a vault — often the one irreplaceable asset — with no off-machine backup
+# is the nightmare failure. The full-relocate path must REFUSE unless a backup is
+# verified (check-vault-backup.py) OR --force is passed. The no-backup signal is
+# made hermetic with an empty backup-conf + the Time Machine probe skipped, so
+# "no backup" is deterministic even on a dev Mac that has Time Machine set up.
+NOBK_CONF="$TMP/no-backup-conf.json" ; echo '{}' > "$NOBK_CONF"
+
+# 7a REFUSE: no backup, no --force -> refuses (rc!=0), vault NOT moved, names remedy.
+gb_src="$TMP/gate-src" ; gb_dst="$TMP/gate-dst" ; mkdir -p "$gb_src" ; echo n > "$gb_src/n.md"
+out="$(CLAUDE_CONFIG_DIR="$CFG" VAULT_BACKUP_CONF="$NOBK_CONF" VAULT_BACKUP_SKIP_TIMEMACHINE=1 \
+       bash "$SCRIPT" "$gb_src" "$gb_dst" 2>&1)" ; rc=$?
+[ "$rc" != 0 ] && pass "backup gate: refuses a backup-less move (rc=$rc)" \
+               || fail "backup gate: expected a refusal, moved with rc=$rc"
+{ [ -d "$gb_src" ] && [ ! -e "$gb_dst" ]; } && pass "backup gate: vault NOT moved on refusal" \
+               || fail "backup gate: vault was moved despite the refusal"
+echo "$out" | grep -qi 'backup' && pass "backup gate: refusal names the backup remedy" \
+               || fail "backup gate: refusal output lacked a backup remedy: $out"
+
+# 7b PROCEED: a verified vault-backup archive present, no --force -> moves.
+ok_src="$TMP/gate-ok-src" ; ok_dst="$TMP/gate-ok-dst" ; mkdir -p "$ok_src" ; echo n > "$ok_src/n.md"
+OK_RES="$(cd "$ok_src" && pwd -P)"   # the physical path relocate-vault.sh hands the guard
+OK_DEST="$TMP/gate-backups" ; mkdir -p "$OK_DEST" ; touch "$OK_DEST/vault-backup-now.tar.gz"
+OK_CONF="$TMP/ok-backup-conf.json"
+printf '{"vaults": {"%s": {"dest": "%s", "archive_stem": "vault-backup"}}}\n' "$OK_RES" "$OK_DEST" > "$OK_CONF"
+CLAUDE_CONFIG_DIR="$CFG" VAULT_BACKUP_CONF="$OK_CONF" VAULT_BACKUP_SKIP_TIMEMACHINE=1 \
+  bash "$SCRIPT" "$ok_src" "$ok_dst" >/dev/null 2>&1 ; rc=$?
+[ "$rc" = 0 ] && pass "backup gate: proceeds with a verified backup (rc=0)" \
+             || fail "backup gate: a verified backup was still refused (rc=$rc)"
+{ [ -d "$ok_dst" ] && [ -L "$ok_src" ]; } && pass "backup gate: verified backup -> moved + symlink left" \
+             || fail "backup gate: verified backup did not relocate the vault"
+
+# 7c FORCE OVERRIDE: no backup but --force -> moves (same no-backup condition as 7a).
+fb_src="$TMP/gate-force-src" ; fb_dst="$TMP/gate-force-dst" ; mkdir -p "$fb_src" ; echo n > "$fb_src/n.md"
+CLAUDE_CONFIG_DIR="$CFG" VAULT_BACKUP_CONF="$NOBK_CONF" VAULT_BACKUP_SKIP_TIMEMACHINE=1 \
+  bash "$SCRIPT" "$fb_src" "$fb_dst" --force >/dev/null 2>&1 ; rc=$?
+[ "$rc" = 0 ] && pass "backup gate: --force overrides the gate (rc=0)" \
+             || fail "backup gate: --force did not override the gate (rc=$rc)"
+[ -d "$fb_dst" ] && pass "backup gate: --force -> vault moved despite no backup" \
+             || fail "backup gate: --force did not move the vault"
 
 echo
 if [ "$fails" -gt 0 ]; then echo "FAILED: $fails"; exit 1; fi


### PR DESCRIPTION
## What

`relocate-vault.sh` only **printed** a "BACK UP FIRST" reminder before moving a vault — it did not enforce one. Moving a vault (often the one irreplaceable asset) with no off-machine backup is the nightmare failure for a paying client. This makes the full-relocate path **REFUSE** a backup-less move.

## How

- **`scripts/relocate-vault.sh`** — a backup gate inside the existing `--force`-skippable soft-gate block (same tier as the Obsidian-running / active-session checks). It routes through `scripts/check-vault-backup.py` (the single source of truth for "is there a backup"): `NO_BACKUP` → `die` (exit 1) with the one-command fix, `--force` overrides by construction. Fail-closed if the guard errors or is missing. The old static reminder becomes a status line: a verified-backup confirmation on the gated path, or a "skipping the backup check" warning on the `--force` path.
- **`scripts/test-relocate-vault.sh`** — negative control covering **refuse** (no backup, no `--force`) / **proceed** (verified backup) / **`--force` override**. Proven RED against the unmodified script, GREEN after the gate.
- **`docs/CLOUD_SYNC.md`** — the bash move example now names the backup requirement.

MYC-2360's SessionStart cloud-sync offer ("stand up a backup first") is now enforced by the mechanism, not just the prose plus good behavior.

## Verification

- `bash scripts/test-relocate-vault.sh` — all pass, incl. 7 new backup-gate assertions (refuse / proceed / force).
- `bash scripts/ci.sh` — full canonical gate green (py_compile + integration tests + shellcheck), on the state rebased onto `origin/main`.
- Personal-data + API-key scrub on the diff: clean.

## Scope note — Windows parity

Rebased onto #270 (MYC-2383, PowerShell parity). That landed a native `relocate-vault.ps1` which does **not** yet enforce the backup gate — the native PS port deliberately avoids a `python3` dependency, so it can't shell out to `check-vault-backup.py`. A correct PS gate needs a native `check-vault-backup.ps1` + Windows-runner verification, tracked as a dedicated follow-up: **MYC-2395**. The PS doc block in `docs/CLOUD_SYNC.md` is intentionally left unchanged here, since it remains truthful for the `.ps1`'s current behavior.

Closes MYC-2382.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
