### PR TITLE
feat(journal-guard): SessionStart self-heal + fix matcher-blind hook merge

### DIFF
--- a/hooks.json
+++ b/hooks.json
@@ -279,6 +279,11 @@
             "type": "command",
             "command": "[PYTHON] ~/.claude/skills/ai-brain-starter/hooks/surface-deployed-hooks-behind.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'",
             "statusMessage": "Checking deployed hooks match what was pulled (deploy-fails-open drift)..."
+          },
+          {
+            "type": "command",
+            "command": "[PYTHON] ~/.claude/skills/ai-brain-starter/scripts/heal-journal-guard.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'",
+            "statusMessage": "Self-healing the /journal Step-0 context guard (registration + vault preflight)..."
           }
         ]
       }

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -194,6 +194,10 @@ INTEGRATION_TESTS=(
   # lint FAILS an unguarded non-ASCII-printing CLI and that the guard is load-bearing
   # under a real cp1252 console; also asserts the real scripts/ tree is clean.
   test_utf8_console_guard
+  # Journal Step-0 context-guard self-heal (2026-07-07): end-to-end proof the
+  # SessionStart repair restores an unprotected account (registration under both
+  # matchers + vault preflight) and no-ops on a healthy one, with pos/neg controls.
+  test_heal_journal_guard
 )
 # ---- Gate-coverage invariant -------------------------------------------------
 # The list above is an explicit allow-list, and allow-lists rot: a new

