### PR TITLE
Harden vault aggregators: script-vault guard + backup-before-write (MYC-2439)

### DIFF
--- a/scripts/aggregate-decisions.py
+++ b/scripts/aggregate-decisions.py
@@ -17,14 +17,22 @@ Rotation (added 2026-05-03 after Decision Log hit 351 KB / +4600 lines/month):
   Default window: 6 months. Override via --inline-window-months.
 
 Usage:
-  VAULT_ROOT=/path/to/vault python3 aggregate-decisions.py
+  python3 aggregate-decisions.py                # vault auto-detected from script location
   python3 aggregate-decisions.py --dry-run
   python3 aggregate-decisions.py --no-legacy
   python3 aggregate-decisions.py --inline-window-months 12
+  VAULT_ROOT_FORCE=1 VAULT_ROOT=/other/vault python3 aggregate-decisions.py  # deliberate cross-vault
 
 Environment variables:
-  VAULT_ROOT   — absolute path to the Obsidian vault root.
-                 Defaults to $HOME/Documents/MyVault — CUSTOMIZE or set env var.
+  VAULT_ROOT        — absolute path to the vault root. Optional: by default the
+                      vault is auto-detected from this script's OWN location
+                      (⚙️ Meta/scripts/ → 2 levels up). If VAULT_ROOT is set but
+                      points at a DIFFERENT vault than the one this copy lives
+                      in, it is IGNORED (with a stderr warning) and the script's
+                      own vault is used — so a globally-exported VAULT_ROOT can't
+                      silently redirect a ported copy at the wrong vault.
+  VAULT_ROOT_FORCE  — set to 1 to honor VAULT_ROOT even when it differs from the
+                      script's own vault (deliberate cross-vault runs).
 
 File format (Decisions/ entries):
   Each file must start with YAML frontmatter containing:
@@ -53,9 +61,37 @@ import re
 import sys
 from pathlib import Path
 
-# Auto-detect from script location (⚙️ Meta/scripts/ → 2 levels up), or override via env var.
-_SCRIPT_DIR = Path(__file__).resolve().parent
-VAULT_ROOT = Path(os.environ.get("VAULT_ROOT", str(_SCRIPT_DIR.parent.parent)))
+# --- VAULT_ROOT resolution ------------------------------------------------
+# Ground truth is THIS script's own location: ⚙️ Meta/scripts/ → 2 levels up
+# is the vault this physical copy belongs to. A VAULT_ROOT env var is honored
+# only when it points at that same vault, or when the caller explicitly sets
+# VAULT_ROOT_FORCE=1.
+#
+# Why: a globally-exported VAULT_ROOT (e.g. a shell-profile export) otherwise
+# silently redirects EVERY copy of this script — including copies ported into
+# other vaults — at that one vault, causing wrong-vault reads and destructive
+# wrong-vault writes with NO error. Preferring the script's own location on
+# mismatch is fail-safe: a copy can only ever touch the vault it lives in.
+def _resolve_vault_root() -> tuple[Path, str]:
+    auto_root = Path(__file__).resolve().parent.parent.parent
+    env_raw = os.environ.get("VAULT_ROOT")
+    if not env_raw:
+        return auto_root, "auto-detect (script location)"
+    env_root = Path(os.path.expanduser(env_raw)).resolve()
+    if env_root == auto_root:
+        return env_root, "env VAULT_ROOT (matches script location)"
+    if os.environ.get("VAULT_ROOT_FORCE", "").strip().lower() in ("1", "true", "yes"):
+        return env_root, f"env VAULT_ROOT (FORCED, differs from script vault {auto_root})"
+    print(
+        f"WARNING: VAULT_ROOT env points at {env_root}, but this script lives in "
+        f"{auto_root}. Operating on the script's own vault ({auto_root}); this "
+        f"copy will NOT touch {env_root}. Set VAULT_ROOT_FORCE=1 to override.",
+        file=sys.stderr,
+    )
+    return auto_root, "auto-detect (env VAULT_ROOT ignored: vault mismatch)"
+
+
+VAULT_ROOT, _VAULT_ROOT_SOURCE = _resolve_vault_root()
 META_DIR = VAULT_ROOT / "⚙️ Meta"
 DECISIONS_DIR = META_DIR / "Decisions"
 DECISION_LOG = META_DIR / "Decision Log.md"
