### PR TITLE
feat(relocate): --ensure-backup stands up a verified backup, then moves (MYC-2404)

### DIFF
--- a/docs/CLOUD_SYNC.md
+++ b/docs/CLOUD_SYNC.md
@@ -49,11 +49,21 @@ re-homes that Claude state (copying it, so the old location stays a backup):
 
 ```bash
 # preview first (changes nothing)
-bash scripts/relocate-vault.sh ~/Desktop/MyVault ~/MyVault --dry-run
-# do it (quit Obsidian + close Claude sessions + have a verified off-machine backup first;
-# it REFUSES to move a backup-less vault. --force overrides the soft gates.)
+bash scripts/relocate-vault.sh --ensure-backup ~/Desktop/MyVault ~/MyVault --dry-run
+# do it — quit Obsidian + close Claude sessions first. --ensure-backup stands up AND
+# verifies an off-machine backup, THEN moves, in one step. Fail-closed: if the backup
+# can't be verified it refuses and leaves the vault untouched.
+bash scripts/relocate-vault.sh --ensure-backup ~/Desktop/MyVault ~/MyVault
+# already have a verified backup? the plain form moves once it confirms one exists
+# (it still REFUSES a backup-less vault unless you pass --force):
 bash scripts/relocate-vault.sh ~/Desktop/MyVault ~/MyVault
 ```
+
+`--ensure-backup` writes the archive to `<parent-of-your-vault>/ai-brain-backups` by
+default — for a cloud vault that sibling folder is off-machine, and a single daily
+archive syncs without the storm the churning `.git` tree causes. Send it to an
+external disk instead with `--backup-dest /Volumes/YourDrive`. This is exactly what
+the SessionStart cloud-sync offer runs for you, so you usually never type it by hand.
 
 **On Windows (PowerShell)** use the `.ps1` parity script — same behavior, same
 Claude-history migration, but it leaves a **junction** at the old path (needs no

--- a/hooks/worktree-footprint-signal.py
+++ b/hooks/worktree-footprint-signal.py
@@ -231,10 +231,27 @@ def _offer_block(vault: Path, service: str, dest: Path) -> str:
             f'"{SKILL_SCRIPTS}/relocate-machinery-sidecar.ps1" "{vault}"'
         )
         rb = "-Rollback"
+        # The .ps1 does not yet stand up a backup itself (MYC-2383 tracks Windows
+        # parity for --ensure-backup), so keep asking the assistant to stand one up
+        # first for Windows/OneDrive users.
+        move_note = (
+            "move the whole vault to a local disk (leaves a link so nothing "
+            "breaks). Stand up a verified off-machine backup FIRST"
+        )
     else:
-        move_cmd = f'bash {SKILL_SCRIPTS}/relocate-vault.sh "{vault}" "{dest}"'
+        # --ensure-backup makes THIS the one approved step: it stands up + verifies
+        # an off-machine backup before moving, and refuses if that can't be verified
+        # — so a non-technical user never has to know --force or run a backup by hand
+        # (MYC-2404 — fulfills this offer's "stand up a backup first" promise in the
+        # mechanism instead of relying on the assistant to remember).
+        move_cmd = f'bash {SKILL_SCRIPTS}/relocate-vault.sh --ensure-backup "{vault}" "{dest}"'
         sidecar_cmd = f'bash {SKILL_SCRIPTS}/relocate-machinery-sidecar.sh "{vault}"'
         rb = "--rollback"