--- a/scripts/heal-journal-guard.py
+++ b/scripts/heal-journal-guard.py
@@ -1,0 +1,535 @@
+#!/usr/bin/env python3
+"""heal-journal-guard.py - SessionStart self-heal for the /journal Step-0 context guard.
+
+WHY THIS EXISTS
+  The ENFORCEMENT of daily-journal Step 0 is three pieces of PER-ACCOUNT state under
+  ~/.claude, not the vault:
+    - the guard hook `warn-journal-saved-without-context.py` on disk,
+    - its registration in ~/.claude/settings.json PreToolUse under BOTH matchers,
+    - the vault-side `journal-preflight.py` in <vault>/<meta>/scripts/.
+  If an account's auto-sync never ran `install-hooks-user-level.py`, the guard is
+  unregistered and /journal can silently ship an entry with ZERO context again - the
+  2026-07-07 incident this whole layer exists to kill. Instructions in a repo are not
+  durable across accounts; only infrastructure is. This SessionStart check re-derives
+  the guard from the vault-synced substrate on EVERY session and repairs it if missing,
+  so a stale/unprotected account self-heals with no manual per-account update.
+
+WHAT IT VERIFIES + REPAIRS  (idempotent, FAIL-OPEN, fast - never a corpus walk)
+  1. REGISTRATION: the guard is wired in ~/.claude/settings.json PreToolUse under every
+     matcher hooks.json declares (Bash and Write|Edit|MultiEdit today) AND each such
+     command points at a guard script that exists on disk. Repair: merge the CANONICAL
+     guard entries straight out of the clone's hooks.json using
+     install-hooks-user-level.py's OWN merge/interpreter/platformize/write helpers (the
+     existing hook-add mechanism), so what lands is byte-identical to a normal install
+     and dedups cleanly against a later installer run.
+  2. PREFLIGHT: `journal-preflight.py` is present in the vault's <meta>/scripts/. Repair:
+     invoke the existing sync-vault-scripts.sh (sync-vault-scripts.ps1 on Windows) -
+     REUSE, never reimplement the vault-script sync.
+
+  If it repairs anything it appends to ~/.claude/heal-journal-guard.log and surfaces ONE
+  SessionStart line so the operator learns that account had been unprotected.
+
+FAIL-OPEN: any ambiguity / error -> emit a silent continue and exit 0. It must NEVER
+block or slow a healthy session start. A repair subprocess is gated behind a cooldown so
+a persistently-broken box cannot re-spawn the installer every single session.
+
+Registered on SessionStart via hooks.json; OWNED + verified by install-hooks-user-level.py
+(ARTIFACT-WITHOUT-ACTIVATION: a self-heal the installer does not register is dormant).
+Bypass: HEAL_JOURNAL_GUARD_BYPASS=1 (env).
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+GUARD_BASENAME = "warn-journal-saved-without-context.py"
+GUARD_TOKEN = "warn-journal-saved-without-context"
+PREFLIGHT_BASENAME = "journal-preflight.py"
+# Fallback only if the clone's hooks.json is unreadable; the live source of truth is
+# always the matchers hooks.json actually registers the guard under.
+FALLBACK_MATCHERS = ("Bash", "Write|Edit|MultiEdit")
+HEAL_COOLDOWN_SECONDS = 6 * 3600
+# A guard command names its script as a quoted or bare ~/ or / path ending in the guard
+# basename. Tolerates the `python3 <path> 2>/dev/null || echo ...` fallback-chain form.
+_GUARD_PATH_RE = re.compile(
+    r"['\"]?((?:~|/)[^\s'\"|&;]*" + re.escape(GUARD_BASENAME) + r")['\"]?"
+)
+# The installed vault hooks embed the absolute vault path right before the meta folder;
+# same regex sync-vault-scripts.sh uses, so both resolve the identical root.
+_VAULT_FROM_CMD_RE = re.compile(r"(/[^'\"]+?)/(?:⚙️ Meta|Meta)/scripts/")
+
+
+# --------------------------------------------------------------------------- helpers
+def clone_root() -> Path:
+    """The ai-brain-starter checkout this script ships in (scripts/.. == clone root)."""
+    return Path(__file__).resolve().parents[1]
+
+
+def _read_json(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+
+
+def guard_registrations_from_template(clone: Path) -> "list[tuple]":
+    """Every (matcher, command) pair for the guard in the clone's hooks.json PreToolUse."""
+    tmpl = _read_json(clone / "hooks.json")
+    out = []
+    for group in (tmpl.get("hooks") or {}).get("PreToolUse", []) or []:
+        matcher = group.get("matcher")
+        for h in group.get("hooks", []) or []:
+            cmd = h.get("command", "") or ""
+            if GUARD_TOKEN in cmd:
+                out.append((matcher, cmd))
+    return out
+
+
+def wanted_matchers(clone: Path) -> "set":
+    """Matchers the guard MUST be registered under - read from hooks.json, so this hook
+    follows the template if the canonical matcher set ever changes (zero drift)."""
+    regs = guard_registrations_from_template(clone)
+    matchers = {m for (m, _c) in regs if m}
+    return matchers or set(FALLBACK_MATCHERS)
+
+
+def _guard_script_exists(cmd: str) -> bool:
+    """True if the guard script named in this command resolves to a real file on disk."""
+    m = _GUARD_PATH_RE.search(cmd)
+    if not m:
+        return False
+    return Path(os.path.expanduser(m.group(1))).is_file()
+
+
+def healthy_matchers(settings: dict) -> "set":
+    """Matchers under which the guard is registered AND its script exists on disk.
+
+    Folding script-existence into the per-matcher health means a registration that
+    points at a MISSING script (a stale path from a moved clone) counts as a gap and
+    gets re-registered to the canonical hooks.json form, not silently trusted."""
+    ok = set()
+    for group in (settings.get("hooks") or {}).get("PreToolUse", []) or []:
+        matcher = group.get("matcher")
+        for h in group.get("hooks", []) or []:
+            cmd = h.get("command", "") or ""
+            if GUARD_TOKEN in cmd and _guard_script_exists(cmd):
+                ok.add(matcher)
+    return ok
+
+
+def resolve_vault(settings: dict) -> "str":
+    """Vault root from $VAULT_ROOT, else parsed out of an installed vault-hook command.
+    Empty string when no vault can be resolved (a box with no vault set up yet)."""
+    env = os.environ.get("VAULT_ROOT")
+    if env and Path(env).is_dir():
+        return env
+    for _ev, groups in (settings.get("hooks") or {}).items():
+        for g in groups or []:
+            for h in g.get("hooks", []) or []:
+                m = _VAULT_FROM_CMD_RE.search(h.get("command", "") or "")
+                if m and Path(m.group(1)).is_dir():
+                    return m.group(1)
+    return ""
+
+
+def preflight_state(settings: dict) -> str:
+    """'ok' | 'missing' | 'no-vault' for journal-preflight.py in the vault's meta scripts."""
+    vault = resolve_vault(settings)
+    if not vault:
+        return "no-vault"
+    for meta in ("⚙️ Meta", "Meta"):
+        if (Path(vault) / meta / "scripts" / PREFLIGHT_BASENAME).is_file():
+            return "ok"
+    return "missing"
+
+
+def diagnose(settings: dict, clone: Path) -> dict:
+    """Pure. Returns the gap report; no side effects, no subprocess, no filesystem walk."""
+    want = wanted_matchers(clone)
+    have = healthy_matchers(settings)
+    return {
+        "missing_matchers": sorted(want - have),
+        "want_matchers": sorted(want),
+        "preflight": preflight_state(settings),
+        "vault": resolve_vault(settings),
+    }
+
+
+def has_gap(report: dict) -> bool:
+    return bool(report["missing_matchers"]) or report["preflight"] == "missing"
+
+
+# --------------------------------------------------------------------------- repair
+def _load_installer(clone: Path):
+    """Import install-hooks-user-level.py (its filename is not importable by name)."""
+    path = clone / "scripts" / "install-hooks-user-level.py"
+    spec = importlib.util.spec_from_file_location("_abs_installer", str(path))
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load {path}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def repair_registration(settings_path: Path, clone: Path) -> bool:
+    """Merge the canonical guard entries from the clone's hooks.json into settings.json,
+    reusing install-hooks-user-level.py's own helpers so the write is byte-identical to a
+    normal install. Returns True if a change was written. Fail-open: any error -> False."""
+    regs = guard_registrations_from_template(clone)
+    if not regs:
+        return False
+    try:
+        ihul = _load_installer(clone)
+    except Exception:
+        return False
+
+    groups = []
+    for matcher, cmd in regs:
+        group = {"hooks": [{"type": "command", "command": cmd}]}
+        if matcher:
+            group["matcher"] = matcher
+        groups.append(group)
+    minimal = {"hooks": {"PreToolUse": groups}}
+
+    try:
+        minimal = ihul.substitute_python_interpreter(minimal)
+        if ihul._is_windows():
+            minimal, _skipped = ihul.platformize_template_for_windows(minimal)
+        existing = _read_json(settings_path) if settings_path.is_file() else {}
+        merged, summary = ihul.merge_hooks(existing, minimal)
+        if not summary.get("added") and not summary.get("updated"):
+            return False  # already in sync
+        backup = ihul.backup_settings(settings_path)
+        return bool(ihul.write_settings_with_verify(settings_path, merged, backup))
+    except Exception:
+        return False
+
+
+def _preflight_present(vault: str) -> bool:
+    """True if journal-preflight.py is in the vault's meta scripts. Success is measured on
+    the TARGET, never the subprocess exit code."""
+    resolved = vault or resolve_vault(_read_json(Path.home() / ".claude" / "settings.json"))
+    if not resolved:
+        return False
+    for meta in ("⚙️ Meta", "Meta"):
+        if (Path(resolved) / meta / "scripts" / PREFLIGHT_BASENAME).is_file():
+            return True
+    return False
+
+
+def repair_preflight(clone: Path, vault: str) -> bool:
+    """Invoke the existing sync-vault-scripts.(sh|ps1) to land journal-preflight.py in the
+    vault - REUSE, never reimplement. Returns True if the preflight is present afterward.
+    Fail-open on any error (bash/pwsh absent, spawn failure)."""
+    env = dict(os.environ)
+    if vault:
+        env["VAULT_ROOT"] = vault  # the sync self-resolves the vault from this too
+    try:
+        if os.name == "nt":
+            # PowerShell param style (-Quiet / -Vault), NOT the bash --flags. Prefer PS7
+            # (pwsh); fall back to Windows PowerShell 5.1 (powershell). The .ps1 is
+            # compatible with both.
+            import shutil
+            script = clone / "scripts" / "sync-vault-scripts.ps1"
+            launcher = next((x for x in ("pwsh", "powershell") if shutil.which(x)), None)
+            if not script.is_file() or launcher is None:
+                return _preflight_present(vault)
+            cmd = [launcher, "-NoProfile", "-File", str(script), "-Quiet"]
+            if vault:
+                cmd += ["-Vault", vault]
+        else:
+            script = clone / "scripts" / "sync-vault-scripts.sh"
+            if not script.is_file():
+                return _preflight_present(vault)
+            cmd = ["bash", str(script), "--quiet"]
+            if vault:
+                cmd += ["--vault", vault]
+        subprocess.run(cmd, capture_output=True, timeout=90, env=env)
+    except Exception:
+        return _preflight_present(vault)
+    return _preflight_present(vault)
+
+
+# --------------------------------------------------------------------------- cooldown + log
+def _cooldown_stamp() -> Path:
+    return Path.home() / ".claude" / ".heal-journal-guard-last"
+
+
+def _cooldown_active() -> bool:
+    if os.environ.get("HEAL_JOURNAL_GUARD_NO_COOLDOWN") == "1":
+        return False
+    stamp = _cooldown_stamp()
+    try:
+        last = float(stamp.read_text(encoding="utf-8").strip())
+    except Exception:
+        return False
+    return (time.time() - last) < HEAL_COOLDOWN_SECONDS
+
+
+def _stamp_cooldown() -> None:
+    try:
+        _cooldown_stamp().write_text(str(time.time()), encoding="utf-8")
+    except Exception:
+        pass
+
+
+def _log(message: str) -> None:
+    try:
+        stamp = time.strftime("%Y-%m-%dT%H:%M:%S")
+        with (Path.home() / ".claude" / "heal-journal-guard.log").open(
+            "a", encoding="utf-8"
+        ) as fh:
+            fh.write(f"{stamp} {message}\n")
+    except Exception:
+        pass
+
+
+# --------------------------------------------------------------------------- outputs
+def _emit_silent() -> None:
+    print(json.dumps({"continue": True, "suppressOutput": True}))
+
+
+def _emit_context(message: str) -> None:
+    print(json.dumps({"hookSpecificOutput": {
+        "hookEventName": "SessionStart", "additionalContext": message}}))
+
+
+# --------------------------------------------------------------------------- session-start
+def run_session_start() -> None:
+    """The wired path. Diagnose the real account; repair gaps; surface ONE line. Exit 0."""
+    if os.environ.get("HEAL_JOURNAL_GUARD_BYPASS") == "1":
+        _emit_silent()
+        return
+    try:
+        clone = clone_root()
+        settings_path = Path.home() / ".claude" / "settings.json"
+        settings = _read_json(settings_path)
+        report = diagnose(settings, clone)
+    except Exception:
+        _emit_silent()
+        return
+
+    if not has_gap(report):
+        _emit_silent()
+        return
+
+    # A real gap. Repair is subprocess-bearing, so gate it behind a cooldown: a box that
+    # keeps failing to heal must not re-spawn the installer every session. On cooldown we
+    # still surface the unprotected state so it stays visible.
+    if _cooldown_active():
+        _emit_context(
+            "[heal-journal-guard] This account's /journal Step-0 context guard is "
+            "incomplete (registration or vault preflight) and a recent auto-repair has "
+            "not taken. Journaling could skip context. Run: python3 "
+            "~/.claude/skills/ai-brain-starter/scripts/install-hooks-user-level.py"
+        )
+        return
+
+    _stamp_cooldown()
+    healed = []
+    try:
+        if report["missing_matchers"]:
+            if repair_registration(settings_path, clone):
+                healed.append("registration")
+        if report["preflight"] == "missing":
+            if repair_preflight(clone, report["vault"]):
+                healed.append("preflight")
+    except Exception:
+        pass
+
+    if healed:
+        _log("healed " + "+".join(healed) + f" (had gap: {report})")
+        _emit_context(
+            "[heal-journal-guard] This account was missing part of the /journal "
+            "Step-0 context guard (" + " + ".join(healed) + "); restored it so "
+            "journaling cannot silently skip context. Your ai-brain-starter auto-update "
+            "may be stale - a full re-sync would prevent it recurring."
+        )
+    else:
+        # A gap we could not close (e.g. installer import failed). Fail-open but visible.
+        _emit_context(
+            "[heal-journal-guard] The /journal Step-0 context guard is incomplete on "
+            "this account and auto-repair could not complete. Run: python3 "
+            "~/.claude/skills/ai-brain-starter/scripts/install-hooks-user-level.py"
+        )
+
+
+# --------------------------------------------------------------------------- test modes
+def cmd_check_only(args) -> int:
+    """Read-only diagnosis of a given (or the real) settings.json. Exit 1 on any gap.
+    Used by the fresh-install smoke test's negative control."""
+    clone = Path(args.clone).resolve() if args.clone else clone_root()
+    settings_path = (
+        Path(args.settings).expanduser() if args.settings
+        else Path.home() / ".claude" / "settings.json"
+    )
+    report = diagnose(_read_json(settings_path), clone)
+    gap = has_gap(report)
+    print(
+        "GAP" if gap else "OK",
+        "missing_matchers=" + ",".join(report["missing_matchers"] or ["-"]),
+        "preflight=" + report["preflight"],
+    )
+    return 1 if gap else 0
+
+
+def cmd_heal_now(args) -> int:
+    """Force the repair against a given (or the real) settings.json. Exit 0 always.
+    Used by the integration test to prove the repair closes the gap."""
+    clone = Path(args.clone).resolve() if args.clone else clone_root()
+    settings_path = (
+        Path(args.settings).expanduser() if args.settings
+        else Path.home() / ".claude" / "settings.json"
+    )
+    settings = _read_json(settings_path)
+    report = diagnose(settings, clone)
+    if report["missing_matchers"]:
+        repair_registration(settings_path, clone)
+    if report["preflight"] == "missing":
+        repair_preflight(clone, args.vault or report["vault"])
+    return 0
+
+
+def self_test() -> int:
+    """Hermetic pos/neg controls proving diagnose distinguishes healthy from unprotected
+    and that the registration repair actually wires the guard. Exit 0 iff all pass."""
+    import shutil
+    import tempfile
+
+    fails = []
+
+    def check(name, cond):
+        if not cond:
+            fails.append(name)
+
+    # Hermetic: the real account's VAULT_ROOT must not leak into the no-vault control
+    # (self-test runs as its own short-lived process, so a plain pop is enough).
+    os.environ.pop("VAULT_ROOT", None)
+
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        clone = root / "clone"
+        (clone / "hooks").mkdir(parents=True)
+        (clone / "scripts").mkdir()
+        # A real-enough guard script on disk so the "script exists" health check passes.
+        guard = clone / "hooks" / GUARD_BASENAME
+        guard.write_text("#!/usr/bin/env python3\nprint('{}')\n", encoding="utf-8")
+        # The installer is needed by the repair path; copy the real one beside a hooks.json.
+        real_installer = clone_root() / "scripts" / "install-hooks-user-level.py"
+        if real_installer.is_file():
+            shutil.copy(str(real_installer), str(clone / "scripts" / "install-hooks-user-level.py"))
+        guard_cmd = (
+            f"[PYTHON] {guard} 2>/dev/null || echo "
+            "'{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\","
+            "\"permissionDecision\":\"allow\"}}'"
+        )
+        (clone / "hooks.json").write_text(json.dumps({"hooks": {"PreToolUse": [
+            {"matcher": "Bash", "hooks": [{"type": "command", "command": guard_cmd}]},
+            {"matcher": "Write|Edit|MultiEdit",
+             "hooks": [{"type": "command", "command": guard_cmd}]},
+        ]}}), encoding="utf-8")
+
+        # want_matchers is driven by the template.
+        check("wanted-both-matchers",
+              wanted_matchers(clone) == {"Bash", "Write|Edit|MultiEdit"})
+
+        # POSITIVE control: a settings.json already carrying the guard under both matchers
+        # (pointing at the existing guard script) shows NO gap.
+        healthy = {"hooks": {"PreToolUse": [
+            {"matcher": "Bash", "hooks": [{"type": "command", "command": f"python3 {guard}"}]},
+            {"matcher": "Write|Edit|MultiEdit",
+             "hooks": [{"type": "command", "command": f"python3 {guard}"}]},
+        ]}}
+        check("positive-healthy-no-gap", not diagnose(healthy, clone)["missing_matchers"])
+
+        # NEGATIVE control: empty settings.json is missing the guard under BOTH matchers.
+        empty_path = root / "settings_empty.json"
+        empty_path.write_text(json.dumps({"hooks": {}}), encoding="utf-8")
+        neg = diagnose(_read_json(empty_path), clone)
+        check("negative-absent-detects-both",
+              set(neg["missing_matchers"]) == {"Bash", "Write|Edit|MultiEdit"})
+
+        # NEGATIVE control 2: registered but the referenced SCRIPT is missing -> still a gap.
+        stale = {"hooks": {"PreToolUse": [
+            {"matcher": "Bash", "hooks": [{"type": "command",
+             "command": f"python3 {root}/does-not-exist/{GUARD_BASENAME}"}]},
+        ]}}
+        check("negative-stale-script-is-gap",
+              "Bash" in diagnose(stale, clone)["missing_matchers"])
+
+        # REPAIR closes the gap: run the real registration repair against the empty
+        # settings and re-diagnose. Proves the guard IS wired under both matchers.
+        if real_installer.is_file():
+            wrote = repair_registration(empty_path, clone)
+            after = diagnose(_read_json(empty_path), clone)
+            check("repair-wrote-something", wrote)
+            check("repair-closes-registration-gap", not after["missing_matchers"])
+
+        # PREFLIGHT diagnose: no vault -> 'no-vault'; vault with the file -> 'ok'; without
+        # -> 'missing'. (The subprocess repair is exercised end-to-end in the .sh test.)
+        check("preflight-no-vault", preflight_state({"hooks": {}}) == "no-vault")
+        vault = root / "vault"
+        (vault / "⚙️ Meta" / "scripts").mkdir(parents=True)
+        os.environ["VAULT_ROOT"] = str(vault)
+        try:
+            check("preflight-missing", preflight_state({"hooks": {}}) == "missing")
+            (vault / "⚙️ Meta" / "scripts" / PREFLIGHT_BASENAME).write_text(
+                "x", encoding="utf-8")
+            check("preflight-ok", preflight_state({"hooks": {}}) == "ok")
+        finally:
+            os.environ.pop("VAULT_ROOT", None)
+
+    if fails:
+        print("self-test FAIL: " + ", ".join(fails))
+        return 1
+    print("self-test OK: registration + preflight diagnose/repair controls pass")
+    return 0
+
+
+# --------------------------------------------------------------------------- main
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--self-test", action="store_true", help="run hermetic pos/neg controls")
+    ap.add_argument("--check-only", action="store_true",
+                    help="read-only diagnosis; exit 1 on any gap")
+    ap.add_argument("--heal-now", action="store_true",
+                    help="force the repair against --settings (test helper)")
+    ap.add_argument("--settings", help="settings.json path (default ~/.claude/settings.json)")
+    ap.add_argument("--clone", help="ai-brain-starter clone root (default: this checkout)")
+    ap.add_argument("--vault", help="vault root for the preflight repair")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+    if args.check_only:
+        return cmd_check_only(args)
+    if args.heal_now:
+        return cmd_heal_now(args)
+
+    # Default: the wired SessionStart path. Belt-and-suspenders fail-open.
+    try:
+        run_session_start()
+    except Exception:
+        try:
+            _emit_silent()
+        except Exception:
+            pass
+    return 0
+
+
+if __name__ == "__main__":
+    # Windows cp1252-console safety (ai-brain-starter#313): force UTF-8 so a non-ASCII
+    # print (a surfaced line, a path with the gear-Meta emoji) can't crash the hook.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
+    sys.exit(main())

