### PR TITLE
fix(router): structured --output-format json envelope gate, not banner denylist

### DIFF
--- a/scripts/_claude_router.py
+++ b/scripts/_claude_router.py
@@ -56,6 +56,7 @@ __all__ = [
     "call_claude_text",
     "call_claude_json",
     "RouterUnavailable",
+    "RateLimitExhausted",
 ]
 
 
@@ -65,6 +66,16 @@ API_TIMEOUT_SECONDS = 180
 
 class RouterUnavailable(RuntimeError):
     """Raised when neither the CLI nor an API key is available."""
+
+
+class RateLimitExhausted(RouterUnavailable):
+    """Subclass for transient rate-limit refusals (weekly Max cap, 5h burst, etc.).
+
+    Distinguished from the parent so callers can return a transient-failure exit
+    code (e.g. EX_TEMPFAIL, 75) and signal a scheduler that the next run — after
+    the limit window resets — will likely succeed, versus a hard config failure.
+    A subclass, so existing ``except RouterUnavailable`` handlers still catch it.
+    """
 
 
 def _log(msg: str) -> None:
@@ -104,23 +115,103 @@ def _resolve_api_key() -> str | None:
     return os.environ.get("ANTHROPIC_API_KEY") or None
 
 
+def _extract_result_envelope(stdout: str) -> dict | None:
+    """Return the `--output-format json` result envelope, or None if stdout is
+    not a parseable result envelope.
+
+    None is itself a STRUCTURAL failure signal: in json mode a real response is
+    always a valid envelope, so unparseable stdout can never be a success — this
+    is the positive content-validity gate. Tolerant of a stray hook line leaked
+    ahead of the envelope (scans from the last line back)."""
+    if not stdout:
+        return None
+    try:
+        obj = json.loads(stdout)
+        if isinstance(obj, dict) and obj.get("type") == "result":
+            return obj
+    except json.JSONDecodeError:
+        pass
+    for line in reversed(stdout.splitlines()):
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict) and obj.get("type") == "result":
+            return obj
+    return None
+
+
+# Marker tuple is a failure CLASSIFIER (rate-limit vs generic-unavailable) on an
+# ALREADY-determined failure — never the success gate. The old code sniffed raw
+# stdout against a denylist to DECIDE success and was patched repeatedly, always
+# one banner phrasing behind: an unrecognized banner (login / connection /
+# weekly-limit / session-limit) was consumed as a successful response. The fix
+# makes success purely structural (a valid result envelope with is_error false),
+# so an unknown future banner has no envelope and can never be consumed as
+# content. Bug class: PRODUCER-OUTPUT-CONSUMED-WITHOUT-CONTENT-VALIDITY-CHECK.
+_RATELIMIT_MARKERS = (
+    "weekly limit",
+    "hit your weekly",
+    "session limit",        # 5-hour rolling cap (newer CLI)
+    "hit your session",
+    "rate limit",
+    "rate_limit_exceeded",
+    "usage limit",
+    "quota exceeded",
+)
+
+
+def _classify_cli_failure(text: str, raw: str = "") -> RouterUnavailable:
+    """Map a known-failure error string to the right typed exception.
+
+    Rate-limit markers -> RateLimitExhausted (transient; the next scheduled run
+    after the window reset should succeed). Everything else (auth/network
+    refusal OR an unrecognized banner) -> RouterUnavailable. Default-unavailable
+    on unknown is the safe direction: a banner we don't recognize fails loudly
+    instead of being consumed as a response."""
+    low = (text or "").lower()
+    snippet = ((raw or text or "")[:200])
+    if any(m in low for m in _RATELIMIT_MARKERS):
+        return RateLimitExhausted(
+            f"claude CLI rate-limit signal: {snippet!r}. Transient — the next "
+            "scheduled run after the limit window resets should succeed."
+        )
+    return RouterUnavailable(
+        f"claude CLI failure (no valid result envelope): {snippet!r}. "
+        "Auth/network refusal or an unrecognized banner — not a model response."
+    )
+
+
 def _call_via_cli(
     cli: str, system: str, user: str, model: str
 ) -> str:
-    """Run `claude -p` and return stdout text.
+    """Run `claude -p --output-format json` and return the envelope's result text.
 
