### PR TITLE
guard: verify the graph artifact, never trust the state-file stamp

### DIFF
--- a/scripts/graph-context-hook.sh
+++ b/scripts/graph-context-hook.sh
@@ -98,7 +98,17 @@ freshness_note() {
   local path="$1"
   local label="$2"
   if [ ! -f "$path" ]; then
-    printf "missing (run /graphify on %s to build it)" "$label"
+    # Distinguish a NEVER-BUILT graph from one that was built and then LOST.
+    # graphify-out/ is gitignored, so a lost graph leaves NO trace while the
+    # second-brain-mapping state file still records that graphify ran. That
+    # silent gap is exactly how a graph can vanish for weeks unnoticed — a bare
+    # "missing" note reads identically whether it was never built or just lost.
+    local _state="$VAULT_ROOT/⚙️ Meta/.second-brain-mapping-state.json"
+    if [ -f "$_state" ] && python3 -c "import json,sys; sys.exit(0 if json.load(open(sys.argv[1])).get('phase_2_graphify') else 1)" "$_state" 2>/dev/null; then
+      printf "⚠ LOST — this graph was built before but is GONE now (gitignored + untracked, no git trace). Your SOURCE is intact; rebuild it: /graphify --update on %s" "$label"
+    else
+      printf "missing (run /graphify on %s to build it)" "$label"
+    fi
     return
   fi
   local mtime now days

--- a/scripts/graph-liveness-check.py
+++ b/scripts/graph-liveness-check.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""graph-liveness-check.py — verify the graphify knowledge graph ARTIFACT exists,
+instead of trusting the second-brain-mapping state-file stamp.
+
+Bug class killed: STAMP-GREEN-WHILE-ARTIFACT-GONE.
+
+`graphify-out/` is gitignored by design (a large, regenerable derived artifact
+should not bloat a repo). But gitignored + untracked means it can vanish to ANY
+filesystem operation — a folder move, a `git clean`, a disk cleanup — with ZERO
+trace, while `.second-brain-mapping-state.json` still records
+`phase_2_graphify: <date>`. The stamp says "built"; the file is gone. A recency
+check that trusts the stamp is therefore lying. Probe the leaf (the file), never
+the proxy (the timestamp). Existence is not enough either — a truncated / empty
+graph.json is "present but not populated", so we check size (and, with --deep,
+node count).
+
+Two consumers:
+  1. second-brain-mapping Step 1 — call with --heal so a lost graph nulls its
+     stamp and the pipeline rebuilds instead of skipping on a stale stamp.
+  2. A SessionStart gauge — call with --quiet so a healthy graph is silent and a
+     lost/stale one screams.
+
+Exit codes:
+  0  healthy (graph present + populated), OR absent-and-never-stamped (nothing
+     to rebuild yet — not an error)
+  3  LOST: graph absent/empty BUT phase_2_graphify is stamped  (loud)
+  4  STALE: graph present but older than --max-age-days
+  2  usage / unexpected error
+
+Stdlib only, Python 3.10+. No third-party deps (substrate portability).
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import pathlib
+import sys
+
+DEFAULT_MAX_AGE_DAYS = 45
+PRESENT_MIN_BYTES = 200  # smaller than this = empty/truncated, treat as not-built
+STATE_REL = "⚙️ Meta/.second-brain-mapping-state.json"
+GRAPH_RELS = ("⚙️ Meta/graphify-out/graph.json", "graphify-out/graph.json")
+
+
+def find_vault_root(start: str) -> pathlib.Path:
+    """Walk up from `start` looking for the ⚙️ Meta marker dir; fall back to start."""
+    p = pathlib.Path(start).resolve()
+    for cand in (p, *p.parents):
+        if (cand / "⚙️ Meta").is_dir():
+            return cand
+    return p
+
+
+def inspect_graph(root: pathlib.Path, deep: bool):
+    """Return dict: {path, present, populated, size, node_count, mtime}."""
+    for rel in GRAPH_RELS:
+        c = root / rel
+        if not c.is_file():
+            continue
+        try:
+            st = c.stat()
+        except OSError:
+            continue
+        mtime = datetime.datetime.fromtimestamp(st.st_mtime).astimezone()
+        present = st.st_size >= PRESENT_MIN_BYTES
+        node_count = None
+        populated = present
+        if deep and present:
+            try:
+                data = json.loads(c.read_text(encoding="utf-8", errors="ignore"))
+                nodes = data.get("nodes") if isinstance(data, dict) else None
+                if isinstance(nodes, list):
+                    node_count = len(nodes)
+                    populated = node_count > 0
+            except Exception:
+                node_count = -1  # unparseable — suspect, but don't hard-fail on parse alone
+        return {
+            "path": str(c),
+            "present": present,
+            "populated": populated,
+            "size": st.st_size,
+            "node_count": node_count,
+            "mtime": mtime,
+        }
+    return {
+        "path": None,
+        "present": False,
+        "populated": False,
+        "size": 0,
+        "node_count": None,
+        "mtime": None,
+    }
+
+
+def read_state(root: pathlib.Path):
+    sf = root / STATE_REL
+    if sf.is_file():
+        try:
+            return sf, json.loads(sf.read_text(encoding="utf-8"))
+        except Exception:
+            return sf, {}
+    return sf, {}
+
+
+def heal_state(sf: pathlib.Path, state: dict) -> list[str]:
+    """Null the graph-dependent phases so the pipeline rebuilds. Returns keys nulled."""
+    nulled = []
+    for k in ("phase_2_graphify", "phase_3_wikilinks"):
+        if state.get(k):
+            state[k] = None
+            nulled.append(k)
+    if nulled:
+        sf.write_text(json.dumps(state, indent=2), encoding="utf-8")
+    return nulled
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--vault", default=".", metavar="ROOT", help="Vault root (default: auto-detect from cwd)")
+    ap.add_argument("--max-age-days", type=int, default=DEFAULT_MAX_AGE_DAYS, metavar="N")
+    ap.add_argument("--deep", action="store_true", help="Parse graph.json and count nodes (slower)")
+    ap.add_argument("--heal", action="store_true", help="On LOST, null phase_2/phase_3 stamps so SBM rebuilds")
+    ap.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    ap.add_argument("--quiet", action="store_true", help="Print nothing when healthy")
+    args = ap.parse_args()
+
+    root = find_vault_root(args.vault)
+    g = inspect_graph(root, deep=args.deep)
+    sf, state = read_state(root)
+    stamp = state.get("phase_2_graphify")
+
+    now = datetime.datetime.now().astimezone()
+    age_days = None
+    if g["mtime"] is not None:
+        age_days = (now - g["mtime"]).days
+
+    # classify
+    if g["present"] and g["populated"]:
+        if age_days is not None and age_days > args.max_age_days:
+            status, code = "STALE", 4
+        else:
+            status, code = "HEALTHY", 0
+    elif stamp:
+        status, code = "LOST", 3
+    else:
+        status, code = "ABSENT_UNSTAMPED", 0
+
+    nulled = heal_state(sf, state) if (status == "LOST" and args.heal) else []
+
+    if args.json:
+        print(json.dumps({
+            "status": status, "exit": code, "vault": str(root),
+            "graph_path": g["path"], "present": g["present"], "populated": g["populated"],
+            "size": g["size"], "node_count": g["node_count"],
+            "graph_mtime": g["mtime"].isoformat() if g["mtime"] else None,
+            "age_days": age_days, "phase_2_stamp": stamp,
+            "healed": nulled, "max_age_days": args.max_age_days,
+        }, indent=2))
+        return code
+
+    if status == "LOST":
+        print("╔═══════════════════════════════════════════════════════════════════╗")
+        print("║  ⚠  KNOWLEDGE GRAPH LOST — stamp says built, artifact is GONE       ║")
+        print("╚═══════════════════════════════════════════════════════════════════╝")
+        print(f"  vault:        {root}")
+        print(f"  expected at:  {root / GRAPH_RELS[0]}")
+        print(f"  last 'built': phase_2_graphify = {stamp}")
+        print("  source is intact — the graph is a DERIVED artifact, rebuild it:")
+        print(f'      cd "{root}" && /graphify "." --update')
+        if nulled:
+            print(f"  healed: nulled {', '.join(nulled)} so second-brain-mapping will rebuild.")
+        elif args.heal is False:
+            print("  (run with --heal to null the stamp so SBM rebuilds automatically.)")
+    elif status == "STALE":
+        print(f"[graph-liveness] STALE: graph is {age_days}d old (> {args.max_age_days}d). "
+              f"Refresh: /graphify \".\" --update   ({g['path']})")
+    elif status == "ABSENT_UNSTAMPED":
+        if not args.quiet:
+            print("[graph-liveness] no graph yet and none ever built — run /graphify to create one.")
+    else:  # HEALTHY
+        if not args.quiet:
+            nc = f", {g['node_count']} nodes" if g["node_count"] and g["node_count"] > 0 else ""
+            print(f"[graph-liveness] HEALTHY: graph present ({g['size']:,} bytes{nc}, {age_days}d old).")
+
+    return code
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(2)

--- a/scripts/test_graph_liveness_check.py
+++ b/scripts/test_graph_liveness_check.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Behavior tests for graph-liveness-check.py — the STAMP-GREEN-WHILE-ARTIFACT-GONE guard.
+
+Proves the guard fires on the real failure (LOST) AND stays quiet on the clean
+path (HEALTHY) — a guard that always-screams is as useless as one that never does.
+
+Run standalone:  python3 scripts/test_graph_liveness_check.py
+Run under pytest: pytest scripts/test_graph_liveness_check.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+CHECK = Path(__file__).with_name("graph-liveness-check.py")
+
+
+def _vault(tmp: Path, name: str) -> Path:
+    root = tmp / name
+    (root / "⚙️ Meta" / "graphify-out").mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _state(root: Path, **kw):
+    (root / "⚙️ Meta" / ".second-brain-mapping-state.json").write_text(json.dumps(kw))
+
+
+def _graph(root: Path, nodes: int = 40, old: bool = False):
+    p = root / "⚙️ Meta" / "graphify-out" / "graph.json"
+    p.write_text(json.dumps({
+        "nodes": [{"id": i, "label": f"entity_{i}", "type": "concept"} for i in range(nodes)],
+        "edges": [{"s": i, "t": (i + 1) % nodes, "kind": "MENTIONS"} for i in range(nodes)],
+    }))
+    if old:
+        past = time.time() - 60 * 24 * 3600  # 60 days
+        os.utime(p, (past, past))
+
+
+def _run(root: Path, *extra):
+    r = subprocess.run(
+        [sys.executable, str(CHECK), "--vault", str(root), "--json", *extra],
+        capture_output=True, text=True,
+    )
+    return r.returncode, json.loads(r.stdout)
+
+
+def test_absent_unstamped_is_not_an_error():
+    with tempfile.TemporaryDirectory() as d:
+        root = _vault(Path(d), "absent"); _state(root)
+        code, out = _run(root)
+        assert code == 0 and out["status"] == "ABSENT_UNSTAMPED", out
+
+
+def test_lost_graph_with_stamp_fires_loud():
+    # THE NEGATIVE CONTROL: the exact incident — stamp present, artifact gone.
+    with tempfile.TemporaryDirectory() as d:
+        root = _vault(Path(d), "lost")
+        _state(root, phase_2_graphify="2026-05-27T15:36:55-05:00",
+               phase_3_wikilinks="2026-05-27T15:37:35-05:00")
+        code, out = _run(root)
+        assert code == 3 and out["status"] == "LOST", out
+
+
+def test_healthy_graph_is_silent():
+    with tempfile.TemporaryDirectory() as d:
+        root = _vault(Path(d), "healthy"); _graph(root)
+        _state(root, phase_2_graphify="2026-07-09T00:00:00-05:00")
+        code, out = _run(root)
+        assert code == 0 and out["status"] == "HEALTHY", out
+
+
+def test_stale_graph_flags_refresh():
+    with tempfile.TemporaryDirectory() as d:
+        root = _vault(Path(d), "stale"); _graph(root, old=True)
+        _state(root, phase_2_graphify="2026-05-01T00:00:00-05:00")
+        code, out = _run(root)
+        assert code == 4 and out["status"] == "STALE", out
+
+
+def test_empty_graph_counts_as_lost():
+    # existence is not enough — a truncated 0-byte graph.json is "present but not populated"
+    with tempfile.TemporaryDirectory() as d:
+        root = _vault(Path(d), "truncated")
+        (root / "⚙️ Meta" / "graphify-out" / "graph.json").write_text("")
+        _state(root, phase_2_graphify="2026-05-27T00:00:00-05:00")
+        code, out = _run(root)
+        assert code == 3 and out["status"] == "LOST", out
+
+
+def test_heal_nulls_graph_dependent_stamps():
+    with tempfile.TemporaryDirectory() as d:
+        root = _vault(Path(d), "heal")
+        _state(root, phase_1_metadata="2026-06-24T00:00:00-05:00",
+               phase_2_graphify="2026-05-27T15:36:55-05:00",
+               phase_3_wikilinks="2026-05-27T15:37:35-05:00")
+        _run(root, "--heal")
+        st = json.loads((root / "⚙️ Meta" / ".second-brain-mapping-state.json").read_text())
+        assert st["phase_2_graphify"] is None, st
+        assert st["phase_3_wikilinks"] is None, st
+        # unrelated phases must be preserved
+        assert st["phase_1_metadata"] == "2026-06-24T00:00:00-05:00", st
+
+
+def test_deep_counts_nodes():
+    with tempfile.TemporaryDirectory() as d:
+        root = _vault(Path(d), "deep"); _graph(root, nodes=40)
+        _state(root, phase_2_graphify="2026-07-09T00:00:00-05:00")
+        code, out = _run(root, "--deep")
+        assert out["node_count"] == 40, out
+
+
+def _main() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  [PASS] {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"  [FAIL] {t.__name__}: {e}")
+    print("ALL PASS" if not failed else f"{failed} FAILED")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/skills/second-brain-mapping/SKILL.md
+++ b/skills/second-brain-mapping/SKILL.md
@@ -101,9 +101,22 @@ State file format (JSON):
 
 `null` means never completed OR killed mid-run. A timestamp means last successful completion.
 
+**A stamp is NOT proof the artifact still exists.** `graphify-out/` is gitignored (a large, regenerable derived artifact should not bloat the repo). Untracked means it can vanish to ANY filesystem operation — a folder move, `git clean`, a disk cleanup — with zero trace, while this state file still says `phase_2_graphify: <date>`. The stamp then lies. Before honoring the graph-dependent stamps, PROBE THE FILE:
+
+```bash
+python3 "$(vault-root)/scripts/graph-liveness-check.py" --heal
+```
+
+- Exit `0` → graph present (or never built) — proceed normally.
+- Exit `3` (`LOST`) → the graph is GONE despite a stamp. `--heal` has already nulled `phase_2_graphify` + `phase_3_wikilinks` so the decision rule below rebuilds them. Tell the user loudly: the graph was lost, the source is intact, rebuilding. NEVER skip Phase 2/3 on a stamp the liveness check just invalidated.
+- Exit `4` (`STALE`) → graph older than the freshness window; recommend a refresh.
+
+Bug class STAMP-GREEN-WHILE-ARTIFACT-GONE. The recency check probes the leaf (the file), never the proxy (the timestamp).
+
 **Decision rule:**
 - If `--force` flag: run everything regardless.
 - Else for each phase: if stamp < 4 hours old AND not null → skip (report "Phase X: skipped, ran Y ago"). If stamp is null OR > 4 hours old → run it. Phase 2 (graphify) always confirms before running regardless of stamp.
+- **Phase 2/3 stamps are only honored if the liveness check above reported the graph present.** A `LOST` graph forces a rebuild regardless of stamp age — the artifact, not the timestamp, is the source of truth.
 - Report the plan BEFORE running: "Will run: Phase 3 (null), Phase 4 (>4h). Skipping: Phase 1 (1h ago). OK? y/N"
 
 After each phase succeeds, update its stamp with the current ISO-8601 timestamp. If a phase is killed or errors, leave the stamp untouched so next run sees it as incomplete.
@@ -159,22 +172,24 @@ for fp in glob.glob(os.path.join(vault, "**", "*.md"), recursive=True):
 input_tok = int(total_words * 1.3 * 0.15)   # after dedupe + cache + preextract
 output_tok = int(input_tok * 0.12)
 
-# Sonnet 4.6 public pricing (as of 2025): $3/M input, $15/M output
-cost_usd = (input_tok / 1_000_000) * 3 + (output_tok / 1_000_000) * 15
-
-# Incremental run (cache warm): roughly 10% of cold-start
-cold_cost = cost_usd
-warm_cost = cost_usd * 0.10
+# The TOKEN estimate is real. The DOLLAR cost depends on how graphify is routed.
+# Default in an ai-brain-starter install: semantic extraction runs via SUBAGENTS on
+# your Claude subscription (Max/Pro), and ~80% of edges come from zero-LLM
+# deterministic passes (AST + typed-edge frontmatter/wikilink extraction). So the
+# marginal DOLLAR cost is ~$0. The figure below is the paid-API-EQUIVALENT — only
+# meaningful for users who run graphify on metered API billing, NOT a subscription.
+api_cost = (input_tok / 1_000_000) * 3 + (output_tok / 1_000_000) * 15  # Sonnet public $/M
+warm_cost = api_cost * 0.10  # incremental run, cache warm
 
 existing = pathlib.Path("graphify-out/graph.json").exists()
 mode = "incremental (cache warm)" if existing else "cold start (no cache yet)"
-est_cost = warm_cost if existing else cold_cost
+est_api = warm_cost if existing else api_cost
 
 print(f"Corpus:   {total_files:,} files · ~{total_words:,} words")
 print(f"Mode:     {mode}")
 print(f"Tokens:   ~{input_tok:,} input · ~{output_tok:,} output (estimate)")
-print(f"Cost:     ~${est_cost:.2f} at Sonnet 4.6 public pricing")
-print(f"          (cold start would be ~${cold_cost:.2f}; incremental ~${warm_cost:.2f})")
+print(f"Dollars:  ~$0 on a Max/Pro subscription (subagent-routed — the default here)")
+print(f"          Paid-API-equivalent (metered billing only): ~${est_api:.2f}")
 PY
 
 stat -f "%Sm" "$(pwd)/graphify-out/graph.json" 2>/dev/null || echo "Last graph: none yet"
@@ -184,7 +199,7 @@ Then ask: **"Run graphify on this corpus? y/N"**
 
 If yes, invoke `/graphify --update`. Read `~/.claude/skills/graphify/SKILL.md` first. On success, stamp `phase_2_graphify`.
 
-**Pricing caveat:** the cost estimate uses public Sonnet rates and graphify's typical compression ratio. Actual cost depends on cache hit rate, chunk granularity, and whether `--mode deep` is used. Treat the number as an order-of-magnitude guide, not a quote.
+**Cost framing (do not misquote):** the token estimate is real, but on a Claude Max/Pro subscription graphify's semantic extraction runs through subagents (no per-token dollar charge) and ~80% of edges come from zero-LLM deterministic passes — so the marginal dollar cost is effectively **$0**. Only quote dollars if the user is on metered API billing. Never let a paid-API figure talk a subscription user out of a rebuild — that inverts the whole point of maximum context.
 
 ### Step 4 — Phase 3: wikilinks
 


### PR DESCRIPTION
## Incident

The personal-vault knowledge graph (`graphify-out/graph.json`) was **gone**, while `.second-brain-mapping-state.json` still recorded `phase_2_graphify: 2026-05-27`. The graph was built that day (the wikilink phase consumed it), then vanished — most likely dropped by a folder move, since `graphify-out/` is **gitignored** and therefore untracked, backed up nowhere, and leaves **zero trace** of which operation removed it. Nothing detected it for ~6 weeks.

Two root causes, not one:
1. **The loss** — gitignored + untracked derived artifact, no backup, no git trace.
2. **The silence** — the one watcher (`graph-context-hook.sh`) only whispered "missing" on keyword prompts, indistinguishable from a graph that was simply never built; and `second-brain-mapping`'s recency check trusted the stamp instead of the file.

Bug class **STAMP-GREEN-WHILE-ARTIFACT-GONE**. Source data was never at risk — the graph is a derived index over intact markdown — but "maximum context" quietly degraded to zero.

## Fix (three layers)

- **`scripts/graph-liveness-check.py`** (new) — probes the FILE (both `⚙️ Meta/graphify-out` and root `graphify-out`), classifies `LOST` (stamped-but-gone) / `STALE` / `HEALTHY` / never-built. Existence isn't enough: a truncated `graph.json` is "present but not populated." `--heal` nulls `phase_2`+`phase_3` stamps so the pipeline rebuilds.
- **`skills/second-brain-mapping/SKILL.md`** — Step 1 now probes the artifact before honoring graph-dependent stamps; a `LOST` graph forces a rebuild regardless of stamp age. Also fixes the cost estimator, which quoted paid-API dollars for a run routed through Max-subscription subagents (marginal cost ~$0) and could scare a user out of a free rebuild.
- **`scripts/graph-context-hook.sh`** — the per-prompt watcher now emits a loud `⚠ LOST (built then gone)` instead of a soft "missing," so a disappearance can't hide as never-built.

## Proof

`scripts/test_graph_liveness_check.py` — 7 behavior tests including the **negative control** (LOST fires, exit 3) and the **positive control** (HEALTHY stays silent). Verified firing on the real incident before rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)