--- a/scripts/install-hooks-user-level.py
+++ b/scripts/install-hooks-user-level.py
@@ -109,6 +109,12 @@ ABS_FINGERPRINTS = [
     # Client-side deployed==committed drift detector (MYC-2507): surfaces when this
     # deploy step itself failed silently and settings.json fell behind hooks.json.
     "ai-brain-starter/hooks/surface-deployed-hooks-behind.py",
+    # Journal Step-0 context guard (2026-07-07) + its SessionStart self-heal. OWNED so
+    # the installer dedups the guard (skill-path vs a ~/.claude/hooks/ copy) PER MATCHER,
+    # verifies both scripts on disk, and can retire/relocate them. Registered under two
+    # matchers each; the matcher-aware merge above keeps both copies.
+    "ai-brain-starter/hooks/warn-journal-saved-without-context.py",
+    "ai-brain-starter/scripts/heal-journal-guard.py",
 ]
 
 # Path-divergence-robust matching: an ai-brain-starter hook may be wired at the
@@ -134,6 +140,8 @@ ABS_OWNED_BASENAMES = {
     "session-start-context.py", "inject-instinct-context.py",
     # Client-side deployed==committed drift detector (MYC-2507):
     "surface-deployed-hooks-behind.py",
+    # Journal Step-0 context guard + its SessionStart self-heal (2026-07-07):
+    "warn-journal-saved-without-context.py", "heal-journal-guard.py",
 }
 
 # Hooks ai-brain-starter USED TO ship and has deliberately RETIRED. The
