### PR TITLE
windows: guard every vault CLI against the cp1252 print crash + lint the class

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -339,3 +339,22 @@ jobs:
         run: pipx install ruff || python3 -m pip install --user ruff
       - name: lint phase-doc Python for undefined names (F821)
         run: python3 scripts/check-phase-python.py
+
+  utf8-console-guard:
+    name: UTF-8 console guard (no cp1252 print crash)
+    runs-on: ubuntu-latest
+    # A vault script that print()s non-ASCII (the "gear Meta" emoji, an em dash, an
+    # accented name) from a runnable CLI crashes on a Windows cp1252 console with
+    # UnicodeEncodeError; the caller captures the empty output and misreads it as
+    # failure (ai-brain-starter#313: sync-vault-scripts.ps1 read it as "no Meta
+    # folder" and fell back to a manual copy). PR #313 fixed the two files that had
+    # already broken; scripts/check-utf8-stdout.py fails ANY runnable vault CLI that
+    # writes non-ASCII to the console without the 5-line stdout/stderr UTF-8
+    # reconfigure guard, so the class cannot recur. scripts/ci.sh runs the SAME
+    # checker locally (the `ci-test` pre-push gate), so CI and the laptop gate cannot
+    # drift. Pure stdlib, no linter to install. No untrusted user input is referenced
+    # in any run: command.
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: run the UTF-8 console guard over tracked vault scripts
+        run: python3 scripts/check-utf8-stdout.py

--- a/scripts/_nvidia_router.py
+++ b/scripts/_nvidia_router.py
@@ -24,6 +24,7 @@ Raises NvidiaUnavailable if the key is missing or the endpoint errors.
 
 from __future__ import annotations
 
+import sys
 import json
 import os
 import re
@@ -193,6 +194,12 @@ def call_nvidia_json(
 
 if __name__ == "__main__":
     # Quick smoke test
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     import sys
     try:
         result = call_nvidia_text(

--- a/scripts/_project_key.py
+++ b/scripts/_project_key.py
@@ -23,6 +23,7 @@ Importable + runnable:
 
 from __future__ import annotations
 
+import sys
 import os
 import re
 from pathlib import Path
@@ -101,6 +102,12 @@ def memory_dir_for(vault: str | os.PathLike, *, must_exist: bool = False) -> Pat
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     import sys
 
     if len(sys.argv) != 2:

--- a/scripts/aggregate-decisions.py
+++ b/scripts/aggregate-decisions.py
@@ -474,4 +474,10 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/aggregate-sessions.py
+++ b/scripts/aggregate-sessions.py
@@ -373,4 +373,10 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/ai-brain-auto-update.py
+++ b/scripts/ai-brain-auto-update.py
@@ -249,4 +249,10 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     main()

--- a/scripts/audit-sessionstart-boundedness.py
+++ b/scripts/audit-sessionstart-boundedness.py
@@ -599,4 +599,10 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/auto-crm-from-mentions.py
+++ b/scripts/auto-crm-from-mentions.py
@@ -225,4 +225,10 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     main()

--- a/scripts/auto-wikilink.py
+++ b/scripts/auto-wikilink.py
@@ -436,4 +436,10 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     main()

--- a/scripts/build-journal-index.py
+++ b/scripts/build-journal-index.py
@@ -110,4 +110,10 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     main()

--- a/scripts/caveman_lint.py
+++ b/scripts/caveman_lint.py
@@ -169,4 +169,10 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/check-claude-md-drift.py
+++ b/scripts/check-claude-md-drift.py
@@ -300,4 +300,10 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/check-cloud-sync.py
+++ b/scripts/check-cloud-sync.py
@@ -29,6 +29,12 @@ from pathlib import Path
 
 # detect_cloud_sync lives in the shared worktree-safety lib. Resolve it whether
 # this script runs from the repo (hooks/_lib) or the deployed skill dir.
+# Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+    except (AttributeError, ValueError):
+        pass
 _HERE = Path(__file__).resolve().parent
 for _cand in (_HERE.parent / "hooks", _HERE.parent):
     if (_cand / "_lib" / "worktree_safety.py").is_file():

--- a/scripts/check-connector-liveness.py
+++ b/scripts/check-connector-liveness.py
@@ -331,4 +331,10 @@ def main(argv):
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main(sys.argv[1:]))

--- a/scripts/check-context-load.py
+++ b/scripts/check-context-load.py
@@ -268,4 +268,10 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     raise SystemExit(main(sys.argv[1:]))

--- a/scripts/check-rule-conflicts.py
+++ b/scripts/check-rule-conflicts.py
@@ -664,4 +664,10 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     main()

--- a/scripts/check-split-meta.py
+++ b/scripts/check-split-meta.py
@@ -64,4 +64,10 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     raise SystemExit(main(sys.argv[1:]))

--- a/scripts/check-template-purity.py
+++ b/scripts/check-template-purity.py
@@ -26,6 +26,12 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+    except (AttributeError, ValueError):
+        pass
 REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "hooks"))
 

