### PR TITLE
fix(install): repair all-platform NameError in Phase 2 plugin installer

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -315,3 +315,27 @@ jobs:
         run: pipx install ruff || python3 -m pip install --user ruff || true
       - name: run the canonical CI gate
         run: bash scripts/ci.sh
+
+  phase-python:
+    name: phase-doc Python (no undefined names / F821)
+    runs-on: ubuntu-latest
+    # The Phase 2 plugin installer and the Phase 10a graph-config block are
+    # `python3` heredocs / ```python fences INSIDE Markdown. The `ci` job's
+    # py_compile only lints tracked *.py, and py_compile cannot catch an undefined
+    # name (a runtime NameError) anyway - so a bare `VAULT_DIR` typo shipped and
+    # crashed the installer on every platform (2026-07-07). windows-install.yml
+    # runs bootstrap.ps1 end-to-end but stubs Obsidian and never executes these
+    # blocks, so it did not catch it either. This job extracts every Python block
+    # from phases/*.md and runs the undefined-name check (ruff F821) over each.
+    # ruff is installed WITHOUT a `|| true` fallback: if it cannot install, the
+    # job fails closed (a silent skip would make the gate vacuous exactly when the
+    # linter is missing). No untrusted user input is referenced in any run: command.
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
+        with:
+          python-version: "3.12"
+      - name: install ruff (the undefined-name linter this gate needs)
+        run: pipx install ruff || python3 -m pip install --user ruff
+      - name: lint phase-doc Python for undefined names (F821)
+        run: python3 scripts/check-phase-python.py

--- a/phases/phase-02-03-plugins-folders.md
+++ b/phases/phase-02-03-plugins-folders.md
@@ -8,7 +8,7 @@ Then run this Python helper, substituting `[VAULT_PATH]` with the actual vault p
 
 ```bash
 python3 - <<'PY'
-import json, os, sys, urllib.request, zipfile, io, shutil
+import json, sys, urllib.request, zipfile, io, shutil
 from pathlib import Path
 
 VAULT = Path("[VAULT_PATH]")
@@ -86,13 +86,13 @@ cp_file = OBSIDIAN_DIR / "community-plugins.json"
 existing = []
 if cp_file.exists():
     try:
-        existing = json.loads(cp_file.read_text())
+        existing = json.loads(cp_file.read_text(encoding="utf-8"))
     except Exception:
         existing = []
 for pid in installed:
     if pid not in existing:
         existing.append(pid)
-cp_file.write_text(json.dumps(existing, indent=2))
+cp_file.write_text(json.dumps(existing, indent=2), encoding="utf-8")
 
 # Configure app.json — sort files by most recently modified (newest first).
 # Merge with existing settings so we don't clobber anything the user already set.
@@ -100,7 +100,7 @@ app_file = OBSIDIAN_DIR / "app.json"
 app_settings = {}
 if app_file.exists():
     try:
-        app_settings = json.loads(app_file.read_text())
+        app_settings = json.loads(app_file.read_text(encoding="utf-8"))
     except Exception:
         app_settings = {}
 app_settings.setdefault("fileSortOrder", "byModifiedTime")
@@ -127,16 +127,17 @@ machinery_excludes = [
 existing_filters = app_settings.get("userIgnoreFilters") or []
 app_settings["userIgnoreFilters"] = list(dict.fromkeys(existing_filters + machinery_excludes))
 
-app_file.write_text(json.dumps(app_settings, indent=2))
+app_file.write_text(json.dumps(app_settings, indent=2), encoding="utf-8")
 
 # Write sortspec.md for custom-sort plugin — sorts ALL folders by the most
 # recently modified file inside them recursively (newest first).
 # Uses "advanced recursive modified" which traverses the full folder tree,
 # so folders bubble up based on the newest note anywhere inside them.
-sortspec_file = VAULT_DIR / "sortspec.md"
+sortspec_file = VAULT / "sortspec.md"
 if not sortspec_file.exists():
     sortspec_file.write_text(
-        "---\nsorting-spec: |\n  target-folder: /*\n  > advanced recursive modified\n---\n"
+        "---\nsorting-spec: |\n  target-folder: /*\n  > advanced recursive modified\n---\n",
+        encoding="utf-8",
     )
     print("sortspec.md created — folders will sort by most recently modified note (recursive).")
 else:
@@ -148,7 +149,7 @@ else:
 # here skips that manual step entirely.
 custom_sort_data = PLUGINS_DIR / "custom-sort" / "data.json"
 if "custom-sort" in installed and not custom_sort_data.exists():
-    custom_sort_data.write_text(json.dumps({"suspended": False}, indent=2))
+    custom_sort_data.write_text(json.dumps({"suspended": False}, indent=2), encoding="utf-8")
     print("custom-sort pre-activated (suspended: false written to data.json).")
 
 print(f"\nDone. Installed {len(installed)}/{len(PLUGINS)} plugins.")

--- a/phases/phase-10a-journaling.md
+++ b/phases/phase-10a-journaling.md
@@ -274,13 +274,14 @@ After creating the floor concept notes, configure the vault's `.obsidian/graph.j
 ```python
 import json, os
 
+VAULT_PATH = "[VAULT_PATH]"
 graph_path = os.path.join(VAULT_PATH, ".obsidian", "graph.json")
 os.makedirs(os.path.dirname(graph_path), exist_ok=True)
 
 # Load existing or create new
 graph = {}
 if os.path.exists(graph_path):
-    with open(graph_path) as f:
+    with open(graph_path, encoding="utf-8") as f:
         graph = json.load(f)
 
 # Add floor exclusion filter to search
@@ -292,7 +293,7 @@ if "Shame" not in existing_search:
 
 graph["showOrphans"] = False
 
-with open(graph_path, "w") as f:
+with open(graph_path, "w", encoding="utf-8") as f:
     json.dump(graph, f, indent=2)
 ```
 