@@ -483,14 +491,24 @@ def merge_hooks(existing: dict, new_template: dict) -> tuple[dict, dict]:
         existing_groups = merged["hooks"][event]
         # Collect all ABS-owned commands from new template (flattened)
         for new_group in new_groups:
+            # A hook is identified by (matcher, command): the SAME command under two
+            # DIFFERENT matchers is two DISTINCT registrations, not a duplicate. The
+            # journal-context guard and observe-tool-calls both ship one byte-identical
+            # command under two matchers; a matcher-BLIND dedup collapsed the second copy
+            # into the first, so a fresh install landed the guard under Bash only and
+            # left Write|Edit|MultiEdit journal saves unguarded. Scope every replace /
+            # dedup decision below to groups carrying THIS matcher.
+            matcher = new_group.get("matcher")
             new_hooks = new_group.get("hooks", [])
             for new_hook in new_hooks:
                 cmd = new_hook.get("command", "")
                 if not cmd:
                     continue
-                # Look for this command in any existing group
+                # Look for this command in an existing group WITH THE SAME MATCHER.
                 replaced = False
                 for eg in existing_groups:
+                    if eg.get("matcher") != matcher:
+                        continue
                     eg_hooks = eg.get("hooks", [])
                     for i, eh in enumerate(eg_hooks):
                         eh_cmd = eh.get("command", "")
