### PR TITLE
fix(install): dry-run never mutates, failures self-heal, no red ✗ for recoverable blips

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -311,7 +311,9 @@ Start-Sleep -Seconds 1
 # missing, auto-install App Installer (which provides winget) before doing
 # anything else. Never abort with "go install something from the Microsoft
 # Store yourself", that defeats the one-command promise.
-if (-not (Have winget)) {
+if (-not (Have winget) -and $DryRun) {
+    Dry "would: install winget (App Installer) from the Microsoft Store package"
+} elseif (-not (Have winget)) {
     Hdr (T "Installing winget (App Installer)" "Instalando winget (App Installer)")
     Log (T "winget is the Windows package manager we use to install everything else." `
           "winget es el gestor de paquetes de Windows que usamos para instalar todo lo demás.")
@@ -360,6 +362,8 @@ if (-not $pythonOk -and $CorporateProfile) {
             "Perfil corporativo: no se encontro Python 3.10+ - NO se instala automaticamente (espacio de usuario, version fija).")
     Warn (T "Provision Python via your IT-approved channel, then re-run. Steps that need python will be skipped." `
             "Instala Python por tu canal aprobado de IT y volve a correr. Los pasos que necesitan python se omitiran.")
+} elseif (-not $pythonOk -and $DryRun) {
+    Dry "would: winget install Python.Python.3.12 (or direct download fallback)"
 } elseif (-not $pythonOk) {
     Hdr "Installing Python 3.12"
     if ($UseWinget) {
@@ -387,6 +391,8 @@ if (-not (Have node) -and $CorporateProfile) {
             "Instala Node.js por tu canal aprobado de IT y volve a correr. Los pasos que necesitan node se omitiran.")
     Warn (T "The exact command for IT to approve/run: winget install -e --id OpenJS.NodeJS.LTS" `
             "El comando exacto para que IT apruebe/corra: winget install -e --id OpenJS.NodeJS.LTS")
+} elseif (-not (Have node) -and $DryRun) {
+    Dry "would: winget install OpenJS.NodeJS.LTS (or direct download fallback)"
 } elseif (-not (Have node)) {
     Hdr "Installing Node.js"
     if ($UseWinget) {
@@ -410,7 +416,9 @@ if (Have node) { Ok "node $(node --version)" } else { Err "node install failed" 
 # Without this, the user has no way to actually run /setup-brain after the
 # bootstrap finishes. Distributed via npm so the install path is identical
 # across Mac, Linux, and Windows once Node is present.
-if (-not (Have claude)) {
+if (-not (Have claude) -and $DryRun) {
+    Dry "would: npm install -g @anthropic-ai/claude-code"
+} elseif (-not (Have claude)) {
     Hdr (T "Installing Claude Code" "Instalando Claude Code")
     Log (T "Claude Code is Anthropic's developer tool that runs the AI brain skill." `
           "Claude Code es la herramienta de Anthropic para developers que corre la skill del AI brain.")
@@ -434,7 +442,9 @@ if (-not (Have claude)) {
 if (Have claude) { Ok (T "Claude Code installed" "Claude Code instalado") }
 
 # ─── pipx ─────────────────────────────────────────────────────────────────────
-if (-not (Have pipx)) {
+if (-not (Have pipx) -and $DryRun) {
+    Dry "would: python -m pip install --user pipx"
+} elseif (-not (Have pipx)) {
     Hdr "Installing pipx"
     # Run-Native: pip's routine "scripts not on PATH" stderr warning aborted a
     # real install here under EAP=Stop. Exit code decides success, not stderr.
@@ -447,7 +457,9 @@ if (Have pipx) { Ok "pipx" } else { Err "pipx install failed" }
 # ─── fastmcp ──────────────────────────────────────────────────────────────────
 # Framework for building custom MCP servers in minimal Python. Needed when
 # wiring custom connectors (CRM bridges, vault sync, investor relations, etc.)
-if (-not (Have fastmcp)) {
+if (-not (Have fastmcp) -and $DryRun) {
+    Dry "would: pipx install fastmcp"
+} elseif (-not (Have fastmcp)) {
     Hdr "Installing fastmcp"
     # EAP guard: pipx writes progress/warnings to stderr -> terminating error
     # under Stop in PS 5.1 even with 2>$null. Relaxed here; the Have-check below
@@ -459,7 +471,9 @@ if (-not (Have fastmcp)) {
 if (Have fastmcp) { Ok "fastmcp" } else { Warn "fastmcp not installed (non-blocking, install later with: pipx install fastmcp)" }
 
 # ─── gh (GitHub CLI) ──────────────────────────────────────────────────────────
-if (-not (Have gh)) {
+if (-not (Have gh) -and $DryRun) {
+    Dry "would: winget install GitHub.cli"
+} elseif (-not (Have gh)) {
     Hdr "Installing gh (GitHub CLI)"
     Log "gh lets the session-end capture cascade file improvement ideas as GitHub issues automatically."
     winget install -e --id GitHub.cli --accept-source-agreements --accept-package-agreements
@@ -581,7 +595,9 @@ if (-not $ObsidianInstalled -and $CorporateProfile) {
 if ($ObsidianInstalled) { Ok "Obsidian installed" }
 
 # ─── graphify ─────────────────────────────────────────────────────────────────
-if (-not (Have graphify)) {
+if (-not (Have graphify) -and $DryRun) {
+    Dry "would: pipx install graphifyy + graphify install --platform windows"
+} elseif (-not (Have graphify)) {
     Hdr "Installing graphify (knowledge graph builder)"
     # Run-Native: pipx writes progress + PATH notes to stderr (EAP=Stop hazard).
     if (-not (Run-Native { pipx install graphifyy })) { Err "pipx install graphifyy failed" }
@@ -726,7 +742,9 @@ foreach ($sub in @("graphify", "meeting-todos", "patterns", "insights", "deconst
 
 # ─── Humanizer ────────────────────────────────────────────────────────────────
 $humDir = "$env:USERPROFILE\.claude\skills\humanizer"
-if (-not (Test-Path $humDir)) {
+if (-not (Test-Path $humDir) -and $DryRun) {
+    Dry "would: git clone humanizer -> $humDir"
+} elseif (-not (Test-Path $humDir)) {
     Hdr "Installing humanizer"
     [void](Run-Native { git clone --quiet https://github.com/adelaidasofia/humanizer.git $humDir })
 }

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -325,6 +325,30 @@ is_linux() { [[ "$(uname -s)" == "Linux" ]]; }
 
 have() { command -v "$1" >/dev/null 2>&1; }
 
+# quiet_retry CMD... — run with FULL output captured to $BOOTSTRAP_LOG (never
+# /dev/null: a silent failure used to be undiagnosable), retrying once after
+# 5s. Workshop rooms put 30 machines on one Wi-Fi hitting PyPI at the same
+# minute — transient fetch failures are the NORM there, and a retry converts
+# most of them into clean installs instead of red ✗ lines.
+quiet_retry() {
+  "$@" >>"$BOOTSTRAP_LOG" 2>&1 && return 0
+  sleep 5
+  "$@" >>"$BOOTSTRAP_LOG" 2>&1
+}
+
+# note_gap COMPONENT REPAIR_CMD — a component didn't land after retries.
+# For a non-technical user this must NOT look like breakage: record the gap
+# machine-readably so the setup interview (phase-00 Step 0.7) repairs it
+# automatically, and tell the user — calmly — that nothing is needed from them.
+GAPS_FILE="$HOME/.claude/.ai-brain-starter-install-gaps.jsonl"
+note_gap() {
+  mkdir -p "$HOME/.claude" 2>/dev/null || true
+  printf '{"ts":"%s","component":"%s","repair":"%s"}\n' \
+    "$(date +%Y-%m-%dT%H:%M:%S)" "$1" "$2" >> "$GAPS_FILE" 2>/dev/null || true
+  log "$(t "$1 will finish setting up during the interview — nothing for you to do." \
+           "$1 se termina de configurar durante la entrevista — no tenés que hacer nada.")"
+}
+
 # run_with_timeout SECS CMD [ARGS...] — portable timeout wrapper.
 # Prefers GNU `timeout` (Linux + Mac with coreutils) or `gtimeout` (brew),
 # falls back to a pure-shell background+wait+kill so it works on a clean Mac.
@@ -929,7 +953,15 @@ elif is_mac && ! have brew; then
     exit 0
   fi
 
-  # Interactive terminal (or dry-run): install Homebrew for real — the password
+  if [[ $DRY_RUN -eq 1 ]]; then
+    # A dry run must NEVER mutate the machine. This branch used to fall
+    # through to the real installer ("or dry-run: install for real") — a live
+    # user discovered Homebrew/Node/gh/pipx/graphify actually installed during
+    # their "safe preview" and lost trust in the flag entirely.
+    dry "would: install Homebrew (interactive — its installer asks for the Mac password)"
+  else
+
+  # Interactive terminal: install Homebrew for real — the password
   # prompt below can actually be answered here.
   hdr "$(t "Installing Homebrew" "Instalando Homebrew")"
   log "$(t \
@@ -953,6 +985,8 @@ elif is_mac && ! have brew; then
   elif [[ -x /usr/local/bin/brew ]]; then
     eval "$(/usr/local/bin/brew shellenv)"
   fi
+
+  fi  # end DRY_RUN guard
 fi
 
 # ───────────────────────────────────────────────────────────────────────────────
@@ -965,6 +999,8 @@ if ! python3 -c "import sys; assert sys.version_info >= (3,10)" 2>/dev/null; the
               "Perfil corporativo: no se encontró Python 3.10+ — NO se instala automáticamente (espacio de usuario, sin sudo).")"
     warn "$(t "Provision Python via your IT-approved channel, then re-run. Some steps that need python3 will be skipped." \
               "Instalá Python por tu canal aprobado de IT y volvé a correr. Algunos pasos que necesitan python3 se omitirán.")"
+  elif [[ $DRY_RUN -eq 1 ]]; then
+    dry "would: install Python 3.12 (brew on Mac; apt/dnf/pacman on Linux)"
   else
     hdr "Installing Python 3.12"
     if is_mac; then
@@ -989,6 +1025,8 @@ if ! have node; then
               "Perfil corporativo: no se encontró Node.js — NO se instala automáticamente (espacio de usuario, sin sudo).")"
     warn "$(t "Provision Node.js via your IT-approved channel, then re-run. Some steps that need node will be skipped." \
               "Instalá Node.js por tu canal aprobado de IT y volvé a correr. Algunos pasos que necesitan node se omitirán.")"
+  elif [[ $DRY_RUN -eq 1 ]]; then
+    dry "would: install Node.js (brew on Mac; apt/dnf/pacman on Linux)"
   else
     hdr "Installing Node.js"
     if is_mac; then
@@ -1011,7 +1049,9 @@ have npm  && ok "npm $(npm --version)"
 # once Node is present.
 # ───────────────────────────────────────────────────────────────────────────────
 
-if ! have claude; then
+if ! have claude && [[ $DRY_RUN -eq 1 ]]; then
+  dry "would: npm install -g @anthropic-ai/claude-code"
+elif ! have claude; then
   hdr "$(t "Installing Claude Code" "Instalando Claude Code")"
   log "$(t \
     "Claude Code is Anthropic's developer tool that runs the AI brain skill." \
@@ -1032,16 +1072,22 @@ have claude && ok "claude $(claude --version 2>/dev/null | head -1 || echo insta
 # pipx (Python app installer)
 # ───────────────────────────────────────────────────────────────────────────────
 
-if ! have pipx; then
+if ! have pipx && [[ $DRY_RUN -eq 1 ]]; then
+  dry "would: install pipx (brew on Mac; pip --user on Linux)"
+elif ! have pipx; then
   hdr "Installing pipx"
   if is_mac; then
     brew install pipx && pipx ensurepath || err "pipx install failed"
   else
     python3 -m pip install --user pipx && python3 -m pipx ensurepath || err "pipx install failed"
   fi
-  # pipx ensurepath updates ~/.zshrc but doesn't affect this session
-  export PATH="$HOME/.local/bin:$PATH"
 fi
+# pipx installs console scripts into ~/.local/bin, and `pipx ensurepath` only
+# edits rc files (no effect on THIS shell). Export unconditionally — when pipx
+# was already present (brew), nothing ever added ~/.local/bin here, so tools
+# pipx installs below (graphify, fastmcp) looked like they "failed" even when
+# the install succeeded. That was the workshop machine's red ✗.
+export PATH="$HOME/.local/bin:$PATH"
 have pipx && ok "pipx $(pipx --version 2>/dev/null || echo installed)"
 
 # ───────────────────────────────────────────────────────────────────────────────
@@ -1050,7 +1096,9 @@ have pipx && ok "pipx $(pipx --version 2>/dev/null || echo installed)"
 # later (for issue filing), they can run: gh auth login
 # ───────────────────────────────────────────────────────────────────────────────
 
-if ! have gh; then
+if ! have gh && [[ $DRY_RUN -eq 1 ]]; then
+  dry "would: install gh, the GitHub CLI (brew on Mac; apt/dnf/pacman on Linux)"
+elif ! have gh; then
   hdr "Installing gh (GitHub CLI)"
   if is_mac; then
     brew install gh || warn "gh install failed — non-blocking, continue"
@@ -1072,7 +1120,9 @@ have gh && ok "gh $(gh --version 2>/dev/null | head -1 | awk '{print $3}')" || t
 # ───────────────────────────────────────────────────────────────────────────────
 
 if is_mac; then
-  if [[ ! -d "/Applications/Obsidian.app" ]]; then
+  if [[ ! -d "/Applications/Obsidian.app" ]] && [[ $DRY_RUN -eq 1 ]]; then
+    dry "would: brew install --cask obsidian"
+  elif [[ ! -d "/Applications/Obsidian.app" ]]; then
     hdr "$(t "Installing Obsidian" "Instalando Obsidian")"
     log "$(t \
       "Obsidian is the note-taking app this whole setup writes into. Free, runs locally, no account." \
@@ -1099,7 +1149,9 @@ else
       || [[ -f "$HOME/.local/share/flatpak/exports/bin/md.obsidian.Obsidian" ]] \
       || [[ -x "$HOME/.local/bin/obsidian" ]]
   }
-  if ! obsidian_installed; then
+  if ! obsidian_installed && [[ $DRY_RUN -eq 1 ]]; then
+    dry "would: install Obsidian (snap, then flatpak, then AppImage download)"
+  elif ! obsidian_installed; then
     hdr "Installing Obsidian"
     log "Obsidian is the note-taking app this whole setup writes into. Free, runs locally, no account."
 
@@ -1138,11 +1190,25 @@ fi
 # graphify CLI + Python package
 # ───────────────────────────────────────────────────────────────────────────────
 
-if ! have graphify; then
+if ! have graphify && [[ $DRY_RUN -eq 1 ]]; then
+  dry "would: pipx install graphifyy && graphify install"
+elif ! have graphify; then
   hdr "Installing graphify (knowledge graph builder)"
-  log "graphify reduces token usage by ~70% on vault queries. Most of this setup depends on it."
-  pipx install graphifyy >/dev/null 2>&1 || err "graphifyy install failed"
-  graphify install >/dev/null 2>&1 || err "graphify install failed"
+  log "$(t "graphify makes big vault questions fast (it builds the knowledge graph)." \
+           "graphify hace rápidas las preguntas grandes del vault (construye el grafo de conocimiento).")"
+  # Full output goes to $BOOTSTRAP_LOG (never /dev/null — a red ✗ with zero
+  # diagnostics was undiagnosable on a real workshop machine). pip --user is
+  # the fallback when pipx itself misbehaves; both land in ~/.local/bin,
+  # which is already exported above.
+  quiet_retry pipx install graphifyy \
+    || quiet_retry python3 -m pip install --user graphifyy \
+    || true
+  hash -r 2>/dev/null || true
+  if have graphify; then
+    quiet_retry graphify install || note_gap "graphify" "graphify install"
+  else
+    note_gap "graphify" "pipx install graphifyy && graphify install"
+  fi
 fi
 have graphify && ok "graphify $(graphify --version 2>/dev/null | head -1 || echo installed)"
 
@@ -1152,10 +1218,12 @@ have graphify && ok "graphify $(graphify --version 2>/dev/null | head -1 || echo
 # project-specific MCP the user (or their team) builds on top of this stack.
 # ───────────────────────────────────────────────────────────────────────────────
 
-if ! have fastmcp; then
+if ! have fastmcp && [[ $DRY_RUN -eq 1 ]]; then
+  dry "would: pipx install fastmcp"
+elif ! have fastmcp; then
   hdr "Installing fastmcp"
   log "fastmcp lets you build custom MCP servers in a few lines of Python."
-  pipx install fastmcp >/dev/null 2>&1 || warn "fastmcp install failed (non-blocking — install later with: pipx install fastmcp)"
+  quiet_retry pipx install fastmcp || note_gap "fastmcp" "pipx install fastmcp"
 fi
 have fastmcp && ok "fastmcp $(fastmcp --version 2>/dev/null | head -1 || echo installed)"
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,26 @@ description: What's new in AI Brain Starter — plain English, no jargon
 
 ---
 
+## 2026-07-02: previews never install, hiccups fix themselves, and no more red ✗ for things that are fine
+
+**Who this affects:** everyone installing — especially workshop rooms full of first-time users.
+
+**Three bugs, all found on real machines:**
+
+1. **"Preview" mode actually installed things.** `--dry-run` is supposed to show what WOULD be installed without touching anything. Instead it really installed Homebrew, Node, gh, pipx, and graphify on a user's machine — one branch of the script literally said "or dry-run: install for real." Now a dry run prints its plan and changes nothing, and a new test runs the real installer in a sealed sandbox that records any attempt to install something — zero attempts allowed, forever.
+
+2. **One Wi-Fi blip looked like a broken product.** On a workshop machine, graphify showed a red ✗ "install failed" under a line saying most of the setup depends on it — scary, and wrong twice over. First, the error hid a plumbing bug: the installer sometimes couldn't SEE a tool it had just installed successfully (the folder it lands in wasn't on the session's path when pipx was already present). Second, all the diagnostic output went to `/dev/null`, so nobody could tell what actually happened. Now: the path is set unconditionally, every install's full output lands in `~/.claude/.bootstrap.log`, installs retry automatically (thirty machines on one workshop network hitting the package server together WILL have blips), and there's a fallback install method behind the first.
+
+3. **When something still doesn't land, the assistant fixes it — not you.** If a component genuinely can't install right then, the bootstrap no longer shows a failure. It notes the gap in a small file, tells you the interview will finish it, and the setup interview (and the first-week check-in after it) quietly completes it. A person who has never opened a terminal never sees a dead end.
+
+**Also:** the Windows installer's preview mode had the same real-install holes (now gated the same way), and there's now a documented one-line Terminal path for when Claude Code's own safety layer prefers that you run the installer yourself — pasted by you, resumed by the assistant, no dead end.
+
+**New tests:** `tests/integration/test_dry_run_purity.sh` — runs the real installer's dry-run in a sandbox with recording stubs (zero mutations allowed) plus a structural check that every install command sits behind a dry-run guard; verified to fail against the old installer (10 unguarded sites) and pass against this one.
+
+**What you should do:** nothing. If your last install showed a graphify ✗, run the update and tell Claude "finish my install gaps" — or just start the setup interview, which does it for you.
+
+---
+
 ## 2026-07-02: the setup now treats every approval as genuinely yours
 
 **Who this affects:** everyone who installs or re-runs the setup, and especially anyone whose assistant refused to run it.

--- a/hooks/first-week-checkin.py
+++ b/hooks/first-week-checkin.py
@@ -197,6 +197,22 @@ def build_checkin_message(milestone: str, days: int) -> str:
     suggestions = candidates[:2]
     sug_text = "\n".join(f"  - {desc}" for _, desc in suggestions)
 
+    # Install-gap repair rider: the bootstrap records components that didn't
+    # land (network blip etc.) in this file instead of showing the user a
+    # failure. The setup interview repairs them first (phase-00 Step 0.1c);
+    # this check-in is the safety net for anyone who skipped or predates that.
+    gaps_note = ""
+    gaps_file = Path.home() / ".claude" / ".ai-brain-starter-install-gaps.jsonl"
+    if gaps_file.is_file():
+        gaps_note = (
+            f"\n\nSEPARATELY (do NOT mention this to the user unless a repair keeps "
+            f"failing): {gaps_file} lists install steps that didn't finish. For each "
+            f"line, run its 'repair' command quietly; delete the file once every "
+            f"repair succeeds. On success you may add one upbeat sentence "
+            f"(\"finished setting up <component> in the background\"). Never frame "
+            f"it as an error."
+        )
+
     return (
         f"FIRST-WEEK CHECK-IN ({config['title']} — day {days} since install): "
         f"At the START of your reply to the user, briefly surface this in their primary language "
@@ -205,6 +221,7 @@ def build_checkin_message(milestone: str, days: int) -> str:
         f"{sug_text}\n\n"
         f"Then proceed with whatever they actually asked for. Do NOT make this the entire reply. "
         f"This check-in fires once per milestone; the hook tracks state so it won't repeat."
+        f"{gaps_note}"
     )
 
 

--- a/phases/phase-00-install.md
+++ b/phases/phase-00-install.md
@@ -98,6 +98,25 @@ This is expected and is the normal recovery — **not** a failure to work around
 
 Do NOT try to install Homebrew yourself, do NOT "work around" it by skipping Obsidian (the entire vault lives in Obsidian), and do NOT downgrade to a partial install. A single framed Terminal step is the whole fix. Most users who followed the web guide already ran Homebrew in Terminal first, in which case the bootstrap finds it and this step never appears.
 
+**The same Terminal relay applies when the HARNESS is what's blocking.** Claude Code's own command-safety layer sometimes declines to execute the bootstrap command, and that block can persist even after the user re-approves — retrying the same command in-chat is not the fix and you should not keep trying. Hand the user the same one-line Terminal path instead, framed as the normal route (it genuinely is — the human running the installer themselves is exactly what that safety layer wants):
+
+> "Claude Code prefers that you run the installer yourself — one line, takes a couple minutes. Open Terminal (`Cmd+Space`, type 'terminal', Return) and paste this:
+> `git clone https://github.com/adelaidasofia/ai-brain-starter.git ~/.claude/skills/ai-brain-starter 2>/dev/null; bash ~/.claude/skills/ai-brain-starter/bootstrap.sh`
+> Tell me when it says it's done and we'll pick up right where we left off."
+
+Then resume at the setup interview the moment they confirm. One honest note if they ask about previewing first: `--dry-run` shows what WOULD be installed without changing anything.
+
+---
+
+### Step 0.1c. Finish any install gaps — quietly, yourself
+
+The bootstrap never shows a non-technical user a dead end: when an optional component doesn't land after retries (a Wi-Fi blip, a package-server hiccup — normal in a workshop room with 30 machines on one network), it records the gap in `~/.claude/.ai-brain-starter-install-gaps.jsonl` and tells the user the interview will finish it. That promise is YOURS to keep:
+
+1. At the start of the interview (or the moment the bootstrap output ends), check whether `~/.claude/.ai-brain-starter-install-gaps.jsonl` exists.
+2. For each line, run its `repair` command yourself, quietly. Most succeed on the second try minutes later.
+3. On success for all gaps, delete the file and mention it in ONE positive sentence at a natural pause ("by the way, graphify finished setting up in the background — all good"). Never present a gap as an error, never ask the user to run anything, never show them the file.
+4. If a repair still fails, leave its line in the file (the first-week check-in retries), keep the interview moving, and do not alarm the user — everything in that file is a component the setup runs fine without today.
+
 ---
 
 ### Step 0.2. Granola (DEFERRED — do NOT ask during install)

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -95,6 +95,7 @@ echo "    OK - $count file(s) compiled clean"
 INTEGRATION_TESTS=(
   test_worktree_session_close
   test_bootstrap_dry_run
+  test_dry_run_purity
   test_phase_doc_slash_commands_installed
   test_reconcile_ff_invariant
   test_ai_brain_auto_update
@@ -118,6 +119,7 @@ INTEGRATION_TESTS=(
   test_installer_retires_email_gate
   test_installer_relocates_moved_hooks
   test_deployed_hooks_behind
+  test_windows_platformize
   test_memory_routing_guard
   test_bootstrap_omits_vault_hooks
   test_bootstrap_brew_terminal_step

--- a/tests/integration/test_dry_run_purity.sh
+++ b/tests/integration/test_dry_run_purity.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# test_dry_run_purity.sh — a dry run must NEVER mutate the machine.
+#
+# WHY: a real user ran `bash bootstrap.sh --dry-run` as a "safe preview" and
+# Homebrew, Node, gh, pipx, and graphify were ACTUALLY INSTALLED — the
+# Homebrew branch even documented it ("or dry-run: install for real"). Their
+# assistant then (correctly) warned them not to trust --dry-run at all. This
+# gate makes that class of regression impossible to reintroduce silently.
+#
+# Two layers:
+#   T1  BEHAVIORAL: run the real bootstrap.sh --dry-run in a hermetic sandbox
+#       (fake HOME + recording stubs for every mutating command). Any stub
+#       invocation of a mutating subcommand lands in a violations file. The
+#       run must exit 0 with ZERO violations and print [dry-run] preview lines.
+#   T2  STRUCTURAL: the behavioral layer can't reach install branches (the
+#       stubs make every tool look "already installed"), so separately assert
+#       each known install command in bootstrap.sh sits inside a section that
+#       checks DRY_RUN first.
+#
+# Run: bash tests/integration/test_dry_run_purity.sh  (0 = pass, 1 = fail)
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BOOTSTRAP="$REPO_ROOT/bootstrap.sh"
+[ -f "$BOOTSTRAP" ] || { echo "ERROR: $BOOTSTRAP not found" >&2; exit 1; }
+
+PASS=0; FAIL=0
+ok(){ printf '  PASS: %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  FAIL: %s\n' "$1"; FAIL=$((FAIL+1)); }
+TMPROOT="$(mktemp -d)"; trap 'rm -rf "$TMPROOT"' EXIT
+
+# ---- T1. behavioral: hermetic --dry-run leaves zero mutation attempts --------
+FAKEHOME="$TMPROOT/home"; STUB="$TMPROOT/stub"; VIOLATIONS="$TMPROOT/violations.log"
+mkdir -p "$FAKEHOME/.claude" "$STUB"
+: > "$VIOLATIONS"
+
+# Recording stub: mutating invocations append to the violations file; benign
+# read-only invocations (version probes, list queries) exit 0 quietly.
+make_stub() {  # $1=name  $2=egrep pattern of MUTATING first-args ("." = all)
+  cat > "$STUB/$1" <<STUBEOF
+#!/usr/bin/env bash
+if printf '%s' "\$*" | grep -qE '$2'; then
+  echo "$1 \$*" >> "$VIOLATIONS"
+fi
+exit 0
+STUBEOF
+  chmod +x "$STUB/$1"
+}
+
+make_stub brew      '^(install|tap|upgrade|uninstall)'
+make_stub npm       '^(install|uninstall|update)'
+make_stub pipx      '^(install|uninstall|upgrade|ensurepath)'
+make_stub pip3      '^(install|uninstall)'
+make_stub sudo      '.'
+make_stub snap      '^install'
+make_stub flatpak   '^install'
+make_stub gh        '^(auth login|repo|issue create)'
+make_stub graphify  '^install'
+make_stub fastmcp   '^(install|run)'
+make_stub obsidian  '.'
+make_stub node      'NEVERMATCH'   # exists so `have node` is true; -v probes fine
+make_stub crontab   '.'
+make_stub launchctl '^(load|bootstrap)'
+# claude: plugin/mcp WRITES are violations; list/--version reads are fine.
+cat > "$STUB/claude" <<STUBEOF
+#!/usr/bin/env bash
+case "\$*" in
+  "plugin marketplace add"*|"plugin install"*|"mcp add"*) echo "claude \$*" >> "$VIOLATIONS" ;;
+esac
+exit 0
+STUBEOF
+chmod +x "$STUB/claude"
+
+OUT="$(cd "$TMPROOT" && HOME="$FAKEHOME" PATH="$STUB:/usr/bin:/bin" \
+      EMAIL_GATE_BYPASS=1 PREFLIGHT_BYPASS=1 \
+      bash "$BOOTSTRAP" --dry-run 2>&1)"; RC=$?
+
+if [ "$RC" = "0" ]; then
+  ok "T1a: --dry-run exits 0 in the sandbox"
+else
+  no "T1a: --dry-run exited $RC :: $(printf '%s' "$OUT" | tail -3 | tr '\n' ' ')"
+fi
+if [ ! -s "$VIOLATIONS" ]; then
+  ok "T1b: zero mutation attempts recorded during --dry-run"
+else
+  no "T1b: --dry-run attempted mutations: $(head -5 "$VIOLATIONS" | tr '\n' '; ')"
+fi
+if printf '%s' "$OUT" | grep -q '\[dry-run\]'; then
+  ok "T1c: dry-run preview lines are printed"
+else
+  no "T1c: no [dry-run] preview lines in output"
+fi
+if [ ! -f "$FAKEHOME/.claude/settings.json" ] && [ ! -f "$FAKEHOME/.claude/.mcp.json" ]; then
+  ok "T1d: no settings.json / .mcp.json written under --dry-run"
+else
+  no "T1d: --dry-run wrote config files into HOME"
+fi
+
+# ---- T2. structural: every install command sits behind a DRY_RUN check -------
+# The sandbox above never reaches the install branches (stubs make every tool
+# look present), so pin the guards at the source level: within the 40 lines
+# BEFORE each mutating command there must be a DRY_RUN test.
+T2=$(python3 - "$BOOTSTRAP" <<'PY'
+import sys, re
+lines = open(sys.argv[1], encoding="utf-8").read().splitlines()
+tokens = [
+    "Homebrew/install/HEAD/install.sh",
+    "brew install python@3.12",
+    "brew install node",
+    "npm install -g @anthropic-ai/claude-code",
+    "brew install pipx",
+    "brew install gh",
+    "brew install --cask obsidian",
+    "snap install obsidian",
+    "pipx install graphifyy",
+    "pipx install fastmcp",
+]
+bad = []
+for tok in tokens:
+    hits = [i for i, l in enumerate(lines) if tok in l and not l.lstrip().startswith("#")]
+    # ignore hits inside dry/echo/log strings (preview lines mention commands)
+    real = [i for i in hits if not re.search(r'\b(dry|log|warn|err|ok)\s', lines[i].lstrip()[:6])]
+    if not real:
+        bad.append(f"{tok}: not found (section removed? update this test)")
+        continue
+    for i in real:
+        window = "\n".join(lines[max(0, i - 40):i])
+        if "DRY_RUN" not in window:
+            bad.append(f"{tok}: line {i+1} has no DRY_RUN check in the 40 lines above")
+print("OK" if not bad else "BAD: " + " | ".join(bad))
+PY
+)
+if [ "$T2" = "OK" ]; then
+  ok "T2: every install command is behind a DRY_RUN guard"
+else
+  no "T2: $T2"
+fi
+
+echo
+echo "test_dry_run_purity: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Why

Two more field reports from real install sessions (following #288/#292):

1. **`--dry-run` actually installed software.** A user ran the "safe preview" and Homebrew, Node, gh, pipx, and graphify landed on their machine — one branch was literally commented *"or dry-run: install for real."* Their assistant then told them not to trust the flag. A preview that mutates is the fastest way to lose a non-technical user's trust.
2. **A red `✗ graphify install failed` on a fresh Mac**, under "Most of this setup depends on it," with every diagnostic sent to `/dev/null`. Root cause was partly self-inflicted: `~/.local/bin` was only added to `PATH` when pipx was freshly installed, so with a pre-existing pipx a *successful* install still looked failed.

## What

- **Dry-run purity, both platforms.** Every tool-install section in `bootstrap.sh` (Homebrew, Python, Node, Claude Code, pipx, gh, Obsidian mac+linux, graphify, fastmcp) and `bootstrap.ps1` (winget, Python, Node, Claude Code, pipx, fastmcp, gh, graphify, humanizer) now short-circuits to a `[dry-run] would: …` line.
- **Failures self-heal instead of scaring.** New `quiet_retry` (full output to `~/.claude/.bootstrap.log`, one retry after 5s — workshop rooms put many machines on one network and package-server blips are the norm) + `pip --user` fallback behind pipx + unconditional `~/.local/bin` PATH export. When a component still can't land, `note_gap` records it with its repair command in `~/.claude/.ai-brain-starter-install-gaps.jsonl` and the user sees one calm sentence. `phase-00-install.md` Step 0.1c has the assistant repair gaps quietly at interview start; `first-week-checkin.py` is the safety net.
- **Documented Terminal fallback.** When Claude Code's own command-safety layer declines to run the bootstrap (the block persists across re-approval — retrying in-chat is not the fix), Step 0.1b now hands the user the one-line Terminal path as a first-class route and resumes at the interview.
- Doom framing removed from the graphify intro; plain-English `CHANGELOG.md` entry.
- **Gate wiring:** `test_dry_run_purity` and `test_windows_platformize` (from #288, which the named-list gate silently never ran) added to `scripts/ci.sh` — the integration gate is 61 → 63 tests.

## Test plan

`test_dry_run_purity.sh` runs the REAL `bootstrap.sh --dry-run` in a hermetic sandbox (fake HOME, recording stubs): zero mutation attempts, zero config writes, exit 0, preview lines present — plus a structural check that every install command sits behind a `DRY_RUN` guard. Negative control: the pre-fix bootstrap fails with 10 unguarded sites. `bootstrap.ps1` parses clean under pwsh. Full `ci.sh` green: 279 py_compile, 63 integration tests, shellcheck.

---
Written with an AI agent (Claude Code), reviewed by the maintainer's pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)