### PR TITLE
fix(install): --verify no longer false-FAILs ||-fallback hook chains (MYC-2558)

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -100,6 +100,7 @@ INTEGRATION_TESTS=(
   test_reconcile_ff_invariant
   test_ai_brain_auto_update
   test_installer_replaces_auto_update
+  test_verify_fallback_chain_optional
   test_detect_closing_signal_worktree
   test_detect_closing_signal_repo_aware_vault
   test_closing_claim_shared

--- a/scripts/install-hooks-user-level.py
+++ b/scripts/install-hooks-user-level.py
@@ -822,8 +822,10 @@ def verify_paths_on_disk(settings: dict) -> tuple[list[tuple[str, str, str]], li
 
       - REQUIRED: command runs the script directly (`python3 <path> ...`).
         Script missing = silent hook failure at runtime.
-      - OPTIONAL: command wraps in `[ -f <path> ] && ...`. Missing is fine;
-        the guard suppresses the call.
+      - OPTIONAL: command wraps in `[ -f <path> ] && ...` (the guard suppresses
+        the call), OR the missing path has a present same-basename sibling in
+        the SAME command — a `||` fallback chain (`python3 <vault-copy> ||
+        python3 <home-copy>`) is satisfied as long as one copy exists (MYC-2558).
 
     Returns (missing_required, missing_optional), each a list of
     (event, script_path, full_command_short).
@@ -839,8 +841,13 @@ def verify_paths_on_disk(settings: dict) -> tuple[list[tuple[str, str, str]], li
     #   Windows runner form: every path is a QUOTED argument. The quoted
     #   pattern also fixes a false "missing" on POSIX vault paths containing
     #   spaces, which the unquoted pattern used to truncate at the space.
+    # Both patterns REQUIRE a .py/.sh extension (matching _SCRIPT_RE). Without
+    # it, a fallback chain whose first path is quoted — `python3 '<vault>' ...`
+    # — leaves `python3  2>/dev/null` after the quoted path is stripped for the
+    # bare pass, and the bare pattern would capture `2>/dev/null` as a bogus
+    # "missing required path" (MYC-2558). A shell redirection is not a script.
     quoted_re = re.compile(r"['\"]((?:~|/|[A-Za-z]:)[^'\"]+\.(?:py|sh))['\"]")
-    bare_re = re.compile(r"(?:python3|bash)\s+(~?[^\s'\"|&;]+)")
+    bare_re = re.compile(r"(?:python3|bash)\s+(~?[^\s'\"|&;]+\.(?:py|sh))\b")
 
     for event, groups in (settings.get("hooks") or {}).items():
         for g in groups:
@@ -853,13 +860,27 @@ def verify_paths_on_disk(settings: dict) -> tuple[list[tuple[str, str, str]], li
                 candidates = quoted_re.findall(cmd)
                 unquoted = re.sub(r"['\"][^'\"]*['\"]", " ", cmd)
                 candidates += bare_re.findall(unquoted)
-                for raw in dict.fromkeys(candidates):
-                    p = Path(os.path.expanduser(raw))
-                    if p.is_file():
+                paths = list(dict.fromkeys(candidates))
+                exists = {r: Path(os.path.expanduser(r)).is_file() for r in paths}
+                # A `||` fallback chain names the same script by more than one
+                # path (vault copy || ~/.claude home copy || echo). On a vault
+                # install only the home copy exists, which still satisfies the
+                # chain at runtime. So a missing path whose basename ALSO has a
+                # present same-basename sibling IN THIS COMMAND is optional, not
+                # required. Scoped to one command — never across commands — so a
+                # genuinely-missing single required script (no present sibling)
+                # stays required (MYC-2558).
+                satisfied_basenames = {
+                    os.path.basename(r) for r in paths if exists[r]
+                }
+                for raw in paths:
+                    if exists[raw]:
                         continue
+                    p = Path(os.path.expanduser(raw))
                     short = cmd[:80] + ("…" if len(cmd) > 80 else "")
                     entry = (event, str(p), short)
-                    if _is_gated_command(cmd, raw):
+                    if _is_gated_command(cmd, raw) or \
+                            os.path.basename(raw) in satisfied_basenames:
                         missing_optional.append(entry)
                     else:
                         missing_required.append(entry)
@@ -885,7 +906,7 @@ def run_verification(settings: dict, fail_on_missing: bool = False) -> int:
     ok_count -= len(missing_required) + len(missing_optional)
     print(f"  OK     {ok_count} hook(s) — referenced scripts exist on disk")
     if missing_optional:
-        print(f"  SKIP   {len(missing_optional)} hook(s) — optional (gated by [ -f ... ] guard):")
+        print(f"  SKIP   {len(missing_optional)} hook(s) — optional ([ -f ] guard, or a same-basename fallback sibling exists):")
         for event, p, _short in missing_optional:
             print(f"           {event}: {p}")
     if missing_required:

--- a/tests/integration/test_verify_fallback_chain_optional.sh
+++ b/tests/integration/test_verify_fallback_chain_optional.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Regression test for install-hooks-user-level.py --fail-on-missing on
+# ||-fallback chains (MYC-2558).
+#
+# Bug: verify_paths_on_disk treated EVERY script path referenced in a hook
+# command as REQUIRED. The detect-closing-signal hook is a fallback chain
+#   python3 '<vault-copy>' 2>/dev/null || python3 <home-copy> 2>/dev/null || echo {...}
+# On a healthy vault install the vault-side copy legitimately does NOT exist
+# (only the ~/.claude home copy does). The verifier flagged the missing vault
+# copy as REQUIRED -> --fail-on-missing exit 1 -> the auto-update told the user
+# "the hook re-install didn't finish cleanly" every ~6-day cycle, forever, on
+# otherwise-healthy macOS/Linux vault installs.
+#
+# Two defects are fixed, both exercised here:
+#   1. Same-basename siblings in ONE command: when >=1 copy exists on disk the
+#      chain is satisfied at runtime, so the missing sibling(s) are OPTIONAL,
+#      not REQUIRED. Scoped to a single command; never across commands.
+#   2. Quoting the first path used to leave `2>/dev/null` captured as a bogus
+#      "missing required path" (the path-extraction regex grabbed the redirect
+#      once the quoted script was stripped). It is no longer captured as a path.
+#
+# Asserts:
+#   (a) a detect-closing-signal-shaped `||` chain where ONLY the ~/.claude home
+#       copy exists on disk -> --fail-on-missing exits 0.  (the primary fix)
+#   (b) NEGATIVE CONTROL: neither copy exists -> --fail-on-missing exits 1 and
+#       the FAIL block names the missing script.  (proves the gate still bites)
+#   (c) `2>/dev/null` never appears as a flagged path in the (a) report.
+#
+# Self-contained. Exit 0 = pass.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+INSTALLER="$REPO_ROOT/scripts/install-hooks-user-level.py"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+[[ -f "$INSTALLER" ]] || fail "installer missing at $INSTALLER"
+
+# Throwaway HOME so we never touch the real ~/.claude/settings.json.
+TMP_HOME="$(mktemp -d)"
+trap 'rm -rf "$TMP_HOME"' EXIT
+
+# Fake skill repo. is_abs_owned() matches the substring
+# "ai-brain-starter/hooks/detect-closing-signal.py", so we mirror that layout.
+SKILL_DIR="$TMP_HOME/.claude/skills/ai-brain-starter"
+mkdir -p "$SKILL_DIR/hooks"
+
+# The two copies the detect-closing-signal fallback chain references:
+#   HOME_COPY  — ~/.claude/skills/... — guaranteed present on every install.
+#   VAULT_COPY — inside the vault — legitimately absent on a vault install.
+HOME_COPY="$SKILL_DIR/hooks/detect-closing-signal.py"
+VAULT_COPY="$TMP_HOME/MyVault/.claude/skills/ai-brain-starter/hooks/detect-closing-signal.py"
+
+# Only the home copy exists on disk — the healthy-vault-install state.
+cat > "$HOME_COPY" <<'EOF'
+#!/usr/bin/env python3
+print('{"continue": true}')
+EOF
+
+# The real production command shape: quoted vault path + 2>/dev/null + `||`
+# home path + `||` echo fallback. Keep the vault path quoted — that is what
+# used to leave `2>/dev/null` captured as a bogus missing path, so the test
+# bites defect #2 as well as #1. Inlined in the heredoc (not via a shell var)
+# so the `\"` JSON escapes survive: an unquoted heredoc only treats
+# $ ` \ newline as special, so `\"` is preserved verbatim while $VAULT_COPY /
+# $HOME_COPY expand and the single quotes stay literal.
+cat > "$SKILL_DIR/hooks.json" <<EOF
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 '$VAULT_COPY' 2>/dev/null || python3 $HOME_COPY 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'"
+          }
+        ]
+      }
+    ]
+  }
+}
+EOF
+
+SETTINGS_PATH="$TMP_HOME/.claude/settings.json"
+
+# --- (a) only the home copy exists -> exit 0 -------------------------------
+echo "{}" > "$SETTINGS_PATH"
+set +e
+OUT=$(python3 "$INSTALLER" --hooks-source "$SKILL_DIR/hooks.json" \
+        --settings "$SETTINGS_PATH" --fail-on-missing 2>&1)
+RC=$?
+set -e
+[[ $RC -eq 0 ]] || fail "(a) healthy vault install (home copy present, vault copy absent) should exit 0, got $RC. Output:
+$OUT"
+
+# --- (c) 2>/dev/null must never be captured as a script path --------------
+if echo "$OUT" | grep -qE 'dev/null'; then
+    fail "(c) '2>/dev/null' was captured as a path in the verification report:
+$OUT"
+fi
+
+# --- (b) NEGATIVE CONTROL: neither copy exists -> exit 1 ------------------
+rm -f "$HOME_COPY"
+echo "{}" > "$SETTINGS_PATH"
+set +e
+OUT=$(python3 "$INSTALLER" --hooks-source "$SKILL_DIR/hooks.json" \
+        --settings "$SETTINGS_PATH" --fail-on-missing 2>&1)
+RC=$?
+set -e
+[[ $RC -eq 1 ]] || fail "(b) NEGATIVE CONTROL: neither copy present should exit 1, got $RC. Output:
+$OUT"
+echo "$OUT" | grep -q "FAIL.*hook(s) — script not on disk" || \
+    fail "(b) expected FAIL line naming the missing script. Got:
+$OUT"
+echo "$OUT" | grep -qF "detect-closing-signal.py" || \
+    fail "(b) expected the missing detect-closing-signal.py path in the FAIL block. Got:
+$OUT"
+
+echo "PASS: ||-fallback chain optional-classification (MYC-2558) — home-only install rc 0; neither-copy negative control rc 1; no 2>/dev/null false-capture"