@@ -505,7 +523,6 @@ def merge_hooks(existing: dict, new_template: dict) -> tuple[dict, dict]:
 
                 if not replaced:
                     # Find or create a group with the same matcher (if any)
-                    matcher = new_group.get("matcher")
                     target_group = None
                     for eg in existing_groups:
                         if eg.get("matcher") == matcher:

--- a/scripts/post-install-smoke-test.sh
+++ b/scripts/post-install-smoke-test.sh
@@ -162,6 +162,31 @@ else
   warn "dev-hub-refresh-on-session-start.py not present"
 fi
 
+# === 4c. Journal Step-0 context-guard self-heal (2026-07-07) ===
+# The SessionStart self-heal that re-derives the /journal context guard from the
+# vault-synced substrate on every session, so a stale account cannot silently skip
+# Step 0. --self-test carries the pos/neg + repair controls; the direct negative
+# control here proves the check BITES on an unprotected settings.json.
+hdr "Journal-guard self-heal"
+HEALER="$SKILL_DIR/scripts/heal-journal-guard.py"
+if [[ -f "$HEALER" ]]; then
+  if python3 "$HEALER" --self-test >/dev/null 2>&1; then
+    ok "heal-journal-guard.py --self-test (registration + preflight controls)"
+  else
+    fail "heal-journal-guard.py --self-test failed"
+  fi
+  NEG_SET=$(mktemp)
+  printf '%s' '{"hooks": {}}' > "$NEG_SET"
+  if python3 "$HEALER" --check-only --settings "$NEG_SET" >/dev/null 2>&1; then
+    fail "self-heal --check-only PASSED an unprotected settings.json (guard asleep)"
+  else
+    ok "self-heal --check-only trips on an unprotected account (exit 1)"
+  fi
+  rm -f "$NEG_SET"
+else
+  warn "heal-journal-guard.py not present"
+fi
+
 # === 5. Aggregator smoke ===
 hdr "Aggregator scripts"
 for s in aggregate-sessions.py aggregate-decisions.py rotate-meta-archives.py; do