@@ -66,6 +102,28 @@ AGGREGATOR_END = "<!-- aggregate-decisions:END -->"
 LEGACY_HEADER = "## Legacy (pre-split) historical decisions"
 
 INLINE_WINDOW_MONTHS_DEFAULT = 6
+
+
+def _backup_before_write(path: Path, keep: int = 3) -> Path | None:
+    """Write a timestamped backup of `path` before it is overwritten, so a
+    bad aggregation — or a wrong-vault run that somehow slips past the
+    vault-root guard — can never silently destroy the prior good file. Keeps
+    the most recent `keep` backups (older ones pruned) so a file rebuilt on
+    every session-close never fills the vault with .bak files. Returns the
+    backup path, or None when there was nothing to back up."""
+    if not path.exists():
+        return None
+    stamp = dt.datetime.now().strftime("%Y-%m-%d-%H%M%S")
+    backup = path.with_name(f"{path.stem}.bak-{stamp}{path.suffix}")
+    backup.write_text(path.read_text(encoding="utf-8"), encoding="utf-8")
+    for old in sorted(
+        path.parent.glob(f"{path.stem}.bak-*{path.suffix}"), reverse=True
+    )[keep:]:
+        try:
+            old.unlink()
+        except OSError:
+            pass
+    return backup
 
 
 def preamble() -> str:
@@ -319,6 +377,8 @@ def main() -> int:
     )
     args = parser.parse_args()
 