+        move_note = (
+            "move the whole vault to a local disk. This ONE command stands up + "
+            "verifies an off-machine backup FIRST, then moves (leaves a link so "
+            "nothing breaks), and refuses to move if the backup can't be verified"
+        )
     return (
         f"🟡 [cloud-sync] The user's brain `{vault}` is inside **{service}** — the "
         f"#1 cause of the \"whole machine froze\" failure (the sync daemon chokes on "
@@ -249,7 +266,7 @@ def _offer_block(vault: Path, service: str, dest: Path) -> str:
         f"stops choking. Reversible (`{rb}`), deletes nothing:\n"
         f"      {sidecar_cmd}\n"
         f"  Fallback — ONLY if they explicitly say they don't want {service} at all: "
-        f"move the whole vault to a local disk (leaves a link so nothing breaks):\n"
+        f"{move_note}:\n"
         f"      {move_cmd}\n"
         f"Say it to them roughly like: \"Your notes are in {service}, and that combo "
         f"can freeze your computer. I can fix it safely in the background — your notes "

--- a/scripts/relocate-vault.sh
+++ b/scripts/relocate-vault.sh
@@ -35,8 +35,21 @@
 # Options:
 #   --dry-run            print intended actions, change nothing
 #   --no-symlink         do NOT leave a symlink at the old path (default leaves one)
-#   --force              skip the soft gates (Obsidian-running, active-session).
-#                        target-exists and source-already-a-symlink stay FATAL.
+#   --force              skip the soft gates (Obsidian-running, active-session,
+#                        backup-first). target-exists and source-already-a-symlink
+#                        stay FATAL.
+#   --ensure-backup      if there is no surviving off-machine backup, STAND ONE UP
+#                        (vault-backup.sh setup + verify) BEFORE moving, then proceed
+#                        — so a non-technical user reaches a backed-up, relocated
+#                        vault in ONE step, without knowing --force or running
+#                        vault-backup.sh by hand. Fail-closed: if the stand-up does
+#                        not verify, the move is REFUSED (vault untouched). This is
+#                        what the SessionStart cloud-sync offer runs.
+#   --backup-dest <dir>  where --ensure-backup writes the backup archive (default:
+#                        <parent-of-vault>/ai-brain-backups — one file that survives
+#                        the move; for a cloud vault that sibling is off-machine).
+#   --backup-schedule <daily|none>
+#                        schedule the stood-up backup installs (default: daily).
 #   --config-dir <dir>   Claude Code config dir (default: $CLAUDE_CONFIG_DIR or ~/.claude)
 #   -h, --help           this help
 #
@@ -47,6 +60,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 OLD="" ; NEW="" ; DRYRUN=0 ; FORCE=0 ; NOSYMLINK=0 ; MIGRATE_ONLY=0 ; SWEEP=0 ; DROP=0
+ENSURE_BACKUP=0 ; BACKUP_DEST="" ; BACKUP_SCHEDULE="daily"
 SWEEP_EXTRA=()
 CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
 
@@ -55,6 +69,9 @@ while [ $# -gt 0 ]; do
     --dry-run|--dryrun) DRYRUN=1; shift;;
     --no-symlink) NOSYMLINK=1; shift;;
     --force) FORCE=1; shift;;
+    --ensure-backup) ENSURE_BACKUP=1; shift;;
+    --backup-dest) BACKUP_DEST="${2:?--backup-dest needs a path}"; shift 2;;
+    --backup-schedule) BACKUP_SCHEDULE="${2:?--backup-schedule needs daily|none}"; shift 2;;
     --config-dir) CONFIG_DIR="${2:?--config-dir needs a path}"; shift 2;;
     --migrate-claude-state) MIGRATE_ONLY=1; shift;;
     --sweep) SWEEP=1; shift;;
@@ -203,6 +220,42 @@ PY
   fi
 }
 
