### PR TITLE
feat(hooks): client-side deployed==committed drift surfacer (MYC-2507)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,22 @@ description: What's new in AI Brain Starter — plain English, no jargon
 
 ---
 
+## 2026-07-01: your machine now tells you if an auto-update half-landed
+
+**Who this affects:** everyone. This is the safety net for the auto-update in the entry just below.
+
+**The bug:** the previous entry made the auto-update install its own hooks the moment you pull them. But that install step is allowed to fail without stopping your session (that's on purpose — a stuck installer must never wedge your prompt). When it *does* fail, it prints one warning for that one turn and moves on. A few days later the auto-update looks, sees your checkout is already current, and does nothing — so the warning is gone for good and the hooks it never finished wiring just stay off. The result is a quieter version of the exact problem the auto-update was built to kill: your copy of the starter is up to date, but the hooks Claude actually runs are behind it, and nothing tells you. The daily "are you up to date?" check only compares your *download* to the latest — it never checks whether the download was actually *wired in*.
+
+**What's new:** every session now does a quick, local check that the hooks you've downloaded are actually the hooks that are turned on. If a background install half-landed, the next session says so in one line and gives you the single command to finish it. If everything's wired correctly (the normal case) you never hear a word. It's a plain file comparison — no network, no waiting, and it can never crash your session (any hiccup just makes it stay quiet).
+
+**Under the hood:** the check reuses the installer's own definition of which hooks belong to the starter, rather than keeping its own copy of that list — so it can't fall out of step the next time a hook is added (which would have been the same class of silent drift all over again). It deliberately ignores the handful of hooks that only turn on once you've set up a vault, since those are wired by a different step and were never part of what a background update touches.
+
+**New tests:** `tests/integration/test_deployed_hooks_behind.sh` — proves it stays silent on a real, correct install, fires (and names the culprit) when a hook is missing or a retired one is still wired, and never falsely flags a vault-only hook. Includes negative controls in both directions.
+
+**What you should do:** nothing. If your last update half-landed, your next session will tell you the one command to run.
+
+---
+
 ## 2026-07-01: updates now install themselves the moment you pull them
 
 **Who this affects:** everyone. This is about how the starter keeps itself up to date.

--- a/hooks.json
+++ b/hooks.json
@@ -266,6 +266,11 @@
           {
             "type": "command",
             "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/dev-hub-refresh-on-session-start.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'"
+          },
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/surface-deployed-hooks-behind.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'",
+            "statusMessage": "Checking deployed hooks match what was pulled (deploy-fails-open drift)..."
           }
         ]
       }