--- a/tests/integration/test_heal_journal_guard.sh
+++ b/tests/integration/test_heal_journal_guard.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# test_heal_journal_guard.sh - end-to-end proof that the SessionStart self-heal
+# (scripts/heal-journal-guard.py) restores the /journal Step-0 context guard on an
+# account that lost it, and no-ops on a healthy one.
+#
+# Hermetic: a throwaway $HOME + throwaway vault. The REAL repo checkout is the
+# canonical source (its hooks.json + install-hooks-user-level.py + sync-vault-scripts.sh),
+# the fake $HOME is the target - the same split a real stale account has.
+#
+# Controls (a guard earns trust only by FAILING on the thing it catches):
+#   1. NEGATIVE: an unprotected account (no registration, no preflight) trips
+#      --check-only (exit 1).
+#   2. The wired SessionStart run REPAIRS it: guard registered under BOTH matchers,
+#      journal-preflight.py landed in the vault, and ONE surface line emitted.
+#   3. POSITIVE: the now-healthy account passes --check-only (exit 0).
+#   4. IDEMPOTENT: a second run stays clean and does not duplicate the registration.
+#   5. In-script pos/neg controls (--self-test) pass.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HEAL="$REPO_ROOT/scripts/heal-journal-guard.py"
+
+PASS=0
+FAIL=0
+TMPDIRS=()
+cleanup() { for d in "${TMPDIRS[@]:-}"; do [ -n "$d" ] && rm -rf "$d"; done; }
+trap cleanup EXIT
+
+ok()  { PASS=$((PASS + 1)); echo "PASS  $1"; }
+bad() { FAIL=$((FAIL + 1)); echo "FAIL  $1 :: $2"; }
+
+echo "=== precondition ==="
+if [ -f "$HEAL" ]; then ok "heal-journal-guard.py present"; else bad "present" "missing $HEAL"; fi
+
+echo "=== 0. in-script controls (--self-test) ==="
+if python3 "$HEAL" --self-test >/dev/null 2>&1; then
+  ok "--self-test passes"
+else
+  bad "--self-test passes" "run: python3 $HEAL --self-test"
+fi
+
+# --- build a throwaway account + vault ---------------------------------------
+FAKE_HOME="$(mktemp -d)"; TMPDIRS+=("$FAKE_HOME")
+FAKE_VAULT="$(mktemp -d)"; TMPDIRS+=("$FAKE_VAULT")
+# The registered guard command resolves ~ against $HOME, so the guard script must
+# exist under the fake skill path for the "script on disk" health check to pass.
+mkdir -p "$FAKE_HOME/.claude/skills/ai-brain-starter/hooks"
+cp "$REPO_ROOT/hooks/warn-journal-saved-without-context.py" \
+   "$FAKE_HOME/.claude/skills/ai-brain-starter/hooks/warn-journal-saved-without-context.py"
+# A vault the sync can resolve + write into (Decisions/Sessions disambiguate the human
+# Meta folder for _meta_resolver), but WITHOUT journal-preflight.py yet.
+mkdir -p "$FAKE_VAULT/⚙️ Meta/scripts" "$FAKE_VAULT/⚙️ Meta/Decisions" "$FAKE_VAULT/⚙️ Meta/Sessions"
+# An unprotected settings.json: valid, but no journal guard registered anywhere.
+printf '%s\n' '{"hooks": {}}' > "$FAKE_HOME/.claude/settings.json"
+
+run_heal() {  # runs the wired SessionStart path against the fake account
+  printf '%s' '{}' | env HOME="$FAKE_HOME" VAULT_ROOT="$FAKE_VAULT" \
+    HEAL_JOURNAL_GUARD_NO_COOLDOWN=1 python3 "$HEAL" 2>/dev/null
+}
+check_only() {  # read-only diagnosis; exit 1 on any gap
+  env HOME="$FAKE_HOME" VAULT_ROOT="$FAKE_VAULT" python3 "$HEAL" --check-only >/dev/null 2>&1
+}
+guard_matchers() {  # prints the sorted PreToolUse matchers the guard is registered under
+  python3 - "$FAKE_HOME/.claude/settings.json" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1], encoding="utf-8"))
+ms = sorted({g.get("matcher") for g in d.get("hooks", {}).get("PreToolUse", [])
+             for h in g.get("hooks", [])
+             if "warn-journal-saved-without-context" in h.get("command", "")})
+print(",".join(m or "" for m in ms))
+PY
+}
+
+echo "=== 1. NEGATIVE control: unprotected account trips --check-only ==="
+if check_only; then
+  bad "neg control --check-only trips" "an unprotected account PASSED --check-only (guard asleep)"
+else
+  ok "neg control --check-only trips (exit 1)"
+fi
+
+echo "=== 2. the SessionStart run repairs it ==="
+OUT="$(run_heal)"
+rc=$?
+if [ "$rc" -eq 0 ]; then ok "heal exits 0 (fail-open)"; else bad "heal exits 0" "exit $rc"; fi
+if printf '%s' "$OUT" | python3 -c 'import json,sys; d=json.loads(sys.stdin.read()); ctx=d.get("hookSpecificOutput",{}).get("additionalContext",""); sys.exit(0 if "heal-journal-guard" in ctx else 1)' 2>/dev/null; then
+  ok "surfaced ONE line about the repaired guard"
+else
+  bad "surface line" "no additionalContext line: $OUT"
+fi
+if [ "$(guard_matchers)" = "Bash,Write|Edit|MultiEdit" ]; then
+  ok "guard registered under BOTH matchers"
+else
+  bad "guard both matchers" "got: $(guard_matchers)"
+fi
+if [ -f "$FAKE_VAULT/⚙️ Meta/scripts/journal-preflight.py" ]; then
+  ok "journal-preflight.py landed in the vault"
+else
+  bad "preflight in vault" "sync did not copy journal-preflight.py"
+fi
+
+echo "=== 3. POSITIVE control: healthy account passes --check-only ==="
+if check_only; then
+  ok "positive control --check-only passes (exit 0)"
+else
+  bad "positive control passes" "a repaired account still reports a gap"
+fi
+
+echo "=== 4. IDEMPOTENT: second run stays clean, no duplicate registration ==="
+run_heal >/dev/null 2>&1
+count="$(python3 -c 'import json,sys; d=json.load(open(sys.argv[1],encoding="utf-8")); print(sum(1 for g in d.get("hooks",{}).get("PreToolUse",[]) for h in g.get("hooks",[]) if "warn-journal-saved-without-context" in h.get("command","")))' "$FAKE_HOME/.claude/settings.json")"
+if [ "$count" = "2" ]; then
+  ok "no duplicate registration after re-run (2 entries: one per matcher)"
+else
+  bad "idempotent registration" "expected 2 guard entries, got $count"
+fi
+
+echo
+echo "=== summary: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Makes the `/journal` Step-0 context enforcement durable across accounts, and fixes a latent installer bug found on the way.