+# ---- stand up a verified off-machine backup, THEN let the move proceed (MYC-2404) ---
+# The MYC-2382 gate REFUSES a backup-less move but only PRINTS the fix — a non-
+# technical user on a melting cloud-sync setup doesn't know --force and won't run
+# vault-backup.sh by hand, so they stay stuck on the very setup the offer meant to
+# rescue them from. --ensure-backup FULFILLS the SessionStart offer's "I'll stand
+# up a verified backup first" promise IN the mechanism: run vault-backup.sh setup
+# (snapshots immediately) then verify (proves it restores). FAIL-CLOSED — if either
+# step fails, die BEFORE the move so the vault is never touched. The caller RE-CHECKS
+# with check-vault-backup.py afterward, so a tool that lies about success can't slip
+# an unbacked move through. VAULT_BACKUP_CMD overrides the tool (test injection).
+ensure_backup_standup() {  # uses $OLD_ABS $BACKUP_DEST $BACKUP_SCHEDULE $DRYRUN $SCRIPT_DIR
+  local backup_cmd dest
+  backup_cmd="${VAULT_BACKUP_CMD:-$SCRIPT_DIR/vault-backup.sh}"
+  dest="${BACKUP_DEST:-$(dirname "$OLD_ABS")/ai-brain-backups}"
+  if [ ! -f "$backup_cmd" ]; then
+    die "--ensure-backup cannot stand up a backup — the vault-backup tool is missing ($backup_cmd). Restore it, or re-run with --force to move without a backup."
+  fi
+  if [ "$DRYRUN" = 1 ]; then
+    say "DRY  would: stand up + verify an off-machine backup BEFORE the move —"
+    say "DRY    bash \"$backup_cmd\" setup --vault \"$OLD_ABS\" --dest \"$dest\" --schedule \"$BACKUP_SCHEDULE\""
+    say "DRY    bash \"$backup_cmd\" verify --vault \"$OLD_ABS\""
+    return 0
+  fi
+  say "relocate-vault: --ensure-backup — standing up a verified off-machine backup BEFORE the move"
+  say "  · backup destination: $dest"
+  if ! bash "$backup_cmd" setup --vault "$OLD_ABS" --dest "$dest" --schedule "$BACKUP_SCHEDULE"; then
+    die "backup stand-up FAILED at 'setup' — NOT moving the vault (fail-closed; your vault is untouched).
+  Check the backup destination (disk reachable? space? permissions?), then re-run; or re-run with --force to move without a backup." 1
+  fi
+  if ! bash "$backup_cmd" verify --vault "$OLD_ABS"; then
+    die "backup stand-up FAILED at 'verify' — the snapshot did not restore, so it is not a trustworthy backup. NOT moving the vault (fail-closed; your vault is untouched).
+  Re-run once the backup verifies, or re-run with --force to move without a verified backup." 1
+  fi
+  say "relocate-vault: backup stood up + verified — proceeding with the move."
+}
+
 # =============================================================================
 # state-only mode: the vault is already at the new path; just fix Claude history
 # =============================================================================
@@ -306,21 +359,40 @@ if [ "$FORCE" != 1 ]; then
   # that survive — a vault-backup archive, Time Machine, a pushed git remote —
   # count here.
   backup_guard="$SCRIPT_DIR/check-vault-backup.py"
-  if [ -f "$backup_guard" ]; then
-    set +e
-    BACKUP_TOKEN="$(python3 "$backup_guard" --porcelain --ignore-cloud "$OLD_ABS" 2>/dev/null)"
-    brc=$?
-    set -e
-    if [ "$brc" != 0 ]; then
+  if [ ! -f "$backup_guard" ]; then
+    die "cannot verify a backup — the guard is missing ($backup_guard). Restore it, or re-run with --force to move without the check."
+  fi
+  set +e
+  BACKUP_TOKEN="$(python3 "$backup_guard" --porcelain --ignore-cloud "$OLD_ABS" 2>/dev/null)"
+  brc=$?
+  set -e
+  if [ "$brc" != 0 ]; then
+    if [ "$ENSURE_BACKUP" = 1 ]; then
+      # No surviving backup, but the caller asked us to STAND ONE UP. Do it, then
+      # RE-CHECK through the same single source of truth — never trust the stand-up's
+      # own exit code alone. A stand-up that "succeeds" but lands no archive must
+      # still refuse the move (fail-closed; no silent no-op). Dry-run only previews.
+      ensure_backup_standup
+      if [ "$DRYRUN" != 1 ]; then
+        set +e
+        BACKUP_TOKEN="$(python3 "$backup_guard" --porcelain --ignore-cloud "$OLD_ABS" 2>/dev/null)"
+        brc=$?
+        set -e
+        if [ "$brc" != 0 ]; then
+          die "backup stand-up reported success but no surviving backup is detectable (${BACKUP_TOKEN:-none}) — NOT moving the vault (fail-closed; your vault is untouched).
+  Check the backup destination, then re-run; or re-run with --force to move without the check." 1
+        fi
+      fi
+    else
       die "no verified off-machine backup of '$OLD_ABS' that survives this move (${BACKUP_TOKEN:-backup check failed}).
   Moving a vault with no backup is the one move you cannot undo if the disk dies mid-flight.
   A cloud-sync copy does NOT count here — this move takes the vault OUT of the sync folder, so that copy goes away too.
