### PR TITLE
test(smoke): make detect-closing-signal 'bye' check hermetic (MYC-1988)

### DIFF
--- a/scripts/post-install-smoke-test.sh
+++ b/scripts/post-install-smoke-test.sh
@@ -95,23 +95,32 @@ done
 }
 
 # === 4. Hook smoke test (sample stdin) ===
+# Hermetic fixture: a throwaway vault with a Meta/ dir and NO CLAUDE.md, with
+# VAULT_ROOT pinned to it. This isolates the detector from the operator's own
+# closingSignals config and any ambient VAULT_ROOT. Without it, a machine whose
+# real vault sets `closingSignals.customOnly: true` (which makes the detector
+# fire ONLY on the user's custom phrases and skip the shared pack) sees the
+# shared-pack "bye" correctly suppressed — and this check false-FAILs even though
+# the detector is behaving as configured (MYC-1988). CLOSING_SIGNAL_DETECTION is
+# unset so the check never reaches the optional Haiku/API path.
 hdr "Hook smoke tests"
 DETECTOR="$SKILL_DIR/hooks/detect-closing-signal.py"
 if [[ -f "$DETECTOR" ]]; then
-  TMPDIR_HOOK=$(mktemp -d)
-  resp=$(echo '{"prompt":"hello world","session_id":"smoke","cwd":"'"$TMPDIR_HOOK"'"}' | python3 "$DETECTOR" 2>/dev/null)
+  FIXTURE_VAULT=$(mktemp -d)
+  mkdir -p "$FIXTURE_VAULT/Meta/Sessions"
+  resp=$(echo '{"prompt":"hello world","session_id":"smoke","cwd":"'"$FIXTURE_VAULT"'"}' | env -u CLOSING_SIGNAL_DETECTION VAULT_ROOT="$FIXTURE_VAULT" python3 "$DETECTOR" 2>/dev/null)
   if echo "$resp" | python3 -c "import json,sys; json.loads(sys.stdin.read())" 2>/dev/null; then
     ok "detect-closing-signal.py returns valid JSON for non-close input"
   else
     fail "detect-closing-signal.py returned invalid JSON"
   fi
-  resp=$(echo '{"prompt":"bye","session_id":"smoke","cwd":"'"$TMPDIR_HOOK"'"}' | python3 "$DETECTOR" 2>/dev/null)
+  resp=$(echo '{"prompt":"bye","session_id":"smoke","cwd":"'"$FIXTURE_VAULT"'"}' | env -u CLOSING_SIGNAL_DETECTION VAULT_ROOT="$FIXTURE_VAULT" python3 "$DETECTOR" 2>/dev/null)
   if echo "$resp" | python3 -c "import json,sys; d=json.loads(sys.stdin.read()); assert 'hookSpecificOutput' in d" 2>/dev/null; then
-    ok "detect-closing-signal.py injects context on 'bye'"
+    ok "detect-closing-signal.py injects context on 'bye' (hermetic shared-pack fixture)"
   else
     fail "detect-closing-signal.py did not inject context on 'bye'"
   fi
-  rm -rf "$TMPDIR_HOOK"
+  rm -rf "$FIXTURE_VAULT"
 fi
 
 LINTER="$SKILL_DIR/hooks/lint-vault-frontmatter.py"


### PR DESCRIPTION
## What

Make the `detect-closing-signal.py` "bye" check in `post-install-smoke-test.sh` **hermetic**.

## Why

The check ran the detector against a bare `mktemp -d` while inheriting the ambient environment. With `cwd` an empty tmpdir, the detector's `resolve_vault_root` falls through to the operator's `VAULT_ROOT`, then reads that vault's `CLAUDE.md` `closingSignals.customOnly`.

On a machine whose real vault sets `closingSignals.customOnly: true`, the detector **correctly** fires only on the user's custom phrases and skips the shared pack — so the shared-pack `bye` is suppressed and the smoke false-FAILs, even though nothing is wrong with the detector.

This surfaced running the MYC-1988 fresh-install smoke: `450 pass · 1 warn · 1 fail`, the fail being this leaked-config check.

## Fix

Pin the check to a throwaway fixture vault (a `Meta/` dir + no `CLAUDE.md`) with `VAULT_ROOT` set to it, and unset `CLOSING_SIGNAL_DETECTION` so it never reaches the optional Haiku/API path. The test now verifies the substrate's own shared-pack contract deterministically, independent of the operator's config.

No product change — `detect-closing-signal.py` is untouched and was never wrong.

## Verify

`bash scripts/post-install-smoke-test.sh` → **451 pass · 1 warn · 0 fail** (the warn is `humanizer` SKILL.md not bundled, expected).

Completes the last open leg of MYC-1988 (Done #3: fresh-install smoke passes). The reconcile (Done #1) and fail-loud (Done #2, #279) were already shipped.
