### PR TITLE
test(relocate-vault): make the Obsidian soft-gate hermetic

### DIFF
--- a/scripts/relocate-vault.ps1
+++ b/scripts/relocate-vault.ps1
@@ -84,6 +84,18 @@ function Say  { param([string]$m) Write-Host $m }
 function Warn { param([string]$m) Write-Host "WARN  $m" -ForegroundColor Yellow }
 function Die  { param([string]$m, [int]$code = 1) Write-Host "relocate-vault: REFUSE - $m" -ForegroundColor Red; exit $code }
 
+# Obsidian-running probe with a test seam (parity with the .sh sibling's
+# obsidian_running). Default is the real Get-Process probe, so production
+# behavior is unchanged. $env:RELOCATE_VAULT_OBSIDIAN: 'running' -> report
+# running, 'absent' -> report not running, unset/anything else -> real probe.
+function Test-ObsidianRunning {
+  switch ("$($env:RELOCATE_VAULT_OBSIDIAN)") {
+    "running" { return $true }
+    "absent"  { return $false }
+    default   { return [bool](Get-Process -Name Obsidian -ErrorAction SilentlyContinue) }
+  }
+}
+
 # ---- python (path-key transform + manifest, for byte-identical semantics) -----
 $script:PyExe = $null
 function Get-PyExe {
@@ -339,7 +351,7 @@ if (Test-Path -LiteralPath $NewAbs) { Die "target '$NewAbs' already exists (will
 
 # Soft gates - skippable with -Force.
 if (-not $Force) {
-  if (Get-Process -Name Obsidian -ErrorAction SilentlyContinue) {
+  if (Test-ObsidianRunning) {
     Die "Obsidian is running - quit it first (moving an open vault is unsafe), or pass -Force"
   }
   $wt = Join-Path $OldAbs ".claude/worktrees"

--- a/scripts/relocate-vault.sh
+++ b/scripts/relocate-vault.sh
@@ -87,6 +87,24 @@ say()  { printf '%s\n' "$*"; }
 warn() { printf 'WARN  %s\n' "$*" >&2; }
 die()  { printf 'relocate-vault: REFUSE — %s\n' "$1" >&2; exit "${2:-1}"; }
 
+# Obsidian-running probe, with a test seam so the negative-control suite can drive
+# BOTH outcomes deterministically on any host. RELOCATE_VAULT_OBSIDIAN:
+#   unset / auto -> real `pgrep -x Obsidian` probe — the production default;
+#                   behavior is IDENTICAL to before this seam existed.
+#   running      -> report Obsidian as running    (drives the refusal assertion).
+#   absent       -> report Obsidian as not running (lets the tests exercise the
+#                   OTHER soft gates on a dev box that has Obsidian open — the
+#                   normal state when developing an Obsidian-vault tool).
+# Mirrors the VAULT_BACKUP_SKIP_TIMEMACHINE / VAULT_BACKUP_CMD test seams already
+# used below: the default path runs the real check, so real safety is unchanged.
+obsidian_running() {
+  case "${RELOCATE_VAULT_OBSIDIAN:-auto}" in
+    running) return 0 ;;
+    absent)  return 1 ;;
+    *) command -v pgrep >/dev/null 2>&1 && pgrep -x Obsidian >/dev/null 2>&1 ;;
+  esac
+}
+
 # abspath/pathkey via python3 so the key transform matches Claude Code's JS
 # `cwd.replace(/[^a-zA-Z0-9]/g, "-")` for spaces, dots, slashes, and the ⚙️
 # variation-selector exactly. A byte-wise `sed` would mis-key multibyte paths.
@@ -347,7 +365,7 @@ if [ -e "$NEW_ABS" ]; then die "target '$NEW_ABS' already exists (will not overw
 # Soft gates — skippable with --force.
 BACKUP_TOKEN=""
 if [ "$FORCE" != 1 ]; then
-  if command -v pgrep >/dev/null 2>&1 && pgrep -x Obsidian >/dev/null 2>&1; then
+  if obsidian_running; then
     die "Obsidian is running — quit it first (moving an open vault is unsafe), or pass --force"
   fi
   if [ -d "$OLD_ABS/.claude/worktrees" ]; then

--- a/scripts/test-relocate-vault.ps1
+++ b/scripts/test-relocate-vault.ps1
@@ -15,6 +15,14 @@ $Here = $PSScriptRoot
 $RV   = Join-Path $Here "relocate-vault.ps1"
 $script:fails = 0
 
+# HERMETICITY: Obsidian-running is a SOFT gate in relocate-vault.ps1 (skippable
+# with -Force). Its real probe (Get-Process -Name Obsidian) reads AMBIENT host
+# state, so a developer with Obsidian open would see the no--Force cases below
+# (the dry-run) die at that gate. Pin the probe to "absent" for the suite (child
+# pwsh processes inherit this env var); Section 6 flips it to "running" to cover
+# the refusal itself. Parity with the .sh suite's RELOCATE_VAULT_OBSIDIAN seam.
+$env:RELOCATE_VAULT_OBSIDIAN = "absent"
+
 function Check { param([string]$Label, [bool]$Cond)
   if ($Cond) { Write-Host "PASS  $Label" } else { Write-Host "FAIL  $Label"; $script:fails++ }
 }
@@ -124,6 +132,28 @@ try {
   $r = Run-RV -RvArgs @("-MigrateClaudeState", $old5, $new5) -ConfigDir $cfg5
   Check "state-only: rc 0"                    ($r.rc -eq 0)
   Check "state-only: transcript at new key"   (Test-Path -LiteralPath (Join-Path $cfg5 "projects/$nk5/t.jsonl"))
+
+  # ---- 6. OBSIDIAN SOFT GATE: refuses while Obsidian runs; -Force overrides --
+  # The suite pins RELOCATE_VAULT_OBSIDIAN=absent (top of file) so the dry-run
+  # case runs on a dev box with Obsidian open. Here we flip it to "running" to
+  # prove the gate itself still refuses, and that -Force escapes it -
+  # deterministically, no real Obsidian. Parity with Section 10 of the .sh suite.
+  $old6 = Join-Path $TMP "cloud6/Brain"; New-Item -ItemType Directory -Force -Path $old6 | Out-Null
+  Set-Content -LiteralPath (Join-Path $old6 "CLAUDE.md") -Value "# brain"
+  $new6 = Join-Path $TMP "local6/Brain"
+  $cfg6 = Join-Path $TMP "cfg6"
+  $env:RELOCATE_VAULT_OBSIDIAN = "running"
+  try {
+    $r = Run-RV -RvArgs @($old6, $new6) -ConfigDir $cfg6
+    Check "obsidian gate: refuses while Obsidian runs -> rc 1" ($r.rc -eq 1)
+    Check "obsidian gate: refusal names Obsidian"              ($r.out -match "Obsidian is running")
+    Check "obsidian gate: target not created on refusal"       (-not (Test-Path -LiteralPath $new6))
+    $r = Run-RV -RvArgs @($old6, $new6, "-Force") -ConfigDir $cfg6
+    Check "obsidian gate: -Force overrides while Obsidian runs -> rc 0" ($r.rc -eq 0)
+    Check "obsidian gate: -Force moved the vault (new exists)"          (Test-Path -LiteralPath (Join-Path $new6 "CLAUDE.md"))
+  } finally {
+    $env:RELOCATE_VAULT_OBSIDIAN = "absent"
+  }
 }
 finally {
   Remove-Item -LiteralPath $TMP -Recurse -Force -ErrorAction SilentlyContinue

--- a/scripts/test-relocate-vault.sh
+++ b/scripts/test-relocate-vault.sh
@@ -39,6 +39,16 @@ fails=0
 pass() { echo "PASS  $1"; }
 fail() { echo "FAIL  $1"; fails=$((fails + 1)); }
 
+# HERMETICITY: Obsidian-running is a SOFT gate in relocate-vault.sh, skippable
+# with --force. Its real probe (pgrep -x Obsidian) reads AMBIENT host state, so a
+# developer with Obsidian OPEN — the normal state when developing an Obsidian-vault
+# tool — would see every full-relocate case below that omits --force die at that
+# gate instead of exercising the backup/cloud/ensure-backup gate it targets (15
+# such failures on a dev Mac). Pin the probe to "absent" for the whole suite so
+# those OTHER gates are what get tested; Section 10 flips it to "running" per-call
+# to cover the Obsidian refusal itself, deterministically, with no real Obsidian.
+export RELOCATE_VAULT_OBSIDIAN=absent
+
 # Mirror the script's projkey EXACTLY (resolve ancestry, keep leaf literal) so
 # fixtures land at the same key the script computes, even where $TMPDIR resolves
 # /var -> /private/var on macOS.
@@ -299,6 +309,40 @@ out="$(CLAUDE_CONFIG_DIR="$CFG" VAULT_BACKUP_CONF="$NOBK_CONF" VAULT_BACKUP_SKIP
 echo "$out" | grep -qi 'would' \
   && pass "ensure-backup 9e: --dry-run names the stand-up it would run" \
   || fail "ensure-backup 9e: --dry-run did not preview the stand-up: $out"
+
+# --- 10. OBSIDIAN SOFT GATE: the refusal fires when Obsidian IS detected --------
+# The whole suite pins RELOCATE_VAULT_OBSIDIAN=absent so the other gates are
+# testable on any host; here we flip it to "running" to prove the Obsidian gate
+# itself STILL refuses (and stays escapable with --force), deterministically and
+# with no real Obsidian process. This is the dedicated coverage the seam must keep:
+# a soft gate that silently stopped firing would otherwise pass every test.
+ob_src="$TMP/obsidian-src" ; ob_dst="$TMP/obsidian-dst" ; mkdir -p "$ob_src" ; echo n > "$ob_src/n.md"
+
+# 10a REFUSE: Obsidian "running", no --force -> refuses at the Obsidian gate FIRST
+# (before the backup gate), names Obsidian + the --force remedy, vault NOT moved.
+out="$(CLAUDE_CONFIG_DIR="$CFG" RELOCATE_VAULT_OBSIDIAN=running \
+       bash "$SCRIPT" "$ob_src" "$ob_dst" 2>&1)" ; rc=$?
+[ "$rc" = 1 ] && pass "obsidian gate: refuses a move while Obsidian runs (rc=1)" \
+             || fail "obsidian gate: expected rc=1, got $rc"
+{ [ -d "$ob_src" ] && [ ! -L "$ob_src" ] && [ ! -e "$ob_dst" ]; } \
+  && pass "obsidian gate: vault NOT moved on refusal" \
+  || fail "obsidian gate: vault was moved despite the refusal"
+echo "$out" | grep -qi 'obsidian' \
+  && pass "obsidian gate: refusal names Obsidian (fired before the backup gate)" \
+  || fail "obsidian gate: refusal did not mention Obsidian: $out"
+echo "$out" | grep -qi -- '--force' \
+  && pass "obsidian gate: refusal names the --force escape hatch" \
+  || fail "obsidian gate: refusal did not name --force: $out"
+
+# 10b ESCAPE HATCH: Obsidian "running" + --force -> gate skipped, move proceeds
+# (the refusal's own promise; also proves the seam does not leak past --force).
+CLAUDE_CONFIG_DIR="$CFG" RELOCATE_VAULT_OBSIDIAN=running \
+  bash "$SCRIPT" "$ob_src" "$ob_dst" --force >/dev/null 2>&1 ; rc=$?
+[ "$rc" = 0 ] && pass "obsidian gate: --force overrides it even while Obsidian runs (rc=0)" \
+             || fail "obsidian gate: --force did not override the Obsidian gate (rc=$rc)"
+{ [ -d "$ob_dst" ] && [ -L "$ob_src" ]; } \
+  && pass "obsidian gate: --force -> vault moved + symlink left despite Obsidian running" \
+  || fail "obsidian gate: --force did not relocate with Obsidian running"
 
 echo
 if [ "$fails" -gt 0 ]; then echo "FAILED: $fails"; exit 1; fi


### PR DESCRIPTION
## Problem

`tests/integration/test_relocate_vault.sh` (and its `.ps1` parity twin) were non-hermetic. relocate-vault's Obsidian-running **soft gate** probes ambient host state (`pgrep -x Obsidian` in `relocate-vault.sh`, `Get-Process -Name Obsidian` in `relocate-vault.ps1`). The negative-control suites drive full relocations *without* `--force`, so on any dev machine with Obsidian open (the normal state when developing an Obsidian-vault tool) every such case died at that gate instead of exercising the backup / cloud / ensure-backup gate it targeted.

Impact on the local gate: **15** failed assertions in the `.sh` suite, all with the same refusal `Obsidian is running - quit it first ...`. Because `scripts/ci.sh` runs under `set -e` with `test_relocate_vault` near position 45, this aborted the whole local gate before later tests ran, and forced a `CI_PARITY_BYPASS=1` on any push made while Obsidian was open. The `.ps1` dry-run suite (`test_relocate_ps1`) held **2** more of the same, masked behind that earlier abort. Hosted CI runners have no Obsidian, so CI itself was unaffected. This was a local-parity / dev-experience bug.

## Fix

Add a `RELOCATE_VAULT_OBSIDIAN` test seam to both scripts, mirroring the existing `VAULT_BACKUP_SKIP_TIMEMACHINE` / `VAULT_BACKUP_CMD` seams the suites already inject:

- **unset or any unrecognized value runs the real probe.** Production behavior is byte-identical to before the seam existed; a typo fails *safe* (guard stays active) and *loud* (a real-host refusal breaks the test visibly), never silently disabling the guard.
- `absent` reports not-running; `running` reports running.

Both suites pin `absent` so the OTHER gates stay testable on any host, and each adds a dedicated section pinning `running` to prove the Obsidian refusal **still fires** and **stays escapable with `--force`** - coverage the soft gate never had before.

**Scope:** test-hermeticity only. relocate-vault's real safety behavior is unchanged; the default (real-probe) path is untouched.

## Verification (with Obsidian open on the dev host)

- `bash scripts/test-relocate-vault.sh` -> `ALL TESTS PASSED` (was 15 failures)
- `pwsh -File scripts/test-relocate-vault.ps1` -> `ALL TESTS PASSED` (was 2)
- `bash scripts/ci.sh` -> exit 0, 77 integration tests + shellcheck
- Real-behavior guardrails, no seam: a plain relocate still **refuses** while Obsidian is open, and **clears** the Obsidian gate (advances to the backup gate) when Obsidian is closed.

*Authored by Claude Code (Opus 4.8) on the maintainer's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
