### PR TITLE
test(install): dogfood the real hooks.json through --fail-on-missing (MYC-2558)

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -101,6 +101,7 @@ INTEGRATION_TESTS=(
   test_ai_brain_auto_update
   test_installer_replaces_auto_update
   test_verify_fallback_chain_optional
+  test_verify_real_hooksjson_healthy_install
   test_detect_closing_signal_worktree
   test_detect_closing_signal_repo_aware_vault
   test_closing_claim_shared

--- a/tests/integration/test_verify_real_hooksjson_healthy_install.sh
+++ b/tests/integration/test_verify_real_hooksjson_healthy_install.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Dogfoods the REAL shipped hooks.json through the installer's --fail-on-missing
+# verifier on a faithfully-reconstructed HEALTHY vault install (MYC-2558 follow-up).
+#
+# Why this exists on top of test_verify_fallback_chain_optional.sh: that test
+# proves the classification LOGIC on a synthetic one-command hooks.json. It would
+# NOT catch a false-positive introduced by some OTHER hook's command shape — the
+# exact blind spot behind MYC-2558, where a healthy macOS/Linux vault install
+# nagged "the hook re-install didn't finish cleanly" every ~6-day cycle. This
+# test asserts the property against the ACTUAL artifact clients install, so any
+# future hooks.json change that reintroduces the recurring-warning class fails CI.
+#
+# Faithful healthy-install state:
+#   - ~/.claude/skills/ai-brain-starter/... home copies present (every install has these)
+#   - vault-content hooks under <vault>/⚙️ Meta/scripts/... present (phase-05 wires them)
+#   - the skill repo is NOT cloned into <vault>/.claude/skills/ai-brain-starter/, so the
+#     vault-side copy of the ||-fallback hook is ABSENT — only the home copy backs it.
+#
+# Asserts:
+#   (a) that healthy install -> `--fail-on-missing` exits 0.
+#   (b) NEGATIVE CONTROL: delete one genuinely-required home hook -> exits 1.
+#
+# The installer's OWN path extractor enumerates what to create, so the test can
+# never drift from however the installer parses commands. Self-contained; exit 0 = pass.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+export REPO_ROOT
+
+python3 <<'PY'
+import importlib.util, os, tempfile, json, subprocess, sys
+from pathlib import Path
+
+repo = os.environ["REPO_ROOT"]
+installer = repo + "/scripts/install-hooks-user-level.py"
+spec = importlib.util.spec_from_file_location("ih", installer)
+ih = importlib.util.module_from_spec(spec); spec.loader.exec_module(ih)
+
+def fail(msg):
+    print("FAIL:", msg); sys.exit(1)
+
+TMP = Path(tempfile.mkdtemp()).resolve()
+HOME = TMP / "home";      HOME.mkdir()
+VAULT = TMP / "FakeVault"; VAULT.mkdir()
+env = dict(os.environ, HOME=str(HOME))
+os.environ["HOME"] = str(HOME)  # module-level expanduser during enumeration
+
+tmpl = json.load(open(repo + "/hooks.json"))
+norm = ih.normalize_path_substitutions(tmpl, str(VAULT))
+merged, _ = ih.merge_hooks({}, norm)
+
+# Empty sandbox -> the verifier reports every referenced path as missing, which
+# is exactly the enumeration of what a real install must have on disk.
+req, opt = ih.verify_paths_on_disk(merged)
+all_paths = [p for _, p, _ in req] + [p for _, p, _ in opt]
+if not all_paths:
+    fail("no script paths extracted from the real hooks.json — enumeration broke")
+
+vres = str(VAULT.resolve())
+def is_skill_in_vault(p):
+    # Realistic: skill repo NOT cloned into the vault, so its vault-side copy is absent.
+    return p.startswith(vres) and "/.claude/skills/ai-brain-starter/" in p
+
+left_absent = []
+for p in all_paths:
+    if is_skill_in_vault(p):
+        left_absent.append(p); continue
+    fp = Path(p); fp.parent.mkdir(parents=True, exist_ok=True)
+    fp.write_text("#!/usr/bin/env python3\nprint('{}')\n")
+
+if not left_absent:
+    fail("expected >=1 skill-in-vault ||-fallback copy to leave absent; found none "
+         "(did the fallback hook change shape?)")
+
+settings = TMP / "settings.json"
+def run_installer():
+    settings.write_text("{}")
+    return subprocess.run(
+        [sys.executable, installer, "--hooks-source", repo + "/hooks.json",
+         "--vault-path", str(VAULT), "--settings", str(settings),
+         "--fail-on-missing", "--quiet"],
+        capture_output=True, text=True, env=env)
+
+# (a) healthy install -> rc 0
+r = run_installer()
+if r.returncode != 0:
+    fail("healthy vault install of the REAL hooks.json exited %d (want 0).\n"
+         "STDOUT:\n%s\nSTDERR:\n%s" % (r.returncode, r.stdout[-1500:], r.stderr[-1500:]))
+
+# (b) NEGATIVE CONTROL: a genuinely-missing required hook must still fail the gate.
+victim = Path(os.path.expanduser("~/.claude/skills/ai-brain-starter/hooks/log-skill-usage.py"))
+if not victim.is_file():
+    fail("expected required home hook log-skill-usage.py present before neg-control delete "
+         "(hook removed from template? update this test)")
+victim.unlink()
+r2 = run_installer()
+if r2.returncode != 1:
+    fail("NEGATIVE CONTROL: a genuinely-missing required hook should exit 1, got %d.\n"
+         "STDOUT:\n%s" % (r2.returncode, r2.stdout[-1200:]))
+
+print("PASS: REAL hooks.json healthy vault install -> rc 0 (%d ||-fallback vault copy(ies) "
+      "left absent); neg control (missing required hook) -> rc 1" % len(left_absent))
+PY


### PR DESCRIPTION
Follow-up hardening to MYC-2558 (#295). Does not reopen it — strengthens its test coverage.

## Why

The fix in #295 shipped with `test_verify_fallback_chain_optional.sh`, which proves the classification **logic** on a *synthetic* one-command `hooks.json`. That test cannot catch a false-positive introduced by some **other** hook's command shape — which is precisely the blind spot that produced MYC-2558 (a healthy macOS/Linux vault install nagging *"the hook re-install didn't finish cleanly"* every ~6-day cycle, forever).

This is the [recurring-warning class](https://github.com/mycelium-hq/ai-brain-starter/pull/288) that #288/#292/#293/#295 have each swatted individually. This PR adds the missing **dogfood-the-real-artifact** assertion so the class fails CI instead of reaching a client's terminal.

## What

`tests/integration/test_verify_real_hooksjson_healthy_install.sh` reconstructs a faithful healthy vault install from the **actual shipped `hooks.json`** (home copies present; the skill repo *not* cloned into the vault, so the `||`-fallback hook's vault-side copy is absent) and asserts:

- **(a)** `install-hooks-user-level.py --fail-on-missing` exits **0**.
- **(b) negative control** — deleting one genuinely-required home hook → exits **1**.

The installer's **own** path extractor enumerates what to create, so the test can never drift from how the installer parses commands. Verified locally against `origin/main`: healthy install → rc 0 (1 `||`-fallback vault copy left absent), neg control → rc 1.

`bash scripts/ci.sh` green: py_compile (279) + **74** integration tests + shellcheck (no findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
