### PR TITLE
fix(session-close): resolve vault root repo-aware, not from a global VAULT_ROOT default

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,24 @@ description: What's new in AI Brain Starter — plain English, no jargon
 
 ---
 
+## 2026-06-30: session-close now writes to the vault you're actually working in, not just your default one
+
+**Who this affects:** anyone who works across more than one vault or repo that each has its own CLAUDE.md and its own Sessions/Decisions setup — for example, a personal vault plus one or more separate team or client repos.
+
+**The bug:** the session-close cascade resolves a "vault root" to decide where your session file, decisions, and captures get written. That resolution checked an environment variable (`VAULT_ROOT`) first and only fell back to your current folder if it was unset. Most installs set `VAULT_ROOT` once, globally, as a convenience default — which meant the fallback never ran, for any session, ever. A session spent entirely inside a separate repo with its own session-close setup still had every path resolved against the unrelated default vault. Notes didn't error or warn; they just landed in the wrong place. Bug class: **WRONG-VAULT-ROOT-FROM-GLOBAL-DEFAULT**.
+
+**What's new:** closing a session now checks first whether the folder you're actually in (or one of its parent folders, up to your home directory) has its own CLAUDE.md declaring a "Session End" or "Session Close" setup with a real Sessions folder already in place. If it finds one, that's where your session goes — even if a different vault is configured as the default. If it doesn't find one (a scratch folder, a one-off script, or your actual default vault itself), everything falls back exactly like before. Single-vault setups see no change at all.
+
+The safety-net hooks that double-check a session actually got saved before letting you close (`verify-session-close-cascade.py`, `verify-discoverability-on-close.py`) now use the SAME resolution, for the same reason the writing hook does — otherwise a session correctly saved to its own repo could get hard-blocked at close because the safety check was still looking for it in the unrelated default vault.
+
+**New:** `hooks/_lib/vault_root.py` — the shared resolver all three hooks now import, so this can't drift out of sync the way three independent copies eventually would have.
+
+**New tests:** `tests/integration/test_detect_closing_signal_repo_aware_vault.sh` and `tests/integration/test_verify_cascade_repo_aware_vault.sh` — both include a negative control that fails against the old behavior and passes against the fix.
+
+**What you should do:** nothing. The SessionStart auto-update flow picks this up on your next session (or `git pull` manually in `~/.claude/skills/ai-brain-starter/` to grab it immediately).
+
+---
+
 ## 2026-06-30: the "what your setup injects" meter is now honest and safe
 
 The meter from the previous entry got a hardening pass after an adversarial review found three sharp edges. All fixed:

