### PR TITLE
guard: block session-close artifacts committed off the default branch

### DIFF
--- a/git-hooks/guard-session-artifacts-on-default-branch.sh
+++ b/git-hooks/guard-session-artifacts-on-default-branch.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# guard-session-artifacts-on-default-branch.sh
+#
+# Refuse committing session-close vault artifacts while the checkout is on a
+# NON-default branch. Prevents the SESSIONCLOSE-COMMITS-TO-CURRENT-BRANCH-NOT-MAIN
+# stranding class: if a checkout is parked off the default branch, every
+# session-close artifact (Sessions/, Decisions/, the aggregates, ...) silently
+# accumulates on a topic branch instead of landing on the default branch, and the
+# local default branch quietly diverges — a failure that can go unnoticed for days
+# under multiple concurrent sessions sharing one git dir.
+#
+# Fires at the git pre-commit CHOKEPOINT so it catches EVERY committer (a
+# session-close cascade, an auto-append, a manual commit, an agent), not just one
+# call site. Off-branch code work is unaffected — it only blocks when a
+# session-close artifact is staged.
+#
+# INSTALL: called by the pre-commit hook (pre-commit-template.sh chains it, or a
+# repo-local .githooks/pre-commit invokes it). Vendor this file byte-for-byte into
+# consuming repos that keep their own .githooks/.
+#
+# CONFIG: extend the artifact path set per repo with a file at
+#   <repo>/.githooks/session-artifact-paths.txt   (one substring per line; # comments ok)
+#
+# Exit 0 = allow. Exit 1 = refuse. Bypass: SESSION_ARTIFACT_BRANCH_BYPASS=1.
+set -uo pipefail
+
+[ -n "${SESSION_ARTIFACT_BRANCH_BYPASS:-}" ] && exit 0
+
+_cur="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)"
+# Detached HEAD (mid rebase/cherry-pick/bisect) is not the parked-branch case — allow.
+[ "${_cur}" = "HEAD" ] && exit 0
+
+# Default branch: prefer origin/HEAD, then init.defaultBranch, then "main".
+_def="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##')"
+[ -z "${_def}" ] && _def="$(git config --get init.defaultBranch 2>/dev/null || true)"
+[ -z "${_def}" ] && _def="main"
+
+# On the default branch nothing strands — allow.
+[ "${_cur}" = "${_def}" ] && exit 0
+
+# Off the default branch: block ONLY if a session-close artifact is staged.
+_staged="$(git -c core.quotepath=false diff --cached --name-only 2>/dev/null || true)"
+[ -z "${_staged}" ] && exit 0
+
+# Generic session-close outputs. Substring match (grep -F) so a folder icon prefix
+# (e.g. an emoji-tagged "Meta" folder) still matches on "Meta/Sessions/".
+_patterns='Meta/Sessions/
+Meta/Decisions/
+Meta/Last Session.md
+Meta/Decision Log.md
+Meta/Current Priorities.md'
+
+# Optional per-repo extensions (one substring per line; # comments allowed).
+_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+_extra="${_root}/.githooks/session-artifact-paths.txt"
+[ -n "${_root}" ] && [ -f "${_extra}" ] && _patterns="${_patterns}
+$(cat "${_extra}")"
+
+_hit=""
+while IFS= read -r _pat; do
+  [ -z "${_pat}" ] && continue
+  case "${_pat}" in \#*) continue ;; esac
+  if printf '%s\n' "${_staged}" | grep -F -q -- "${_pat}"; then
+    _hit="${_hit}
+    ${_pat}"
+  fi
+done <<EOF
+${_patterns}
+EOF
+
+[ -z "${_hit}" ] && exit 0
+
+{
+  echo "pre-commit: REFUSED — checkout is on '${_cur}', not the default branch '${_def}'."
+  echo "  You are staging session-close artifact(s) that must land on '${_def}', or they STRAND on"
+  echo "  this topic branch (never reaching '${_def}'; local '${_def}' then diverges)."
+  echo "  Matched pattern(s):${_hit}"
+  echo "  Fix:    git checkout ${_def}    (then re-run the session close)."
+  echo "  Bypass: SESSION_ARTIFACT_BRANCH_BYPASS=1 git commit ...   (or git commit --no-verify)."
+} >&2
+exit 1

--- a/git-hooks/pre-commit-template.sh
+++ b/git-hooks/pre-commit-template.sh
@@ -12,6 +12,9 @@
 #      cp pre-commit-template.sh ~/.git-hooks/pre-commit
 #      chmod +x ~/.git-hooks/pre-commit
 #      git config --global core.hooksPath ~/.git-hooks
+#    ...and ship the strand guard alongside it (chained by this hook):
+#      cp guard-session-artifacts-on-default-branch.sh ~/.git-hooks/
+#      chmod +x ~/.git-hooks/guard-session-artifacts-on-default-branch.sh
 #
 # 2. Create your personal token list (the strings the hook should refuse to publish):
 #      cp scrub-personal-tokens.txt.example ~/.scrub-personal-tokens.txt
@@ -32,6 +35,15 @@
 #   SCRUB_PUBLIC=1 git commit -m "..."     # force public (run even if URL doesn't match)
 
 set -euo pipefail