--- a/scripts/check-phase-python.py
+++ b/scripts/check-phase-python.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""
+check-phase-python.py - lint the Python embedded in phases/*.md for undefined
+names (pyflakes / ruff F821).
+
+WHY THIS EXISTS
+---------------
+The Phase 2 plugin installer is a `python3` heredoc *inside a Markdown file*.
+The `ci` job's py_compile pass only sees tracked *.py files, so it never lints
+this code - and py_compile would not catch it anyway, because an undefined name
+is a RUNTIME error (NameError), not a syntax error. A bare `VAULT_DIR` typo
+therefore shipped to users and crashed the installer on every platform
+(ai-brain-starter install outage, 2026-07-07). windows-install.yml runs
+bootstrap.ps1 end-to-end but stubs Obsidian and never executes this block, so
+it did not catch it either.
+
+This gate closes that hole: it extracts every Python block from the phase docs
+(both ```python fences and `python3 ... <<'DELIM'` heredocs) and runs the
+undefined-name check (ruff F821, the same check the repo already relies on for
+its F821 path) over each. A reintroduced undefined name turns the gate red
+before it reaches a user.
+
+FAILS CLOSED: if neither ruff nor pyflakes is importable it exits non-zero. A
+silent skip would make the gate vacuous exactly when the linter is missing
+(fail-loud-not-silent-noop).
+
+Run: python3 scripts/check-phase-python.py   (exit 0 clean, 1 on any finding)
+Wired into scripts/ci.sh so the local pre-push gate and CI run the same check.
+"""
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+PHASES_DIR = Path(__file__).resolve().parent.parent / "phases"
+
+# A block may opt out with this exact marker on its own line (e.g. a deliberately
+# partial snippet that references names defined in surrounding prose).
+SKIP_MARKER = "# check-phase-python: skip"
+
+FENCE_OPEN = re.compile(r"^\s*```(?:python|py)\s*$")
+FENCE_CLOSE = re.compile(r"^\s*```\s*$")
+HEREDOC = re.compile(r"<<\s*[\"']?([A-Za-z_][A-Za-z0-9_]*)[\"']?")
+
+
+def extract_blocks(md_text, fname):
+    """Yield (label, code) for each Python block in one phase doc."""
+    lines = md_text.splitlines()
+    i, n = 0, len(lines)
+    while i < n:
+        line = lines[i]
+        if FENCE_OPEN.match(line):
+            start = i + 1
+            j = start
+            while j < n and not FENCE_CLOSE.match(lines[j]):
+                j += 1
+            yield (f"{fname}:{start + 1} (```python)", "\n".join(lines[start:j]))
+            i = j + 1
+            continue
+        m = HEREDOC.search(line)
+        if m and "python" in line:
+            delim = m.group(1)
+            start = i + 1
+            j = start
+            while j < n and lines[j].strip() != delim:
+                j += 1
+            yield (f"{fname}:{start + 1} (<<{delim})", "\n".join(lines[start:j]))
+            i = j + 1
+            continue
+        i += 1
+
+
+def lint_block_ruff(label, code):
+    """Return list of finding lines via ruff F821. ruff exits 1 on findings."""
+    res = subprocess.run(
+        ["ruff", "check", "--select", "F821", "--no-cache",
+         "--output-format", "concise", "--stdin-filename", label, "-"],
+        input=code, capture_output=True, text=True,
+    )
+    out = (res.stdout + res.stderr).strip()
+    if res.returncode == 0:
+        return []
+    return [ln for ln in out.splitlines() if "F821" in ln or "undefined" in ln.lower()]
+
+
+def lint_block_pyflakes(label, code):
+    """Fallback: pyflakes reports `undefined name 'X'`; relabel to the block."""
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as tf:
+        tf.write(code)
+        tmp = tf.name
+    try:
+        res = subprocess.run(
+            [sys.executable, "-m", "pyflakes", tmp],
+            capture_output=True, text=True,
+        )
+    finally:
+        Path(tmp).unlink(missing_ok=True)
+    findings = []
+    for ln in (res.stdout + res.stderr).splitlines():
+        if "undefined name" in ln:
+            findings.append(ln.replace(tmp, label))
+    return findings
+
+
+def pick_linter():
+    if shutil.which("ruff"):
+        return "ruff", lint_block_ruff
+    try:
+        import pyflakes  # noqa: F401
+        return "pyflakes", lint_block_pyflakes
+    except ImportError:
+        # pyflakes not installed. A broken-but-present pyflakes should raise
+        # loudly rather than be swallowed into the fail-closed path below.
+        return None, None
+
+
+def main():
+    name, lint = pick_linter()
+    if lint is None:
+        print("::error::check-phase-python needs ruff or pyflakes to lint phase-doc "
+              "Python (undefined-name check). Install one: pip install ruff", file=sys.stderr)
+        return 2  # fail closed - never silently pass
+
+    phase_docs = sorted(PHASES_DIR.glob("*.md"))
+    total_blocks = 0
+    findings = []
+    for doc in phase_docs:
+        for label, code in extract_blocks(doc.read_text(encoding="utf-8"), doc.name):
+            if SKIP_MARKER in code:
+                continue
+            total_blocks += 1
+            for f in lint(label, code):
+                findings.append(f)
+
+    if findings:
+        print(f"check-phase-python ({name}): undefined names in phase-doc Python:\n")
+        for f in findings:
+            print(f"::error::{f}")
+        print(f"\n{len(findings)} finding(s) across {total_blocks} block(s) in "
+              f"{len(phase_docs)} phase doc(s). An undefined name is a NameError at "
+              f"install time - fix the reference before it ships.")
+        return 1
+
+    print(f"check-phase-python ({name}): OK - {total_blocks} Python block(s) across "
+          f"{len(phase_docs)} phase doc(s), no undefined names (F821).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -20,6 +20,14 @@
 #                           when running inside GitHub Actions (the dedicated job
 #                           already covers it); locally it is warn-and-skipped
 #                           when the shellcheck binary is absent (CI enforces it).
+#   (d) Phase-doc Python  - scripts/check-phase-python.py extracts every Python
+#                           block from phases/*.md and runs the undefined-name
+#                           check (ruff F821). Catches a bare-identifier typo in
+#                           an install heredoc - a runtime NameError that (a)'s
+#                           py_compile cannot see (it lints tracked *.py only, and
+#                           py_compile does not catch undefined names). A dedicated
+#                           lint.yml job enforces this in CI (as the shellcheck job
+#                           does); here it is best-effort, skipped without a linter.
 #
 # It does NOT run the OTHER pure-lint jobs (bash -n, pwsh ParseFile, BOM, em-dash,
 # JSON, privacy, references, no-remote-pipe-install). Those stay as their own
@@ -229,5 +237,26 @@ else
   echo "    install: brew install shellcheck  (macOS)  /  sudo apt-get install -y shellcheck  (Debian/Ubuntu)"
 fi
 
+# ---- (d) Phase-doc Python undefined-name gate ------------------------------
+# The Phase 2 plugin installer and Phase 10a graph-config block are python3
+# heredocs / ```python fences inside Markdown, so gate (a) py_compile never sees
+# them - and py_compile cannot catch an undefined name (a runtime NameError)
+# anyway. A bare `VAULT_DIR` typo shipped and crashed the installer on every
+# platform (2026-07-07). Mirrors the shellcheck arrangement: a dedicated lint.yml
+# 'phase-python' job is authoritative in CI (installs ruff, fails closed); here it
+# is local best-effort, warn-skipped when no linter is installed (CI enforces it).
+if [ -n "${GITHUB_ACTIONS:-}" ]; then
+  phasepy_note="skipped in CI (dedicated lint.yml 'phase-python' job runs scripts/check-phase-python.py)"
+  echo "==> (d) phase-doc python: $phasepy_note"
+elif command -v ruff >/dev/null 2>&1 || "$PY" -c 'import pyflakes' >/dev/null 2>&1; then
+  echo "==> (d) phase-doc python: $PY scripts/check-phase-python.py"
+  "$PY" scripts/check-phase-python.py
+  phasepy_note="passed"
+else
+  phasepy_note="skipped (no ruff/pyflakes locally; CI enforces it)"
+  echo "==> (d) phase-doc python: $phasepy_note"
+  echo "    install: pip install ruff"
+fi
+
 echo
-echo "All gates passed: py_compile ($count file(s)) + ${#INTEGRATION_TESTS[@]} integration tests + shellcheck [$shellcheck_note]."
+echo "All gates passed: py_compile ($count file(s)) + ${#INTEGRATION_TESTS[@]} integration tests + shellcheck [$shellcheck_note] + phase-doc python [$phasepy_note]."


### PR DESCRIPTION
## What

The Phase 2 plugin-install heredoc referenced an undefined `VAULT_DIR` (only `VAULT` is defined), so the installer crashed with `NameError: name 'VAULT_DIR' is not defined` on every platform, right after writing `app.json`. Plugins downloaded and were enabled, but the run ended on a traceback (which reads as a failed install). Reported by a user installing on Windows.

The earlier UnicodeEncodeError hunch is wrong: `json.dumps` defaults to `ensure_ascii=True`, so the emoji settings are escaped to ASCII before `write_text`, and that write never crashes on Windows cp1252. Verified empirically.

## Fixes + hardening

- `VAULT_DIR` -> `VAULT` in `phase-02-03-plugins-folders.md` (the actual crash).
- `phase-10a-journaling.md` graph-config block: define `VAULT_PATH` from the standard `[VAULT_PATH]` placeholder. Same latent `NameError` class, surfaced only by the new guard.
- `encoding="utf-8"` on every `read_text` / `write_text` / `open` in both install blocks (Windows-correct; also closes a latent re-run UTF-8 decode failure).
- Remove the dead `os` import from the Phase 2 block.

## Why CI missed it, and the guard that closes the gap

This code is a `python3` heredoc inside Markdown. `windows-install.yml` runs `bootstrap.ps1` end to end but stubs Obsidian and never executes these blocks; the `ci` job's `py_compile` lints tracked `*.py` only, and `py_compile` cannot catch a runtime `NameError` anyway.

- `scripts/check-phase-python.py` extracts every Python block from `phases/*.md` (fenced and heredoc) and runs the undefined-name check (ruff F821). Fails closed if no linter is available.
- A dedicated `phase-python` job in `lint.yml` is authoritative in CI (installs ruff, no `|| true` fallback); it is also wired into `scripts/ci.sh` gate (d) for local pre-push parity.

## Verification

- The guard flags both bugs pre-fix (`VAULT_DIR` and `VAULT_PATH`) and is clean post-fix.
- The fixed Phase 2 block runs end to end against a temp vault (network stubbed) and writes `sortspec.md` instead of crashing.
- Change-relevant integration suites pass locally (`test_template_purity`, `test_open_core_boundary`, `test_phase_doc_slash_commands_installed`, `test_personal_brain_not_optional`, `test_phase11_writes_to_vault_rule_file`). The only local full-run failures are environmental (an open Obsidian blocking `test_relocate_vault`), unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