### PR DESCRIPTION
Fixes MYC-2558. Closes #291.

## The bug

`scripts/install-hooks-user-level.py::verify_paths_on_disk()` treated **every** script path referenced in a hook command as REQUIRED. But `detect-closing-signal` is wired as a `||` fallback chain:

```
python3 '[VAULT_PATH]/.../detect-closing-signal.py' 2>/dev/null || python3 ~/.claude/.../detect-closing-signal.py 2>/dev/null || echo '{...}'
```

On a healthy vault install the first (vault-path) copy legitimately does **not** exist — only the `~/.claude` home copy does. The verifier flagged the missing vault copy as REQUIRED, so `--fail-on-missing` exited 1, and the auto-update (`scripts/ai-brain-auto-update.py`) then told the user *"the hook re-install didn't finish cleanly"* on every ~6-day cycle, forever. Observed live 2026-07-02 during the PR #288 close-out: 3 FAIL rows on an otherwise-healthy macOS install. Same scary-recurring-warning class the Windows fixes (#288/#292/#293) already killed, still live on macOS/Linux vault installs.

## The fix (two defects, both required to reach rc 0)

1. **Same-basename fallback siblings.** Within **one** command string, when multiple referenced paths share the same basename and at least one exists on disk, the chain is satisfied at runtime — the missing sibling(s) are classified `missing_optional`, not `missing_required`. Scoped to a single command, never across commands, so a genuinely-missing single required script (no present sibling) still fails the gate. This extends the existing `_is_gated_command()` optional-classification.