--- a/hooks/surface-deployed-hooks-behind.py
+++ b/hooks/surface-deployed-hooks-behind.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""SessionStart hook: surface when the DEPLOYED ai-brain-starter hook set in
+~/.claude/settings.json has fallen BEHIND the COMMITTED hooks.json in the
+checkout (MYC-2507). The client-facing twin of the maintainer-only
+surface-deployed-hook-drift.py.
+
+THE GAP THIS FILLS (bug class DEPLOY-FAILS-OPEN-SILENTLY-ON-CLIENT):
+MYC-720 made the ai-brain-starter CHECKOUT reach every machine — the auto-update
+(scripts/ai-brain-auto-update.sh) ff-pulls AND runs install-hooks-user-level.py
+itself. But that deploy step is fail-OPEN: if it times out / errors / rolls back,
+the updater emits a ONE-SHOT warning for that turn and moves on. The next ~6-day
+cycle finds HEAD == origin/main, so it no-ops (no pull, no re-deploy) and the
+warning is gone forever. Result: the checkout is current but ~/.claude/settings.json
+is STALE — deployed hooks != committed hooks.json — the exact silent-drift class
+MYC-720 fought, moved one level up. update-check.sh only checks CHECKOUT-behind
+(HEAD..origin), never deployed==committed; the maintainer detector is adelaida-
+skills-only. So a paying client whose deploy silently failed has ZERO signal.
+
+WHAT IT CHECKS (cheap, LOCAL only — no git, no network):
+  committed = the ABS-owned hooks in this checkout's hooks.json
+  deployed  = the ABS-owned hooks in ~/.claude/settings.json
+  drift  ==  a committed hook is MISSING from settings.json on its event, OR a
+             RETIRED hook is STILL wired there (the install should have removed it).
+On drift: one line + the one-command fix. Healthy install: silent (neg-control).
+A pinned install (~/.claude/.ai-brain-starter-pinned) is silent too — that file is
+the auto-update system's advertised opt-out, and a pinned client never runs the
+fail-open auto-deploy this hook watches, so nagging it would break the escape hatch.
+
+WHY IMPORT, NOT COPY, THE OWNERSHIP LOGIC: which hooks are "ai-brain-starter's",
+which are retired, and which depend on a vault is defined ONCE in
+install-hooks-user-level.py (ABS_FINGERPRINTS / ABS_OWNED_BASENAMES / _is_retired /
+_hook_depends_on_vault). A copied list here would rot the instant a hook is
+added — the SAME deployed!=committed drift class this hook exists to catch. So we
+import those predicates; a new hook is covered automatically once it is added to
+the installer's ABS_* lists (which wiring it requires anyway).
+
+SCOPE — NON-vault-dependent hooks only (for the MISSING direction): the auto-
+update deploy runs install-hooks-user-level.py WITHOUT a vault path, which PRUNES
+vault-content hooks (graph-context-hook.sh / session-end-hook.sh / write-hook.sh —
+[VAULT_PATH] with no ~/.claude fallback); those are wired later by /setup-brain
+with the real vault path, on a path this fail-open class never touches. Demanding
+them here would false-fire on every no-vault / pre-setup client. So this covers
+exactly the class the auto-update deploy can silently break, and stays quiet
+whether or not a vault exists. Comparing by BASENAME (not full command string)
+makes the diff invariant under [VAULT_PATH] substitution — no false positives from
+resolved-vs-placeholder paths.
+
+LIMITATION (honest): a detector can only fire once it is itself deployed, so it
+cannot report its own first-time non-deployment. After the first successful
+deploy it self-perpetuates and catches every subsequent stale deploy. Checkout-
+behind (HEAD..origin) is a sibling concern covered by update-check.sh and the
+maintainer detector's substrate-checkout section — deliberately NOT re-done here.
+
+Stdlib-only (json/os/sys/importlib/pathlib). Any error -> emit `{}` (fail-open: a
+SessionStart surfacer must never crash session start). Hermetically testable via
+ABS_SKILL_DIR (committed hooks.json source) + HOME/ABS_SETTINGS_JSON (deployed
+settings.json). Test + negative control: tests/integration/test_deployed_hooks_behind.sh.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+MAX_LISTED = 12
+FIX_CMD = (
+    "python3 ~/.claude/skills/ai-brain-starter/scripts/"
+    "install-hooks-user-level.py --quiet --fail-on-missing"
+)
+
+
+def _emit(message: str | None = None) -> None:
+    """SessionStart additionalContext (reaches the model) or `{}` (silent)."""
+    if message:
+        print(json.dumps({
+            "hookSpecificOutput": {
+                "hookEventName": "SessionStart",
+                "additionalContext": message,
+            }
+        }))
+    else:
+        print(json.dumps({}))
+    sys.exit(0)
+
+
+def _skill_dir() -> Path:
+    """The ai-brain-starter checkout this hook ships in — source of the COMMITTED
+    hooks.json. ABS_SKILL_DIR overrides (hermetic tests); default is resolved from
+    this file's location (hooks/<me>.py -> the checkout root)."""
+    env = os.environ.get("ABS_SKILL_DIR")
+    if env:
+        return Path(env)
+    return Path(__file__).resolve().parent.parent
+
+
+def _load_installer():
+    """Import the ownership predicates + retired lists from
+    install-hooks-user-level.py so this hook shares ONE source of truth with the
+    deploy step. Returns the module, or None (caller fails open)."""
+    candidates = [
+        Path(__file__).resolve().parent.parent / "scripts" / "install-hooks-user-level.py",
+        _skill_dir() / "scripts" / "install-hooks-user-level.py",
+        Path.home() / ".claude" / "skills" / "ai-brain-starter" / "scripts" / "install-hooks-user-level.py",
+    ]
+    for path in candidates:
+        try:
+            if not path.is_file():
+                continue
+            spec = importlib.util.spec_from_file_location("_abs_installer", path)
+            if spec is None or spec.loader is None:
+                continue
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            return mod
+        except Exception:
+            continue
+    return None
+
+
+def _load_json(path: Path) -> dict | None:
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        return data if isinstance(data, dict) else None
+    except Exception:
+        return None
+
+
+def _iter_commands(config: dict):
+    """Yield (event, command) for every hook command in a settings/hooks config,
+    defensive against missing keys and non-list shapes."""
+    for event, groups in (config.get("hooks") or {}).items():
+        if not isinstance(groups, list):
+            continue
+        for group in groups:
+            if not isinstance(group, dict):
+                continue
+            for hook in (group.get("hooks") or []):
+                if not isinstance(hook, dict):
+                    continue
+                cmd = hook.get("command", "")
+                if cmd:
+                    yield event, cmd
+
+
+def _committed_by_event(template: dict, owned_basenames, depends_on_vault) -> dict[str, set[str]]:
+    """event -> set of ABS-owned, NON-vault-dependent basenames the checkout ships.
+    Vault-dependent hooks are excluded (the auto-update deploy never wires them;
+    /setup-brain does, on a different path)."""
+    out: dict[str, set[str]] = {}
+    for event, cmd in _iter_commands(template):
+        if depends_on_vault(cmd):
+            continue
+        bns = owned_basenames(cmd)
+        if bns:
+            out.setdefault(event, set()).update(bns)
+    return out
+
+
+def _deployed_by_event(settings: dict, owned_basenames) -> dict[str, set[str]]:
+    """event -> set of ABS-owned basenames wired in settings.json (vault or not —
+    membership only; the missing-direction diff subtracts these)."""
+    out: dict[str, set[str]] = {}
+    for event, cmd in _iter_commands(settings):
+        bns = owned_basenames(cmd)
+        if bns:
+            out.setdefault(event, set()).update(bns)
+    return out
+
+
+def _retired_present(settings: dict, is_retired, retired_basenames, retired_fingerprints) -> list[str]:
+    """Human labels for RETIRED hooks still wired in settings.json (the deploy
+    should have un-wired them). Sorted, de-duplicated."""
+    labels: set[str] = set()
+    for _event, cmd in _iter_commands(settings):
+        if not is_retired(cmd):
+            continue
+        # Prefer a concrete retired basename; fall back to the fingerprint substring.
+        matched = [bn for bn in retired_basenames if bn in cmd]
+        if not matched:
+            matched = [fp for fp in retired_fingerprints if fp in cmd]
+        labels.add(matched[0] if matched else (cmd[:60] + "..."))
+    return sorted(labels)
+
+
+def _build_message(missing: dict[str, set[str]], retired: list[str]) -> str | None:
+    if not missing and not retired:
+        return None
+
+    # Flatten missing to (basename, [events]) for a stable, de-duplicated listing.
+    events_by_bn: dict[str, list[str]] = {}
+    for event, bns in missing.items():
+        for bn in bns:
+            events_by_bn.setdefault(bn, []).append(event)
+    missing_bns = sorted(events_by_bn)
+
+    n = len(missing_bns) + len(retired)
+    plural = "s" if n != 1 else ""
+    lines = [
+        "[deployed-hooks-behind]",
+        "",
+        (
+            f"{n} ai-brain-starter hook{plural} you pulled {'are' if n != 1 else 'is'} "
+            f"NOT correctly wired in ~/.claude/settings.json — the auto-update's deploy "
+            f"step (install-hooks-user-level.py) failed silently on this machine, so the "
+            f"checkout is current but the deployed hooks are stale (bug class "
+            f"DEPLOY-FAILS-OPEN-SILENTLY-ON-CLIENT). Re-run the deploy:"
+        ),
+        "",
+        "```bash",
+        FIX_CMD,
+        "```",
+    ]
+
+    if missing_bns:
+        m = len(missing_bns)
+        plural_m = "s" if m != 1 else ""
+        lines += [
+            "",
+            f"Pulled but not deployed ({m} hook{plural_m}):",
+        ]
+        for bn in missing_bns[:MAX_LISTED]:
+            evs = ", ".join(sorted(set(events_by_bn[bn])))
+            lines.append(f"- `{bn}` (event: {evs})")
+        if m > MAX_LISTED:
+            lines.append(f"- ... and {m - MAX_LISTED} more")
+
+    if retired:
+        r = len(retired)
+        plural_r = "s" if r != 1 else ""
+        lines += [
+            "",
+            f"Retired but still wired ({r} hook{plural_r} — the deploy should have removed {'them' if r != 1 else 'it'}):",
+        ]
+        for label in retired[:MAX_LISTED]:
+            lines.append(f"- `{label}`")
+        if r > MAX_LISTED:
+            lines.append(f"- ... and {r - MAX_LISTED} more")
+
+    return "\n".join(lines)
+
+
+def _drift_message() -> str | None:
+    installer = _load_installer()
+    if installer is None:
+        return None  # can't determine ownership -> fail open
+
+    try:
+        owned_basenames = installer._owned_basenames
+        is_retired = installer._is_retired
+        depends_on_vault = installer._hook_depends_on_vault
+        retired_basenames = installer.ABS_RETIRED_BASENAMES
+        retired_fingerprints = installer.ABS_RETIRED_FINGERPRINTS
+    except AttributeError:
+        return None  # installer shape changed -> fail open rather than misfire
+
+    committed_path = _skill_dir() / "hooks.json"
+    settings_path = Path(
+        os.environ.get("ABS_SETTINGS_JSON")
+        or (Path.home() / ".claude" / "settings.json")
+    )
+
+    # Honor the escape hatch the auto-update machinery advertises: a pinned user
+    # has disabled auto-update (ai-brain-auto-update.sh no-ops on this file), so
+    # they manage deploys by hand and the fail-open auto-deploy this hook watches
+    # can't even run for them. Nagging them would contradict the opt-out (operating
+    # rule: A Gate Must Honor the Escape Hatch It Advertises). Pin lives next to
+    # settings.json (~/.claude/.ai-brain-starter-pinned), same base the updater uses.
+    if (settings_path.parent / ".ai-brain-starter-pinned").exists():
+        return None
+
+    template = _load_json(committed_path)
+    settings = _load_json(settings_path)
+    # No committed source or no deployed target -> cannot prove drift -> silent.
+    if template is None or settings is None:
+        return None
+
+    committed = _committed_by_event(template, owned_basenames, depends_on_vault)
+    deployed = _deployed_by_event(settings, owned_basenames)
+
+    missing: dict[str, set[str]] = {}
+    for event, bns in committed.items():
+        gap = bns - deployed.get(event, set())
+        if gap:
+            missing[event] = gap
+
+    retired = _retired_present(settings, is_retired, retired_basenames, retired_fingerprints)
+
+    return _build_message(missing, retired)
+
+
+def main() -> None:
+    try:
+        json.load(sys.stdin)
+    except Exception:
+        pass
+    _emit(_drift_message())
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        # Absolute backstop: a SessionStart surfacer must never crash the session.
+        print(json.dumps({}))
+        sys.exit(0)

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -117,6 +117,7 @@ INTEGRATION_TESTS=(
   test_post_update_email_ask
   test_installer_retires_email_gate
   test_installer_relocates_moved_hooks
+  test_deployed_hooks_behind
   test_memory_routing_guard
   test_bootstrap_omits_vault_hooks
   test_bootstrap_brew_terminal_step

--- a/scripts/install-hooks-user-level.py
+++ b/scripts/install-hooks-user-level.py
@@ -103,6 +103,9 @@ ABS_FINGERPRINTS = [
     # Bare ~/dev hub-rot guard (read-time detection) + surfacer (MYC-1893):
     "ai-brain-starter/hooks/warn-stale-dev-checkout.py",
     "ai-brain-starter/hooks/dev-hub-refresh-on-session-start.py",
+    # Client-side deployed==committed drift detector (MYC-2507): surfaces when this
+    # deploy step itself failed silently and settings.json fell behind hooks.json.
+    "ai-brain-starter/hooks/surface-deployed-hooks-behind.py",
 ]
 
 # Path-divergence-robust matching: an ai-brain-starter hook may be wired at the
@@ -126,6 +129,8 @@ ABS_OWNED_BASENAMES = {
     "warn-stale-dev-checkout.py", "dev-hub-refresh-on-session-start.py",
     # Session-start context loaders (MYC-2359 UPS -> SessionStart relocation):
     "session-start-context.py", "inject-instinct-context.py",
+    # Client-side deployed==committed drift detector (MYC-2507):
+    "surface-deployed-hooks-behind.py",
 }
 
 # Hooks ai-brain-starter USED TO ship and has deliberately RETIRED. The

--- a/tests/integration/test_deployed_hooks_behind.sh
+++ b/tests/integration/test_deployed_hooks_behind.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# CI lock + negative control for the client-side deployed==committed hook drift
+# surfacer (MYC-2507, hooks/surface-deployed-hooks-behind.py).
+#
+# WHY: "a guard earns trust only by failing on the thing it catches" (fail-loud-
+# not-silent-noop). The auto-update's deploy step (install-hooks-user-level.py)
+# fails OPEN: on a silent failure the checkout is current but ~/.claude/settings.json
+# falls behind hooks.json, and the client gets ZERO signal. This surfacer closes
+# that gap; this test proves it fires on a stale deploy and stays silent on a
+# healthy one — both directions.
+#
+# Asserts:
+#   1. NEG-CONTROL: the detector is SILENT on exactly what the REAL installer
+#      produces from the REAL hooks.json (ties detection to the deploy's real
+#      output — no cry-wolf, and no drift between "committed" and "deployed").
+#   2. MISSING: a committed ABS hook removed from settings.json -> FIRES, names it,
+#      gives the one-command fix.
+#   3. RETIRED: a retired hook still wired in settings.json -> FIRES, names it.
+#   4. FAIL-OPEN: missing settings.json / missing hooks.json -> SILENT (never crash).
+#   5. VAULT-EXCLUSION (the key false-positive guard): a committed VAULT hook
+#      absent from a no-vault deploy -> SILENT (the deploy never wires vault hooks;
+#      /setup-brain does). A non-vault hook missing in the same fixture -> FIRES,
+#      and it must NOT name the vault hook.
+#
+# Stdlib python3 + bash only. No network, no git. Tmpdir removed on exit.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HOOK="$REPO_ROOT/hooks/surface-deployed-hooks-behind.py"
+INSTALLER="$REPO_ROOT/scripts/install-hooks-user-level.py"
+
+PASS=0; FAIL=0
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+ok()  { PASS=$((PASS + 1)); echo "  PASS  $1"; }
+bad() { FAIL=$((FAIL + 1)); echo "  FAIL  $1 :: ${2:-}"; }
+
+# run_hook SKILL_DIR SETTINGS_JSON — drive the detector with an explicit committed
+# hooks.json source (SKILL_DIR/hooks.json) and deployed settings.json path.
+run_hook() { OUT="$(ABS_SKILL_DIR="$1" ABS_SETTINGS_JSON="$2" python3 "$HOOK" <<<'{}' 2>/dev/null)"; }
+fired()       { printf '%s' "$OUT" | grep -q 'additionalContext'; }
+mentions()    { printf '%s' "$OUT" | grep -q "$1"; }
+notmentions() { ! printf '%s' "$OUT" | grep -q "$1"; }
+
+# strip_hook FILE BASENAME — remove every hook command referencing BASENAME.
+strip_hook() {
+  python3 - "$1" "$2" <<'PY'
+import json, sys
+f, bn = sys.argv[1], sys.argv[2]
+cfg = json.load(open(f))
+for ev, groups in (cfg.get("hooks") or {}).items():
+    for g in groups:
+        g["hooks"] = [h for h in g.get("hooks", []) if bn not in h.get("command", "")]
+json.dump(cfg, open(f, "w"), indent=2)
+PY
+}
+
+# inject_hook FILE EVENT COMMAND — append a hook command onto EVENT.
+inject_hook() {
+  python3 - "$1" "$2" "$3" <<'PY'
+import json, sys
+f, ev, cmd = sys.argv[1], sys.argv[2], sys.argv[3]
+cfg = json.load(open(f))
+cfg.setdefault("hooks", {}).setdefault(ev, [{"hooks": []}])
+cfg["hooks"][ev][0].setdefault("hooks", []).append({"type": "command", "command": cmd})
+json.dump(cfg, open(f, "w"), indent=2)
+PY
+}
+
+echo "=== 1. NEG-CONTROL: healthy deploy (real installer + real hooks.json) -> silent ==="
+H1="$TMP/case1"; mkdir -p "$H1/.claude"
+HOME="$H1" python3 "$INSTALLER" --hooks-source "$REPO_ROOT/hooks.json" \
+  --settings "$H1/.claude/settings.json" --quiet >/dev/null 2>&1
+run_hook "$REPO_ROOT" "$H1/.claude/settings.json"
+if ! fired; then ok "silent on a real, correct deploy (no cry-wolf)"; else bad "cry-wolf on a healthy deploy" "$(printf '%s' "$OUT" | head -c 300)"; fi
+
+echo "=== 2. MISSING: a committed ABS hook removed from settings.json -> FIRES ==="
+cp "$H1/.claude/settings.json" "$TMP/stale.json"
+strip_hook "$TMP/stale.json" "dev-hub-refresh-on-session-start.py"
+run_hook "$REPO_ROOT" "$TMP/stale.json"
+if fired && mentions 'dev-hub-refresh-on-session-start.py'; then ok "fired + named the missing hook"; else bad "missing hook not surfaced" "$(printf '%s' "$OUT" | head -c 300)"; fi
+if mentions 'deployed-hooks-behind'; then ok "carries the drift headline tag"; else bad "missing headline tag"; fi
+if mentions 'install-hooks-user-level.py'; then ok "carries the one-command fix"; else bad "missing fix command"; fi
+
+echo "=== 3. RETIRED: a retired hook still wired -> FIRES ==="
+cp "$H1/.claude/settings.json" "$TMP/retired.json"
+inject_hook "$TMP/retired.json" "UserPromptSubmit" \
+  "python3 ~/.claude/skills/ai-brain-starter/scripts/email-gate-hook.py 2>/dev/null || true"
+run_hook "$REPO_ROOT" "$TMP/retired.json"
+if fired && mentions 'email-gate-hook.py' && mentions 'Retired'; then ok "fired + named the retired hook"; else bad "retired hook not surfaced" "$(printf '%s' "$OUT" | head -c 300)"; fi
+
+echo "=== 4. FAIL-OPEN: missing settings.json / missing hooks.json -> silent ==="
+run_hook "$REPO_ROOT" "$TMP/does-not-exist.json"
+if ! fired; then ok "silent when settings.json is absent"; else bad "fired without a deployed target"; fi
+mkdir -p "$TMP/empty-skill"
+run_hook "$TMP/empty-skill" "$H1/.claude/settings.json"
+if ! fired; then ok "silent when hooks.json is absent"; else bad "fired without a committed source"; fi
+
+echo "=== 5. VAULT-EXCLUSION: committed vault hook absent from a no-vault deploy -> silent ==="
+FX="$TMP/fx-skill"; mkdir -p "$FX"
+cat > "$FX/hooks.json" <<'JSON'
+{ "hooks": { "UserPromptSubmit": [ { "hooks": [
+  { "type": "command", "command": "bash '[VAULT_PATH]/⚙️ Meta/scripts/graph-context-hook.sh'" },
+  { "type": "command", "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/log-skill-usage.py 2>/dev/null || echo '{}'" }
+] } ] } }
+JSON
+# Deployed as a no-vault client would have it: the non-vault hook, NOT the vault one.
+cat > "$TMP/novault-settings.json" <<'JSON'
+{ "hooks": { "UserPromptSubmit": [ { "hooks": [
+  { "type": "command", "command": "python3 ~/.claude/skills/ai-brain-starter/hooks/log-skill-usage.py 2>/dev/null || echo '{}'" }
+] } ] } }
+JSON
+run_hook "$FX" "$TMP/novault-settings.json"
+if ! fired; then ok "vault hook not demanded on a no-vault deploy (no false positive)"; else bad "false-fired on an unwired vault hook" "$(printf '%s' "$OUT" | head -c 300)"; fi
+
+echo "=== 5b. same fixture, non-vault hook ALSO missing -> FIRES, but NOT for the vault hook ==="
+cat > "$TMP/novault-broken.json" <<'JSON'
+{ "hooks": { "UserPromptSubmit": [ { "hooks": [
+  { "type": "command", "command": "SOMETHING_ELSE --unrelated" }
+] } ] } }
+JSON
+run_hook "$FX" "$TMP/novault-broken.json"
+if fired && mentions 'log-skill-usage.py'; then ok "fired for the genuinely-missing non-vault hook"; else bad "real non-vault drift went silent" "$(printf '%s' "$OUT" | head -c 300)"; fi
+if notmentions 'graph-context-hook.sh'; then ok "never names the vault hook (correctly out of scope)"; else bad "REGRESSION: demanded a vault hook"; fi
+
+echo "=== 6. ESCAPE HATCH: a pinned install stays silent even with real drift ==="
+# Same stale settings.json that FIRED in case 2, but with the auto-update pin next
+# to it. A pinned user opted out of the auto-update machinery -> no nag.
+PINDIR="$TMP/pinned"; mkdir -p "$PINDIR"
+cp "$TMP/stale.json" "$PINDIR/settings.json"
+run_hook "$REPO_ROOT" "$PINDIR/settings.json"
+if fired; then ok "control: drift fires without the pin (case 2 confirmed reproducible)"; else bad "stale.json unexpectedly clean"; fi
+touch "$PINDIR/.ai-brain-starter-pinned"
+run_hook "$REPO_ROOT" "$PINDIR/settings.json"
+if ! fired; then ok "pinned install stays silent (escape hatch honored)"; else bad "nagged a pinned install" "$(printf '%s' "$OUT" | head -c 300)"; fi
+
+echo
+echo "=== summary: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## What

`MYC-2507`. The auto-update's deploy step (`install-hooks-user-level.py`, run by `ai-brain-auto-update.sh`) is fail-open: on a silent failure the checkout is current but `~/.claude/settings.json` falls behind `hooks.json`, and the next ~6-day cycle no-ops (HEAD==origin) so the one-shot warning is gone forever. `update-check.sh` only checks checkout-behind; the maintainer drift detector is adelaida-skills-only. A client whose deploy half-landed had **zero** signal. Bug class `DEPLOY-FAILS-OPEN-SILENTLY-ON-CLIENT` (relates `MYC-720`, operating rule *A Control's Liveness Is Part of the Control*).