--- a/hooks/_lib/vault_root.py
+++ b/hooks/_lib/vault_root.py
@@ -1,0 +1,162 @@
+"""vault_root — single source of truth for session-close vault-root resolution.
+
+Used by every consumer in the session-close cascade:
+  - hooks/detect-closing-signal.py            (Layer 1, UserPromptSubmit)
+  - hooks/verify-session-close-cascade.py     (Layer 3, Stop)
+  - hooks/verify-discoverability-on-close.py  (Layer 3, Stop)
+
+Each of these previously computed its own vault root independently from
+`os.environ.get("VAULT_ROOT", ...)`, with no awareness of cwd or which repo
+the session was actually working in.
+
+Bug this fixes: a machine-wide VAULT_ROOT default (set once, e.g. in Claude
+Code's settings.json `env` block, so every hook subprocess always sees it
+set) permanently wins over cwd — `os.environ.get("VAULT_ROOT") or cwd` never
+reaches the `or cwd` branch once VAULT_ROOT is set globally. A session
+working inside a SEPARATE vault-shaped repo (its own CLAUDE.md, its own
+Session End/Close cascade, its own Sessions/Decisions folders — e.g. a
+standalone vault repo, or a team folder with its own cascade) had its
+session artifacts silently resolved against the unrelated default vault
+instead, and any Stop-hook verifier checked the wrong vault for the
+artifacts Layer 1 told the model to write — a fix to Layer 1 alone would
+have turned that silent mis-filing into a false hard-block, since the
+verifiers would look for files that now correctly exist somewhere else.
+
+resolve_vault_root() restores cwd-derived detection as the HIGHER-priority
+signal: it walks up from cwd looking for the nearest self-contained vault
+(a CLAUDE.md that declares its own Session End/Close cascade + an existing
+Meta folder) and uses that when found. The VAULT_ROOT env var / cwd fallback
+is now exactly that — a fallback for when no such repo is found (untracked
+locations, or a session already rooted in the default vault itself, which
+never needs the walk-up to win since it's reached via the fallback anyway).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+__all__ = [
+    "collapse_worktree",
+    "find_repo_vault_root",
+    "resolve_vault_root",
+]
+
+# Matches "## Session End", "## Session end", "# Session Close", etc. Deliberately
+# does NOT match "Session Protocol" or other session-adjacent headings — a vault
+# can discuss sessions without declaring itself the owner of a close cascade for
+# THIS purpose, and headings like that are exactly how the default/fallback
+# vault stays reachable only through the fallback path, never a false walk-up win.
+_SESSION_HEADING_RE = re.compile(r"^#+\s*Session\s+(?:End|Close)\b", re.IGNORECASE | re.MULTILINE)
+
+# Defensive bound on the walk-up, independent of the $HOME/filesystem-root
+# stop conditions below — cheap insurance against an unexpected filesystem
+# structure (symlink loop, cwd reported outside $HOME) turning a hook that
+# has a documented <500ms budget into an unbounded stat loop.
+_MAX_WALKUP_LEVELS = 25
+
+_WORKTREE_MARKER = "/.claude/worktrees/"
+
+
+def collapse_worktree(path: Path) -> Path:
+    """Collapse a `<vault>/.claude/worktrees/<slug>/...` path to `<vault>`.
+
+    A worktree checkout carries the full tree, including CLAUDE.md — so an
+    unqualified walk-up from inside one would stop AT the worktree and
+    strand session artifacts on its throwaway `claude/<slug>` branch,
+    exactly the bug find_repo_vault_root must not reintroduce. Always
+    collapse before searching.
+    """
+    text = str(path)
+    if _WORKTREE_MARKER in text:
+        return Path(text.split(_WORKTREE_MARKER, 1)[0])
+    return path
+
+
+def _has_meta_dir(candidate: Path) -> bool:
+    """True iff `candidate` has a "⚙️ Meta" or Meta-suffixed directory.
+
+    Read-only existence probe (decorated name checked first, matching the
+    convention every consumer's own meta-dir resolver already uses, so a
+    machine-memory plain "Meta" can't shadow "⚙️ Meta" here either) — this
+    does not create anything; it only decides whether `candidate` looks
+    like an already-established vault worth trusting.
+    """
+    for name in ("⚙️ Meta", "Meta"):
+        if (candidate / name).is_dir():
+            return True
+    try:
+        return any(
+            child.is_dir() and child.name.endswith("Meta")
+            for child in candidate.iterdir()
+        )
+    except OSError:
+        return False
+
+
+def _declares_own_session_close_cascade(candidate: Path) -> bool:
+    """True iff `candidate` is a self-contained vault for session-close purposes.
+
+    Both signals required:
+      - a CLAUDE.md documenting its OWN "Session End"/"Session Close" cascade
+        (heading match, case-insensitive), AND
+      - an existing Meta folder to write into.
+    Either alone is too weak: a CLAUDE.md can mention sessions without owning
+    a cascade for this purpose (a default vault's own CLAUDE.md may use a
+    different heading — e.g. "Session Protocol" — precisely so it keeps
+    reaching itself through the fallback, not a walk-up match); a Meta
+    folder can exist without any CLAUDE.md ever declaring it canonical.
+    """
+    claude_md = candidate / "CLAUDE.md"
+    if not claude_md.is_file():
+        return False
+    try:
+        text = claude_md.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    if not _SESSION_HEADING_RE.search(text):
+        return False
+    return _has_meta_dir(candidate)
+
+
+def find_repo_vault_root(start: Path) -> Path | None:
+    """Walk up from `start` (inclusive) for the nearest self-contained vault.
+
+    Stops at $HOME (checked, then not exceeded) or the filesystem root,
+    whichever comes first, bounded defensively at _MAX_WALKUP_LEVELS.
+    Returns None when nothing matches — callers fall back to their
+    pre-existing default. This function only ever ADDS a higher-priority
+    match; it never removes the old behavior.
+    """
+    home = Path.home()
+    current = start
+    for _ in range(_MAX_WALKUP_LEVELS):
+        if _declares_own_session_close_cascade(current):
+            return current
+        if current == home:
+            break
+        parent = current.parent
+        if parent == current:  # reached filesystem root
+            break
+        current = parent
+    return None
+
+
+def resolve_vault_root(cwd: Path, env_vault_root: str | None) -> Path:
+    """Single source of truth: which vault does THIS session's close cascade write to?
+
+    Priority:
+      1. The nearest ancestor of `cwd` (worktree-collapsed) that declares its
+         own Session End/Close cascade — even when a global VAULT_ROOT
+         default is configured. This is what makes a session rooted in its
+         own vault-shaped repo resolve to itself instead of an unrelated
+         default vault.
+      2. VAULT_ROOT env var, if set.
+      3. cwd itself (worktree-collapsed) — today's behavior when no env
+         override exists at all.
+    """
+    base = collapse_worktree(cwd)
+    repo_match = find_repo_vault_root(base)
+    if repo_match is not None:
+        return repo_match
+    return collapse_worktree(Path(env_vault_root) if env_vault_root else cwd)

--- a/hooks/detect-closing-signal.py
+++ b/hooks/detect-closing-signal.py
@@ -40,9 +40,11 @@ Or via absolute path during install:
   python3 ~/.claude/skills/ai-brain-starter/hooks/detect-closing-signal.py
 
 Environment variables (all optional):
-  VAULT_ROOT — vault path. Defaults to cwd. Worktree paths are collapsed to
-               the main vault root so session artifacts never strand on a
-               worktree (see resolve_main_vault).
+  VAULT_ROOT — fallback vault path, used only when cwd is not inside a repo
+               that declares its own Session End/Close cascade (see
+               _lib/vault_root.resolve_vault_root). Defaults to cwd.
+               Worktree paths are collapsed to the main vault root so
+               session artifacts never strand on a worktree.
   CLOSING_SIGNAL_LANGS — comma-separated language packs to load (default: en,es,pt)
   CLOSING_SIGNAL_DETECTION — "regex" (default) or "hybrid" (regex + Haiku fallback)
   CLOSING_SIGNAL_DEBUG — set to 1 for stderr trace
@@ -70,6 +72,17 @@ import sys
 import time
 from pathlib import Path
 from datetime import datetime
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    from _lib.vault_root import resolve_vault_root  # noqa: E402
+except Exception:  # fail-open: if the lib cannot load, behave as before
+    def resolve_vault_root(cwd: Path, env_vault_root: str | None) -> Path:  # type: ignore
+        text = str(Path(env_vault_root) if env_vault_root else cwd)
+        marker = "/.claude/worktrees/"
+        if marker in text:
+            return Path(text.split(marker, 1)[0])
+        return Path(text)
 
 
 def log_debug(msg: str) -> None:
@@ -417,30 +430,6 @@ def derive_worktree(cwd: Path) -> str:
         except OSError:
             pass
     return "main"
-
-
-def resolve_main_vault(path: Path) -> Path:
-    """Collapse a worktree path to the MAIN vault root.
-
-    If `path` is inside `<vault>/.claude/worktrees/<slug>/...`, return
-    `<vault>` — the main vault root. Otherwise return `path` unchanged.
-
-    Session artifacts (the session file, Decisions/, Captures, Time
-    Tracking) MUST land in the main vault. A worktree's own checkout sits
-    on a throwaway `claude/<slug>` branch; anything written there is
-    discarded when the worktree is archived. The close cascade can fire
-    from inside a worktree, so the cwd-derived vault root must be
-    collapsed back to main before any artifact path is resolved.
-
-    Mirrors resolve_main_vault() in scripts/session-end-hook.sh — the same
-    fix applied to the Stop hook for issue #65 / PR #66. This hook (the
-    UserPromptSubmit Layer 1 of the cascade) was never brought to parity.
-    """
-    marker = "/.claude/worktrees/"
-    text = str(path)
-    if marker in text:
-        return Path(text.split(marker, 1)[0])
-    return path
 
 
 def find_meta_dir(vault_root: Path) -> Path:
@@ -887,13 +876,15 @@ def main() -> int:
             emit_passthrough()
             return 0
 
-        # Resolve the vault root. When the close cascade fires from inside a
-        # worktree, cwd IS the worktree; resolve_main_vault collapses it back
-        # so every session artifact lands in the main vault, never a throwaway
-        # claude/<slug> branch that gets discarded when the worktree archives.
-        vault_root = resolve_main_vault(
-            Path(os.environ.get("VAULT_ROOT") or cwd)
-        )
+        # Resolve the vault root. Priority: (1) the nearest ancestor of cwd
+        # that declares its own Session End/Close cascade — even when a
+        # global VAULT_ROOT default is configured, so a session rooted in
+        # its own vault-shaped repo resolves to itself, not an unrelated
+        # default vault; (2) VAULT_ROOT env var; (3) cwd, worktree-collapsed
+        # so a close cascade firing inside a worktree never strands
+        # artifacts on its throwaway claude/<slug> branch. See
+        # _lib/vault_root.py for the full contract.
+        vault_root = resolve_vault_root(cwd, os.environ.get("VAULT_ROOT"))
 
         langs = [
             x.strip() for x in

--- a/hooks/verify-discoverability-on-close.py
+++ b/hooks/verify-discoverability-on-close.py
@@ -66,8 +66,26 @@ except Exception:  # fail-open: if the lib cannot load, never block a close
     def is_closing_claim(_text: str) -> bool:  # type: ignore
         return False
 
-VAULT_ROOT = Path(os.environ.get("VAULT_ROOT", str(Path.home() / "vault")))
+# Shared vault-root resolver - single source of truth (_lib/vault_root.py).
+# Repo-aware, mirroring detect-closing-signal.py and
+# verify-session-close-cascade.py: a session working inside its own
+# vault-shaped repo resolves gaps against that repo, not an unrelated
+# global VAULT_ROOT default (which would otherwise scan a DIFFERENT vault's
+# git history / Agent Memory for "did this session wire discoverability" —
+# a scope leak as well as a correctness bug).
+try:
+    from _lib.vault_root import resolve_vault_root  # noqa: E402
+except Exception:  # fail-open: if the lib cannot load, fall back to env/home
+    def resolve_vault_root(cwd: Path, env_vault_root: str | None) -> Path:  # type: ignore
+        return Path(env_vault_root) if env_vault_root else (cwd or Path.home() / "vault")
+
 DEV_ROOT = Path.home() / "dev"
+
+# Import-time placeholders so the module stays importable without a hook
+# payload. main() calls _resolve_vault_context(cwd) right after confirming
+# there's a closing claim worth acting on, rebinding these to the SAME
+# repo-aware vault detect-closing-signal.py resolved for this session.
+VAULT_ROOT = Path(os.environ.get("VAULT_ROOT", str(Path.home() / "vault")))
 MEMORY_ROOT = VAULT_ROOT / "⚙️ Meta" / "Agent Memory"
 # Test seam: DISCOVERABILITY_VERIFIER_PATH overrides the verifier the hook
 # shells out to, so tests can inject a deterministic stub verifier and stay
@@ -79,6 +97,24 @@ VERIFIER = Path(
         str(VAULT_ROOT / "⚙️ Meta" / "scripts" / "discoverability-verifier.py"),
     )
 )
+
+
+def _resolve_vault_context(cwd: str) -> None:
+    """Recompute VAULT_ROOT/MEMORY_ROOT/VERIFIER for THIS invocation's cwd,
+    repo-aware. DISCOVERABILITY_VERIFIER_PATH still wins outright when set
+    (test seam, unchanged). Every helper below reads these as module
+    globals, so rebinding here (called once, early in main()) is enough to
+    put the whole hook in lockstep with the cwd it was invoked with.
+    """
+    global VAULT_ROOT, MEMORY_ROOT, VERIFIER
+    VAULT_ROOT = resolve_vault_root(Path(cwd) if cwd else Path.cwd(), os.environ.get("VAULT_ROOT"))
+    MEMORY_ROOT = VAULT_ROOT / "⚙️ Meta" / "Agent Memory"
+    VERIFIER = Path(
+        os.environ.get(
+            "DISCOVERABILITY_VERIFIER_PATH",
+            str(VAULT_ROOT / "⚙️ Meta" / "scripts" / "discoverability-verifier.py"),
+        )
+    )
 
 # Tool calls that author/modify a file by an explicit file_path argument.
 # These are the primary "this session wrote X" signal.
@@ -294,6 +330,11 @@ def main() -> int:
     last_text = _get_last_assistant_text(transcript_path)
     if not is_closing_claim(last_text):
         return 0
+
+    # Repo-aware vault resolution, now that we know this is worth the work:
+    # put this hook in lockstep with whichever vault
+    # detect-closing-signal.py resolved for THIS cwd (see _lib/vault_root.py).
+    _resolve_vault_context(payload.get("cwd", ""))
 
     gaps = _run_verifier()
     if not gaps:

--- a/hooks/verify-session-close-cascade.py
+++ b/hooks/verify-session-close-cascade.py
@@ -29,6 +29,16 @@ Spanish closing patterns added 2026-05-13 — the same session's goodbye
 ("Que descanses, Ade") slipped past the English-only regex, so the
 three-gate check never even fired.
 
+2026-06-30: VAULT_ROOT is now resolved repo-aware (see _lib/vault_root.py),
+in lockstep with detect-closing-signal.py. Before this fix, VAULT_ROOT was
+read straight from the env var — permanently, for every repo, whenever a
+machine-wide default was configured. A session working inside its own
+vault-shaped repo (own CLAUDE.md, own Session End/Close cascade) had its
+session file correctly written there by detect-closing-signal.py's own
+repo-aware fix, but THIS hook still checked the unrelated default vault's
+Sessions/ dir and runner state — turning a silent mis-filing into an
+active false hard-block quoting the wrong vault's missing files.
+
 FAIL-SAFE / conditional enforcement (so this hook is safe to wire by
 default for every vault):
   - The hard-block (exit 2) is gated on the session-close cascade actually
@@ -65,7 +75,19 @@ except Exception:  # fail-open: if the lib cannot load, never block a close
     def is_closing_claim(_text: str) -> bool:  # type: ignore
         return False
 
-VAULT_ROOT = Path(os.environ.get("VAULT_ROOT", str(Path.home() / "vault")))
+# Shared vault-root resolver - single source of truth (_lib/vault_root.py).
+# Repo-aware: a session working inside its own vault-shaped repo (own
+# CLAUDE.md declaring a Session End/Close cascade) resolves to that repo,
+# not a global VAULT_ROOT default. Must stay in lockstep with
+# detect-closing-signal.py's resolution — that hook decides where the model
+# writes the session file; this hook must look in the SAME place, or a
+# correctly-written artifact false-blocks the close because this hook is
+# still checking an unrelated default vault.
+try:
+    from _lib.vault_root import resolve_vault_root  # noqa: E402
+except Exception:  # fail-open: if the lib cannot load, fall back to env/home
+    def resolve_vault_root(cwd: Path, env_vault_root: str | None) -> Path:  # type: ignore
+        return Path(env_vault_root) if env_vault_root else (cwd or Path.home() / "vault")
 
 
 def _find_meta_dir(vault_root: Path) -> Path:
@@ -92,10 +114,31 @@ def _find_meta_dir(vault_root: Path) -> Path:
     return vault_root / "Meta"
 
 
+# Import-time placeholders (env-var-only, home-relative default) so the
+# module stays importable without a hook payload. main() calls
+# _resolve_vault_context(cwd) immediately after reading cwd from stdin,
+# before any gate function runs, rebinding these to the SAME repo-aware
+# vault detect-closing-signal.py resolved for this session.
+VAULT_ROOT = Path(os.environ.get("VAULT_ROOT", str(Path.home() / "vault")))
 META_DIR = _find_meta_dir(VAULT_ROOT)
 META_NAME = META_DIR.name
 SESSIONS_DIR = META_DIR / "Sessions"
 RUNNER_SCRIPT = META_DIR / "scripts" / "session-close-runner.sh"
+
+
+def _resolve_vault_context(cwd: str) -> None:
+    """Recompute VAULT_ROOT/META_DIR/META_NAME/SESSIONS_DIR/RUNNER_SCRIPT for
+    THIS invocation's cwd, repo-aware. Every gate function below reads these
+    as module globals, so rebinding here (called once, early in main()) is
+    sufficient to put the whole hook in lockstep with the cwd it was invoked
+    with — no signature changes needed downstream.
+    """
+    global VAULT_ROOT, META_DIR, META_NAME, SESSIONS_DIR, RUNNER_SCRIPT
+    VAULT_ROOT = resolve_vault_root(Path(cwd), os.environ.get("VAULT_ROOT"))
+    META_DIR = _find_meta_dir(VAULT_ROOT)
+    META_NAME = META_DIR.name
+    SESSIONS_DIR = META_DIR / "Sessions"
+    RUNNER_SCRIPT = META_DIR / "scripts" / "session-close-runner.sh"
 # Default is the exact path session-close-runner.sh writes; the env override is
 # for hermetic tests (and any setup where both sides agree to relocate it).
 RUNNER_REPORT = Path(os.environ.get("ABS_RUNNER_REPORT", "/tmp/abs-session-close-runner.report"))
@@ -315,6 +358,11 @@ def main() -> int:
     last_text = get_last_assistant_text(transcript_path)
     if not is_closing_claim(last_text):
         return 0  # no closing claim — skip
+
+    # Repo-aware vault resolution, now that we know this is worth the work:
+    # put every gate below in lockstep with whichever vault
+    # detect-closing-signal.py resolved for THIS cwd (see _lib/vault_root.py).
+    _resolve_vault_context(cwd)
 
     # Enforcement (hard-block) is conditional on the session-close cascade
     # being INSTALLED in this vault — see runner_installed(). This is what

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -98,12 +98,14 @@ INTEGRATION_TESTS=(
   test_phase_doc_slash_commands_installed
   test_reconcile_ff_invariant
   test_detect_closing_signal_worktree
+  test_detect_closing_signal_repo_aware_vault
   test_closing_claim_shared
   test_meta_resolver
   test_meta_resolution_guard
   test_split_meta
   test_context_load_selftest
   test_verify_cascade_failsafe
+  test_verify_cascade_repo_aware_vault
   test_discoverability_partition
   test_stranded_session_artifacts_watchdog
   test_session_coordination_guards

--- a/tests/integration/test_detect_closing_signal_repo_aware_vault.sh
+++ b/tests/integration/test_detect_closing_signal_repo_aware_vault.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Test: detect-closing-signal.py resolves session-artifact paths against the
+# repo a session is actually working in, even when a DIFFERENT vault is
+# configured as the machine-wide VAULT_ROOT default.
+#
+# Bug class: VAULT_ROOT is commonly set once, globally, in Claude Code's
+# settings.json `env` block (so every hook subprocess always sees it set).
+# The hook's old resolution was `os.environ.get("VAULT_ROOT") or cwd` — once
+# VAULT_ROOT is set globally, the `or cwd` branch is DEAD, permanently, for
+# every session on the machine. A session working inside a SEPARATE
+# vault-shaped repo (its own CLAUDE.md declaring its own "Session End" /
+# "Session Close" cascade, its own Sessions/Decisions folders) had its
+# session file, decisions dir, and captures file silently resolved against
+# the unrelated default vault instead of the repo it was actually in.
+#
+# Reproduced 2026-06-30 against a real mycelium-vault-rooted session: the
+# injected SESSION CLOSE context resolved every path under the personal
+# vault (the global VAULT_ROOT default) despite cwd being entirely inside a
+# separate repo with its own Session End cascade.
+#
+# Assertions:
+#   1. NEGATIVE CONTROL — cwd inside a repo-vault, VAULT_ROOT set to a
+#      DIFFERENT default vault: resolves to the repo-vault, NOT the default.
+#      (This is the case that reproduced the bug: without the fix, this
+#      assertion fails and meta_dir/session_file land under DEFAULT_VAULT.)
+#   2. Same, fired from inside a WORKTREE of the repo-vault: still resolves
+#      to the repo-vault's MAIN root (combines with the worktree-collapse
+#      invariant — never the worktree, never the default vault).
+#   3. Heading match is case-insensitive ("Session end", lowercase "end",
+#      as used by at least one real confirmed second case).
+#   4. FALLBACK PRESERVED — cwd in an untracked location (no CLAUDE.md
+#      anywhere in its ancestry): still resolves to VAULT_ROOT (today's
+#      default/fallback behavior, unchanged).
+#   5. FALLBACK PRESERVED — cwd inside the default vault itself, whose
+#      CLAUDE.md uses a heading that does NOT declare a Session End/Close
+#      cascade (e.g. "Session Protocol", the personal vault's real
+#      heading): still resolves via the VAULT_ROOT/cwd fallback, not a
+#      false walk-up match.
+#
+# Self-contained: tmpdir fake vaults, HOME redirected so the marker file
+# never touches the real ~/.claude and so the walk-up's $HOME boundary is
+# deterministic. Exit 0 = pass, 1 = fail with detail on stderr.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOK="$REPO_ROOT/hooks/detect-closing-signal.py"
+if [ ! -f "$HOOK" ]; then
+  echo "ERROR: $HOOK not found" >&2
+  exit 1
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# DEFAULT_VAULT simulates the machine-wide VAULT_ROOT default (e.g. the
+# personal vault) — a real vault shape, but its CLAUDE.md heading is
+# "Session Protocol", which must NOT match the repo-vault heading pattern.
+DEFAULT_VAULT="$TMP/default-vault"
+mkdir -p "$DEFAULT_VAULT/Meta/Sessions" "$DEFAULT_VAULT/Meta/Decisions"
+cat > "$DEFAULT_VAULT/CLAUDE.md" <<'EOF'
+# Default Vault
+
+# Session Protocol
+
+1. Read Last Session.md
+EOF
+
+# REPO_VAULT simulates a session-close-aware repo distinct from the default
+# vault (e.g. mycelium-vault) — its own CLAUDE.md declares its own cascade.
+REPO_VAULT="$TMP/repo-vault"
+mkdir -p "$REPO_VAULT/Meta/Sessions" "$REPO_VAULT/Meta/Decisions"
+cat > "$REPO_VAULT/CLAUDE.md" <<'EOF'
+# Repo Vault
+
+## Session End — capture cascade
+
+Route session content to Meta/Sessions/.
+EOF
+REPO_WT="$REPO_VAULT/.claude/worktrees/test-slug"
+mkdir -p "$REPO_WT/Meta/Sessions" "$REPO_WT/Meta/Decisions"
+cp "$REPO_VAULT/CLAUDE.md" "$REPO_WT/CLAUDE.md"   # a real worktree carries the full tree
+
+# LOWERCASE_VAULT: same as REPO_VAULT but with a lowercase "Session end"
+# heading, matching the real second confirmed case (a team-folder CLAUDE.md
+# used "## Session end — capture cascade", lowercase "end").
+LOWERCASE_VAULT="$TMP/lowercase-vault"
+mkdir -p "$LOWERCASE_VAULT/Meta/Sessions"
+cat > "$LOWERCASE_VAULT/CLAUDE.md" <<'EOF'
+## Session end — capture cascade
+EOF
+
+# UNTRACKED: no CLAUDE.md anywhere in its ancestry (up to $TMP == $HOME below).
+UNTRACKED="$TMP/untracked/deeply/nested"
+mkdir -p "$UNTRACKED"
+
+# run_hook <cwd> <session_id> <vault_root_env> -> echoes the marker file path.
+run_hook() {
+  local cwd="$1" sid="$2" vault_root_env="$3" stdin_json
+  stdin_json=$(python3 -c "import json,sys; print(json.dumps({'prompt':sys.argv[1],'session_id':sys.argv[2],'cwd':sys.argv[3]}))" \
+    "let's close this session" "$sid" "$cwd")
+  if [ -n "$vault_root_env" ]; then
+    printf '%s' "$stdin_json" | env HOME="$TMP" VAULT_ROOT="$vault_root_env" python3 "$HOOK" >/dev/null 2>&1 || true
+  else
+    printf '%s' "$stdin_json" | env -u VAULT_ROOT HOME="$TMP" python3 "$HOOK" >/dev/null 2>&1 || true
+  fi
+  echo "$TMP/.claude/.closing-signal-${sid}.json"
+}
+
+marker_field() {
+  python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get(sys.argv[2],''))" "$1" "$2"
+}
+
+assert_meta_dir() {  # label marker expected
+  local label="$1" marker="$2" expected="$3"
+  if [ ! -f "$marker" ]; then
+    echo "FAIL: $label — hook wrote no marker (close signal not detected?)" >&2
+    exit 1
+  fi
+  local got
+  got="$(marker_field "$marker" meta_dir)"
+  if [ "$got" != "$expected" ]; then
+    echo "FAIL: $label" >&2
+    echo "  expected meta_dir: $expected" >&2
+    echo "  got:               $got" >&2
+    exit 1
+  fi
+  echo "PASS: $label"
+}
+
+# --- 1. NEGATIVE CONTROL: repo-vault cwd wins over a DIFFERENT VAULT_ROOT --
+MARKER1="$(run_hook "$REPO_VAULT" "test-repo-aware" "$DEFAULT_VAULT")"
+assert_meta_dir \
+  "repo-vault cwd resolves to itself, not the configured default VAULT_ROOT" \
+  "$MARKER1" "$REPO_VAULT/Meta"
+
+# --- 2. Same, fired from inside a worktree of the repo-vault ---------------
+MARKER2="$(run_hook "$REPO_WT" "test-repo-aware-wt" "$DEFAULT_VAULT")"
+assert_meta_dir \
+  "repo-vault worktree cwd resolves to the repo-vault's MAIN root, not the worktree, not the default" \
+  "$MARKER2" "$REPO_VAULT/Meta"
+SESSION2="$(marker_field "$MARKER2" session_file)"
+case "$SESSION2" in
+  *"/.claude/worktrees/"*)
+    echo "FAIL: session file resolved inside the worktree" >&2
+    echo "  got: $SESSION2" >&2
+    exit 1
+    ;;
+esac
+echo "PASS: repo-vault worktree session file resolves outside .claude/worktrees/"
+
+# --- 3. Heading match is case-insensitive ("Session end") ------------------
+MARKER3="$(run_hook "$LOWERCASE_VAULT" "test-lowercase-heading" "$DEFAULT_VAULT")"
+assert_meta_dir \
+  "lowercase 'Session end' heading still matches" \
+  "$MARKER3" "$LOWERCASE_VAULT/Meta"
+
+# --- 4. FALLBACK PRESERVED: untracked location uses VAULT_ROOT -------------
+MARKER4="$(run_hook "$UNTRACKED" "test-untracked" "$DEFAULT_VAULT")"
+assert_meta_dir \
+  "untracked cwd (no CLAUDE.md in its ancestry) falls back to VAULT_ROOT" \
+  "$MARKER4" "$DEFAULT_VAULT/Meta"
+
+# --- 5. FALLBACK PRESERVED: default vault's own CLAUDE.md doesn't self-match
+# via a "Session Protocol" heading -- it still reaches itself, but through
+# the VAULT_ROOT/cwd fallback, not a walk-up match (proves the heading
+# regex is discriminating, not accidentally permissive).
+MARKER5="$(run_hook "$DEFAULT_VAULT" "test-default-vault-cwd" "")"
+assert_meta_dir \
+  "default-vault cwd (VAULT_ROOT unset) resolves via cwd fallback, unchanged" \
+  "$MARKER5" "$DEFAULT_VAULT/Meta"
+
+echo
+echo "All assertions passed. detect-closing-signal.py repo-aware vault-root invariant holds."

--- a/tests/integration/test_verify_cascade_repo_aware_vault.sh
+++ b/tests/integration/test_verify_cascade_repo_aware_vault.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Test: verify-session-close-cascade.py resolves its vault root the SAME
+# repo-aware way as detect-closing-signal.py, so a Layer-1 fix that starts
+# correctly writing session artifacts into a session's own repo-vault does
+# not turn into a Layer-3 false hard-block against an unrelated default
+# vault's runner/session-file state.
+#
+# Bug class this guards: BEFORE this fix, this hook computed its own
+# VAULT_ROOT independently, straight from `os.environ.get("VAULT_ROOT", ...)`
+# with zero cwd-awareness. If a global VAULT_ROOT default happens to have
+# the session-close-runner.sh cascade installed (a real, common case — the
+# default vault is usually the one that installed it first), this hook's
+# fail-safe (`runner_installed()`) would see "installed" for EVERY session
+# on the machine, regardless of which repo it's actually in, and switch
+# into hard-block enforcement mode using the WRONG vault's Sessions/ dir —
+# which never has this worktree's session file, because it was correctly
+# written into the repo-vault instead. Silent mis-filing (the bug
+# detect-closing-signal.py's own repo-aware fix corrects) would turn into
+# an active false block quoting a path in the wrong vault, UNLESS this
+# verifier resolves to the same repo-vault.
+#
+# Assertions:
+#   1. NEGATIVE CONTROL — repo-vault has NOT opted into the cascade (no
+#      runner installed there), but the configured default VAULT_ROOT DOES
+#      have one installed. A closing claim from inside the repo-vault must
+#      degrade to advisory (never block) — the presence of a DIFFERENT
+#      vault's runner must not leak into this repo's enforcement decision.
+#   2. Repo-vault HAS its own runner installed and the cascade actually
+#      ran cleanly: allows the close (proves enforcement still engages
+#      correctly for a repo that legitimately opted in, using the
+#      repo-vault's OWN Sessions/ dir — not the default vault's).
+#   3. Repo-vault HAS its own runner installed but the cascade is
+#      incomplete: BLOCKS, and the diagnostic message is emitted — proves
+#      gate 1 (session file) is checked against the repo-vault, not the
+#      default vault (which would show DIFFERENT missing-file evidence).
+#
+# Self-contained: tmpdir fake vaults, ABS_RUNNER_REPORT redirected. Exit 0 = pass.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOK="$REPO_ROOT/hooks/verify-session-close-cascade.py"
+if [ ! -f "$HOOK" ]; then
+  echo "ERROR: $HOOK not found" >&2
+  exit 1
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+REPORT="$TMP/runner.report"
+TODAY="$(date +%Y-%m-%d)"
+CLOSING="Closing the session now — that's all for today."
+
+run_hook() {  # VAULT_ROOT_env CWD TEXT [EXTRA_ENV=val ...] -> exit code
+  local vault_root_env="$1" cwd="$2" text="$3"; shift 3
+  local tpath="$TMP/transcript.jsonl"
+  python3 -c "import json,sys; open(sys.argv[1],'w',encoding='utf-8').write(json.dumps({'type':'assistant','message':{'content':[{'type':'text','text':sys.argv[2]}]}})+'\n')" "$tpath" "$text"
+  local stdin_json
+  stdin_json=$(python3 -c "import json,sys; print(json.dumps({'cwd':sys.argv[1],'transcript_path':sys.argv[2]}))" "$cwd" "$tpath")
+  set +e
+  printf '%s' "$stdin_json" | env -u VERIFY_CASCADE_BYPASS -u VERIFY_CASCADE_SOFT \
+    VAULT_ROOT="$vault_root_env" ABS_RUNNER_REPORT="$REPORT" "$@" \
+    python3 "$HOOK" >"$TMP/out.txt" 2>"$TMP/err.txt"
+  local rc=$?
+  set -e
+  echo "$rc"
+}
+
+assert_rc() {  # label expected actual
+  if [ "$2" != "$3" ]; then
+    echo "FAIL: $1 — expected exit $2, got $3" >&2
+    echo "  --- stderr ---" >&2; sed 's/^/  /' "$TMP/err.txt" >&2
+    exit 1
+  fi
+  echo "PASS: $1 (exit $3)"
+}
+
+# DEFAULT_VAULT: simulates the machine-wide VAULT_ROOT default that HAS the
+# cascade installed (e.g. the personal vault, where it was built first).
+DEFAULT_VAULT="$TMP/default-vault"
+mkdir -p "$DEFAULT_VAULT/⚙️ Meta/scripts" "$DEFAULT_VAULT/⚙️ Meta/Sessions"
+: > "$DEFAULT_VAULT/⚙️ Meta/scripts/session-close-runner.sh"
+
+# REPO_VAULT_NORUNNER: a session-close-aware repo that has NOT installed the
+# runner cascade — the common case for a repo that just adopted the pattern.
+REPO_NORUN="$TMP/repo-norunner"
+mkdir -p "$REPO_NORUN/⚙️ Meta/Sessions"
+cat > "$REPO_NORUN/CLAUDE.md" <<'EOF'
+## Session End — capture cascade
+EOF
+WT_NORUN="$REPO_NORUN/.claude/worktrees/slug1"
+mkdir -p "$WT_NORUN"
+
+# --- 1. NEGATIVE CONTROL: default vault's runner must not leak into a
+#        repo-vault session's enforcement decision ------------------------
+rm -f "$REPORT"
+rc=$(run_hook "$DEFAULT_VAULT" "$WT_NORUN" "$CLOSING")
+assert_rc "default vault's installed runner does not leak into repo-vault enforcement" 0 "$rc"
+
+# --- 2. Repo-vault has ITS OWN runner + all gates pass ---------------------
+REPO_PASS="$TMP/repo-pass"
+mkdir -p "$REPO_PASS/⚙️ Meta/scripts" "$REPO_PASS/⚙️ Meta/Sessions"
+cat > "$REPO_PASS/CLAUDE.md" <<'EOF'
+## Session End — capture cascade
+EOF
+: > "$REPO_PASS/⚙️ Meta/scripts/session-close-runner.sh"
+echo "session" > "$REPO_PASS/⚙️ Meta/Sessions/${TODAY}T120000-slugpass.md"
+git -C "$REPO_PASS" init -q
+git -C "$REPO_PASS" -c user.email=t@t -c user.name=t add -A
+git -C "$REPO_PASS" -c user.email=t@t -c user.name=t commit -qm init
+WT_PASS="$REPO_PASS/.claude/worktrees/slugpass"
+mkdir -p "$WT_PASS"
+printf 'RUNNER COMPLETE @ %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" > "$REPORT"
+rc=$(run_hook "$DEFAULT_VAULT" "$WT_PASS" "$CLOSING")
+assert_rc "repo-vault with its own runner + all gates pass allows close (checked against the repo, not the default)" 0 "$rc"
+
+# --- 3. Repo-vault has ITS OWN runner but the cascade is incomplete --------
+REPO_INCOMPLETE="$TMP/repo-incomplete"
+mkdir -p "$REPO_INCOMPLETE/⚙️ Meta/scripts" "$REPO_INCOMPLETE/⚙️ Meta/Sessions"
+cat > "$REPO_INCOMPLETE/CLAUDE.md" <<'EOF'
+## Session End — capture cascade
+EOF
+: > "$REPO_INCOMPLETE/⚙️ Meta/scripts/session-close-runner.sh"
+WT_INCOMPLETE="$REPO_INCOMPLETE/.claude/worktrees/sluginc"
+mkdir -p "$WT_INCOMPLETE"
+rm -f "$REPORT"   # gate 2: no fresh report -> incomplete
+rc=$(run_hook "$DEFAULT_VAULT" "$WT_INCOMPLETE" "$CLOSING")
+assert_rc "repo-vault with its own runner + incomplete cascade blocks (evaluated against the repo)" 2 "$rc"
+if ! grep -q "BLOCKED by verify-session-close-cascade" "$TMP/err.txt"; then
+  echo "FAIL: block message missing from stderr" >&2; exit 1
+fi
+echo "PASS: block emits the diagnostic message"
+
+echo
+echo "All assertions passed. verify-session-close-cascade.py repo-aware vault-root invariant holds."


### PR DESCRIPTION
## Summary
- The session-close cascade's three hooks (`detect-closing-signal.py`, `verify-session-close-cascade.py`, `verify-discoverability-on-close.py`) each resolved a "vault root" straight from `os.environ.get("VAULT_ROOT", ...)`. Once a machine-wide `VAULT_ROOT` default is configured (the common case), the `or cwd` fallback in that expression never runs again, for any session, in any repo — a session working inside its own vault-shaped repo (own CLAUDE.md declaring its own "Session End"/"Session Close" cascade) had every session-close path silently resolved against the unrelated default vault instead.
- New `hooks/_lib/vault_root.py` adds `resolve_vault_root()`: walk up from cwd (worktree-collapsed) for the nearest ancestor that declares its own Session End/Close cascade; fall back to `VAULT_ROOT`/cwd exactly as before when nothing matches. All three hooks now use it, computed once `cwd` is known from the hook payload rather than at Python-module-import time (a structural change for the two Stop-hook verifiers, which previously computed `VAULT_ROOT` as a module-level constant before `main()` even read stdin).
- Fixing only the injection hook (`detect-closing-signal.py`) would have turned the prior silent mis-filing into an active false hard-block: it would correctly write the session file into the repo-vault, but the two Stop-hook verifiers would still check the unrelated default vault's `Sessions/` dir and runner-installed state and block the close. All three are fixed together and share one resolver so they can't drift back out of sync.

## Test plan
- [x] `hooks/_lib/vault_root.py` new module, `python3 -m py_compile` clean
- [x] New `tests/integration/test_detect_closing_signal_repo_aware_vault.sh` — 6 assertions incl. worktree-collapse interaction, case-insensitive heading match, and two fallback-preserved cases. Verified to FAIL against the pre-fix hook (via `git stash`) with the exact reported symptom, and PASS against the fix.
- [x] New `tests/integration/test_verify_cascade_repo_aware_vault.sh` — proves the Stop-hook verifier no longer false-blocks when a different (default) vault happens to have the runner cascade installed. Verified to FAIL against the pre-fix hook and PASS against the fix.
- [x] Both new tests added to `scripts/ci.sh`'s explicit `INTEGRATION_TESTS` allow-list (this repo intentionally does not glob `tests/integration/`, so an unlisted test never runs).
- [x] Full `bash scripts/ci.sh`: py_compile clean across 274 tracked `.py` files, 57/57 integration tests pass (55 pre-existing + 2 new), shellcheck clean.
- [x] Personal-data scrub run against every changed file (superset of `.github/workflows/personal-pii-scrub.yml`'s pattern list) — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)