-  Stand up + verify a backup first (one command), then re-run:
+  Hands-off fix — stand up a verified backup AND move, in ONE step:
+    bash \"$0\" --ensure-backup \"$OLD_ABS\" \"$NEW_ABS\"
+  Or stand it up yourself first, then re-run this move:
     bash \"$SCRIPT_DIR/vault-backup.sh\" setup && bash \"$SCRIPT_DIR/vault-backup.sh\" verify
   Or move anyway, accepting the risk: re-run with --force."
     fi
-  else
-    die "cannot verify a backup — the guard is missing ($backup_guard). Restore it, or re-run with --force to move without the check."
   fi
 fi
 
@@ -329,8 +401,11 @@ if [ "$FORCE" = 1 ]; then
   warn "relocate-vault: --force — skipping the backup check. A vault is often your one"
   warn "  irreplaceable asset; stand up + verify an off-machine backup as soon as the move lands:"
   warn "    bash \"$SCRIPT_DIR/vault-backup.sh\" setup && bash \"$SCRIPT_DIR/vault-backup.sh\" verify"
-else
+elif [ "$brc" = 0 ]; then
   say "relocate-vault: verified off-machine backup present (${BACKUP_TOKEN}) — proceeding."
+else
+  # Reachable only under --dry-run --ensure-backup: no real backup yet, just previewing.
+  say "relocate-vault: (dry-run) a verified backup would be stood up before the move."
 fi
 say ""
 

--- a/scripts/test-relocate-vault.sh
+++ b/scripts/test-relocate-vault.sh
@@ -20,6 +20,13 @@
 #     cloud-sync it's being moved OUT of REFUSES (that copy doesn't survive the
 #     move); a cloud vault with a surviving backup (archive/TM/git-remote) still
 #     PROCEEDS.
+#   - ENSURE-BACKUP (MYC-2404): --ensure-backup STANDS UP a verified backup as
+#     part of the flow so a non-technical user reaches a backed-up, relocated
+#     vault in ONE approved step (no --force, no vault-backup.sh by hand).
+#     Negative controls prove fail-closed: a stand-up that FAILS at setup, and a
+#     stand-up that reports success but lands NO archive, BOTH refuse the move and
+#     preserve the vault. A real vault-backup.sh stand-up proceeds; a pre-existing
+#     surviving backup skips the stand-up (idempotent).
 # Hermetic: a temp HOME-like sandbox + an isolated --config-dir; the real
 # ~/.claude is never touched.
 # Run: bash scripts/test-relocate-vault.sh
@@ -180,6 +187,113 @@ CLAUDE_CONFIG_DIR="$CFG" VAULT_BACKUP_CONF="$CL2_CONF" VAULT_BACKUP_SKIP_TIMEMAC
              || fail "cloud vault with a surviving archive should proceed, got rc=$rc"
 { [ -d "$cl2_dst" ] && [ -L "$cl2_src" ]; } && pass "cloud+archive move-out: moved + symlink left" \
              || fail "cloud+archive: did not relocate"