## Why
The Step-0 guard is three pieces of **per-account** `~/.claude` state: `warn-journal-saved-without-context.py`, its `settings.json` registration under both PreToolUse matchers, and the vault-side `journal-preflight.py`. An account whose auto-sync never re-ran `install-hooks-user-level.py` has no guard, so `/journal` can silently ship an entry with zero context (the 2026-07-07 incident). Instructions in a repo are not durable; only infrastructure is.

## What
- **`scripts/heal-journal-guard.py`** (new): a SessionStart check that re-derives the guard from the vault-synced substrate every session and repairs it — registration via `install-hooks-user-level.py`'s own merge helpers (the existing hook-add mechanism), preflight via the existing `sync-vault-scripts` (`.ps1` on Windows). Fail-open, idempotent, cooldown-gated, no corpus walk. Surfaces one line when it heals.
- **Activation**: registered on `SessionStart` in `hooks.json` and owned by `install-hooks-user-level.py` (a self-heal the installer never registers is dormant).
- **Root-cause fix**: `merge_hooks` deduped by command text globally across matchers, so a byte-identical command under two matchers collapsed to one. A fresh install landed the guard under `Bash` only (leaving `Write|Edit|MultiEdit` journal saves unguarded) and dropped a matcher from `observe-tool-calls`. Dedup is now scoped per-matcher.

## Proof
`test_heal_journal_guard.sh` (negative + positive + idempotent controls), a hermetic `--self-test` in the script, and a `post-install-smoke-test.sh` section. Full `scripts/ci.sh` green: 285 files compile, 80 integration tests, shellcheck, UTF-8 console guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
