### PR TITLE
windows: cp1252 console + python3 Store shim break vault-script sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,9 @@ secrets.json
 hooks/.last-secret-scan
 hooks/.last-secret-scan-full
 hooks/.secret-scan.lock
+
+# Stray vault "Meta" folders left by local sync / resolver runs against a real
+# vault (e.g. a script writing "⚙️ Meta/logs/"). Never ship a user's vault
+# folder into this public substrate repo.
+/⚙️ Meta/
+/Meta/

--- a/scripts/_meta_resolver.py
+++ b/scripts/_meta_resolver.py
@@ -61,6 +61,16 @@ def _cli(argv: list[str]) -> int:
     vault has no Meta-suffixed folder at all (caller applies its own fallback);
     exits 2 on a usage error.
     """
+    # The resolved path usually contains the "⚙️ Meta" emoji. On a Windows
+    # cp1252 console (or a C-locale pipe) print() raises UnicodeEncodeError, and
+    # the caller then sees an empty result and misreads it as "no Meta folder".
+    # Force UTF-8 on the CLI streams so the path always round-trips; PowerShell
+    # and POSIX shell callers decode UTF-8 on their side.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     if not argv:
         print("usage: _meta_resolver.py VAULT_ROOT [SUBFOLDER ...]", file=sys.stderr)
         return 2

--- a/scripts/journal-preflight.py
+++ b/scripts/journal-preflight.py
@@ -18,8 +18,8 @@ Sources:
     - slack      : on-disk Slack export (recent)
   MCP (preflight prints the exact call; the skill makes it — pure Python can't):
     - calendar   : cal_list_events for the window
-    - email_live : gmail_search since last journal (the digest is often stale)
-    - slack_live : slack search/read recent (on-disk export is sparse)
+    - email_live : your email MCP (gmail_search / outlook_search) since last journal (digest often stale)
+    - slack_live : your chat MCP (e.g. slack) search/read recent (on-disk export is sparse)
     - health     : latest Health Pattern Report + yesterday's Body track
 
 Writes a marker at `<vault>/⚙️ Meta/.journal-context/<date>.json`; the save-time guard
@@ -270,6 +270,14 @@ def _age_note(path):
 
 
 def main():
+    # Windows cp1252-console safety: this digest print()s the "⚙️ Meta" emoji and
+    # em dashes, which raise UnicodeEncodeError on a non-UTF-8 console. Force UTF-8
+    # on our own streams so the preflight always renders instead of crashing.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     args = sys.argv[1:]
     json_only = "--json" in args
     since = until = None
@@ -435,10 +443,12 @@ def main():
         if "calendar" in pending_mcp:
             print(f"- CALENDAR: cal_list_events({cal}, verbose=true) — meetings + attendees into ## Today.")
         if "email_live" in pending_mcp:
-            print(f"- EMAIL (fresh, relational): gmail_search each account, e.g. "
+            print(f"- EMAIL (fresh, relational): search your connected email MCP each account "
+                  f"(gmail_search on Gmail, outlook_search on Microsoft 365), e.g. "
                   f"`after:{since.replace('-','/')}` — surface FAMILY / friends / commitments, not just the stale triage above.")
         if "slack_live" in pending_mcp:
-            print("- SLACK (fresh): slack search_messages / read recent DMs + #daily-updates since the last entry.")
+            print("- CHAT (fresh): search your connected chat MCP (e.g. slack search_messages) — "
+                  "recent DMs + daily-updates since the last entry.")
         if "body_health" in pending_mcp:
             print("- HEALTH: latest 🏠 Home/Health Pattern Report + yesterday's ## Body track (or regenerate-health-pattern-report.py).")
         print("\nAfter these land, the entry frontmatter MUST carry `context_sources:` naming every "

--- a/scripts/relocate-machinery-sidecar.ps1
+++ b/scripts/relocate-machinery-sidecar.ps1
@@ -91,7 +91,7 @@ function Invoke-OrDry { param([string]$What, [scriptblock]$Action)
 $script:PyExe = $null
 function Get-PyExe {
   if ($script:PyExe) { return $script:PyExe }
-  foreach ($n in @("python3", "python")) {
+  foreach ($n in @("py", "python", "python3")) {
     $c = Get-Command $n -ErrorAction SilentlyContinue
     if ($c) {
       try {

--- a/scripts/relocate-vault.ps1
+++ b/scripts/relocate-vault.ps1
@@ -100,7 +100,7 @@ function Test-ObsidianRunning {
 $script:PyExe = $null
 function Get-PyExe {
   if ($script:PyExe) { return $script:PyExe }
-  foreach ($n in @("python3", "python")) {
+  foreach ($n in @("py", "python", "python3")) {
     $c = Get-Command $n -ErrorAction SilentlyContinue
     if ($c) {
       try {

--- a/scripts/sync-vault-scripts.ps1
+++ b/scripts/sync-vault-scripts.ps1
@@ -34,10 +34,35 @@ $StarterDir = if ($env:STARTER_DIR) { $env:STARTER_DIR } else { Split-Path -Pare
 
 function Note($m) { if (-not $Quiet) { Write-Output $m } }
 
-# --- pick a python interpreter (for the shared meta resolver) -----------------
+# --- pick a REAL python interpreter (for the shared meta resolver) ------------
+# 'py' first: the Windows launcher is always a real Python. A bare 'python3' on
+# PATH is often the Microsoft Store app-execution shim, which resolves via
+# Get-Command but prints nothing and pops the Store, so the resolver call comes
+# back empty and the sync misreads it as "no Meta folder". Probe each candidate
+# and only trust one that actually reports Python 3 (mirrors relocate-vault.ps1).
 $Py = $null
-foreach ($c in @("python3", "python", "py")) {
-    if (Get-Command $c -ErrorAction SilentlyContinue) { $Py = $c; break }
+foreach ($c in @("py", "python", "python3")) {
+    $cmd = Get-Command $c -ErrorAction SilentlyContinue
+    if (-not $cmd) { continue }
+    try {
+        $probe = (& $cmd.Source -c "import sys; print(sys.version_info[0])" 2>$null | Select-Object -First 1)
+        if ("$probe".Trim() -eq "3") { $Py = $cmd.Source; break }
+    } catch { }
+}
+
+# Read one line of native-python stdout as UTF-8. The resolver emits the meta
+# path as UTF-8 (it can contain the settings emoji); Windows PowerShell would
+# otherwise decode native output with the OEM code page and mangle the path.
+# Save and restore the console encoding so this cannot leak to the parent shell.
+function Invoke-PyLine {
+    param([string]$PyExe, [object[]]$PyArgs)
+    $prevEnc = [Console]::OutputEncoding
+    try {
+        try { [Console]::OutputEncoding = New-Object System.Text.UTF8Encoding $false } catch { }
+        return (& $PyExe @PyArgs 2>$null | Select-Object -First 1)
+    } finally {
+        try { [Console]::OutputEncoding = $prevEnc } catch { }
+    }
 }
 
 # --- resolve the vault root ---------------------------------------------------
@@ -61,7 +86,7 @@ for _ev, groups in (data.get("hooks") or {}).items():
                 print(m.group(1)); sys.exit(0)
 sys.exit(1)
 '@
-        try { $Vault = (& $Py -c $pyCode $settings 2>$null | Select-Object -First 1) } catch { $Vault = "" }
+        try { $Vault = (Invoke-PyLine $Py @("-c", $pyCode, $settings)) } catch { $Vault = "" }
     }
 }
 if ((-not $Vault) -or (-not (Test-Path $Vault -PathType Container))) {
@@ -74,7 +99,7 @@ $Meta = ""
 if ($Py) {
     $resolver = Join-Path $ScriptDir "_meta_resolver.py"
     if (Test-Path $resolver) {
-        try { $Meta = (& $Py $resolver $Vault scripts Decisions Sessions 2>$null | Select-Object -First 1) } catch { $Meta = "" }
+        try { $Meta = (Invoke-PyLine $Py @($resolver, $Vault, "scripts", "Decisions", "Sessions")) } catch { $Meta = "" }
     }
 }
 if (-not $Meta) {


### PR DESCRIPTION
Two Windows-only bugs stopped `sync-vault-scripts.ps1` from deploying vault scripts on an existing install, so the update reported "no Meta folder" and the user fell back to a manual copy. A Windows cohort member's agent diagnosed both precisely; this fixes them at the source so the automatic sync just works next time.

## Bug 1 — cp1252 crash in the Meta resolver
The `find_meta_dir` CLI `print()`s the resolved `⚙️ Meta` path using the console's default codec. On a Windows cp1252 console (or a C-locale pipe) that raises `UnicodeEncodeError`, so the PowerShell/shell caller captures an empty string and misreads it as "no Meta folder". `_meta_resolver.py` now reconfigures its CLI streams to UTF-8; `journal-preflight.py` gets the same guard (it prints the emoji and em dashes).

## Bug 2 — Microsoft Store `python3` shim
`sync-vault-scripts.ps1` trusted the first interpreter `Get-Command` resolved. On Windows that is usually the Store app-execution shim for `python3`: it resolves but prints nothing and pops the Store, so every resolver call came back empty. It now probes `py` first (the launcher is always a real Python) and only trusts an interpreter that actually reports Python 3 — the pattern already used by `relocate-vault.ps1` — and decodes the resolver's UTF-8 output by save/restoring the console `OutputEncoding`. The two `relocate` pickers gained `py` for the same class.

## Also
- Connector-agnostic `/journal` hints: `outlook_search` alongside `gmail_search`, and "your connected chat MCP" instead of a hardcoded `slack`, so Microsoft 365 users are not told to call tools they do not have.
- `.gitignore` a stray vault `⚙️ Meta/` so a local sync run can never leak a user's vault folder into this public repo.

## Verification
- cp1252 negative control reproduces the exact `UnicodeEncodeError`; the fix prints the path, and the 6-assertion resolver regression test passes.
- Shim negative control: the old picker takes the stub (empty version probe), the new one rejects it.
- End-to-end `sync-vault-scripts.ps1 -DryRun` resolves the emoji Meta folder and would deploy 14 scripts, 0 errors, exit 0.
- `pwsh` ParseFile, UTF-8 BOM, and no-em-dash lints pass on every edited `.ps1`.

Authored by Claude (Claude Code) on behalf of the maintainer.