+    print(f"VAULT_ROOT: {VAULT_ROOT}  [{_VAULT_ROOT_SOURCE}]")
+
     if not META_DIR.exists():
         print(
             f"ERROR: {META_DIR} does not exist. Set VAULT_ROOT env var "
@@ -395,16 +455,20 @@ def main() -> int:
             print(f"  ... +{len(archive_files) - 20} more")
         return 0
 
+    log_backup = _backup_before_write(DECISION_LOG)
     DECISION_LOG.write_text(new_content, encoding="utf-8")
     print(
         f"Aggregated {len(inline_files)} inline decision(s) into "
         f"{DECISION_LOG.name} ({len(new_content):,} bytes)"
+        + (f" [backup: {log_backup.name}]" if log_backup else "")
     )
     if archive_content is not None:
+        archive_backup = _backup_before_write(DECISION_LOG_ARCHIVE)
         DECISION_LOG_ARCHIVE.write_text(archive_content, encoding="utf-8")
         print(
             f"Archived {len(archive_files)} closed decision(s) to "
             f"{DECISION_LOG_ARCHIVE.name} ({len(archive_content):,} bytes)"
+            + (f" [backup: {archive_backup.name}]" if archive_backup else "")
         )
     return 0
 

--- a/scripts/aggregate-sessions.py
+++ b/scripts/aggregate-sessions.py
@@ -14,15 +14,22 @@ function of the sorted input, concurrent runs of this script produce
 identical output — safe against races.
 
 Usage:
-  VAULT_ROOT=/path/to/vault python3 aggregate-sessions.py
+  python3 aggregate-sessions.py                 # vault auto-detected from script location
   python3 aggregate-sessions.py --keep 5
   python3 aggregate-sessions.py --dry-run
   python3 aggregate-sessions.py --no-legacy
+  VAULT_ROOT_FORCE=1 VAULT_ROOT=/other/vault python3 aggregate-sessions.py  # deliberate cross-vault
 
 Environment variables:
-  VAULT_ROOT   — absolute path to the Obsidian vault root.
-                 Defaults to $HOME/Documents/MyVault — CUSTOMIZE THIS or
-                 set the env var in your shell / hook.
+  VAULT_ROOT        — absolute path to the vault root. Optional: by default the
+                      vault is auto-detected from this script's OWN location
+                      (⚙️ Meta/scripts/ → 2 levels up). If VAULT_ROOT is set but
+                      points at a DIFFERENT vault than the one this copy lives
+                      in, it is IGNORED (with a stderr warning) and the script's
+                      own vault is used — so a globally-exported VAULT_ROOT can't
+                      silently redirect a ported copy at the wrong vault.
+  VAULT_ROOT_FORCE  — set to 1 to honor VAULT_ROOT even when it differs from the
+                      script's own vault (deliberate cross-vault runs).
 
 File format (Sessions/ entries):
   Each file must start with YAML frontmatter containing:
@@ -62,10 +69,37 @@ import re
 import sys
 from pathlib import Path
 
-# VAULT_ROOT — auto-detect from script location (⚙️ Meta/scripts/ → 2 levels up),
-# or override via env var.
-_SCRIPT_DIR = Path(__file__).resolve().parent
-VAULT_ROOT = Path(os.environ.get("VAULT_ROOT", str(_SCRIPT_DIR.parent.parent)))
+# --- VAULT_ROOT resolution ------------------------------------------------
+# Ground truth is THIS script's own location: ⚙️ Meta/scripts/ → 2 levels up
+# is the vault this physical copy belongs to. A VAULT_ROOT env var is honored
+# only when it points at that same vault, or when the caller explicitly sets
+# VAULT_ROOT_FORCE=1.
+#
+# Why: a globally-exported VAULT_ROOT (e.g. a shell-profile export) otherwise
+# silently redirects EVERY copy of this script — including copies ported into
+# other vaults — at that one vault, causing wrong-vault reads and destructive
+# wrong-vault writes with NO error. Preferring the script's own location on
+# mismatch is fail-safe: a copy can only ever touch the vault it lives in.
+def _resolve_vault_root() -> tuple[Path, str]:
+    auto_root = Path(__file__).resolve().parent.parent.parent
+    env_raw = os.environ.get("VAULT_ROOT")
+    if not env_raw:
+        return auto_root, "auto-detect (script location)"
+    env_root = Path(os.path.expanduser(env_raw)).resolve()
+    if env_root == auto_root:
+        return env_root, "env VAULT_ROOT (matches script location)"
+    if os.environ.get("VAULT_ROOT_FORCE", "").strip().lower() in ("1", "true", "yes"):
+        return env_root, f"env VAULT_ROOT (FORCED, differs from script vault {auto_root})"
+    print(
+        f"WARNING: VAULT_ROOT env points at {env_root}, but this script lives in "
+        f"{auto_root}. Operating on the script's own vault ({auto_root}); this "
+        f"copy will NOT touch {env_root}. Set VAULT_ROOT_FORCE=1 to override.",
+        file=sys.stderr,
+    )
+    return auto_root, "auto-detect (env VAULT_ROOT ignored: vault mismatch)"
+
+
+VAULT_ROOT, _VAULT_ROOT_SOURCE = _resolve_vault_root()
 META_DIR = VAULT_ROOT / "⚙️ Meta"
 SESSIONS_DIR = META_DIR / "Sessions"
 LAST_SESSION = META_DIR / "Last Session.md"
@@ -73,6 +107,28 @@ LAST_SESSION = META_DIR / "Last Session.md"
 AGGREGATOR_BEGIN = "<!-- aggregate-sessions:BEGIN -->"
 AGGREGATOR_END = "<!-- aggregate-sessions:END -->"
 LEGACY_HEADER = "## Legacy (pre-split) historical entries"
+
+
+def _backup_before_write(path: Path, keep: int = 3) -> Path | None:
+    """Write a timestamped backup of `path` before it is overwritten, so a
+    bad aggregation — or a wrong-vault run that somehow slips past the
+    vault-root guard — can never silently destroy the prior good file. Keeps
+    the most recent `keep` backups (older ones pruned) so a file rebuilt on
+    every session-close never fills the vault with .bak files. Returns the
+    backup path, or None when there was nothing to back up."""
+    if not path.exists():
+        return None
+    stamp = dt.datetime.now().strftime("%Y-%m-%d-%H%M%S")
+    backup = path.with_name(f"{path.stem}.bak-{stamp}{path.suffix}")
+    backup.write_text(path.read_text(encoding="utf-8"), encoding="utf-8")
+    for old in sorted(
+        path.parent.glob(f"{path.stem}.bak-*{path.suffix}"), reverse=True
+    )[keep:]:
+        try:
+            old.unlink()
+        except OSError:
+            pass
+    return backup
 
 
 def preamble() -> str:
@@ -247,6 +303,8 @@ def main() -> int:
     )
     args = parser.parse_args()
 
