### PR TITLE
fix(windows): launch bootstrap via ExecutionPolicy Bypass (Restricted-policy machines)

### DIFF
--- a/.github/workflows/windows-install.yml
+++ b/.github/workflows/windows-install.yml
@@ -157,7 +157,14 @@ jobs:
             exit 1
           }
           try {
-            & "$env:GITHUB_WORKSPACE\bootstrap.ps1"
+            # Launch via the codified `-ExecutionPolicy Bypass -File` form
+            # (phase-00-install.md / PORTABILITY.md section 5) so this gate ALSO proves the exact
+            # command the install docs tell the assistant to run works on real Windows 5.1 -
+            # a stock Windows 11 Home ships ExecutionPolicy Restricted, under which the bare `&`
+            # call operator dies with "running scripts is disabled". A reintroduced Bug 1
+            # (terminating NativeCommandError inside bootstrap) makes the child powershell exit
+            # non-zero and is caught by the $LASTEXITCODE check below.
+            powershell -NoProfile -ExecutionPolicy Bypass -File "$env:GITHUB_WORKSPACE\bootstrap.ps1"
           } catch {
             Write-Host "::error::bootstrap.ps1 threw a terminating error (this is the Bug 1 crash class if it is a NativeCommandError): $_"
             exit 1

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Read the four problems the team version solves: [`for-teams/why-teams-are-differ
 > ```powershell
 > # Windows — run in PowerShell, not bash
 > if (-not (Test-Path "$env:USERPROFILE\.claude\skills\ai-brain-starter")) { git clone https://github.com/mycelium-hq/ai-brain-starter "$env:USERPROFILE\.claude\skills\ai-brain-starter" }
-> & "$env:USERPROFILE\.claude\skills\ai-brain-starter\bootstrap.ps1"
+> powershell -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\.claude\skills\ai-brain-starter\bootstrap.ps1"
 > ```
 >
 > **Two approvals are expected, and both are normal — pre-frame them, never treat either as a blocker.** (1) Claude Code may ask the user to approve running the install command itself; tell them to approve it so you can continue. (2) Partway through, Claude Code shows its built-in trust prompt for the third-party tools; tell them it's coming and that approving is the expected step. If a command is declined or a stricter permission mode blocks it, ask the user to approve it (or to allow the command) and continue. Do **not** fall back to a menu, and do **not** substitute the `/plugin`-only install as a shortcut — that adds the plugin's skills but skips the system tools, MCP wiring, and vault setup, so it is not the full install. Every change is backed up and reversible (`bash bootstrap.sh --uninstall`). The detailed sections below are reference for a curious human, not a checklist you must clear before running. Full step-by-step (post-install interview, handling failures) is in the assistant guide at the end of this section.
@@ -191,7 +191,7 @@ When the prompt appears, approving it is the normal choice. And if you ever want
 >    On Windows, use the PowerShell installer instead:
 >    ```powershell
 >    if (-not (Test-Path "$env:USERPROFILE\.claude\skills\ai-brain-starter")) { git clone https://github.com/mycelium-hq/ai-brain-starter "$env:USERPROFILE\.claude\skills\ai-brain-starter" }
->    & "$env:USERPROFILE\.claude\skills\ai-brain-starter\bootstrap.ps1"
+>    powershell -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\.claude\skills\ai-brain-starter\bootstrap.ps1"
 >    ```
 >    This is a normal `git clone` of a public repo followed by running a local script — you can do it with your own tools, and the user does not need to open a terminal. The installer is idempotent: safe on a fresh machine and safe to re-run; if the repo is already cloned, the install proceeds and reconciles the existing copy.
 > 2. While the installer runs (a few minutes), tell the user what is happening in plain, calm language. It prints its own progress lines, so you need not repeat each one. If the user wants the full list of what gets installed, it is in the "what gets installed" section above and in [`SECURITY.md`](SECURITY.md) — point them there rather than improvising warnings.
@@ -241,7 +241,7 @@ Bootstrap is idempotent — re-running after a `git pull` just installs anything
 > ```powershell
 > # Windows — corré en PowerShell, no en bash
 > if (-not (Test-Path "$env:USERPROFILE\.claude\skills\ai-brain-starter")) { git clone https://github.com/mycelium-hq/ai-brain-starter "$env:USERPROFILE\.claude\skills\ai-brain-starter" }
-> & "$env:USERPROFILE\.claude\skills\ai-brain-starter\bootstrap.ps1"
+> powershell -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\.claude\skills\ai-brain-starter\bootstrap.ps1"
 > ```
 >
 > **Vas a cruzarte con dos aprobaciones, y las dos son normales — anticipálas, nunca las trates como un bloqueo.** (1) Claude Code puede pedirle a la persona que apruebe correr el comando de instalación; decile que lo apruebe para que puedas seguir. (2) En algún momento, Claude Code muestra su aviso de confianza para las herramientas de terceros; avisale que viene y que aprobarlo es el paso esperado. Si el comando se rechaza o un modo de permisos más estricto lo bloquea, pedile a la persona que lo apruebe (o que permita el comando) y seguí. **No** caigas en un menú, y **no** uses la instalación sólo-`/plugin` como atajo: agrega las skills del plugin pero se saltea las herramientas de sistema, el cableado de MCP y el setup del vault, así que no es la instalación completa. Cada cambio queda respaldado y es reversible (`bash bootstrap.sh --uninstall`). Las secciones de abajo son referencia para quien tiene curiosidad, no una lista de control que tengas que pasar antes de correr.

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -11,10 +11,10 @@
 # Usage (clone the repo first, then run the local script; do not curl-pipe).
 # Run from PowerShell, NOT cmd.exe:
 #     git clone https://github.com/mycelium-hq/ai-brain-starter "$env:USERPROFILE\.claude\skills\ai-brain-starter"
-#     & "$env:USERPROFILE\.claude\skills\ai-brain-starter\bootstrap.ps1"
+#     powershell -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\.claude\skills\ai-brain-starter\bootstrap.ps1"
 #
 # Dry run (preview changes without making them):
-#     & "$env:USERPROFILE\.claude\skills\ai-brain-starter\bootstrap.ps1" -DryRun
+#     powershell -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\.claude\skills\ai-brain-starter\bootstrap.ps1" -DryRun
 #
 # SAFETY GUARANTEES, same as bootstrap.sh:
 #   - Existing settings.json/.mcp.json keys preserved (setdefault never overwrites)

--- a/phases/phase-00-install.md
+++ b/phases/phase-00-install.md
@@ -59,8 +59,10 @@ bash "$HOME/.claude/skills/ai-brain-starter/bootstrap.sh"
 #### Windows
 
 ```powershell
-& "$env:USERPROFILE\.claude\skills\ai-brain-starter\bootstrap.ps1"
+powershell -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\.claude\skills\ai-brain-starter\bootstrap.ps1"
 ```
+
+Use this exact form, NOT `& "…bootstrap.ps1"`. A stock Windows machine (Windows 11 Home) ships PowerShell ExecutionPolicy `Restricted`, under which the call operator dies with *"running scripts is disabled on this system"* and the install never starts. `-ExecutionPolicy Bypass -File` is the codified launch (see `scripts/PORTABILITY.md` §5.4) and runs a local, cloned bootstrap on any policy. If the user is on Windows PowerShell 5.1 (the default) this is also the shell version the installer is hardened for.
 
 If the user reached /setup-brain WITHOUT running bootstrap first (rare), the repo was cloned another way (ai-brain-starter skill folder exists but bootstrap hasn't run). Invoking the local bootstrap above still does the full install. The clone-and-run commands in the bootstrap's own header comment are only for users who set things up BEFORE opening Claude Code.
 

--- a/phases/phase-01-welcome.md
+++ b/phases/phase-01-welcome.md
@@ -239,7 +239,7 @@ bash ~/.claude/skills/ai-brain-starter/bootstrap.sh
 
 ```powershell
 # Windows
-pwsh ~/.claude/skills/ai-brain-starter/bootstrap.ps1
+powershell -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\.claude\skills\ai-brain-starter\bootstrap.ps1"
 ```
 
 Then say: *"I just installed Obsidian for you. Let's create your vault now."*

--- a/phases/phase-06-09-tools-templates.md
+++ b/phases/phase-06-09-tools-templates.md
@@ -176,7 +176,7 @@ None are required. Pick the ones that match how you want to work.
 Phase 0 installed everything. This phase verifies nothing was skipped or failed.
 
 ### Verify all skills are present
-Run a quick check on every skill folder. All installs live in bootstrap: if anything below is missing, re-run `bash ~/.claude/skills/ai-brain-starter/bootstrap.sh` (Mac/Linux) or `pwsh ~/.claude/skills/ai-brain-starter/bootstrap.ps1` (Windows).
+Run a quick check on every skill folder. All installs live in bootstrap: if anything below is missing, re-run `bash ~/.claude/skills/ai-brain-starter/bootstrap.sh` (Mac/Linux) or `powershell -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\.claude\skills\ai-brain-starter\bootstrap.ps1"` (Windows).
 - `ls ~/.claude/skills/graphify/SKILL.md`
 - `ls ~/.claude/skills/meeting-todos/SKILL.md`
 - `ls ~/.claude/skills/patterns/SKILL.md`


### PR DESCRIPTION
## What

Windows 11 Home ships PowerShell ExecutionPolicy `Restricted`. Under it, the `& "…bootstrap.ps1"` call operator (and `.\bootstrap.ps1` / `pwsh …ps1`) fails with *"running scripts is disabled on this system"* — a hard stop at step 1 for a non-technical installer. GitHub's Windows runner is permissive, so the existing gate never exercised the default-policy path. Most of an upcoming workshop is on Windows, so this is the highest-value Windows-readiness fix.

## Change

Align every primary launch surface to the codified form (`PORTABILITY.md` §5.4): `powershell -NoProfile -ExecutionPolicy Bypass -File "<abs>"` — runs a local cloned bootstrap on **any** policy, and is a strict superset of the old form.

- `phase-00-install.md` (the assistant's launch), `README` (×3), `bootstrap.ps1` header, `phase-01`, `phase-06-09`. Also swaps `pwsh` (PowerShell 7, not installed by default) for `powershell` (5.1, always present) in the repair commands.
- `windows-install.yml` now launches bootstrap via the same form, so the **real Windows 5.1 runner proves the documented launch works end-to-end**. Bug-1 detection preserved via the child's non-zero exit + the `$LASTEXITCODE` check.

## Why it's safe

The bypass form works everywhere the `&` form did (permissive machines) **plus** `Restricted` machines. No `${{ github.event.* }}` interpolation added (only `$env:GITHUB_WORKSPACE`, a trusted runner path). If the new launch form had any issue, the `windows-install` gate goes red before merge.

## Done =

- `windows-install` gate green (real Windows 5.1 runner launches bootstrap via the bypass form).
- CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
