### PR TITLE
fix(relocate-vault): don't count the cloud copy the move removes as a backup (MYC-2401)

### DIFF
--- a/scripts/check-vault-backup.py
+++ b/scripts/check-vault-backup.py
@@ -29,6 +29,9 @@ gate all route through it so the surfaces never drift.
 Usage:
   check-vault-backup.py <vault-path>          # human-readable verdict + remedy
   check-vault-backup.py --porcelain <path>    # one machine-readable line
+  check-vault-backup.py --ignore-cloud <path> # don't count a cloud-sync copy as
+                                              # a backup (for callers about to
+                                              # REMOVE it, e.g. relocate-vault.sh)
 
 Exit codes:
   0  BACKED UP  — at least one off-machine copy/strategy detected
@@ -186,13 +189,24 @@ def check_git_remote_pushed(vault: Path) -> bool:
         return False
 
 
-def detect(vault: Path, conf_keys: list[str] | None = None) -> tuple[str, str]:
+def detect(vault: Path, conf_keys: list[str] | None = None,
+           ignore_cloud: bool = False) -> tuple[str, str]:
     """Return (porcelain_token, human_remedy). Cheapest checks first.
 
     conf_keys: candidate path strings to look up in the config (the as-given and
     the resolved form). Matching on both makes the lookup robust when the vault
     path contains a symlink (e.g. macOS /var -> /private/var), so the detector
     and vault-backup.sh agree on the key regardless of which form was stored.
+
+    ignore_cloud: when True, a vault that lives inside a cloud-sync root does NOT
+    count as backed up. Used by callers that are about to REMOVE the cloud copy
+    (relocate-vault.sh moves the vault out and leaves a symlink — the sync daemon
+    then follows a few-byte symlink, not the tree, so the cloud copy is gone post
+    -move). For those callers the only backups that count are the ones that
+    survive the move (a vault-backup archive, Time Machine, or a pushed git
+    remote). Default False so the SessionStart/diagnose/onboarding consumers,
+    which are NOT removing the cloud copy, still treat it as a real off-machine
+    copy.
     """
     conf = _read_conf()
     vaults = conf.get("vaults") or {}
@@ -208,11 +222,12 @@ def detect(vault: Path, conf_keys: list[str] | None = None) -> tuple[str, str]:
         return ("BACKED_UP:timemachine",
                 "Time Machine destination configured.")
 
