### PR TITLE
fix(backup): read .vault-backup.conf as utf-8-sig so a BOM'd config isn't misread as no-backup

### DIFF
--- a/scripts/check-vault-backup.py
+++ b/scripts/check-vault-backup.py
@@ -92,7 +92,11 @@ def _now() -> float:
 
 def _read_conf() -> dict:
     try:
-        return json.loads(CONF_PATH.read_text())
+        # utf-8-sig: tolerate a UTF-8 BOM. Windows PowerShell 5.1's
+        # Set-Content -Encoding UTF8 (used by vault-backup.ps1) prepends one;
+        # plain read_text() would raise "Unexpected UTF-8 BOM" (a ValueError),
+        # silently zeroing the config and mis-reporting a real backup as absent.
+        return json.loads(CONF_PATH.read_text(encoding="utf-8-sig"))
     except (OSError, ValueError):
         return {}
 


### PR DESCRIPTION
## What
`check-vault-backup.py` is the single source of truth for "does this vault have an off-machine backup" — `/diagnose` §12, `surface-backup-status.py` (the SessionStart nag), and the phase-01 onboarding gate all route through it. It reads `~/.claude/.vault-backup.conf` with plain `read_text()`.

## Bug
On Windows, `vault-backup.ps1` writes that config via PowerShell 5.1 `Set-Content -Encoding UTF8`, which **prepends a UTF-8 BOM**. `json.loads()` then raises `json.decoder.JSONDecodeError: Unexpected UTF-8 BOM` — a `ValueError` that `_read_conf()`'s `except (OSError, ValueError)` swallows, returning `{}`. Net effect: a configured, snapshotting, restore-verified backup is reported as **`NO_BACKUP`**. Because the daily scheduled run re-writes the BOM every night, it never self-corrects — `/diagnose` shows a red FAIL forever and the SessionStart hook nags every session.

## Repro (Windows 11 / PowerShell 5.1)
1. `pwsh scripts/vault-backup.ps1 setup -Vault <vault> -Dest <onedrive-folder>` → first snapshot written, daily task scheduled.
2. `pwsh scripts/vault-backup.ps1 verify` → restore succeeds (files extracted, CLAUDE.md present).
3. `python scripts/check-vault-backup.py <vault>` → `FAIL ... NO_BACKUP`; `/diagnose` §12 shows the same.

`python -c "import json; json.loads(open(conf).read())"` reproduces the underlying `Unexpected UTF-8 BOM` directly.

## Fix
Read the config with `encoding="utf-8-sig"` — strips an optional BOM, and is a no-op for the BOM-less configs `vault-backup.sh` writes on macOS/Linux. One line + a comment; no behavior change on non-Windows.

## Note for maintainers
The writer side (`vault-backup.ps1` `Set-ConfEntry` → `Set-Content -Encoding UTF8`) is what emits the BOM. Making the reader BOM-tolerant fixes every consumer at once, but you may also want to write the config BOM-less at the source (e.g. `[System.IO.File]::WriteAllText` with a `UTF8Encoding($false)`).

Found on a real Windows install during a `/diagnose` health check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)