## How

New SessionStart hook `surface-deployed-hooks-behind.py` compares the committed `hooks.json` against the deployed `settings.json` by ABS-owned basename **per event**, and flags retired-but-still-wired hooks. On drift: one line + the one-command fix (`install-hooks-user-level.py --quiet --fail-on-missing`); healthy install stays silent.

Design choices:
- **Imports the installer's ownership predicates** (`_owned_basenames`, `_is_retired`, `_hook_depends_on_vault`) rather than copying them, so it can't rot when a hook is added (that would be the same drift class it exists to catch). Registered `surface-deployed-hooks-behind.py` in `ABS_FINGERPRINTS` + `ABS_OWNED_BASENAMES`.
- **Scoped to non-vault hooks** for the missing-direction: the auto-deploy prunes vault-content hooks (wired later by `/setup-brain`), so this covers exactly the class the auto-deploy can silently break and stays false-positive-free whether or not a vault exists. Basename comparison is invariant under `[VAULT_PATH]` substitution.
- **Honors the `~/.claude/.ai-brain-starter-pinned` escape hatch** (a pinned client never runs the auto-deploy, so nagging it would break the opt-out).
- **Fail-open, local-only** (no git, no network); any error emits `{}`.

## Tests

`test_deployed_hooks_behind.sh` (registered in `ci.sh`, 12 assertions): neg-control is silent on exactly what the **real installer** produces from the real `hooks.json`; fires and names the culprit on a missing hook and on a retired-but-wired hook; fail-open on absent files; the key vault-exclusion guard (never demands a vault hook, both a silent and a fires-but-not-for-vault case); and the pin escape-hatch (drift-fires without the pin, silent with it). Full `ci.sh` green: py_compile (276) + 61 integration tests + shellcheck.

_Authored by Claude Code (Opus 4.8) on Adelaida's behalf._