2. **`2>/dev/null` bogus capture.** Quoting the first path meant that once the quoted script was stripped for the bare-path pass, the bare regex grabbed `2>/dev/null` as a "missing required path." `bare_re` now requires a `.py`/`.sh` extension (matching `quoted_re` and `_SCRIPT_RE`), so a shell redirection is never mistaken for a script. Without this, the basename-sibling fix alone could **not** get a healthy install to rc 0 (basename `null` has no sibling).

## Regression test

`tests/integration/test_verify_fallback_chain_optional.sh` (wired into `scripts/ci.sh` INTEGRATION_TESTS, which now enforces a gate-coverage invariant):

- **(a)** a `detect-closing-signal`-shaped `||` chain where only the `~/.claude` home copy exists → `--fail-on-missing` exits **0**.
- **(b) negative control** — neither copy exists → exits **1**, FAIL block names the missing script. Verified this leg bites against the fix.
- **(c)** `2>/dev/null` never appears as a flagged path.

## Doubt-pass (path-extraction regex vs adversarial strings)

Verified empirically: quoted spaced vault paths, quoted vs unquoted, a real `[ -f ]` gate still classified optional, a legitimate single required script still classified required, a `||` chain where the **last** (home) copy is the missing one (→ optional), and a different-basename sibling that must **not** rescue a missing script (basename scoping holds).

`bash scripts/ci.sh` green: py_compile (279 files) + 73 integration tests + shellcheck (148 files, no findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