--- a/scripts/check-utf8-stdout.py
+++ b/scripts/check-utf8-stdout.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""check-utf8-stdout.py - fail-loud guard against the Windows cp1252 print crash.
+
+A vault script that print()s the "gear Meta" emoji, an em dash, or an accented
+name works on macOS/Linux (UTF-8 consoles) and silently ships. On a Windows
+cp1252 console - or any C-locale pipe - the SAME print() raises
+UnicodeEncodeError, the caller captures an empty string, and downstream logic
+misreads it (ai-brain-starter#313: sync-vault-scripts.ps1 read the empty result
+as "no Meta folder"). The fix is a 5-line reconfigure guard at the CLI entry:
+
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
+
+This lint enforces that guard so the class cannot recur. It is the class-level
+watchdog for the SILENT-NO-OP / cp1252-crash bug: PR #313 fixed the two files
+that had already broken; this makes the NEXT one fail CI instead of a user's
+Windows console.
+
+Rule (deterministic, near-zero false positive):
+    A tracked script FAILS if ALL of:
+      - it is a runnable CLI ............ has `if __name__ == "__main__":`
+      - it writes to the console ........ a print() with no non-console file=,
+                                          or sys.stdout/sys.stderr .write()
+      - its source carries non-ASCII .... any byte > 0x7F anywhere in the file
+                                          (the emoji, an em dash, an accented
+                                          name - the exact bytes that crash)
+      - it lacks the guard ............. no stdout/stderr .reconfigure(utf-8)
+      - it is not opted out ............ no `# utf8-stdout-ok: <reason>` marker
+
+Why "source carries non-ASCII" rather than "a print literal is non-ASCII":
+_meta_resolver.py print()s a DYNAMIC Path (`print(resolved)`) that holds the
+emoji at runtime - there is no non-ASCII print literal to key on, yet it was one
+of the two crashing files. The presence of the emoji anywhere in its source is
+the reliable marker that the script handles emoji-bearing text and can emit it.
+A genuinely ASCII-only CLI (no non-ASCII byte anywhere) can never hit the crash
+and is never flagged.
+
+Escape hatch: a script whose console output is provably ASCII-only despite a
+non-ASCII comment can add `# utf8-stdout-ok: <reason>` on its own line. The guard
+itself is a harmless no-op on POSIX (already UTF-8), so adding it is almost
+always the right fix rather than a bypass.
+
+Usage:
+    check-utf8-stdout.py                 # lint tracked scripts/*.py, exit 1 on any violation
+    check-utf8-stdout.py FILE [FILE ...] # lint the named files
+    check-utf8-stdout.py --report [glob] # classify every file, never fail (enumeration)
+"""
+import ast
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# The guard is detected structurally: a .reconfigure(encoding="utf-8") call
+# (single/double quotes, optional hyphen, flexible whitespace). Both files PR
+# #313 fixed use exactly `.reconfigure(encoding="utf-8")`.
+_GUARD_RE = re.compile(r"\.reconfigure\(\s*encoding\s*=\s*['\"]utf-?8['\"]", re.IGNORECASE)
+_BYPASS_RE = re.compile(r"#\s*utf8-stdout-ok\b", re.IGNORECASE)
+
+
+def _utf8_streams():
+    """Reconfigure our own CLI streams; this lint prints file paths that can
+    themselves contain the emoji, so it must not crash on the console it guards."""
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
+
+
+def _is_console_print(node):
+    """True if this Call writes to the console (stdout/stderr)."""
+    func = node.func
+    # print(...) - console unless a non-stdout/stderr file= redirects it.
+    if isinstance(func, ast.Name) and func.id == "print":
+        for kw in node.keywords:
+            if kw.arg == "file":
+                val = kw.value
+                # file=sys.stdout / file=sys.stderr stays console; anything else
+                # (an open file, a StringIO) is not a console write.
+                if isinstance(val, ast.Attribute) and val.attr in ("stdout", "stderr"):
+                    return True
+                return False
+        return True
+    # sys.stdout.write(...) / sys.stderr.write(...) / .writelines(...)
+    if isinstance(func, ast.Attribute) and func.attr in ("write", "writelines"):
+        owner = func.value
+        if isinstance(owner, ast.Attribute) and owner.attr in ("stdout", "stderr"):
+            return True
+    return False
+
+
+def classify(path):
+    """Return a dict describing the file against the four signals."""
+    data = path.read_bytes()
+    has_non_ascii = any(b > 0x7F for b in data)
+    text = data.decode("utf-8", errors="replace")
+
+    has_guard = bool(_GUARD_RE.search(text))
+    has_bypass = bool(_BYPASS_RE.search(text))
+
+    is_cli = False
+    prints_console = False
+    parse_error = None
+    try:
+        tree = ast.parse(text)
+    except SyntaxError as exc:  # py_compile gate owns syntax; we just skip.
+        parse_error = str(exc)
+        tree = None
+
+    if tree is not None:
+        for node in ast.walk(tree):
+            if isinstance(node, ast.If):
+                test = node.test
+                # if __name__ == "__main__":
+                if (
+                    isinstance(test, ast.Compare)
+                    and isinstance(test.left, ast.Name)
+                    and test.left.id == "__name__"
+                ):
+                    is_cli = True
+            if isinstance(node, ast.Call) and _is_console_print(node):
+                prints_console = True
+
+    flagged = (
+        is_cli
+        and prints_console
+        and has_non_ascii
+        and not has_guard
+        and not has_bypass
+        and parse_error is None
+    )
+    return {
+        "path": path,
+        "is_cli": is_cli,
+        "prints_console": prints_console,
+        "has_non_ascii": has_non_ascii,
+        "has_guard": has_guard,
+        "has_bypass": has_bypass,
+        "parse_error": parse_error,
+        "flagged": flagged,
+    }
+
+
+def _tracked_scripts():
+    """Default target: tracked scripts/*.py, resolved from the repo root."""
+    root = Path(__file__).resolve().parent.parent
+    try:
+        out = subprocess.check_output(
+            ["git", "-C", str(root), "ls-files", "--", "scripts/*.py"],
+            text=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        # Not a git checkout - fall back to a plain glob.
+        return sorted((root / "scripts").glob("*.py"))
+    return [root / line for line in out.splitlines() if line.strip()]
+
+
+def main(argv):
+    _utf8_streams()
+    report_mode = False
+    args = list(argv)
+    if args and args[0] == "--report":
+        report_mode = True
+        args = args[1:]
+
+    if args:
+        # In --report mode a bare glob string is allowed; otherwise treat as paths.
+        if report_mode and len(args) == 1 and any(ch in args[0] for ch in "*?"):
+            targets = sorted(Path().glob(args[0]))
+        else:
+            targets = [Path(a) for a in args]
+    else:
+        targets = _tracked_scripts()
+
+    results = [classify(p) for p in targets if p.suffix == ".py" and p.is_file()]
+
+    if report_mode:
+        _print_report(results)
+        return 0
+
+    violations = [r for r in results if r["flagged"]]
+    if violations:
+        print(
+            "::error::vault script(s) print to a Windows-hostile console without "
+            "the UTF-8 stdout/stderr guard (the ai-brain-starter#313 cp1252 crash "
+            "class). Add the 5-line reconfigure block at the CLI entrypoint:",
+            file=sys.stderr,
+        )
+        print(
+            "    for _stream in (sys.stdout, sys.stderr):\n"
+            "        try:\n"
+            '            _stream.reconfigure(encoding="utf-8")  # Python 3.7+\n'
+            "        except (AttributeError, ValueError):\n"
+            "            pass",
+            file=sys.stderr,
+        )
+        for r in violations:
+            rel = r["path"]
+            print(
+                "::error file={f}::{f} is a runnable CLI that writes to the "
+                "console and carries non-ASCII source, but never reconfigures "
+                "stdout/stderr to UTF-8 (add the guard, or `# utf8-stdout-ok: "
+                "<reason>` if its console output is provably ASCII-only).".format(f=rel),
+                file=sys.stderr,
+            )
+        print(
+            "\nFAILED: {n} script(s) missing the UTF-8 console guard.".format(
+                n=len(violations)
+            ),
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        "OK - {n} script(s) checked; every printing CLI with non-ASCII source "
+        "carries the UTF-8 console guard.".format(n=len(results))
+    )
+    return 0
+
+
+def _print_report(results):
+    """Human enumeration: one row per file, with why it is / is not flagged."""
+    flagged = [r for r in results if r["flagged"]]
+    clean_cli = [r for r in results if r["is_cli"] and not r["flagged"]]
+    non_cli = [r for r in results if not r["is_cli"]]
+
+    def _reason(r):
+        bits = []
+        bits.append("cli" if r["is_cli"] else "lib")
+        bits.append("print" if r["prints_console"] else "no-print")
+        bits.append("non-ascii" if r["has_non_ascii"] else "ascii")
+        bits.append("guard" if r["has_guard"] else "no-guard")
+        if r["has_bypass"]:
+            bits.append("bypass")
+        if r["parse_error"]:
+            bits.append("PARSE-ERR")
+        return ",".join(bits)
+
+    print("== FLAGGED (needs the guard) : {} ==".format(len(flagged)))
+    for r in flagged:
+        print("  FIX  {}  [{}]".format(r["path"], _reason(r)))
+    print("\n== printing CLIs already safe : {} ==".format(len(clean_cli)))
+    for r in clean_cli:
+        print("  ok   {}  [{}]".format(r["path"], _reason(r)))
+    print("\n== non-CLI / library files : {} ==".format(len(non_cli)))
+    for r in non_cli:
+        print("  -    {}  [{}]".format(r["path"], _reason(r)))
+    print(
+        "\nTotals: {} flagged, {} safe CLIs, {} non-CLI, {} files.".format(
+            len(flagged), len(clean_cli), len(non_cli), len(results)
+        )
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/check-vault-backup.py
+++ b/scripts/check-vault-backup.py
@@ -282,4 +282,10 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main(sys.argv[1:]))

--- a/scripts/check-worktree-on-vault.py
+++ b/scripts/check-worktree-on-vault.py
@@ -226,6 +226,12 @@ def main(argv):
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     try:
         sys.exit(main(sys.argv[1:]))
     except Exception:

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -28,12 +28,21 @@
 #                           py_compile does not catch undefined names). A dedicated
 #                           lint.yml job enforces this in CI (as the shellcheck job
 #                           does); here it is best-effort, skipped without a linter.
+#   (e) UTF-8 console guard - scripts/check-utf8-stdout.py fails a runnable vault
+#                           CLI that print()s non-ASCII (the "gear Meta" emoji, an
+#                           em dash, an accented name) without reconfiguring
+#                           stdout/stderr to UTF-8. On a Windows cp1252 console
+#                           that print() raises UnicodeEncodeError and the caller
+#                           reads the empty output as failure (ai-brain-starter#313).
+#                           A dedicated lint.yml 'utf8-console-guard' job is
+#                           authoritative in CI; here it runs locally (pure stdlib).
 #
 # It does NOT run the OTHER pure-lint jobs (bash -n, pwsh ParseFile, BOM, em-dash,
 # JSON, privacy, references, no-remote-pipe-install). Those stay as their own
-# lint.yml jobs - they are lint, not the unit/type gate. shellcheck is the one
-# exception: it is the cross-platform CORRECTNESS gate (it catches the GNU-vs-BSD
-# `stat` mtime class), so it is worth enforcing pre-push, not only in CI.
+# lint.yml jobs - they are lint, not the unit/type gate. Two are exceptions,
+# enforced pre-push because they are cross-platform CORRECTNESS gates, not style:
+# the shell static-analysis gate (the GNU-vs-BSD `stat` mtime class) and the UTF-8
+# console guard (the Windows cp1252 print-crash class).
 #
 # Environment the integration tests need (lint.yml provides these in the `ci`
 # job; this script adds a non-invasive fallback so a fresh `bash scripts/ci.sh`
@@ -181,6 +190,10 @@ INTEGRATION_TESTS=(
   test_post_commit_ff_worktrees
   test_write_hook_meeting_folder_i18n
   test_vault_script_sync
+  # UTF-8 console guard (ai-brain-starter#313 follow-up): negative controls prove the
+  # lint FAILS an unguarded non-ASCII-printing CLI and that the guard is load-bearing
+  # under a real cp1252 console; also asserts the real scripts/ tree is clean.
+  test_utf8_console_guard
 )
 # ---- Gate-coverage invariant -------------------------------------------------
 # The list above is an explicit allow-list, and allow-lists rot: a new
@@ -259,5 +272,24 @@ else
   echo "    install: pip install ruff"
 fi
 
+# ---- (e) UTF-8 console guard -----------------------------------------------
+# scripts/check-utf8-stdout.py fails a runnable vault CLI that print()s non-ASCII
+# without the UTF-8 stdout/stderr reconfigure guard - the Windows cp1252 crash
+# class (ai-brain-starter#313: a non-ASCII print raised UnicodeEncodeError, the
+# caller captured an empty string, and read it as "no Meta folder"). Mirrors how
+# the shell static-analysis gate is wired: a dedicated lint.yml 'utf8-console-guard'
+# job is authoritative in CI; here it runs locally so the pre-push gate catches the crash
+# class before a Windows console does. Pure stdlib - no external linter to skip on,
+# so unlike (c)/(d) it always runs locally (and is skipped in CI where the
+# dedicated job owns it, to keep failure attribution clean).
+if [ -n "${GITHUB_ACTIONS:-}" ]; then
+  utf8_note="skipped in CI (dedicated lint.yml 'utf8-console-guard' job runs scripts/check-utf8-stdout.py)"
+  echo "==> (e) utf8 console guard: $utf8_note"
+else
+  echo "==> (e) utf8 console guard: $PY scripts/check-utf8-stdout.py"
+  "$PY" scripts/check-utf8-stdout.py
+  utf8_note="passed"
+fi
+
 echo
-echo "All gates passed: py_compile ($count file(s)) + ${#INTEGRATION_TESTS[@]} integration tests + shellcheck [$shellcheck_note] + phase-doc python [$phasepy_note]."
+echo "All gates passed: py_compile ($count file(s)) + ${#INTEGRATION_TESTS[@]} integration tests + shellcheck [$shellcheck_note] + phase-doc python [$phasepy_note] + utf8 console guard [$utf8_note]."

--- a/scripts/claude_performance_digest.py
+++ b/scripts/claude_performance_digest.py
@@ -711,4 +711,10 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     main()

--- a/scripts/closed-loop-daemon.py
+++ b/scripts/closed-loop-daemon.py
@@ -236,4 +236,10 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/closed-loop-week-report.py
+++ b/scripts/closed-loop-week-report.py
@@ -222,4 +222,10 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/compress-vault-doc.py
+++ b/scripts/compress-vault-doc.py
@@ -315,4 +315,10 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     main()

--- a/scripts/context-audit.py
+++ b/scripts/context-audit.py
@@ -316,4 +316,10 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/crm-collision-check.py
+++ b/scripts/crm-collision-check.py
@@ -106,4 +106,10 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/curate-skills-surface.py
+++ b/scripts/curate-skills-surface.py
@@ -166,4 +166,10 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/decision-outcome-check.py
+++ b/scripts/decision-outcome-check.py
@@ -266,4 +266,10 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/decision-retrospective.py
+++ b/scripts/decision-retrospective.py
@@ -154,4 +154,10 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/dev-hub-refresh.py
+++ b/scripts/dev-hub-refresh.py
@@ -38,6 +38,12 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+# Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+    except (AttributeError, ValueError):
+        pass
 DEV_ROOT = Path(os.environ.get("DEV_HUB_REFRESH_ROOT") or (Path.home() / "dev"))
 STATE_PATH = Path(
     os.environ.get("DEV_HUB_REFRESH_STATE")

--- a/scripts/disambiguate_first_name.py
+++ b/scripts/disambiguate_first_name.py
@@ -296,4 +296,10 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     main()

--- a/scripts/drift-detection.py
+++ b/scripts/drift-detection.py
@@ -377,4 +377,10 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/extractors/_dispatcher.py
+++ b/scripts/extractors/_dispatcher.py
@@ -308,4 +308,10 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     main()

--- a/scripts/footprint-sla-check.py
+++ b/scripts/footprint-sla-check.py
@@ -1369,4 +1369,10 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/generate_floor_stubs.py
+++ b/scripts/generate_floor_stubs.py
@@ -12,6 +12,7 @@ shadow-twin links, Substack series links) — not lived-experience prose.
 Re-run after any change to the 34-floor canonical list in floors.md.
 """
 
+import sys
 from pathlib import Path
 from textwrap import dedent
 
@@ -246,4 +247,10 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     main()

--- a/scripts/graph-liveness-check.py
+++ b/scripts/graph-liveness-check.py
@@ -187,6 +187,12 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     try:
         sys.exit(main())
     except KeyboardInterrupt:

--- a/scripts/graph-to-neo4j.py
+++ b/scripts/graph-to-neo4j.py
@@ -219,4 +219,10 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     main()

--- a/scripts/graphify_apply_wikilinks.py
+++ b/scripts/graphify_apply_wikilinks.py
@@ -723,4 +723,10 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     main()

--- a/scripts/graphify_canonicalize.py
+++ b/scripts/graphify_canonicalize.py
@@ -300,4 +300,10 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     main()

--- a/scripts/graphify_chunk.py
+++ b/scripts/graphify_chunk.py
@@ -21,6 +21,7 @@ Usage:
     python3 graphify_chunk.py <input_dir> --out-dir graphify-out [--target-chunks 12] [--skip-ai-extract]
 """
 
+import sys
 import argparse
 import json
 from pathlib import Path
@@ -132,4 +133,10 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     main()

--- a/scripts/graphify_coverage_audit.py
+++ b/scripts/graphify_coverage_audit.py
@@ -359,4 +359,10 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     main()

--- a/scripts/graphify_dedupe_by_adjacency.py
+++ b/scripts/graphify_dedupe_by_adjacency.py
@@ -46,6 +46,7 @@ test set. Filtered out a known false-positive case (two unrelated concepts
 sharing 5 neighbors at jaccard 1.0) via the label overlap guard.
 """
 
+import sys
 import argparse
 import json
 import shutil
@@ -325,4 +326,10 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     main()

--- a/scripts/graphify_minimax_preprocess.py
+++ b/scripts/graphify_minimax_preprocess.py
@@ -337,4 +337,10 @@ focus on cross-file inference + hyperedge synthesis.
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     main()

--- a/scripts/graphify_preextract_block.py
+++ b/scripts/graphify_preextract_block.py
@@ -73,4 +73,10 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     main()

--- a/scripts/graphify_prep.py
+++ b/scripts/graphify_prep.py
@@ -532,4 +532,10 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     main()

--- a/scripts/graphify_prune_stale_cache.py
+++ b/scripts/graphify_prune_stale_cache.py
@@ -105,4 +105,10 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     main()

--- a/scripts/graphify_stage_finish.py
+++ b/scripts/graphify_stage_finish.py
@@ -639,4 +639,10 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     main()

--- a/scripts/graphify_stage_select.py
+++ b/scripts/graphify_stage_select.py
@@ -303,4 +303,10 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     main()

--- a/scripts/graphify_wikilink_gaps.py
+++ b/scripts/graphify_wikilink_gaps.py
@@ -287,4 +287,10 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     main()

--- a/scripts/hallucination-sample-audit.py
+++ b/scripts/hallucination-sample-audit.py
@@ -548,4 +548,10 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/hallucination-watch.py
+++ b/scripts/hallucination-watch.py
@@ -335,4 +335,10 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/hook_runner.py
+++ b/scripts/hook_runner.py
@@ -103,4 +103,10 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main(sys.argv[1:]))

--- a/scripts/install-hooks-user-level.py
+++ b/scripts/install-hooks-user-level.py
@@ -995,4 +995,10 @@ def run_verification(settings: dict, fail_on_missing: bool = False) -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/install-telemetry.py
+++ b/scripts/install-telemetry.py
@@ -211,4 +211,10 @@ def main(argv: list[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/instinct.py
+++ b/scripts/instinct.py
@@ -527,4 +527,10 @@ def main(argv=None) -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/instinct_lib.py
+++ b/scripts/instinct_lib.py
@@ -30,6 +30,7 @@ Design contracts (load-bearing — do not weaken without a regression test):
 
 from __future__ import annotations
 
+import sys
 import hashlib
 import os
 import re
@@ -415,6 +416,12 @@ def infer_domain(inst: Instinct) -> str:
 
 if __name__ == "__main__":
     # tiny smoke when run directly
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     import sys
     print("instinct_lib OK; current_project_id:", current_project_id())
     md = resolve_memory_dir(sys.argv[1] if len(sys.argv) > 1 else None)

--- a/scripts/link-agent-memory.py
+++ b/scripts/link-agent-memory.py
@@ -165,4 +165,10 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     raise SystemExit(main())

--- a/scripts/mcp-config-check.py
+++ b/scripts/mcp-config-check.py
@@ -215,6 +215,12 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     try:
         sys.exit(main())
     except Exception as e:

--- a/scripts/measure-plugin-load.py
+++ b/scripts/measure-plugin-load.py
@@ -246,4 +246,10 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/monthly-baseline.py
+++ b/scripts/monthly-baseline.py
@@ -434,4 +434,10 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     main()

--- a/scripts/organize-journals.py
+++ b/scripts/organize-journals.py
@@ -15,6 +15,7 @@ The Journals folder is expected at: <vault-root>/Journals/
 Customize JOURNALS_DIR if your vault uses a different name (e.g. "📓 Journals").
 """
 
+import sys
 import argparse
 import os
 import re
@@ -192,4 +193,10 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     main()

--- a/scripts/passive-capture.py
+++ b/scripts/passive-capture.py
@@ -559,4 +559,10 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     main()

--- a/scripts/post-update-email-ask.py
+++ b/scripts/post-update-email-ask.py
@@ -256,6 +256,12 @@ SI dicen "después" / "tal vez" (no es un no rotundo): no hagas nada — no escr
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     try:
         sys.exit(main())
     except Exception:

--- a/scripts/promote-episodic-to-procedural.py
+++ b/scripts/promote-episodic-to-procedural.py
@@ -584,4 +584,10 @@ def main(argv: list[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/recover-last-close.py
+++ b/scripts/recover-last-close.py
@@ -139,4 +139,10 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/recover-orphan-claude-branches.py
+++ b/scripts/recover-orphan-claude-branches.py
@@ -192,4 +192,10 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/relocate-sweep.py
+++ b/scripts/relocate-sweep.py
@@ -1087,4 +1087,10 @@ def main(argv=None):
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/repo-bundle.py
+++ b/scripts/repo-bundle.py
@@ -121,4 +121,10 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     main()

--- a/scripts/resolver-build.py
+++ b/scripts/resolver-build.py
@@ -711,4 +711,10 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/rotate-last-session.py
+++ b/scripts/rotate-last-session.py
@@ -183,4 +183,10 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/session-close-fallback.py
+++ b/scripts/session-close-fallback.py
@@ -283,4 +283,10 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/skill-usage-report.py
+++ b/scripts/skill-usage-report.py
@@ -10,6 +10,7 @@ Usage:
   python3 skill-usage-report.py --log-file /path/to/log.jsonl --report-file /path/to/report.md
 """
 
+import sys
 import argparse
 import json
 import os
@@ -253,4 +254,10 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     main()

--- a/scripts/stub_audit.py
+++ b/scripts/stub_audit.py
@@ -200,4 +200,10 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     main()

--- a/scripts/sync-skills.py
+++ b/scripts/sync-skills.py
@@ -191,4 +191,10 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/test-closing-signals.py
+++ b/scripts/test-closing-signals.py
@@ -290,4 +290,10 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/test-relocate-sweep.py
+++ b/scripts/test-relocate-sweep.py
@@ -402,4 +402,10 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/test-relocate-watch.py
+++ b/scripts/test-relocate-watch.py
@@ -352,4 +352,10 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/test-utf8-console-guard.sh
+++ b/scripts/test-utf8-console-guard.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+#
+# scripts/test-utf8-console-guard.sh - regression test for scripts/check-utf8-stdout.py,
+# the fail-loud guard against the Windows cp1252 print crash class (ai-brain-starter#313).
+#
+# Bug class: a vault script that print()s the "gear Meta" emoji, an em dash, or an
+# accented name works on a UTF-8 console (macOS/Linux) and silently ships. On a
+# Windows cp1252 console - or a C-locale pipe - the SAME print() raises
+# UnicodeEncodeError, the caller captures an empty string, and downstream logic
+# misreads it (#313: sync-vault-scripts.ps1 read the empty output as "no Meta
+# folder"). PR #313 fixed the two files that had already broken; this lint makes
+# the NEXT one fail CI instead of a user's console.
+#
+# The assertions below prove the lint (a) FAILS on an unguarded non-ASCII-printing
+# CLI - the negative control, because a guard earns trust only by failing on the
+# thing it catches - (b) PASSES a guarded one, (c) honors the documented bypass,
+# (d) does NOT over-flag a genuinely ASCII-only CLI, and (e) that the guard it
+# enforces is load-bearing: the unguarded fixture actually crashes under cp1252
+# while the guarded one prints clean. Finally it runs the lint over the real
+# scripts/ tree and requires it clean, so a future unguarded script fails here.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECKER="$HERE/check-utf8-stdout.py"
+
+fail=0
+check() {  # check <description> <expected> <actual>
+  if [ "$2" = "$3" ]; then
+    echo "  ok: $1"
+  else
+    echo "  FAIL: $1"
+    echo "        expected: [$2]"
+    echo "        actual:   [$3]"
+    fail=1
+  fi
+}
+
+# Non-ASCII bytes built at runtime so THIS shell file stays ASCII-clean; the
+# fixture .py files below carry the real UTF-8 bytes that trigger the crash.
+GEAR="$(printf '\xe2\x9a\x99\xef\xb8\x8f')"   # U+2699 U+FE0F  "gear Meta" emoji
+EMDASH="$(printf '\xe2\x80\x94')"             # U+2014          em dash
+
+base="$(mktemp -d)"
+trap 'rm -rf "$base"' EXIT
+
+rc() {  # rc <file...> -> echo the checker's exit code without tripping set -e
+  if python3 "$CHECKER" "$@" >/dev/null 2>&1; then echo 0; else echo $?; fi
+}
+
+# --- Fixture A: unguarded CLI that prints non-ASCII (the crash class) --------
+cat > "$base/unguarded.py" <<PY
+#!/usr/bin/env python3
+import sys
+
+
+def main():
+    print("MARK ${GEAR} Meta ${EMDASH} done")
+
+
+if __name__ == "__main__":
+    main()
+PY
+check "unguarded non-ASCII CLI is FLAGGED (exit 1)" "1" "$(rc "$base/unguarded.py")"
+
+# --- Fixture B: same, guarded -> passes -------------------------------------
+cat > "$base/guarded.py" <<PY
+#!/usr/bin/env python3
+import sys
+
+
+def main():
+    print("MARK ${GEAR} Meta ${EMDASH} done")
+
+
+if __name__ == "__main__":
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")
+        except (AttributeError, ValueError):
+            pass
+    main()
+PY
+check "guarded non-ASCII CLI PASSES (exit 0)" "0" "$(rc "$base/guarded.py")"
+
+# --- Fixture C: unguarded but opted out via the documented bypass ------------
+cat > "$base/bypass.py" <<PY
+#!/usr/bin/env python3
+# utf8-stdout-ok: console output below is provably ASCII; non-ASCII is doc only.
+import sys
+
+
+def main():
+    print("${GEAR}")  # marker only
+
+
+if __name__ == "__main__":
+    main()
+PY
+check "bypass marker is honored (exit 0)" "0" "$(rc "$base/bypass.py")"
+
+# --- Fixture D: genuinely ASCII-only CLI -> never flagged (no over-strict) ---
+cat > "$base/ascii_only.py" <<'PY'
+#!/usr/bin/env python3
+import sys
+
+
+def main():
+    print("plain ascii output only, count", len(sys.argv))
+
+
+if __name__ == "__main__":
+    main()
+PY
+check "ASCII-only CLI is NOT flagged (exit 0)" "0" "$(rc "$base/ascii_only.py")"
+
+# --- Fixture E: the guard is load-bearing under a real cp1252 console --------
+if PYTHONIOENCODING=cp1252 PYTHONUTF8=0 python3 "$base/unguarded.py" >/dev/null 2>"$base/err"; then
+  check "unguarded fixture CRASHES under cp1252" "crash" "no-crash"
+else
+  if grep -q UnicodeEncodeError "$base/err"; then
+    check "unguarded fixture CRASHES under cp1252" "crash" "crash"
+  else
+    check "unguarded fixture CRASHES under cp1252" "crash" "other-error"
+  fi
+fi
+if out="$(PYTHONIOENCODING=cp1252 PYTHONUTF8=0 python3 "$base/guarded.py" 2>/dev/null)"; then
+  case "$out" in
+    *Meta*) check "guarded fixture PRINTS under cp1252" "ok" "ok" ;;
+    *)      check "guarded fixture PRINTS under cp1252" "ok" "bad-output[$out]" ;;
+  esac
+else
+  check "guarded fixture PRINTS under cp1252" "ok" "crash"
+fi
+
+# --- Fixture F: the real scripts/ tree must be clean -------------------------
+check "real scripts/ tree passes the lint (exit 0)" "0" "$(rc)"
+
+if [ "$fail" != 0 ]; then
+  echo "FAILED: utf8-console-guard regression test"
+  exit 1
+fi
+echo "PASSED: utf8-console-guard regression test"

--- a/scripts/test_graph_liveness_check.py
+++ b/scripts/test_graph_liveness_check.py
@@ -129,4 +129,10 @@ def _main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(_main())

--- a/scripts/token-usage-report.py
+++ b/scripts/token-usage-report.py
@@ -598,4 +598,10 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     main()

--- a/scripts/undo-last-close.py
+++ b/scripts/undo-last-close.py
@@ -190,4 +190,10 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/vault-classify-untyped.py
+++ b/scripts/vault-classify-untyped.py
@@ -160,4 +160,10 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     main()

--- a/scripts/vault-hygiene.py
+++ b/scripts/vault-hygiene.py
@@ -228,4 +228,10 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/vault-insight-engine.py
+++ b/scripts/vault-insight-engine.py
@@ -696,4 +696,10 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     main()

--- a/scripts/vault-schema-validator.py
+++ b/scripts/vault-schema-validator.py
@@ -403,4 +403,10 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/vault_maintenance.py
+++ b/scripts/vault_maintenance.py
@@ -326,4 +326,10 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     main()

--- a/scripts/wikilink_misfire_audit.py
+++ b/scripts/wikilink_misfire_audit.py
@@ -338,4 +338,10 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     main()

--- a/scripts/worktree-archive-prep.py
+++ b/scripts/worktree-archive-prep.py
@@ -180,4 +180,10 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/worktree-reclaim.py
+++ b/scripts/worktree-reclaim.py
@@ -195,6 +195,12 @@ from _lib.worktree_safety import WORKTREES_SEG as WORKTREES_SEG_LOCAL  # noqa: E
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     try:
         sys.exit(main())
     except KeyboardInterrupt:

--- a/tests/integration/test_utf8_console_guard.sh
+++ b/tests/integration/test_utf8_console_guard.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# CI integration wrapper - runs the utf8-console-guard regression suite
+# (scripts/test-utf8-console-guard.sh) as part of scripts/ci.sh. Kept thin so the
+# test logic has ONE home next to the lint it exercises.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+exec bash "$ROOT/scripts/test-utf8-console-guard.sh"


### PR DESCRIPTION
Follow-up to #313. On a Windows cp1252 console (or a C-locale pipe) a `print()` of the "gear Meta" emoji, an em dash, or an accented name raises `UnicodeEncodeError`; the caller captures an empty string and reads it as failure (`sync-vault-scripts.ps1` saw "no Meta folder"). #313 fixed `_meta_resolver.py` and `journal-preflight.py`; the same crash lived in **87 more** scripts under `scripts/`.

## What changed

- **New `check-utf8-stdout.py`** flags a runnable CLI (`if __name__ == "__main__"`) that writes non-ASCII to `stdout`/`stderr` without the reconfigure guard. It enumerated 87 scripts: 27 print a non-ASCII literal outright, 41 print non-ASCII string data, 19 print dynamic vault paths/data while their source carries the emoji. A genuinely ASCII-only CLI is never flagged, so the gate sits at the real ship/hold boundary rather than the strictest possible signal.
- **The 5-line `sys.stdout`/`sys.stderr` `reconfigure(encoding="utf-8")` guard** from #313, inserted at each CLI entrypoint. Three scripts print at module load (import fallbacks), so their guard sits at module top; added a module-level `import sys` to the scripts that used `sys` only nested or not at all.
- **A dedicated `utf8-console-guard` job** in `lint.yml` runs the checker over every tracked vault script. `ci.sh` runs the SAME checker locally (step `e`) so the `ci-test` pre-push gate and CI cannot drift, mirroring the shellcheck arrangement.
- **`test-utf8-console-guard.sh`** (wired into the `ci.sh` integration gate) is the negative control: it proves the lint FAILS an unguarded non-ASCII CLI, PASSES a guarded one, honors the `# utf8-stdout-ok:` bypass, does not over-flag an ASCII-only CLI, and that the guard is load-bearing under a real cp1252 console.

## Verification

`PYTHONIOENCODING=cp1252` negative controls reproduce the exact crash on the unguarded files and show the guard prints clean, including the canonical `_meta_resolver` gear-Meta path and the module-level-`import sys` case in `skill-usage-report.py`. `bash scripts/ci.sh` is green: py_compile (284) + 79 integration tests + shellcheck + phase-python + the new guard. Personal-data and API-key scrub clean on the diff.

## Follow-up

`hooks/` shows the same class in 71 files, tracked in #314; the lint extends to them by one glob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
