### PR TITLE
fix(close-signal): don't fire the close cascade on an interrogative ABOUT closing

### DIFF
--- a/templates/closing-signals/en.json
+++ b/templates/closing-signals/en.json
@@ -137,6 +137,10 @@
     {
       "_comment": "Meta-QUESTION about a close word — 'what does ttyl mean?', 'how do I say bye?', 'what's an example of a sign-off?'. Asking ABOUT a close phrase is referenced content, never a close itself. Promoted to strict because the weak-tier meta-question FP guard does NOT override a high_confidence match on the bare close word. MYC-1266 (same family as the definitional guards above).",
       "pattern": "\\b(what|how|why|when|where|who|define|defines|explain|mean[s]?|spell[s]?|example\\s+of|stand[s]?\\s+for)\\b.{0,40}\\b(bye|ttyl|cya|gn|good\\s*night|wrapping|signing\\s+off|sign[\\s-]?off|close\\s+(this|the|out|up)\\s+session|closing\\s+cascade)\\b"
+    },
+    {
+      "_comment": "INTERROGATIVE about whether a close ALREADY happened — 'did you close this session?', 'have you closed the session?', 'is the session closed?'. A question ABOUT the close action's state/completion, not a request to perform it. Requires a STATE/PAST auxiliary (did/do/does/have/has/had/is/are/was/were) + subject + a close verb + a trailing '?'. Modal REQUESTS ('can/could/would/will you close this session?') carry no such auxiliary, so they still fire. Codified 2026-06-30 after 'did you close this session?' fired the full cascade via the high_confidence 'close (this|the) session' pattern; strict tier is required because false_positive_guards do NOT override a high_confidence match.",
+      "pattern": "\\b(did|do|does|have|has|had|is|are|was|were)\\s+(you|we|i|it|the|this|that|everything|already)\\b[^?\\n]{0,45}\\bclos(?:e|ed|ing)\\b[^?\\n]{0,45}\\?"
     }
   ]
 }

--- a/tests/integration/test_detect_closing_signal_strict_guards.sh
+++ b/tests/integration/test_detect_closing_signal_strict_guards.sh
@@ -27,6 +27,15 @@
 #    11. "wrap it up"
 #    12. "thanks that's all"
 #    13. "okay let's close this session" (2026-05-12 regression case)
+#   INTERROGATIVE meta-questions ABOUT a close (should NOT fire — added
+#   2026-06-30 after "did you close this session?" fired the full cascade):
+#    14. "did you close this session?"   (the reported false-positive)
+#    15. "have you closed the session?"
+#    16. "is the session closed?"
+#   MODAL-REQUEST close phrased as a question (should STILL fire — the
+#   negative control proving the interrogative guard discriminates a
+#   question ABOUT closing from a request TO close):
+#    17. "can you close this session?"
 #
 # Self-contained: tmpdir fake vault, HOME redirected. Exit 0 = pass, 1 = fail.
 
@@ -105,6 +114,9 @@ for p in \
   "let me close out the database session" \
   "sessions keep getting auto-archived" \
   "sessions keep firing the cascade" \
+  "did you close this session?" \
+  "have you closed the session?" \
+  "is the session closed?" \
 ; do
   assert_no_fire "$p" || failed=$((failed+1))
 done
@@ -117,6 +129,7 @@ for p in \
   "wrap it up" \
   "thanks that's all" \
   "okay let's close this session" \
+  "can you close this session?" \
 ; do
   assert_fires "$p" || failed=$((failed+1))
 done


### PR DESCRIPTION
## Problem

`did you close this session?` fired the entire session-close cascade. It matches the `high_confidence` pattern `close\s+(this|the)\s+session` — but it's a *question about whether a close happened*, not a request to close. This is exactly the meta-discussion class `strict_guards` exists to suppress; the interrogative form just wasn't covered.

`strict_guards` is the only tier that overrides a `high_confidence` match (`false_positive_guards` are checked *after* the strong tiers already returned), so the guard has to live there.

## Fix

One `strict_guards` entry in `en.json`: suppress when a STATE/PAST auxiliary (`did`/`do`/`does`/`have`/`has`/`had`/`is`/`are`/`was`/`were`) + subject + a close verb + a trailing `?` all appear. Modal *requests* (`can`/`could`/`would`/`will you close this session?`) carry no such auxiliary, so they still fire. Bounded `{0,45}` quantifiers and a `[^?\n]` fence (no crossing a `?` or newline) keep it linear and prevent swallowing a real close that follows an unrelated question.

## Coverage (non-obvious — the discriminator is the point)

`test_detect_closing_signal_strict_guards.sh` gains:
- suppressed: `did you close this session?`, `have you closed the session?`, `is the session closed?`
- **negative control** (still fires): `can you close this session?` — proves the guard separates a question *about* closing from a request *to* close.

Full fixture harness `scripts/test-closing-signals.py` stays **93/93**. Sibling integration tests unaffected.

Scope: `en` pack only, matching the current `strict_guards` scope (`es`/`pt` have none); parity is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)