-    Acceptance logic:
-      - exit 0 with any stdout (including "PONG.") → accept
-      - exit non-zero with non-empty stdout → accept (likely a SessionEnd
-        hook failed AFTER Claude wrote its response; throwing the response
-        away just because the hook failed is a regression we explicitly
-        log + accept past)
-      - exit non-zero with empty stdout → real failure, raise
+    Acceptance logic (structural — independent of exit code):
+      - valid result envelope, is_error=false → accept (return envelope.result)
+      - valid result envelope, is_error=true  → raise (classified)
+      - NO valid envelope, non-empty stdout    → raise (classify the banner)
+      - NO valid envelope, empty stdout        → raise RouterUnavailable
 
-    `claude -p` runs SessionStart and SessionEnd hooks even in print mode;
-    a failing hook (sync-my-skills.sh push, etc.) used to bubble up as exit 1
-    even when Claude succeeded. The earlier MIN_RESPONSE_CHARS heuristic was
-    wrong because legitimate replies can be very short ("PONG.", "Yes", "42").
+    Success is gated on a parseable result envelope, NOT on sniffing raw text
+    for a denylist of bad banners. An unknown future banner has no envelope and
+    can never be returned as content — that is the whole
+    PRODUCER-OUTPUT-CONSUMED-WITHOUT-CONTENT-VALIDITY-CHECK fix.
+
+    HARD DEPENDENCY on `--output-format json`: a CLI that IGNORES the flag and
+    emits plain text on exit 0 (an older `claude`, or a wrapper that strips the
+    flag) has no envelope, so it is treated as UNAVAILABLE and call_claude_text
+    falls through to the API-key tier. This is the safe direction (no envelope
+    is never consumed as content) and is intentional, not silent.
+
+    Exit code is no longer part of the gate: `claude -p` runs SessionStart and
+    SessionEnd hooks even in print mode, and a hook failing AFTER Claude wrote
+    its response exits non-zero while the envelope on stdout is still valid — so
+    we accept it. The earlier MIN_RESPONSE_CHARS heuristic was wrong because
+    legitimate replies can be very short ("PONG.", "Yes", "42").
     """
     cmd = [
         cli,
@@ -130,6 +221,8 @@ def _call_via_cli(
         system,
         "--model",
         model,
+        "--output-format",
+        "json",                 # structured envelope, not raw text
         "--no-session-persistence",
         "--disable-slash-commands",
         "--dangerously-skip-permissions",
@@ -141,7 +234,7 @@ def _call_via_cli(
             capture_output=True,
             text=True,
             timeout=CLI_TIMEOUT_SECONDS,
-            check=False,  # tolerate non-zero exits with valid stdout
+            check=False,  # tolerate non-zero exits with a valid envelope
         )
     except subprocess.TimeoutExpired as e:
         raise RouterUnavailable(
@@ -149,77 +242,51 @@ def _call_via_cli(
         ) from e
 
     stdout = result.stdout.strip()
-    # Refusal markers — CLI returned a string but it's an auth/refusal banner,
-    # not an actual model response. Treat as CLI unavailable so the router
-    # falls back to API. Patched 2026-05-19 after hallucination-sample-audit
-    # accepted "Not logged in · Please run /login" as a 33-char success.
-    # Rate-limit banners — transient refusals when a Max account hits its
-    # weekly cap or 5-hour session cap. The CLI returns the banner as stdout
-    # and exits non-zero, so the accept-non-zero-with-stdout branch below
-    # would otherwise return the banner as a "response" (e.g. 63 chars of
-    # "You've hit your session limit · resets <time>"). Detecting them here
-    # raises RouterUnavailable instead, so callers fall back to the API path
-    # or surface a real error rather than consuming the banner as content.
-    # The bug class is PRODUCER-OUTPUT-CONSUMED-WITHOUT-CONTENT-VALIDITY-CHECK
-    # — substring matching is a stopgap; the principled fix is to use
-    # `claude -p --output-format json` and read `is_error` / `subtype` from
-    # the result envelope. Keeping the substring list short and scoped.
-    ratelimit_markers = (
-        "weekly limit",
-        "hit your weekly",
-        "session limit",
-        "hit your session",
-        "rate limit",
-        "rate_limit_exceeded",
-        "usage limit",
-        "quota exceeded",
-    )
-    if stdout and any(m in stdout.lower() for m in ratelimit_markers):
-        raise RouterUnavailable(
-            f"claude CLI returned rate-limit banner: {stdout[:200]!r}. "
-            "Transient — wait for the limit window to reset, or set "
-            "ANTHROPIC_API_KEY for an API-key fallback."
-        )
 
-    refusal_markers = (
-        "not logged in",
-        "please run /login",
-        "authentication required",
-        "authentication failed",
-        "session expired",
-        # Transport / connectivity errors. When the network is not ready
-        # (e.g. a launchd-fired job during wake-from-sleep), `claude -p` can
-        # emit "API Error: Unable to connect to API (ConnectionRefused)" on
-        # stdout and exit 1 — the accept-non-zero-with-stdout branch below
-        # would otherwise accept that error string as a 55-char "response".
-        # Treat them as RouterUnavailable so the CLI-retry path (below) has
-        # a chance once the network comes up.
-        "api error",
-        "unable to connect to api",
-        "connectionrefused",
-        "failedtoopensocket",
-    )
-    if stdout and any(m in stdout.lower() for m in refusal_markers):
-        raise RouterUnavailable(
-            f"claude CLI returned refusal banner: {stdout[:200]!r}. "
-            "Subprocess cannot reach Max OAuth — set ANTHROPIC_API_KEY for "
-            "API fallback, or run from a shell with claude CLI logged in."
-        )
+    # Structural content-validity gate. SUCCESS requires a valid result envelope
+    # with is_error=false — independent of exit code. No valid envelope, or an
+    # envelope flagged is_error, is a failure classified into the right typed
+    # exception. An unknown future banner has no envelope -> RouterUnavailable,
+    # never consumed as content.
+    envelope = _extract_result_envelope(stdout)
 
-    if result.returncode == 0:
-        return stdout
+    if envelope is not None and not bool(envelope.get("is_error")):
+        text = envelope.get("result")
+        text = "" if text is None else str(text)
+        if not text.strip():
+            # is_error:false but NO content (null / "" / whitespace / missing
+            # result key). A real model response is never empty here; returning
+            # '' as success would let call_claude_json raise a confusing
+            # ValueError that is neither RateLimitExhausted nor
+            # RouterUnavailable. Fail loud instead — an empty result IS the
+            # degenerate error the content-validity gate must reject.
+            _log("CLI returned is_error:false with an empty result — failing")
+            raise RouterUnavailable(
+                "claude CLI returned a success envelope with an empty result "
+                "(no content). Treating as unavailable rather than returning ''."
+            )
+        return text.strip()
+
+    if envelope is not None:
+        # Structured error envelope — classify from its own fields.
+        err_text = " ".join(
+            str(envelope.get(k, ""))
+            for k in ("subtype", "result", "api_error_status",
+                      "stop_reason", "terminal_reason")
+        )
+        _log(f"CLI returned error envelope (is_error): {err_text[:160]!r}")
+        raise _classify_cli_failure(err_text, raw=stdout)
 
     if stdout:
-        _log(
-            f"CLI exit {result.returncode} but stdout has "
-            f"{len(stdout)} chars — accepting (likely SessionEnd "
-            f"hook failure post-response)"
-        )
-        return stdout
+        # Non-JSON stdout in --output-format json mode = failure by
+        # construction (an error banner, or output corruption). Classify the
+        # banner; an unrecognized one defaults to RouterUnavailable.
+        _log(f"CLI returned non-envelope stdout ({len(stdout)} chars); failing")
+        raise _classify_cli_failure(stdout, raw=stdout)
 
     raise RouterUnavailable(
-        f"claude CLI exit {result.returncode} with empty stdout. "
-        f"stderr: {result.stderr[:300]}"
+        f"claude CLI exit {result.returncode} with empty stdout / no JSON "
+        f"envelope. stderr: {result.stderr[:300]}"
     )
 
 

--- a/scripts/test_claude_router_envelope.py
+++ b/scripts/test_claude_router_envelope.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Negative-control suite for the router's structured content-validity gate.
+
+The router used to decide CLI success by sniffing raw `claude -p` text for a
+denylist of bad banners (login / connection / weekly-limit / session-limit).
+That denylist was patched repeatedly and was always one banner phrasing behind:
+an unrecognized banner was CONSUMED as a successful response (the
+PRODUCER-OUTPUT-CONSUMED-WITHOUT-CONTENT-VALIDITY-CHECK bug class).
+
+The fix runs `claude -p --output-format json` and makes success PURELY
+STRUCTURAL: a valid result envelope whose is_error is false. These tests mock
+subprocess.run to feed crafted stdout into the REAL _call_via_cli and prove:
+
+  * a valid success envelope is returned                 (positive path)
+  * an is_error envelope raises (classified)             (structured error)
+  * a KNOWN banner (non-JSON) raises RateLimitExhausted  (old denylist case)
+  * an UNKNOWN banner (non-JSON) raises RouterUnavailable — NOT consumed.
+        ^^^ THE bug-class negative control: the old denylist would miss this
+            banner and return it as a "successful" response. The structural
+            gate rejects it because it is not a valid envelope. Revert the gate
+            and this test goes red — that is the proof the fix is load-bearing.
+  * a SUCCESS envelope whose result TEXT contains "rate limit" is returned,
+        not misclassified (the old denylist false-positive, now fixed)
+  * a non-zero exit with a valid envelope is still accepted
+        (SessionEnd-hook-failed-post-response case preserved)
+  * empty stdout raises RouterUnavailable
+
+Run: python3 scripts/test_claude_router_envelope.py
+Run under pytest: pytest scripts/test_claude_router_envelope.py
+Exit 0 = pass. Vanilla unittest, no third-party deps.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+import _claude_router as R  # noqa: E402
+from _claude_router import RateLimitExhausted, RouterUnavailable  # noqa: E402
+
+
+def _envelope(result="PONG", is_error=False, subtype="success", **extra):
+    d = {"type": "result", "subtype": subtype, "is_error": is_error,
+         "result": result}
+    d.update(extra)
+    return json.dumps(d)
+
+
+class _Res:
+    def __init__(self, stdout="", returncode=0, stderr=""):
+        self.stdout = stdout
+        self.returncode = returncode
+        self.stderr = stderr
+
+
+class EnvelopeGate(unittest.TestCase):
+    def setUp(self):
+        self._orig_run = R.subprocess.run
+
+    def tearDown(self):
+        R.subprocess.run = self._orig_run
+
+    def _run_cli(self, stdout, returncode=0, stderr=""):
+        R.subprocess.run = lambda cmd, **kw: _Res(stdout, returncode, stderr)
+        return R._call_via_cli("/fake/claude", "sys", "usr", "haiku")
+
+    # --- positive path -------------------------------------------------------
+    def test_valid_success_envelope_returns_result(self):
+        self.assertEqual(self._run_cli(_envelope("hello world")), "hello world")
+
+    def test_non_zero_exit_with_valid_envelope_still_accepted(self):
+        # SessionEnd hook failed post-response: exit 1 but envelope is valid.
+        self.assertEqual(
+            self._run_cli(_envelope("body"), returncode=1), "body")
+
+    def test_envelope_with_leading_hook_noise_is_tolerated(self):
+        noisy = '{"hookSpecificOutput":{"x":1}}\n' + _envelope("clean")
+        self.assertEqual(self._run_cli(noisy), "clean")
+
+    # --- structured error envelope ------------------------------------------
+    def test_is_error_envelope_with_ratelimit_text_raises_ratelimit(self):
+        env = _envelope("You've hit your session limit", is_error=True,
+                        subtype="error_during_execution")
+        with self.assertRaises(RateLimitExhausted):
+            self._run_cli(env)
+
+    def test_is_error_envelope_generic_raises_unavailable(self):
+        env = _envelope("internal error", is_error=True,
+                        subtype="error_during_execution")
+        with self.assertRaises(RouterUnavailable) as ctx:
+            self._run_cli(env)
+        self.assertNotIsInstance(ctx.exception, RateLimitExhausted)
+
+    # --- non-JSON banners (the old denylist surface) ------------------------
+    def test_known_banner_non_json_raises_ratelimit(self):
+        # The 5-hour session-limit banner, but as raw (non-envelope) stdout.
+        with self.assertRaises(RateLimitExhausted):
+            self._run_cli("You've hit your session limit · resets 8am", returncode=1)
+
+    def test_UNKNOWN_banner_non_json_is_rejected_not_consumed(self):
+        # THE bug-class negative control. This banner matches NO marker. The old
+        # denylist would have returned it as a ~60-char "successful" response.
+        # The structural gate rejects it (no valid envelope) -> RouterUnavailable.
+        banner = "Heads up: the flux capacitor needs 1.21 gigawatts to continue"
+        with self.assertRaises(RouterUnavailable) as ctx:
+            self._run_cli(banner, returncode=1)
+        self.assertNotIsInstance(ctx.exception, RateLimitExhausted)
+
+    def test_exit0_plaintext_is_rejected_not_consumed(self):
+        # INTENTIONAL hard-dependency on --output-format json. A CLI that
+        # IGNORES the flag and emits a valid plain-text answer on exit 0 (older
+        # claude, or a wrapper that strips the flag) has NO envelope, so it is
+        # treated as UNAVAILABLE — NOT consumed as content. call_claude_text
+        # catches RouterUnavailable and falls through to the API-key tier
+        # (fail-safe, never a wrong answer).
+        with self.assertRaises(RouterUnavailable) as ctx:
+            self._run_cli("The capital of France is Paris.", returncode=0)
+        self.assertNotIsInstance(ctx.exception, RateLimitExhausted)
+
+    # --- empty/null result on a "success" envelope --------------------------
+    def test_is_error_false_but_null_result_raises_unavailable(self):
+        with self.assertRaises(RouterUnavailable) as ctx:
+            self._run_cli(_envelope(result=None))
+        self.assertNotIsInstance(ctx.exception, RateLimitExhausted)
+
+    def test_is_error_false_but_empty_result_raises_unavailable(self):
+        with self.assertRaises(RouterUnavailable):
+            self._run_cli(_envelope(result=""))
+
+    def test_is_error_false_but_whitespace_result_raises_unavailable(self):
+        with self.assertRaises(RouterUnavailable):
+            self._run_cli(_envelope(result="   \n  "))
+
+    def test_call_claude_json_double_parses_envelope_result(self):
+        # Full path: subprocess -> envelope whose `result` is a JSON STRING ->
+        # _call_via_cli extracts it -> call_claude_json parses it.
+        orig = (R._resolve_cli, R._resolve_api_key)
+        R.subprocess.run = lambda cmd, **kw: _Res(_envelope('{"ok": true, "n": 3}'))
+        R._resolve_cli = lambda: "/fake/claude"
+        R._resolve_api_key = lambda: None
+        try:
+            self.assertEqual(
+                R.call_claude_json(system="s", user="u", model="haiku"),
+                {"ok": True, "n": 3})
+        finally:
+            R._resolve_cli, R._resolve_api_key = orig
+
+    # --- false-positive the old denylist had --------------------------------
+    def test_success_result_mentioning_rate_limit_is_returned(self):
+        # A legit response that explains rate limits must NOT be misclassified.
+        text = "To avoid a rate limit, batch your requests and back off on 429."
+        self.assertEqual(self._run_cli(_envelope(text)), text)
+
+    # --- empty / malformed ---------------------------------------------------
+    def test_empty_stdout_raises_unavailable(self):
+        with self.assertRaises(RouterUnavailable):
+            self._run_cli("", returncode=1)
+
+
+if __name__ == "__main__":
+    sys.exit(0 if unittest.main(exit=False).result.wasSuccessful() else 1)


### PR DESCRIPTION
Replaces the enumerated rate-limit/refusal substring denylist in `_call_via_cli` with a structural content-validity gate.

## What changed
- Success is now gated on a valid `claude -p --output-format json` result envelope with `is_error` false — not on sniffing raw stdout for a denylist of known-bad banners.
- An unrecognized future banner has no envelope, so it can never be consumed as a model response. The old denylist was patched repeatedly and was always one banner phrasing behind (login / connection / weekly-limit / session-limit).
- The marker tuple is demoted from the success gate to a failure classifier (`_classify_cli_failure`): rate-limit signals map to a new `RateLimitExhausted(RouterUnavailable)` subclass; everything else (auth / network refusal or an unknown banner) to `RouterUnavailable`. The subclass keeps every existing `except RouterUnavailable` handler working.
- `test_claude_router_envelope.py` ships 14 negative-control cases; the unknown-banner test is load-bearing — revert the gate and it goes red.

## One intentional behavior change
A `claude` old enough to ignore `--output-format json` and emit plain text on exit 0 now yields no envelope, so the router returns `RouterUnavailable` and the caller falls through to the API-key tier (or a clean failure) instead of consuming the plaintext. This is the fail-safe direction and is pinned by `test_exit0_plaintext_is_rejected_not_consumed`.

Bug class: PRODUCER-OUTPUT-CONSUMED-WITHOUT-CONTENT-VALIDITY-CHECK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
