### PR TITLE
feat(relocate): warn loudly that --ensure-backup's stand-up is unencrypted (MYC-2512 phase 1)

### DIFF
--- a/scripts/relocate-vault.sh
+++ b/scripts/relocate-vault.sh
@@ -253,6 +253,17 @@ ensure_backup_standup() {  # uses $OLD_ABS $BACKUP_DEST $BACKUP_SCHEDULE $DRYRUN
     die "backup stand-up FAILED at 'verify' — the snapshot did not restore, so it is not a trustworthy backup. NOT moving the vault (fail-closed; your vault is untouched).
   Re-run once the backup verifies, or re-run with --force to move without a verified backup." 1
   fi
+  # The auto stand-up produces an UNENCRYPTED archive (setup ran without --encrypt,
+  # which needs an interactive passphrase and would break the one-step flow). Say so
+  # LOUDLY: this path only runs when there is no Time Machine / pushed git-remote, so
+  # the archive is the only backup, and its default home is often a synced cloud
+  # folder — and a vault may hold private notes. Do not silently drop a plaintext
+  # copy of someone's brain into their cloud.
+  warn "relocate-vault: the stand-up backup is NOT encrypted — it may contain private notes,"
+  warn "  and now lives in: $dest (often a synced cloud folder)."
+  warn "  To encrypt it, re-run the backup with --encrypt and RECORD the passphrase OFF this"
+  warn "  machine (a password manager) — a keychain-only passphrase dies with the disk:"
+  warn "    bash \"$backup_cmd\" setup --vault \"$OLD_ABS\" --dest \"$dest\" --encrypt"
   say "relocate-vault: backup stood up + verified — proceeding with the move."
 }
 
@@ -401,6 +412,7 @@ if [ "$FORCE" = 1 ]; then
   warn "relocate-vault: --force — skipping the backup check. A vault is often your one"
   warn "  irreplaceable asset; stand up + verify an off-machine backup as soon as the move lands:"
   warn "    bash \"$SCRIPT_DIR/vault-backup.sh\" setup && bash \"$SCRIPT_DIR/vault-backup.sh\" verify"
+  warn "  (or drop --force and add --ensure-backup to stand one up automatically BEFORE the move.)"
 elif [ "$brc" = 0 ]; then
   say "relocate-vault: verified off-machine backup present (${BACKUP_TOKEN}) — proceeding."
 else

--- a/scripts/test-relocate-vault.sh
+++ b/scripts/test-relocate-vault.sh
@@ -261,6 +261,11 @@ out="$(CLAUDE_CONFIG_DIR="$CFG" VAULT_BACKUP_CONF="$EB3_CONF" VAULT_BACKUP_MARKE
 ls "$EB3_DEST"/vault-backup-*.tar.gz >/dev/null 2>&1 \
   && pass "ensure-backup P1: a real verified archive was stood up BEFORE the move" \
   || fail "ensure-backup P1: no archive found in $EB3_DEST"
+# The auto stand-up is UNENCRYPTED — the move must say so loudly (privacy: a vault may
+# hold private notes and the archive often lands in a cloud folder). MYC-2512 phase 1.
+echo "$out" | grep -qiE 'not encrypted' \
+  && pass "ensure-backup P1: warns loudly that the stood-up backup is unencrypted" \
+  || fail "ensure-backup P1: missing the unencrypted-backup warning: $out"
 
 # 9d POSITIVE (idempotent): a pre-existing surviving backup skips the stand-up.
 # VAULT_BACKUP_CMD points at the FAIL stub — if the stand-up were (wrongly) invoked


### PR DESCRIPTION
Refs MYC-2512 (phase 1 mitigation). Parent MYC-2348.

## What

`--ensure-backup` (MYC-2404) runs `vault-backup.sh setup` without `--encrypt`, so the auto-stood-up archive is plaintext and its default home is a synced cloud sibling folder. Automation removed the moment a careful user would have added `--encrypt`, and a vault may hold private notes. The move now says so loudly and tells the user how to encrypt, including that the passphrase must be recorded off the machine (a keychain-only passphrase dies with the disk the backup exists to survive).

Also points the `--force` warning at `--ensure-backup` as the hands-off alternative.

## Scope

Immediate mitigation only. The durable fix, encrypt-by-default with a recoverable key, is MYC-2512 (stays open). A naive keychain-only auto-encrypt would be worse than plaintext (unreadable after the disk failure it protects against), which is why the durable fix needs a design decision rather than a flag flip.

## Tests

`test-relocate-vault.sh` P1 now asserts the unencrypted notice fires on the real stand-up path. Full `ci.sh` green: 275 py_compile, 60 integration, shellcheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)