+    print(f"VAULT_ROOT: {VAULT_ROOT}  [{_VAULT_ROOT_SOURCE}]")
+
     if not META_DIR.exists():
         print(
             f"ERROR: {META_DIR} does not exist. Set VAULT_ROOT env var "
@@ -304,10 +362,12 @@ def main() -> int:
             print(f"  - {f.name}")
         return 0
 
+    backup = _backup_before_write(LAST_SESSION)
     LAST_SESSION.write_text(new_content, encoding="utf-8")
     print(
         f"Aggregated {min(args.keep, len(files))} of {len(files)} session(s) "
         f"into {LAST_SESSION.name} ({len(new_content):,} bytes)"
+        + (f" [backup: {backup.name}]" if backup else "")
     )
     return 0
 

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -106,6 +106,7 @@ INTEGRATION_TESTS=(
   test_context_load_selftest
   test_verify_cascade_failsafe
   test_verify_cascade_repo_aware_vault
+  test_aggregator_vault_root_guard
   test_discoverability_partition
   test_stranded_session_artifacts_watchdog
   test_session_coordination_guards

--- a/scripts/decision-outcome-check.py
+++ b/scripts/decision-outcome-check.py
@@ -31,16 +31,35 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _meta_resolver import find_meta_dir  # noqa: E402
 
 
-def detect_vault_root() -> Path:
-    """Detect vault root from $VAULT_ROOT env var or script location."""
-    env_root = os.environ.get("VAULT_ROOT")
-    if env_root:
-        return Path(env_root)
-    script_dir = Path(__file__).resolve().parent
-    candidate = script_dir.parent.parent
-    if (candidate / "⚙️ Meta").is_dir():
-        return candidate
-    return Path.cwd()
+def _resolve_vault_root(cli_override: Path | None) -> tuple[Path, str]:
+    """Resolve the vault root, defeating the inherited-VAULT_ROOT footgun.
+
+    Precedence: an explicit --vault-root is honored; otherwise the vault is
+    auto-detected from THIS script's own location (⚙️ Meta/scripts/ → 2 levels
+    up). An ambient VAULT_ROOT env var is honored ONLY when it matches the
+    script's own vault, or when VAULT_ROOT_FORCE=1 (deliberate cross-vault).
+    Otherwise it is ignored (with a stderr warning) and the script's own vault
+    is used — so a globally-exported VAULT_ROOT can't silently redirect a
+    ported copy at the wrong vault, causing wrong-vault reads and destructive
+    wrong-vault writes with NO error."""
+    if cli_override is not None:
+        return cli_override.resolve(), "--vault-root (explicit)"
+    auto_root = Path(__file__).resolve().parent.parent.parent
+    env_raw = os.environ.get("VAULT_ROOT")
+    if not env_raw:
+        return auto_root, "auto-detect (script location)"
+    env_root = Path(os.path.expanduser(env_raw)).resolve()
+    if env_root == auto_root:
+        return env_root, "env VAULT_ROOT (matches script location)"
+    if os.environ.get("VAULT_ROOT_FORCE", "").strip().lower() in ("1", "true", "yes"):
+        return env_root, f"env VAULT_ROOT (FORCED, differs from script vault {auto_root})"
+    print(
+        f"WARNING: VAULT_ROOT env points at {env_root}, but this script lives in "
+        f"{auto_root}. Operating on the script's own vault ({auto_root}); this "
+        f"copy will NOT touch {env_root}. Set VAULT_ROOT_FORCE=1 to override.",
+        file=sys.stderr,
+    )
+    return auto_root, "auto-detect (env VAULT_ROOT ignored: vault mismatch)"
 
 
 # Decision entries use this shape:
@@ -70,6 +89,28 @@ PLACEHOLDER_RE = re.compile(r"^\s*\*?\(fill in|\*\(verify|\*\(measure|\*\(check"
 # accumulating duplicates.
 PRIORITIES_MARKER_START = "<!-- decision-outcome-check: START -->"
 PRIORITIES_MARKER_END = "<!-- decision-outcome-check: END -->"
+
+
+def _backup_before_write(path: Path, keep: int = 3) -> Path | None:
+    """Write a timestamped backup of `path` before it is overwritten, so a
+    bad rewrite — or a wrong-vault run that somehow slips past the vault-root
+    guard — can never silently destroy the prior good file. Keeps the most
+    recent `keep` backups (older ones pruned) so repeated runs never fill the
+    vault with .bak files. Returns the backup path, or None when there was
+    nothing to back up."""
+    if not path.exists():
+        return None
+    stamp = dt.datetime.now().strftime("%Y-%m-%d-%H%M%S")
+    backup = path.with_name(f"{path.stem}.bak-{stamp}{path.suffix}")
+    backup.write_text(path.read_text(encoding="utf-8"), encoding="utf-8")
+    for old in sorted(
+        path.parent.glob(f"{path.stem}.bak-*{path.suffix}"), reverse=True
+    )[keep:]:
+        try:
+            old.unlink()
+        except OSError:
+            pass
+    return backup
 
 
 def parse_decisions(content: str) -> list[dict]:
@@ -170,7 +211,8 @@ def main() -> int:
                         help="Path to vault root (default: auto-detected)")
     args = parser.parse_args()
 
-    vault_root = (args.vault_root or detect_vault_root()).resolve()
+    vault_root, _source = _resolve_vault_root(args.vault_root)
+    print(f"VAULT_ROOT: {vault_root}  [{_source}]")
     meta_dir = find_meta_dir(vault_root) or (vault_root / "Meta")
 
     decision_log = meta_dir / "Decision Log.md"
@@ -214,12 +256,12 @@ def main() -> int:
         print("No changes to Current Priorities.md.")
         return 0
 
-    backup = priorities.with_name(
-        f"{priorities.stem}.bak-{dt.datetime.now().strftime('%Y-%m-%d-%H%M')}{priorities.suffix}"
-    )
-    backup.write_text(priorities_content, encoding="utf-8")
+    backup = _backup_before_write(priorities)
     priorities.write_text(updated, encoding="utf-8")
-    print(f"Updated {priorities.name} (backup: {backup.name})")
+    print(
+        f"Updated {priorities.name}"
+        + (f" (backup: {backup.name})" if backup else "")
+    )
     return 0
 
 

--- a/tests/integration/test_aggregator_vault_root_guard.sh
+++ b/tests/integration/test_aggregator_vault_root_guard.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Test: the vault aggregators never clobber a FOREIGN vault on an inherited
+# VAULT_ROOT, and they back up the target before overwriting it (MYC-2439).
+#
+# Bug class this guards: a globally-exported VAULT_ROOT (a shell-profile
+# export is a real, common case) beat the scripts' own autodetect, so ANY
+# copy run WITHOUT an explicit per-invocation VAULT_ROOT= silently operated
+# on — and overwrote, with NO backup — the WRONG vault's Last Session.md /
+# Decision Log.md / Current Priorities.md. Silent data-loss + cross-vault-leak.
+#
+# The fix has two legs, both asserted here against REAL copies of the scripts:
+#   (a) _resolve_vault_root() prefers the script's OWN vault; a mismatched
+#       ambient VAULT_ROOT is ignored (with a stderr warning), so a foreign
+#       vault is never touched. NEGATIVE CONTROL: VAULT_ROOT_FORCE=1 proves the
+#       env var CAN still redirect when explicitly opted in — so the unforced
+#       protection is real, not vacuous.
+#   (b) _backup_before_write() snapshots the target before every overwrite, so
+#       even a forced run can't destroy the prior good file.
+#
+# Self-contained: tmpdir fake vaults, copies of the real scripts. Exit 0 = pass.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SESSIONS_SRC="$REPO_ROOT/scripts/aggregate-sessions.py"
+DECISIONS_SRC="$REPO_ROOT/scripts/aggregate-decisions.py"
+OUTCOME_SRC="$REPO_ROOT/scripts/decision-outcome-check.py"
+for s in "$SESSIONS_SRC" "$DECISIONS_SRC" "$OUTCOME_SRC"; do
+  [ -f "$s" ] || { echo "ERROR: $s not found" >&2; exit 1; }
+done
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+SENTINEL="SENTINEL_DO_NOT_CLOBBER_$$"
+pass() { echo "PASS: $1"; }
+fail() { echo "FAIL: $1" >&2; [ -n "${2:-}" ] && sed 's/^/  /' "$2" >&2; exit 1; }
+newest_bak() {  # dir stem  ->  path of newest "<stem>.bak-*.md", or ""
+  find "$1" -maxdepth 1 -name "$2.bak-*.md" -print 2>/dev/null | sort | tail -1
+}
+
+# --- Build two fake vaults -------------------------------------------------
+# vault_a: the vault the script COPIES physically live in (their own vault).
+# vault_b: a DIFFERENT vault, standing in for the personal vault that a global
+#          VAULT_ROOT points at.
+make_session() {  # vault_dir label
+  cat > "$1/⚙️ Meta/Sessions/2026-07-01T1200-$2.md" <<EOF
+---
+creationDate: 2026-07-01
+type: session
+worktree: main
+session_date: 2026-07-01
+session_label: "$2 session"
+---
+# Session — $2
+$2 body line
+EOF
+}
+make_decision() {  # vault_dir label
+  cat > "$1/⚙️ Meta/Decisions/2026-07-01-$2.md" <<EOF
+---
+creationDate: 2026-07-01
+type: decision
+decision_date: 2026-07-01
+outcome: pending
+---
+# Decision $2
+$2 decision body
+EOF
+}
+
+for v in vault_a vault_b; do
+  mkdir -p "$TMP/$v/⚙️ Meta/scripts" "$TMP/$v/⚙️ Meta/Sessions" "$TMP/$v/⚙️ Meta/Decisions"
+done
+
+# The script COPIES live under vault_a → vault_a is their "own" vault.
+cp "$SESSIONS_SRC"  "$TMP/vault_a/⚙️ Meta/scripts/aggregate-sessions.py"
+cp "$DECISIONS_SRC" "$TMP/vault_a/⚙️ Meta/scripts/aggregate-decisions.py"
+cp "$OUTCOME_SRC"   "$TMP/vault_a/⚙️ Meta/scripts/decision-outcome-check.py"
+# decision-outcome-check.py imports a sibling module — copy it too.
+cp "$REPO_ROOT/scripts/_meta_resolver.py" "$TMP/vault_a/⚙️ Meta/scripts/_meta_resolver.py"
+A_SESSIONS="$TMP/vault_a/⚙️ Meta/scripts/aggregate-sessions.py"
+A_DECISIONS="$TMP/vault_a/⚙️ Meta/scripts/aggregate-decisions.py"
+A_OUTCOME="$TMP/vault_a/⚙️ Meta/scripts/decision-outcome-check.py"
+
+make_session  "$TMP/vault_a" a
+make_session  "$TMP/vault_b" b
+make_decision "$TMP/vault_a" a
+make_decision "$TMP/vault_b" b
+
+A_META="$TMP/vault_a/⚙️ Meta"
+B_META="$TMP/vault_b/⚙️ Meta"
+A_LAST="$A_META/Last Session.md"
+
+# Sentinels in vault_b's OUTPUT files — these must survive a foreign run.
+printf '%s last-session\n'      "$SENTINEL" > "$B_META/Last Session.md"
+printf '%s decision-log\n'      "$SENTINEL" > "$B_META/Decision Log.md"
+# decision-outcome-check reads Decision Log.md and writes Current Priorities.md.
+printf '# Decision Log\n\n### 2026-01-01 — Old\n- **Outcome:**\n' > "$A_META/Decision Log.md"
+printf '# Current Priorities\n\n*live*\n'                          > "$A_META/Current Priorities.md"
+printf '%s current-priorities\n' "$SENTINEL"                       > "$B_META/Current Priorities.md"
+
+# --- 1. No-clobber: aggregate-sessions with a mismatched VAULT_ROOT ---------
+err="$TMP/err1.txt"
+VAULT_ROOT="$B_META/.." python3 "$A_SESSIONS" >/dev/null 2>"$err"
+grep -q "$SENTINEL" "$B_META/Last Session.md" \
+  || fail "aggregate-sessions clobbered the FOREIGN vault's Last Session.md" "$err"
+grep -q "<!-- aggregate-sessions:BEGIN -->" "$B_META/Last Session.md" \
+  && fail "aggregate-sessions rewrote the FOREIGN vault's Last Session.md (should be untouched)"
+pass "aggregate-sessions leaves a foreign (mismatched VAULT_ROOT) vault untouched"
+[ -f "$A_LAST" ] || fail "aggregate-sessions did not write its OWN vault's Last Session.md" "$err"
+grep -q "$SENTINEL" "$A_LAST" && fail "own-vault output unexpectedly contains the foreign sentinel"
+pass "aggregate-sessions wrote its OWN vault instead"
+grep -q "WARNING: VAULT_ROOT env points at" "$err" \
+  || fail "no stderr warning when a mismatched VAULT_ROOT is ignored" "$err"
+pass "aggregate-sessions warns on stderr when it ignores a mismatched VAULT_ROOT"
+
+# --- 2. No-clobber: aggregate-decisions with a mismatched VAULT_ROOT --------
+VAULT_ROOT="$B_META/.." python3 "$A_DECISIONS" >/dev/null 2>/dev/null
+grep -q "$SENTINEL" "$B_META/Decision Log.md" \
+  || fail "aggregate-decisions clobbered the FOREIGN vault's Decision Log.md"
+pass "aggregate-decisions leaves a foreign (mismatched VAULT_ROOT) vault untouched"
+
+# --- 3. No-clobber: decision-outcome-check with a mismatched VAULT_ROOT -----
+VAULT_ROOT="$B_META/.." python3 "$A_OUTCOME" >/dev/null 2>/dev/null
+grep -q "$SENTINEL" "$B_META/Current Priorities.md" \
+  || fail "decision-outcome-check clobbered the FOREIGN vault's Current Priorities.md"
+pass "decision-outcome-check leaves a foreign (mismatched VAULT_ROOT) vault untouched"
+
+# --- 4. Backup-before-write in the script's OWN vault ----------------------
+before="$(cat "$A_LAST")"
+make_session "$TMP/vault_a" a2          # change the input so the re-run differs
+python3 "$A_SESSIONS" >/dev/null 2>/dev/null   # auto-detect, own vault
+bak="$(newest_bak "$A_META" "Last Session")"
+[ -n "$bak" ] || fail "aggregate-sessions did not back up Last Session.md before overwriting"
+[ "$(cat "$bak")" = "$before" ] || fail "backup does not contain the prior good content"
+pass "aggregate-sessions backs up the prior Last Session.md before overwriting"
+
+# --- 5. NEGATIVE CONTROL: FORCE operates cross-vault BUT still backs up -----
+# Proves the unforced protection above is real (the env var CAN redirect when
+# opted in) AND that even a forced cross-vault write preserves the prior file.
+VAULT_ROOT_FORCE=1 VAULT_ROOT="$B_META/.." python3 "$A_SESSIONS" >/dev/null 2>/dev/null
+b_bak="$(newest_bak "$B_META" "Last Session")"
+[ -n "$b_bak" ] || fail "forced cross-vault run did not back up the target vault's Last Session.md"
+grep -q "$SENTINEL" "$b_bak" || fail "forced-run backup does not preserve the prior sentinel content"
+grep -q "<!-- aggregate-sessions:BEGIN -->" "$B_META/Last Session.md" \
+  || fail "forced run did not rewrite the target vault's Last Session.md (FORCE ignored?)"
+pass "VAULT_ROOT_FORCE=1 operates cross-vault but backs up the target first (no destructive clobber)"
+
+echo
+echo "All assertions passed. Aggregators honor the vault-root guard + backup-before-write (MYC-2439)."


### PR DESCRIPTION
## Aggregators never silently target — or clobber — the wrong vault

`aggregate-sessions.py`, `aggregate-decisions.py`, and `decision-outcome-check.py` resolved their target vault as `os.environ.get("VAULT_ROOT", <autodetect from script location>)`. A globally-exported `VAULT_ROOT` (a shell-profile export is common) therefore **beat** autodetect, so any copy of these scripts run without an explicit per-invocation `VAULT_ROOT=` silently operated on that one vault — a wrong-vault read, and for the two aggregators (which overwrote their output with **no backup**) a silent wrong-vault clobber.

### Fix (two legs)
- **`_resolve_vault_root`** — ground-truth is the script's OWN location. A mismatched ambient `VAULT_ROOT` is ignored with a stderr warning; `VAULT_ROOT_FORCE=1` is the deliberate-cross-vault escape hatch. The resolved root + its source is printed on every run (not just `--dry-run`), so a wrong-vault run is at least visible in logs. `decision-outcome-check` keeps its `--vault-root` flag and `_meta_resolver` dual-`Meta` support.
- **`_backup_before_write`** — a timestamped `.bak` is written before every overwrite, pruned to the last 3 so a file rebuilt on every session-close never fills the vault with backups. `decision-outcome-check` is refactored onto the same helper.

### Verification
`tests/integration/test_aggregator_vault_root_guard.sh` (added to the `INTEGRATION_TESTS` allow-list in `scripts/ci.sh`) runs real copies of all three scripts against two tmpdir vaults and asserts: a mismatched `VAULT_ROOT` leaves the foreign vault untouched (no sentinel loss, no aggregator marker written) and warns; the target is backed up before overwrite; and `VAULT_ROOT_FORCE=1` operates cross-vault **but backs up first**. The no-clobber assertion was confirmed to **fail** when the guard is reverted, so it is not vacuous. Full `scripts/ci.sh` is green locally (py_compile 275 files + 58 integration tests + shellcheck).