+
+# --- Off-default-branch session-artifact strand guard (runs for every repo) ---
+# Refuses committing session-close artifacts while the checkout is parked off the
+# default branch, so they can't silently strand on a topic branch. Independent of
+# the scrub gate below; shipped alongside this hook (copied into ~/.git-hooks/).
+_HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+if [[ -x "${_HOOK_DIR}/guard-session-artifacts-on-default-branch.sh" ]]; then
+  "${_HOOK_DIR}/guard-session-artifacts-on-default-branch.sh" || exit 1
+fi
 
 PERSONAL_TOKENS_FILE="${HOME}/.scrub-personal-tokens.txt"
 PUBLIC_REPOS_FILE="${HOME}/.scrub-public-repos.txt"

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -122,6 +122,7 @@ INTEGRATION_TESTS=(
   test_aggregator_vault_root_guard
   test_discoverability_partition
   test_stranded_session_artifacts_watchdog
+  test_offmain_strand_guard
   test_session_coordination_guards
   test_trust_prompt_preframing
   test_onboarding_wrong_surface_and_nudge

--- a/tests/integration/test_offmain_strand_guard.sh
+++ b/tests/integration/test_offmain_strand_guard.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Negative-control test for git-hooks/guard-session-artifacts-on-default-branch.sh
+#
+# Proves the guard FIRES on the failure it exists to catch (a session-close
+# artifact staged while off the default branch) and does NOT over-block
+# (plain code work off-branch, on-branch commits, and the bypass all pass).
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+GUARD="${1:-$HERE/../../git-hooks/guard-session-artifacts-on-default-branch.sh}"
+[ -f "$GUARD" ] || { echo "guard not found: $GUARD"; exit 2; }
+
+fails=0
+pass(){ echo "PASS: $1"; }
+fail(){ echo "FAIL: $1"; fails=$((fails+1)); }
+
+# name, branch, stage-path, bypass(0/1), expect_exit, extra-pattern(optional)
+run_case(){
+  local name="$1" branch="$2" path="$3" bypass="$4" expect="$5" extra="${6:-}"
+  local d; d="$(mktemp -d)"
+  (
+    cd "$d" || exit 99
+    git init -q -b main
+    git config user.email t@t; git config user.name t
+    mkdir -p .githooks
+    cp "$GUARD" .githooks/guard.sh; chmod +x .githooks/guard.sh
+    [ -n "$extra" ] && printf '%s\n' "$extra" > .githooks/session-artifact-paths.txt
+    echo x > seed; git add seed; git commit -qm seed
+    [ "$branch" != "main" ] && git checkout -q -b "$branch"
+    mkdir -p "$(dirname "$path")"; echo content > "$path"; git add -- "$path"
+    [ "$bypass" = "1" ] && export SESSION_ARTIFACT_BRANCH_BYPASS=1
+    .githooks/guard.sh; echo "EXIT=$?"
+  ) > "$d/out" 2>&1
+  local got; got="$(sed -n 's/^EXIT=//p' "$d/out")"
+  if [ "$got" = "$expect" ]; then pass "$name (exit $got)"; else fail "$name (got '$got' want '$expect')"; sed 's/^/    /' "$d/out"; fi
+  rm -rf "$d"
+}
+
+run_case "default-branch + artifact -> ALLOW"          main      "Meta/Sessions/2026-07-07.md"   0 0
+run_case "feature-branch + artifact -> BLOCK"          claude/x  "Meta/Sessions/2026-07-07.md"   0 1
+run_case "feature-branch + code-only -> ALLOW"         claude/x  "src/foo.py"                     0 0
+run_case "feature-branch + artifact + bypass -> ALLOW" claude/x  "Meta/Decisions/d.md"            1 0
+run_case "feature-branch + aggregate -> BLOCK"         claude/x  "Meta/Last Session.md"           0 1
+run_case "feature-branch + emoji-prefixed artifact -> BLOCK" claude/x "⚙️ Meta/Sessions/e.md"     0 1
+run_case "feature-branch + per-repo extension -> BLOCK" claude/x "notes/Weekly Digest.md"         0 1 "Weekly Digest.md"
+run_case "feature-branch + unlisted path -> ALLOW"     claude/x  "notes/random.md"                0 0
+
+echo "---"
+if [ "$fails" -eq 0 ]; then echo "ALL PASS ($((0)) failures)"; exit 0; else echo "$fails FAILED"; exit 1; fi


### PR DESCRIPTION
## Problem

Under multiple concurrent sessions sharing one git dir, a checkout can drift onto a topic branch and sit there. Because session-close commits to whatever branch is checked out, every session-close artifact (`Meta/Sessions/`, `Meta/Decisions/`, the aggregates) then silently accumulates on that topic branch instead of the default branch, and the local default branch quietly diverges. It can go unnoticed for days — the work is committed, just never on the branch that ships.

## Fix

`git-hooks/guard-session-artifacts-on-default-branch.sh` fires at the git pre-commit **chokepoint**, so it catches every committer (a session-close cascade, an auto-append, a manual commit, an agent) rather than one call site. It refuses a commit **only** when a session-close artifact is staged while the checkout is off the default branch. Off-branch code work, on-default commits, and an explicit bypass all pass untouched.

- Chained by `git-hooks/pre-commit-template.sh` (the global hook clients install).
- Generic session-close paths built in; per-repo extensible via `.githooks/session-artifact-paths.txt`.
- Bypass: `SESSION_ARTIFACT_BRANCH_BYPASS=1` (or `git commit --no-verify`).

## Test

`tests/integration/test_offmain_strand_guard.sh` — 8 cases including the two controls that matter:
- **fires**: feature branch + session artifact staged → blocked
- **no over-block**: feature branch + code-only → allowed; on-default → allowed; bypass → allowed; unlisted path → allowed

Bug class: `SESSIONCLOSE-COMMITS-TO-CURRENT-BRANCH-NOT-MAIN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
