### PR TITLE
fix(windows): platform-agnostic Phase-5 scaffolding + corporate launch consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Bootstrap touches your `~/.claude/` directory and registers third-party content.
 
 **Don't want all of it?** Set `SKIP_VENDOR_SKILLS=1` to skip third-party plugin marketplaces. The core ai-brain-starter substrate still installs. Removing later: `bash bootstrap.sh --uninstall` (asks for confirmation, then removes everything bootstrap installed; preserves your vault and your customizations).
 
-**Rolling out to a company / need a security review?** Use the hardened install profile: `bash bootstrap.sh --profile corporate` (Windows: `.\bootstrap.ps1 -Profile corporate`). It installs a minimal named plugin set, excludes external-egress MCPs and shell-execution-capable Obsidian plugins, turns telemetry off, pins versions, runs entirely in user space (no sudo), and emits a reviewable component manifest. Add `--dry-run` to review the manifest before installing. Full spec + security-team checklist: [`docs/CORPORATE_PROFILE.md`](docs/CORPORATE_PROFILE.md).
+**Rolling out to a company / need a security review?** Use the hardened install profile: `bash bootstrap.sh --profile corporate` (Windows: `powershell -NoProfile -ExecutionPolicy Bypass -File .\bootstrap.ps1 -Profile corporate`). It installs a minimal named plugin set, excludes external-egress MCPs and shell-execution-capable Obsidian plugins, turns telemetry off, pins versions, runs entirely in user space (no sudo), and emits a reviewable component manifest. Add `--dry-run` to review the manifest before installing. Full spec + security-team checklist: [`docs/CORPORATE_PROFILE.md`](docs/CORPORATE_PROFILE.md).
 
 Open the [Claude Code desktop app](https://claude.ai/download), sign in with a paid Claude account (Pro, Max, or Team), and paste this into the chat:
 

--- a/docs/CORPORATE_PROFILE.md
+++ b/docs/CORPORATE_PROFILE.md
@@ -22,8 +22,8 @@ bash bootstrap.sh --profile corporate
 
 ```powershell
 # Windows (PowerShell):
-.\bootstrap.ps1 -Profile corporate -DryRun   # review
-.\bootstrap.ps1 -Profile corporate           # install
+powershell -NoProfile -ExecutionPolicy Bypass -File .\bootstrap.ps1 -Profile corporate -DryRun   # review
+powershell -NoProfile -ExecutionPolicy Bypass -File .\bootstrap.ps1 -Profile corporate           # install
 ```
 
 The environment-variable form is equivalent (useful for MDM / scripted rollout):
@@ -32,7 +32,7 @@ The environment-variable form is equivalent (useful for MDM / scripted rollout):
 CORPORATE_PROFILE=1 bash bootstrap.sh
 ```
 ```powershell
-$env:CORPORATE_PROFILE = "1"; .\bootstrap.ps1
+$env:CORPORATE_PROFILE = "1"; powershell -NoProfile -ExecutionPolicy Bypass -File .\bootstrap.ps1
 ```
 
 After the run, the exact manifest is written to

--- a/phases/phase-05-context-layer.md
+++ b/phases/phase-05-context-layer.md
@@ -2,6 +2,18 @@
 
 "Now I'm creating three small notes that let me orient myself in 10 seconds every session."
 
+> **Platform note — read before running any shell command in this phase.** The
+> file and folder operations below are written as Mac/Linux bash (`cp`, `mkdir -p`,
+> `chmod`). **On Windows those error** — `cp`/`chmod` don't exist and `mkdir -p`
+> isn't valid — and the vault silently ends up missing `⚙️ Meta/scripts`,
+> `⚙️ Meta/Sessions`, `⚙️ Meta/Decisions`, and the hook scripts. So on Windows,
+> perform the SAME operations with your native file tools instead: create each
+> folder, and write/copy each file, directly (no bash). The `.sh` scripts are
+> still written to disk — they run under Git Bash/WSL if present — and `chmod +x`
+> is a Mac/Linux-only no-op you skip on Windows. The end state must be identical
+> on every OS: the folders exist and every file is in place. Verify with a
+> directory listing before moving on.
+
 Create these files in the Meta/ folder:
 
 **00 Start Here.md:**


### PR DESCRIPTION
## What

Windows hardening, found via a real Windows install's `/diagnose`.

## Phase-5 scaffolding gap (the main one)

Phase 5 creates `⚙️ Meta/scripts`, `Sessions`, `Decisions`, and the hook scripts with bash `cp`/`mkdir -p`/`chmod` — **no Windows variant** — so on Windows they error and the vault silently ends up without that scaffolding (real report: *"Meta/scripts + Meta/rules missing"*, *"graph-context-hook.sh not installed"*). Fix: a prominent platform note at the top of Phase 5 tells the assistant to perform the same file/folder operations with native tools on Windows (the `.sh` scripts are still written; `chmod` is a Mac/Linux no-op). Since `diagnose.ps1` checks file **presence**, creating the scaffolding clears its warns at the source — no diagnostic patch needed.

## Launch consistency

Remaining corporate launch spots (README + `CORPORATE_PROFILE.md`) → the `-ExecutionPolicy Bypass -File` form, matching phase-00 (a stock Windows 11 Home ships ExecutionPolicy `Restricted`).

## Scope (honest)

Deliberately **skipped**: the `vault-backup.ps1` BOM writer (the reader fix in #301/#302 already handles it — not worth risking a working backup with PS I can't runtime-test on a Mac) and the legacy claude-mem ANSI settings write (only runs on machines that had claude-mem, never a fresh install).

**Tracked follow-up (not here):** porting the 3 bash vault-content hooks (session-end, write-hook, graph-context) to Python so they *run* on Windows rather than only existing as files — a real port that needs on-Windows verification.

## Testing

- `bash scripts/ci.sh` green (docs-only; unit gate unaffected — py_compile 278, 77 integration tests, shellcheck).
- Markdown-only; no PowerShell runtime touched, so zero Mac-path risk.
- The Phase-5 behavior verifies on a real Windows re-run of setup (the test bed).

## Done =

- CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