-    service = detect_cloud_sync(vault)
-    if service:
-        return (f"BACKED_UP:cloud:{service}",
-                f"vault is inside {service} (an off-machine cloud copy — churny "
-                f"but real; see docs/CLOUD_SYNC.md for the safer single-file pattern).")
+    if not ignore_cloud:
+        service = detect_cloud_sync(vault)
+        if service:
+            return (f"BACKED_UP:cloud:{service}",
+                    f"vault is inside {service} (an off-machine cloud copy — churny "
+                    f"but real; see docs/CLOUD_SYNC.md for the safer single-file pattern).")
 
     if check_git_remote_pushed(vault):
         return ("BACKED_UP:git-remote",
@@ -229,9 +244,11 @@ def detect(vault: Path, conf_keys: list[str] | None = None) -> tuple[str, str]:
 
 def main(argv: list[str]) -> int:
     porcelain = "--porcelain" in argv
-    args = [a for a in argv if a != "--porcelain"]
+    ignore_cloud = "--ignore-cloud" in argv
+    args = [a for a in argv if a not in ("--porcelain", "--ignore-cloud")]
     if len(args) != 1:
-        print("usage: check-vault-backup.py [--porcelain] <vault-path>", file=sys.stderr)
+        print("usage: check-vault-backup.py [--porcelain] [--ignore-cloud] <vault-path>",
+              file=sys.stderr)
         return 2
 
     raw = Path(args[0]).expanduser()
@@ -242,7 +259,7 @@ def main(argv: list[str]) -> int:
 
     # Look up the conf by both the as-given and resolved path (symlink-robust).
     conf_keys = list(dict.fromkeys([str(vault), str(raw)]))
-    token, remedy = detect(vault, conf_keys)
+    token, remedy = detect(vault, conf_keys, ignore_cloud=ignore_cloud)
     backed_up = token.startswith("BACKED_UP")
 
     if porcelain:

--- a/scripts/relocate-vault.sh
+++ b/scripts/relocate-vault.sh
@@ -297,15 +297,24 @@ if [ "$FORCE" != 1 ]; then
   # if the disk dies mid-flight. Route through the SINGLE source of truth
   # (check-vault-backup.py) and REFUSE on NO_BACKUP. The whole block is skipped
   # under --force, so --force IS the documented escape hatch — by construction.
+  #
+  # --ignore-cloud (MYC-2401): this move REMOVES the source's cloud-sync copy —
+  # we mv the vault OUT and leave a symlink, so the sync daemon then follows a
+  # few-byte symlink, not the tree. A cloud copy therefore does NOT survive the
+  # move and must NOT satisfy the gate (else we'd green-light the move citing the
+  # very backup the move destroys, leaving the user with nothing). Only backups
+  # that survive — a vault-backup archive, Time Machine, a pushed git remote —
+  # count here.
   backup_guard="$SCRIPT_DIR/check-vault-backup.py"
   if [ -f "$backup_guard" ]; then
     set +e
-    BACKUP_TOKEN="$(python3 "$backup_guard" --porcelain "$OLD_ABS" 2>/dev/null)"
+    BACKUP_TOKEN="$(python3 "$backup_guard" --porcelain --ignore-cloud "$OLD_ABS" 2>/dev/null)"
     brc=$?
     set -e
     if [ "$brc" != 0 ]; then
-      die "no verified off-machine backup of '$OLD_ABS' (${BACKUP_TOKEN:-backup check failed}).
+      die "no verified off-machine backup of '$OLD_ABS' that survives this move (${BACKUP_TOKEN:-backup check failed}).
   Moving a vault with no backup is the one move you cannot undo if the disk dies mid-flight.
+  A cloud-sync copy does NOT count here — this move takes the vault OUT of the sync folder, so that copy goes away too.
   Stand up + verify a backup first (one command), then re-run:
     bash \"$SCRIPT_DIR/vault-backup.sh\" setup && bash \"$SCRIPT_DIR/vault-backup.sh\" verify
   Or move anyway, accepting the risk: re-run with --force."

--- a/scripts/test-relocate-vault.sh
+++ b/scripts/test-relocate-vault.sh
@@ -16,6 +16,10 @@
 #   - BACKUP GATE (MYC-2382): a backup-less full relocate REFUSES (vault not
 #     moved, remedy named); a verified off-machine backup lets it PROCEED;
 #     --force overrides the gate on the same no-backup condition.
+#   - CLOUD MOVE-OUT (MYC-2401): a vault whose only off-machine copy is the
+#     cloud-sync it's being moved OUT of REFUSES (that copy doesn't survive the
+#     move); a cloud vault with a surviving backup (archive/TM/git-remote) still
+#     PROCEEDS.
 # Hermetic: a temp HOME-like sandbox + an isolated --config-dir; the real
 # ~/.claude is never touched.
 # Run: bash scripts/test-relocate-vault.sh
@@ -145,6 +149,37 @@ CLAUDE_CONFIG_DIR="$CFG" VAULT_BACKUP_CONF="$NOBK_CONF" VAULT_BACKUP_SKIP_TIMEMA
              || fail "backup gate: --force did not override the gate (rc=$rc)"
 [ -d "$fb_dst" ] && pass "backup gate: --force -> vault moved despite no backup" \
              || fail "backup gate: --force did not move the vault"
+
+# --- 8. BACKUP GATE x CLOUD (MYC-2401): a cloud copy doesn't count for a move-OUT
+# relocate moves the vault OUT of the cloud root and leaves a symlink, so the cloud
+# copy is gone post-move. The gate passes --ignore-cloud, so a vault whose ONLY
+# off-machine copy is the cloud it's fleeing must REFUSE (else we green-light the
+# move citing the very backup the move destroys). A SURVIVING backup still proceeds.
+# 8a a vault inside a cloud root with NO surviving backup -> REFUSE.
+cl_src="$TMP/OneDrive/Cloud Vault" ; cl_dst="$TMP/cloud-local"
+mkdir -p "$cl_src" ; echo n > "$cl_src/n.md"
+out="$(CLAUDE_CONFIG_DIR="$CFG" VAULT_BACKUP_CONF="$NOBK_CONF" VAULT_BACKUP_SKIP_TIMEMACHINE=1 \
+       bash "$SCRIPT" "$cl_src" "$cl_dst" 2>&1)" ; rc=$?
+[ "$rc" != 0 ] && pass "cloud move-out, no surviving backup -> refuses (rc=$rc)" \
+               || fail "cloud move-out should refuse (cloud copy doesn't survive), got rc=$rc"
+{ [ -d "$cl_src" ] && [ ! -e "$cl_dst" ]; } && pass "cloud move-out refusal: vault NOT moved" \
+               || fail "cloud move-out: vault moved despite no surviving backup"
+echo "$out" | grep -qi 'cloud' && pass "cloud move-out refusal: explains the cloud copy won't survive" \
+               || fail "cloud move-out refusal should mention the cloud copy: $out"
+
+# 8b same cloud vault but WITH a surviving vault-backup archive -> proceeds.
+cl2_src="$TMP/OneDrive/Cloud Vault 2" ; cl2_dst="$TMP/cloud-local-2"
+mkdir -p "$cl2_src" ; echo n > "$cl2_src/n.md"
+CL2_RES="$(cd "$cl2_src" && pwd -P)"
+CL2_DEST="$TMP/cloud2-backups" ; mkdir -p "$CL2_DEST" ; touch "$CL2_DEST/vault-backup-now.tar.gz"
+CL2_CONF="$TMP/cloud2-conf.json"
+printf '{"vaults": {"%s": {"dest": "%s", "archive_stem": "vault-backup"}}}\n' "$CL2_RES" "$CL2_DEST" > "$CL2_CONF"
+CLAUDE_CONFIG_DIR="$CFG" VAULT_BACKUP_CONF="$CL2_CONF" VAULT_BACKUP_SKIP_TIMEMACHINE=1 \
+  bash "$SCRIPT" "$cl2_src" "$cl2_dst" >/dev/null 2>&1 ; rc=$?
+[ "$rc" = 0 ] && pass "cloud vault WITH a surviving archive -> proceeds (rc=0)" \
+             || fail "cloud vault with a surviving archive should proceed, got rc=$rc"
+{ [ -d "$cl2_dst" ] && [ -L "$cl2_src" ]; } && pass "cloud+archive move-out: moved + symlink left" \
+             || fail "cloud+archive: did not relocate"
 
 echo
 if [ "$fails" -gt 0 ]; then echo "FAILED: $fails"; exit 1; fi

--- a/scripts/test-vault-backup-guard.sh
+++ b/scripts/test-vault-backup-guard.sh
@@ -76,6 +76,29 @@ mkdir -p "$CLOUD"
 assert_token "cloud-sync vault -> BACKED_UP:cloud"  "BACKED_UP:cloud"  "$CLOUD"
 assert_rc    "cloud-sync exits 0"                   0                  "$CLOUD"
 
+# ---- --ignore-cloud (MYC-2401): a cloud-only copy does NOT count for a caller
+# about to REMOVE it (relocate-vault.sh moves the vault out + leaves a symlink,
+# so the cloud copy is gone post-move). The default still counts cloud (above);
+# only --ignore-cloud flips it. A guard that approved a move citing the very copy
+# the move destroys would leave the user with zero backup. ----
+echo '{}' > "$CONF"
+ic="$(VAULT_BACKUP_CONF="$CONF" python3 "$CHECK" --porcelain --ignore-cloud "$CLOUD" 2>/dev/null)"
+case "$ic" in
+  NO_BACKUP*) echo "PASS  --ignore-cloud: cloud-only vault -> $ic";;
+  *)          echo "FAIL  --ignore-cloud: want NO_BACKUP got $ic"; fails=$((fails+1));;
+esac
+# --ignore-cloud must NOT suppress a REAL surviving backup (an archive present).
+ICDEST="$TMP/ic-backups" ; mkdir -p "$ICDEST" ; touch "$ICDEST/vault-backup-$(date +%Y%m%d).tar.gz"
+ICRES="$(cd "$CLOUD" && pwd -P)"
+cat > "$CONF" <<EOF
+{"vaults": {"$ICRES": {"dest": "$ICDEST", "archive_stem": "vault-backup"}}}
+EOF
+ic2="$(VAULT_BACKUP_CONF="$CONF" python3 "$CHECK" --porcelain --ignore-cloud "$CLOUD" 2>/dev/null)"
+case "$ic2" in
+  BACKED_UP:vault-backup*) echo "PASS  --ignore-cloud keeps a surviving archive -> $ic2";;
+  *)                       echo "FAIL  --ignore-cloud suppressed a real archive: got $ic2"; fails=$((fails+1));;
+esac
+
 echo
 if [ "$fails" -gt 0 ]; then echo "FAILED: $fails"; exit 1; fi
 echo "ALL TESTS PASSED"


