### PR TITLE
fix(backup): complete the BOM class — surface-backup-status + a structural guard

### DIFF
--- a/hooks/surface-backup-status.py
+++ b/hooks/surface-backup-status.py
@@ -99,7 +99,13 @@ def _porcelain(repo: Path) -> str | None:
 def _verify_age_days(repo: Path) -> float | None:
     """Days since the last verified restore for this vault, or None if never."""
     try:
-        conf = json.loads(CONF_PATH.read_text())
+        # utf-8-sig: tolerate a UTF-8 BOM. vault-backup.ps1 writes this config
+        # via Windows PowerShell 5.1 Set-Content -Encoding UTF8, which prepends
+        # one; plain read_text() raises "Unexpected UTF-8 BOM" (a ValueError),
+        # zeroing verify-age so a verified backup reads as never-verified. The
+        # sibling reader (check-vault-backup.py _read_conf) was fixed in #301;
+        # this direct reader is the same file's second consumer.
+        conf = json.loads(CONF_PATH.read_text(encoding="utf-8-sig"))
     except (OSError, ValueError):
         return None
     entry = (conf.get("vaults") or {}).get(str(repo))

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -136,6 +136,7 @@ INTEGRATION_TESTS=(
   test_orphan_branch_bounded_git
   test_footprint_sla
   test_vault_safety_guards
+  test_vault_backup_conf_bom
   test_resource_aware_session_close
   test_cloud_sync_guard
   test_cloud_sync_offer

--- a/tests/integration/test_vault_backup_conf_bom.sh
+++ b/tests/integration/test_vault_backup_conf_bom.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Structural regression — backfills the #301 sibling-miss.
+#
+# vault-backup.ps1 writes ~/.claude/.vault-backup.conf via Windows PowerShell 5.1
+# `Set-Content -Encoding UTF8`, which prepends a UTF-8 BOM. A reader that decodes
+# with plain read_text() raises "Unexpected UTF-8 BOM" (a ValueError). Every
+# backup-status consumer swallows that in `except (OSError, ValueError)` and
+# returns empty, so a configured, snapshotting, restore-verified backup reads as
+# ABSENT / never-verified — a red /diagnose FAIL and a SessionStart nag that
+# never self-corrects (the daily task re-writes the BOM nightly).
+#
+# #301 fixed one reader (scripts/check-vault-backup.py _read_conf), but a SIBLING
+# reader in the same class (hooks/surface-backup-status.py _verify_age_days) read
+# the same file with plain read_text() and was missed. This test locks the class
+# invariant: EVERY reader of that config must decode utf-8-sig, so a future third
+# reader cannot silently reintroduce the bug. Fails loud if zero readers are found
+# (the config handle was renamed and this guard is now blind).
+#
+# Bash only, no network. exit 0 = every reader is BOM-tolerant.
+set -u
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+conf_readers() {
+  grep -rnE 'CONF_PATH\.read_text\(' "$REPO/hooks" "$REPO/scripts" --include='*.py' 2>/dev/null
+}
+
+total=0
+bad=0
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  total=$((total + 1))
+  if ! printf '%s' "$line" | grep -q 'utf-8-sig'; then
+    echo "FAIL  BOM-unsafe .vault-backup.conf reader (missing utf-8-sig):"
+    echo "        ${line#"$REPO"/}"
+    bad=$((bad + 1))
+  fi
+done < <(conf_readers)
+
+if [ "$total" -eq 0 ]; then
+  echo "FAIL  found ZERO CONF_PATH.read_text() readers — the config handle likely"
+  echo "      renamed. Update this guard to track the new reader(s), or it is blind."
+  exit 1
+fi
+
+if [ "$bad" -eq 0 ]; then
+  echo "PASS  all $total .vault-backup.conf reader(s) decode utf-8-sig (BOM-tolerant)"
+  exit 0
+fi
+echo
+echo "FAIL  $bad of $total reader(s) would choke on a BOM'd config on Windows."
+echo "      Fix: json.loads(CONF_PATH.read_text(encoding=\"utf-8-sig\"))"
+exit 1


### PR DESCRIPTION
## What

Completes the bug class PR #301 opened. #301 fixed `check-vault-backup.py`, but `.vault-backup.conf` has a **second reader** that was missed.

## The residual

`hooks/surface-backup-status.py` routes its main "has backup?" check through the (now-fixed) detector — but `_verify_age_days()` reads the same `.vault-backup.conf` **directly** with plain `read_text()`. On Windows the BOM'd config (from `vault-backup.ps1`'s `Set-Content -Encoding UTF8`) still makes that path raise `Unexpected UTF-8 BOM`, so a verified backup reads as never-verified — the SessionStart-nag half of the same bug #301 fixed for `/diagnose`.

## Fix

- `surface-backup-status.py`: read the config with `encoding="utf-8-sig"` (mirrors #301).
- **Guard** — `tests/integration/test_vault_backup_conf_bom.sh`: a structural regression requiring **every** `CONF_PATH.read_text()` reader to decode `utf-8-sig`. This is the invariant #301 lacked; a test would have caught this sibling. Fails loud if zero readers are found (config handle renamed → guard blind). Wired into `scripts/ci.sh`.

## Scope check

`.mcp.json` and `settings.json` are written by Python (`json.dump`) on Windows, not `Set-Content`, so they carry no BOM — `.vault-backup.conf` was the only config with an active BOM writer. The class is complete.

## Testing

- `bash scripts/ci.sh` green: py_compile 278 files, **76** integration tests, shellcheck over 150 `.sh`.
- Guard verified with a negative control: it **fails** on the pre-fix reader and **passes** with the fix.

## Done =

- CI green.
- Both `.vault-backup.conf` readers decode `utf-8-sig`; the guard enforces it for any future reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