+
+# --- 9. ENSURE-BACKUP (MYC-2404): stand up the backup, don't just refuse --------
+# The MYC-2382 gate REFUSES a backup-less move but leaves a non-technical user
+# stuck (they don't know --force and won't run vault-backup.sh by hand). --ensure
+# -backup STANDS UP a verified off-machine backup as part of the move — one step.
+# The whole point is safety, so the negative controls come FIRST: a stand-up that
+# fails MUST NOT move the vault (fail-closed preserves; it never destroys).
+# VAULT_BACKUP_CMD lets these tests inject a stub backup tool deterministically.
+
+# Stub A: FAILS on setup (unreachable/denied dest, disk full, etc.).
+STUB_FAIL="$TMP/vault-backup-fail.sh"
+cat > "$STUB_FAIL" <<'STUB'
+#!/usr/bin/env bash
+echo "stub: simulated backup failure ($1)" >&2
+exit 1
+STUB
+chmod +x "$STUB_FAIL"
+
+# Stub B: pretends success (exit 0) but lands NO archive + writes NO conf. The
+# re-check must still catch that nothing survives and refuse (no silent no-op).
+STUB_LIE="$TMP/vault-backup-lie.sh"
+cat > "$STUB_LIE" <<'STUB'
+#!/usr/bin/env bash
+echo "stub: reports success but lands nothing ($1)"
+exit 0
+STUB
+chmod +x "$STUB_LIE"
+
+# 9a NEGATIVE CONTROL: stand-up FAILS at setup -> refuse, vault preserved.
+eb1_src="$TMP/eb-fail-src" ; eb1_dst="$TMP/eb-fail-dst"
+mkdir -p "$eb1_src" ; echo n > "$eb1_src/n.md"
+out="$(CLAUDE_CONFIG_DIR="$CFG" VAULT_BACKUP_CONF="$NOBK_CONF" VAULT_BACKUP_SKIP_TIMEMACHINE=1 \
+       VAULT_BACKUP_CMD="$STUB_FAIL" \
+       bash "$SCRIPT" --ensure-backup "$eb1_src" "$eb1_dst" 2>&1)" ; rc=$?
+[ "$rc" != 0 ] && pass "ensure-backup NC1: stand-up fails at setup -> refuses the move (rc=$rc)" \
+               || fail "ensure-backup NC1: expected a refusal when stand-up fails, moved with rc=$rc"
+{ [ -d "$eb1_src" ] && [ ! -L "$eb1_src" ] && [ -f "$eb1_src/n.md" ] && [ ! -e "$eb1_dst" ]; } \
+  && pass "ensure-backup NC1: vault NOT moved on stand-up failure (fail-closed preserves)" \
+  || fail "ensure-backup NC1: vault was moved/altered despite the stand-up failure"
+echo "$out" | grep -qiE 'fail-closed|not moving|untouched' \
+  && pass "ensure-backup NC1: refusal explains it is fail-closed" \
+  || fail "ensure-backup NC1: refusal lacked a fail-closed explanation: $out"
+
+# 9b NEGATIVE CONTROL: stand-up returns 0 but no surviving backup -> re-check refuses.
+eb2_src="$TMP/eb-lie-src" ; eb2_dst="$TMP/eb-lie-dst"
+mkdir -p "$eb2_src" ; echo n > "$eb2_src/n.md"
+out="$(CLAUDE_CONFIG_DIR="$CFG" VAULT_BACKUP_CONF="$NOBK_CONF" VAULT_BACKUP_SKIP_TIMEMACHINE=1 \
+       VAULT_BACKUP_CMD="$STUB_LIE" \
+       bash "$SCRIPT" --ensure-backup "$eb2_src" "$eb2_dst" 2>&1)" ; rc=$?
+[ "$rc" != 0 ] && pass "ensure-backup NC2: stand-up 'succeeds' but no archive -> re-check refuses (rc=$rc)" \
+               || fail "ensure-backup NC2: expected a refusal when no surviving backup materialized, rc=$rc"
+{ [ -d "$eb2_src" ] && [ ! -L "$eb2_src" ] && [ ! -e "$eb2_dst" ]; } \
+  && pass "ensure-backup NC2: vault NOT moved when stand-up produced no backup" \
+  || fail "ensure-backup NC2: vault moved despite no surviving backup"
+
+# 9c POSITIVE: the REAL vault-backup.sh stands up a verified archive -> move proceeds.
+# Hermetic: --backup-schedule none (no launchd/cron), temp conf/marker, temp dest.
+eb3_src="$TMP/eb-real-src" ; eb3_dst="$TMP/eb-real-dst"
+mkdir -p "$eb3_src/⚙️ Meta" ; echo "brain" > "$eb3_src/CLAUDE.md" ; echo "note" > "$eb3_src/note.md"
+EB3_DEST="$TMP/eb-real-backups"
+EB3_CONF="$TMP/eb-real-conf.json" ; echo '{}' > "$EB3_CONF"
+EB3_MARKER="$TMP/eb-real-marker"
+out="$(CLAUDE_CONFIG_DIR="$CFG" VAULT_BACKUP_CONF="$EB3_CONF" VAULT_BACKUP_MARKER="$EB3_MARKER" \
+       VAULT_BACKUP_SKIP_TIMEMACHINE=1 \
+       bash "$SCRIPT" --ensure-backup --backup-dest "$EB3_DEST" --backup-schedule none \
+            "$eb3_src" "$eb3_dst" 2>&1)" ; rc=$?
+[ "$rc" = 0 ] && pass "ensure-backup P1: real stand-up + verify -> move proceeds (rc=0)" \
+             || fail "ensure-backup P1: real stand-up should proceed, rc=$rc; out=$out"
+{ [ -d "$eb3_dst" ] && [ -L "$eb3_src" ] && [ "$(readlink "$eb3_src")" = "$eb3_dst" ]; } \
+  && pass "ensure-backup P1: vault moved + symlink left after stand-up" \
+  || fail "ensure-backup P1: vault not relocated as expected"
+ls "$EB3_DEST"/vault-backup-*.tar.gz >/dev/null 2>&1 \
+  && pass "ensure-backup P1: a real verified archive was stood up BEFORE the move" \
+  || fail "ensure-backup P1: no archive found in $EB3_DEST"
+
+# 9d POSITIVE (idempotent): a pre-existing surviving backup skips the stand-up.
+# VAULT_BACKUP_CMD points at the FAIL stub — if the stand-up were (wrongly) invoked
+# the move would refuse; it proceeds only because a backup already exists.
+eb4_src="$TMP/eb-idem-src" ; eb4_dst="$TMP/eb-idem-dst"
+mkdir -p "$eb4_src" ; echo n > "$eb4_src/n.md"
+EB4_RES="$(cd "$eb4_src" && pwd -P)"
+EB4_DEST="$TMP/eb-idem-backups" ; mkdir -p "$EB4_DEST" ; touch "$EB4_DEST/vault-backup-now.tar.gz"
+EB4_CONF="$TMP/eb-idem-conf.json"
+printf '{"vaults": {"%s": {"dest": "%s", "archive_stem": "vault-backup"}}}\n' "$EB4_RES" "$EB4_DEST" > "$EB4_CONF"
+CLAUDE_CONFIG_DIR="$CFG" VAULT_BACKUP_CONF="$EB4_CONF" VAULT_BACKUP_SKIP_TIMEMACHINE=1 \
+  VAULT_BACKUP_CMD="$STUB_FAIL" \
+  bash "$SCRIPT" --ensure-backup "$eb4_src" "$eb4_dst" >/dev/null 2>&1 ; rc=$?
+[ "$rc" = 0 ] && pass "ensure-backup P2: pre-existing backup -> stand-up skipped, move proceeds (rc=0)" \
+             || fail "ensure-backup P2: pre-existing backup should skip stand-up + proceed, rc=$rc"
+{ [ -d "$eb4_dst" ] && [ -L "$eb4_src" ]; } \
+  && pass "ensure-backup P2: idempotent -> moved + symlink (fail-stub never invoked)" \
+  || fail "ensure-backup P2: did not relocate with a pre-existing backup"
+
+# 9e DRY-RUN: --ensure-backup --dry-run previews the stand-up + move, changes nothing.
+eb5_src="$TMP/eb-dry-src" ; eb5_dst="$TMP/eb-dry-dst"
+mkdir -p "$eb5_src" ; echo n > "$eb5_src/n.md"
+out="$(CLAUDE_CONFIG_DIR="$CFG" VAULT_BACKUP_CONF="$NOBK_CONF" VAULT_BACKUP_SKIP_TIMEMACHINE=1 \
+       VAULT_BACKUP_CMD="$STUB_FAIL" \
+       bash "$SCRIPT" --ensure-backup --dry-run "$eb5_src" "$eb5_dst" 2>&1)" ; rc=$?
+[ "$rc" = 0 ] && pass "ensure-backup 9e: --dry-run previews without refusing (rc=0)" \
+             || fail "ensure-backup 9e: --dry-run should not refuse/execute, rc=$rc; out=$out"
+{ [ -d "$eb5_src" ] && [ ! -L "$eb5_src" ] && [ ! -e "$eb5_dst" ]; } \
+  && pass "ensure-backup 9e: --dry-run changed nothing (no stand-up, no move)" \
+  || fail "ensure-backup 9e: --dry-run mutated the filesystem"
+echo "$out" | grep -qi 'would' \
+  && pass "ensure-backup 9e: --dry-run names the stand-up it would run" \
+  || fail "ensure-backup 9e: --dry-run did not preview the stand-up: $out"
 
 echo
 if [ "$fails" -gt 0 ]; then echo "FAILED: $fails"; exit 1; fi


