### PR TITLE
fix(router): vault parity — strict-mcp-config + no futile rate-limit retry

### DIFF
--- a/scripts/_claude_router.py
+++ b/scripts/_claude_router.py
@@ -226,6 +226,11 @@ def _call_via_cli(
         "--no-session-persistence",
         "--disable-slash-commands",
         "--dangerously-skip-permissions",
+        # Router calls are pure text/JSON generation — none invoke MCP tools.
+        # Without this, `claude -p` cold-loads the whole project .mcp.json fleet
+        # on EVERY call (slow + heavy footprint). With no --mcp-config alongside
+        # it, --strict-mcp-config loads ZERO MCP servers.
+        "--strict-mcp-config",
     ]
     _log(f"calling via CLI ({cli}, model={model})")
     try:
@@ -382,6 +387,7 @@ def call_claude_text(
     prefer_api = os.environ.get("CLAUDE_ROUTER_PREFER_API_KEY") == "1"
 
     cli = None if prefer_api else _resolve_cli()
+    last_ratelimit: RateLimitExhausted | None = None
     if cli is not None:
         # One retry: an unattended `claude -p` (cron, launchd, agent) can
         # intermittently hang or return a stale-OAuth refusal on the first
@@ -391,6 +397,15 @@ def call_claude_text(
         for cli_attempt in range(1, cli_attempts + 1):
             try:
                 return _call_via_cli(cli, system, user, model)
+            except RateLimitExhausted as e:
+                # Retrying the SAME account inside its limit window is futile.
+                # Skip straight to the API-key tier, and remember the signal so
+                # a caller with no API key gets RateLimitExhausted (transient,
+                # retry after reset) rather than a misleading "no CLI" error.
+                # MUST precede the RouterUnavailable handler (it is a subclass).
+                last_ratelimit = e
+                _log(f"CLI rate-limited; not retrying, trying API fallback: {e}")
+                break
             except RouterUnavailable as e:
                 if cli_attempt < cli_attempts:
                     _log(f"CLI attempt {cli_attempt}/{cli_attempts} failed "
@@ -402,6 +417,12 @@ def call_claude_text(
     api_key = _resolve_api_key()
     if api_key is not None:
         return _call_via_api(api_key, system, user, model, max_tokens, cache_system)
+
+    if last_ratelimit is not None:
+        # Every CLI path was rate-limited and no API key is configured. Surface
+        # the transient signal so a scheduled caller can back off and retry
+        # after the window resets, not treat this as a hard config failure.
+        raise last_ratelimit
 
     raise RouterUnavailable(
         "no claude CLI and no ANTHROPIC_API_KEY — install `claude` "

--- a/scripts/test_claude_router_envelope.py
+++ b/scripts/test_claude_router_envelope.py
@@ -158,6 +158,86 @@ class EnvelopeGate(unittest.TestCase):
         with self.assertRaises(RouterUnavailable):
             self._run_cli("", returncode=1)
 
+    # --- footprint guard: pure-generation calls load ZERO MCP servers --------
+    def test_cmd_includes_strict_mcp_config_and_json_format(self):
+        # Router calls never invoke MCP tools; --strict-mcp-config (with no
+        # --mcp-config) prevents cold-loading the whole .mcp.json fleet on every
+        # call. Pin it so the footprint fix cannot silently regress.
+        captured = {}
+
+        def fake_run(cmd, **kw):
+            captured["cmd"] = cmd
+            return _Res(_envelope("ok"))
+
+        R.subprocess.run = fake_run
+        R._call_via_cli("/fake/claude", "sys", "usr", "haiku")
+        self.assertIn("--strict-mcp-config", captured["cmd"])
+        self.assertIn("--output-format", captured["cmd"])
+        self.assertIn("json", captured["cmd"])
+
+
+class CallClaudeTextRouting(unittest.TestCase):
+    """The CLI->API fallback loop: a rate-limit is NOT retried on the same
+    account (futile in-window) and its transient signal survives to the caller."""
+
+    def setUp(self):
+        self._orig = (R._resolve_cli, R._resolve_api_key,
+                      R._call_via_cli, R._call_via_api)
+
+    def tearDown(self):
+        (R._resolve_cli, R._resolve_api_key,
+         R._call_via_cli, R._call_via_api) = self._orig
+
+    def test_ratelimit_no_apikey_raises_ratelimit_and_skips_retry(self):
+        calls = {"cli": 0}
+
+        def cli_raises(*a, **k):
+            calls["cli"] += 1
+            raise RateLimitExhausted("weekly limit")
+
+        R._resolve_cli = lambda: "/fake/claude"
+        R._resolve_api_key = lambda: None
+        R._call_via_cli = cli_raises
+        with self.assertRaises(RateLimitExhausted):
+            R.call_claude_text(system="s", user="u", model="haiku")
+        self.assertEqual(calls["cli"], 1)  # rate-limit NOT retried
+
+    def test_ratelimit_with_apikey_falls_to_api_without_retry(self):
+        calls = {"cli": 0, "api": 0}
+
+        def cli_raises(*a, **k):
+            calls["cli"] += 1
+            raise RateLimitExhausted("session limit")
+
+        def api_ok(*a, **k):
+            calls["api"] += 1
+            return "from-api"
+
+        R._resolve_cli = lambda: "/fake/claude"
+        R._resolve_api_key = lambda: "sk-test"
+        R._call_via_cli = cli_raises
+        R._call_via_api = api_ok
+        self.assertEqual(
+            R.call_claude_text(system="s", user="u", model="haiku"), "from-api")
+        self.assertEqual(calls["cli"], 1)  # rate-limit not retried
+        self.assertEqual(calls["api"], 1)
+
+    def test_generic_unavailable_still_retries_then_falls_to_api(self):
+        # A non-rate-limit failure keeps the cheap one-retry insurance.
+        calls = {"cli": 0}
+
+        def cli_raises(*a, **k):
+            calls["cli"] += 1
+            raise RouterUnavailable("network blip")
+
+        R._resolve_cli = lambda: "/fake/claude"
+        R._resolve_api_key = lambda: "sk-test"
+        R._call_via_cli = cli_raises
+        R._call_via_api = lambda *a, **k: "from-api"
+        self.assertEqual(
+            R.call_claude_text(system="s", user="u", model="haiku"), "from-api")
+        self.assertEqual(calls["cli"], 2)  # retried once, THEN API
+
 
 if __name__ == "__main__":
     sys.exit(0 if unittest.main(exit=False).result.wasSuccessful() else 1)


### PR DESCRIPTION
Two parity follow-ups to #316 (the structured-envelope gate), both already shipped in the canonical vault copy of this helper.

## 1. `--strict-mcp-config` on the `claude -p` call
Router calls are pure text/JSON generation and never invoke MCP tools. Without this flag, `claude -p` cold-loads the entire project `.mcp.json` fleet on *every* call — a real latency + footprint cost for any substrate user with a populated `.mcp.json`. With no `--mcp-config` alongside it, `--strict-mcp-config` loads zero MCP servers.

## 2. No futile same-account retry on rate-limit
`call_claude_text` now catches `RateLimitExhausted` before `RouterUnavailable` and skips the one-shot retry — retrying the same account inside its limit window cannot succeed, it just burns a ~28s CLI spawn. It falls straight to the API-key tier; if no key is configured it re-raises `RateLimitExhausted` so a scheduled caller can back off and retry after the window resets, instead of getting a misleading "no CLI and no API key" error.

## Tests
18 cases pass: a footprint guard pinning `--strict-mcp-config` in the constructed command, plus three `call_claude_text` routing cases (rate-limit → no retry, with and without an API key; a generic failure still keeps the one-retry insurance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