### PR DESCRIPTION
## What

Closes a **confirmed correctness hole** in the MYC-2382 backup gate, found in a post-ship blind-spot audit.

The gate routes through `check-vault-backup.py`, which counts "vault is inside a cloud-sync root (iCloud/OneDrive/Dropbox/...)" as `BACKED_UP:cloud`. But `relocate-vault`'s **primary job is moving a vault OUT of cloud sync** — it `mv`s the tree to a local path and leaves a symlink, so the sync daemon then follows a few-byte symlink, not the tree. The cloud copy is **gone post-move**. So for a vault whose only off-machine copy was that cloud sync, the gate green-lit the move citing the exact backup the move destroys — leaving the user with zero backup, the precise failure MYC-2382 exists to prevent.

Reproduced on origin/main (dry-run): vault under `$TMP/OneDrive/MyVault`, no other backup → gate printed `verified off-machine backup present (BACKED_UP:cloud:OneDrive) — proceeding`.

## How

- **`check-vault-backup.py`** — add `--ignore-cloud` (`detect(ignore_cloud=True)` skips the cloud-sync check). **Default stays `False`**, so the SessionStart status / `diagnose` / onboarding consumers — which do *not* remove the cloud copy — keep counting it as a real off-machine copy.
- **`relocate-vault.sh`** — the gate passes `--ignore-cloud`, so only **move-surviving** backups count (vault-backup archive / Time Machine / pushed git remote). The refusal now explains *why* a cloud copy doesn't count here.
- **Tests** — `test-vault-backup-guard.sh`: `--ignore-cloud` flips cloud → `NO_BACKUP` but does **not** suppress a surviving archive. `test-relocate-vault.sh`: cloud-only → refuse (vault not moved, message names the cloud reason); cloud + surviving archive → proceed.

## Verification

- Post-fix repro: the same OneDrive-only vault now **refuses** with "A cloud-sync copy does NOT count here — this move takes the vault OUT of the sync folder, so that copy goes away too."
- Both targeted suites green; full `bash scripts/ci.sh` green (py_compile + integration tests + shellcheck).
- Personal-data + API-key scrub on the diff: clean.

Part of the MYC-2382 backup-first hardening (parent MYC-2348). Sibling follow-ups still open: MYC-2395 (Windows `.ps1` parity), MYC-2404 (stand-up-backup UX), MYC-2405 ("verified" = recency/completeness semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