### PR DESCRIPTION
Refs MYC-2404. Parent MYC-2348.

## What

`relocate-vault.sh --ensure-backup` stands up a **verified** off-machine backup as part of the move, so a non-technical user on a melting cloud-sync setup reaches a backed-up, relocated vault in **one approved step**, without knowing `--force` or running `vault-backup.sh` by hand.

The MYC-2382 gate correctly REFUSES a backup-less relocate, but it only PRINTS the fix. The SessionStart cloud-sync offer (`worktree-footprint-signal.py`) literally promises *"I'll stand up a verified backup first."* A floor without a ceiling traps the exact non-technical user the offer is for. This makes the mechanism keep that promise.

## How

- `--ensure-backup`: on `NO_BACKUP`, run `vault-backup.sh setup` (snapshots immediately) plus `verify` (proves it restores), then RE-CHECK through `check-vault-backup.py --ignore-cloud` before moving. **Fail-closed:** a setup failure, a verify failure, or a stand-up that reports success but lands no archive all refuse the move and leave the vault untouched.
- `--backup-dest` picks the archive location (default `<parent-of-vault>/ai-brain-backups`: for a cloud vault that sibling is off-machine, and one archive file survives the move without re-storming the sync daemon). `--backup-schedule daily|none`.
- The POSIX cloud-sync offer's fallback now runs `relocate-vault.sh --ensure-backup`, so the one approved step stands up the backup itself. Windows `.ps1` parity rides on MYC-2383, which lacks even the refuse-gate today.
- `--dry-run` previews the stand-up plus move with no side effects.

## Tests

`test-relocate-vault.sh`, negative controls first (the whole point is safety): a stand-up that fails at `setup`, and one that reports success but lands no archive, both refuse the move and preserve the vault. Plus a real `vault-backup.sh` positive, an idempotent-skip (a pre-existing backup skips the redundant stand-up), and a dry-run preview. Full `ci.sh` green: 275 py_compile, 57 integration, shellcheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
