### PR TITLE
fix(secret-scan): stop false alerts on docker run -d container IDs and drizzle migration-hash rows

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,20 @@ description: What's new in AI Brain Starter — plain English, no jargon
 
 ---
 
+## 2026-07-14: the secret detector stopped crying wolf over container IDs and migration checksums
+
+**Who this affects:** everyone — a detector that flags things that aren't secrets teaches you to stop trusting its real alerts.
+
+**The bug:** the secret detector cried wolf 16 times in one session over things that are not secrets: the ID Docker prints when it starts a container, and the checksums a database migration table stores.
+
+**The fix:** those two exact shapes are now recognized by their command context and quietly recorded instead of alarmed. Everything else — including a real secret printed in the same output — still alarms. The scrubbing and scanning layers that protect your session files were not loosened at all.
+
+**New test:** `hooks/test_secret_patterns_fp_filter.py`, run directly by `scripts/ci.sh`'s Python unit-test gate.
+
+**What you should do:** nothing. Update as usual.
+
+---
+
 ## 2026-07-14: the journal now tracks how you MOVE between floors, not just where you stand
 
 **Who this affects:** everyone who uses `/journal`, `/weekly`, or `/monthly`.

--- a/hooks/_lib/secret_patterns.py
+++ b/hooks/_lib/secret_patterns.py
@@ -1,7 +1,7 @@
 """Shared secret-pattern registry.
 
 One module, used by every secret-detection / redaction layer:
-- `hooks/redact-bash-secrets.py` (PostToolUse Bash, alerts on detect)
+- `hooks/detect-secrets-in-bash-output.py` (PostToolUse Bash, alerts on detect)
 - `hooks/scrub-session-jsonl-secrets.py` (SessionEnd, rewrites JSONLs)
 - `hooks/scan-prior-sessions-for-secrets.py` (SessionStart, warns + auto-scrubs closed sessions)
 - Any standalone tool that imports `redact()` or `scan()`
@@ -300,6 +300,112 @@ def scan(text: str) -> list[tuple[str, int]]:
     return results
 
 
+# ---------------------------------------------------------------------------
+# Alert-layer context filter (PostToolUse hook ONLY — scan()/redact() untouched).
+#
+# Two documented tool-output shapes are content-addressed IDs, not credentials,
+# yet share the bare-64-hex shape with real secrets. The regex alone cannot
+# express them (they need the *command* for context), and the scrub / corpus /
+# SessionStart layers must stay aggressive (redacting an ID is harmless;
+# missing a secret is not). So the carve-out lives here as an explicit filter
+# applied only by detect-secrets-in-bash-output.py. Suppressed hits are still
+# audit-logged by the caller with a reason — observability is preserved.
+#
+# Added 2026-07-14 after a database-migration verification run fired 16 false
+# alerts in one session: 1× the container ID echoed on its own line by
+# `docker run -d` (the image digest on the neighboring line was already
+# skipped by the sha256: lookbehind above) and 15× drizzle migration
+# content-hashes from `SELECT id, hash, created_at FROM
+# drizzle.__drizzle_migrations` (psql rows `  1 | <64-hex> | <epoch-millis>`).
+# Security cry-wolf trains dismissal.
+
+# Docker lifecycle verbs whose STDOUT is by contract an ID/name echo.
+# `exec`, `inspect`, `logs`, and foreground `run` are deliberately absent:
+# their output is arbitrary program/config text that can contain a real
+# secret (e.g. `docker exec app printenv KEY` prints the value bare on a
+# line). `run` qualifies only when detached (-d / --detach / common -dit
+# bundles): detached stdout is exactly the new container ID.
+_DOCKER_ID_ECHO_CMD = re.compile(
+    r"\bdocker\s+(?:container\s+)?"
+    r"(?:create\b|start\b|stop\b|restart\b|kill\b|rm\b|wait\b|ps\b"
+    r"|run(?=[^|;&\n]*\s(?:-d|--detach|-dit|-itd|-dt|-td|-di|-id)\b)"
+    r")",
+    re.ASCII,
+)
+# A line that is nothing but one 64-hex token: the docker ID-echo shape, and
+# the single-column `SELECT hash FROM drizzle.__drizzle_migrations` shape.
+_BARE_HEX_LINE = re.compile(r"^\s*[A-Fa-f0-9]{64}\s*$", re.ASCII)
+# psql result-row shapes for drizzle.__drizzle_migrations output:
+#   `  1 | <hex> | 1782448308040`  (SELECT * / SELECT id, hash, created_at;
+#                                   tail also tolerates a cast timestamp)
+#   `hash | <hex>`                 (\x expanded display)
+_DRIZZLE_ROW_LINE = re.compile(
+    r"^\s*(?:\d+\s*\|\s*[A-Fa-f0-9]{64}\s*(?:\|\s*[\d\s:.T+-]*)?"
+    r"|hash\s*\|\s*[A-Fa-f0-9]{64})\s*$",
+    re.ASCII,
+)
+_DRIZZLE_CMD_MARKER = "__drizzle_migrations"
+_HEX_PATTERN_NAME = "hex-256bit-secret"
+
+
+def filter_tool_output_false_positives(
+    hits: list[tuple[str, int]], text: str, command: str
+) -> tuple[list[tuple[str, int]], list[tuple[str, int, str]]]:
+    """Alert-layer-only reclassification of hex-256bit-secret hits.
+
+    Given `scan(text)` results plus the Bash COMMAND that produced `text`,
+    suppress individual hex-256bit matches that are provably content-addressed
+    IDs in this command context:
+
+    - "docker-cli-id-echo": the command is a docker lifecycle invocation whose
+      stdout is by contract an ID echo, AND the match is a line consisting of
+      exactly one bare 64-hex token.
+    - "drizzle-migration-hash": the command queries __drizzle_migrations, AND
+      the match sits on a psql result-row line (or a bare single-column line).
+
+    Returns (remaining_hits, suppressed) where suppressed entries are
+    (pattern_name, suppressed_count, reason). Patterns other than
+    hex-256bit-secret always pass through untouched. A hex match whose line
+    does not match the expected shape keeps alerting (fail toward detection).
+    """
+    hex_entry = next((h for h in hits if h[0] == _HEX_PATTERN_NAME), None)
+    if hex_entry is None or not command:
+        return hits, []
+    docker_ctx = bool(_DOCKER_ID_ECHO_CMD.search(command))
+    drizzle_ctx = _DRIZZLE_CMD_MARKER in command
+    if not (docker_ctx or drizzle_ctx):
+        return hits, []
+
+    hex_regex = next(p.regex for p in PATTERNS if p.name == _HEX_PATTERN_NAME)
+    suppressed_counts: dict[str, int] = {}
+    remaining = 0
+    for m in hex_regex.finditer(text):
+        line_start = text.rfind("\n", 0, m.start()) + 1
+        line_end = text.find("\n", m.end())
+        line = text[line_start: line_end if line_end != -1 else len(text)]
+        if docker_ctx and _BARE_HEX_LINE.match(line):
+            reason = "docker-cli-id-echo"
+        elif drizzle_ctx and (
+            _DRIZZLE_ROW_LINE.match(line) or _BARE_HEX_LINE.match(line)
+        ):
+            reason = "drizzle-migration-hash"
+        else:
+            remaining += 1
+            continue
+        suppressed_counts[reason] = suppressed_counts.get(reason, 0) + 1
+
+    if not suppressed_counts:
+        return hits, []
+    out_hits = [h for h in hits if h[0] != _HEX_PATTERN_NAME]
+    if remaining:
+        out_hits.append((_HEX_PATTERN_NAME, remaining))
+    suppressed = [
+        (_HEX_PATTERN_NAME, count, reason)
+        for reason, count in sorted(suppressed_counts.items())
+    ]
+    return out_hits, suppressed
+
+
 # Self-test (run `python3 -m hooks._lib.secret_patterns`)
 if __name__ == "__main__":
     SAMPLES = {
@@ -379,3 +485,39 @@ if __name__ == "__main__":
     if failures:
         raise SystemExit(f"\n{failures} FP-exclusion check(s) failed.")
     print("  OK: all FP exclusions behave as expected.")
+
+    # Alert-layer FP filter checks (added 2026-07-14; see
+    # filter_tool_output_false_positives above for the docker-run-detached +
+    # drizzle-migration-hash incident this closes — PostToolUse hook only,
+    # scan()/redact() themselves are untouched).
+    print("\nAlert-layer FP filter checks:")
+    _hx = "1" * 64
+    _drizzle_cmd = 'psql -c "SELECT id, hash, created_at FROM drizzle.__drizzle_migrations"'
+    AF_CASES = {
+        "docker-run-detached-id-echo": (
+            ([("hex-256bit-secret", 1)], _hx, "docker run -d --name x postgres:16"),
+            ([], [("hex-256bit-secret", 1, "docker-cli-id-echo")]),
+        ),
+        "drizzle-migration-hash-row": (
+            ([("hex-256bit-secret", 1)], "  1 | " + _hx + " | 1782448308040", _drizzle_cmd),
+            ([], [("hex-256bit-secret", 1, "drizzle-migration-hash")]),
+        ),
+        "export-secret-not-suppressed-in-drizzle-context": (
+            ([("hex-256bit-secret", 1)], "export SECRET=" + _hx, _drizzle_cmd),
+            ([("hex-256bit-secret", 1)], []),
+        ),
+        "no-context-still-fires": (
+            ([("hex-256bit-secret", 1)], _hx, "openssl rand -hex 32"),
+            ([("hex-256bit-secret", 1)], []),
+        ),
+    }
+    af_failures = 0
+    for label, (args, want) in AF_CASES.items():
+        got = filter_tool_output_false_positives(*args)
+        ok = got == want
+        print(f"  [{'OK' if ok else 'FAIL'}] {label}: got={got} want={want}")
+        if not ok:
+            af_failures += 1
+    if af_failures:
+        raise SystemExit(f"\n{af_failures} alert-layer FP filter check(s) failed.")
+    print("  OK: alert-layer FP filter behaves as expected.")

--- a/hooks/detect-secrets-in-bash-output.py
+++ b/hooks/detect-secrets-in-bash-output.py
@@ -12,7 +12,9 @@ log. Two outputs:
 2. Append-only audit log at ~/.claude/hooks/secret-detection-log.jsonl.
    Each entry: timestamp, session_id, tool_input (command hash), patterns
    that matched, match counts. This is the corpus for spotting recurring
-   gaps in PreToolUse coverage.
+   gaps in PreToolUse coverage. Entries may also carry `fp_suppressed` for
+   hits reclassified as content-addressed IDs (docker run -d / drizzle
+   migration hashes) rather than secrets.
 
 Pairs with:
 - PreToolUse hookify rule `block-secret-dump-command-class` (vault
@@ -39,7 +41,7 @@ from pathlib import Path
 HOOK_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(HOOK_DIR))
 
-from _lib.secret_patterns import scan  # noqa: E402
+from _lib.secret_patterns import filter_tool_output_false_positives, scan  # noqa: E402
 
 LOG_PATH = HOOK_DIR / "secret-detection-log.jsonl"
 PLAYBOOK_HINT = "⚙️ Meta/Handoffs/20260513-eng6-secrets-rotation-playbook.md"
@@ -125,6 +127,13 @@ def main() -> int:
         print(json.dumps({"continue": True, "suppressOutput": True}))
         return 0
 
+    # Alert-layer-only reclassification: docker-run-detached ID echoes and
+    # drizzle migration-hash psql rows are content-addressed, not secrets.
+    # scan()/redact() above are untouched — this only trims what THIS hook
+    # alerts on. Suppressed hits are still audit-logged below with a reason.
+    command = (payload.get("tool_input") or {}).get("command", "")
+    hits, fp_suppressed = filter_tool_output_false_positives(hits, output, command)
+
     # Secrets just landed in the transcript. Log + (maybe) alert.
     self_inspection = _is_self_secret_inspection(payload)
     entry = {
@@ -132,8 +141,12 @@ def main() -> int:
         "session_id": payload.get("session_id", "unknown"),
         "command_sha": _hash_command(payload),
         "hits": [{"pattern": n, "count": c} for n, c in hits],
-        "alert_suppressed": self_inspection,
+        "alert_suppressed": bool(self_inspection or not hits),
     }
+    if fp_suppressed:
+        entry["fp_suppressed"] = [
+            {"pattern": n, "count": c, "reason": r} for n, c, r in fp_suppressed
+        ]
     try:
         with LOG_PATH.open("a") as f:
             f.write(json.dumps(entry, separators=(",", ":")) + "\n")
@@ -144,6 +157,13 @@ def main() -> int:
     # Self-inspection of own .env / admin.env / .zsh_secrets: skip the alert.
     # Detection still in audit log; loud rotation message is just noise here.
     if self_inspection:
+        print(json.dumps({"continue": True, "suppressOutput": True}))
+        return 0
+
+    # Every match was a documented content-addressed ID shape (docker ID
+    # echo / drizzle migration hash) — audit entry retained above, no loud
+    # alert; nothing real is left in `hits` to report.
+    if not hits:
         print(json.dumps({"continue": True, "suppressOutput": True}))
         return 0
 

--- a/hooks/test_secret_patterns_fp_filter.py
+++ b/hooks/test_secret_patterns_fp_filter.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Regression tests for the 2026-07-14 alert-layer FP-filter carve-out.
+
+A database-migration verification run fired 16 false positives from the
+PostToolUse secrets hook in one session: 1x the bare 64-hex container ID
+echoed on its own stdout line by `docker run -d ... postgres:16` (the
+`Digest: sha256:<hex>` line right above it was ALREADY excluded by the
+existing `(?<!sha256:)` lookbehind in hex-256bit-secret), and 15x drizzle
+migration content-hashes printed as psql rows shaped
+`  1 | <64-hex> | 1782448308040` by
+`psql ... -c "SELECT id, hash, created_at FROM drizzle.__drizzle_migrations
+ORDER BY id;"`.
+
+The fix is ALERT-LAYER ONLY: `filter_tool_output_false_positives()` in
+`_lib/secret_patterns.py` reclassifies individual hex-256bit-secret hits as
+content-addressed IDs when the *command* context proves it (a docker
+lifecycle verb + detached run, or a __drizzle_migrations query) AND the
+match sits on a line shaped like that ID echo. It is wired ONLY into
+`detect-secrets-in-bash-output.py` (the integration tests below hit that
+hook directly). `scan()` / `redact()` — and every other consumer: the
+SessionEnd scrub, the launchd corpus scan, the SessionStart surfacer — are
+untouched and stay fully aggressive. A suppressed hit is still written to
+the audit log with a reason, same discipline as the existing
+`_is_self_secret_inspection` suppression.
+
+Run: python3 hooks/test_secret_patterns_fp_filter.py
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+HOOKS = Path(__file__).resolve().parent
+sys.path.insert(0, str(HOOKS))
+
+from _lib.secret_patterns import filter_tool_output_false_positives, redact, scan  # noqa: E402
+
+
+def _load(name: str, filename: str):
+    """Load a hyphenated-filename hook module by path (not import-able normally)."""
+    spec = importlib.util.spec_from_file_location(name, HOOKS / filename)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+hook = _load("detect_secrets_hook", "detect-secrets-in-bash-output.py")
+
+_DRIZZLE_CMD = (
+    'psql "postgresql://postgres:localtest@localhost:5544/appdb" -c '
+    '"SELECT id, hash, created_at FROM drizzle.__drizzle_migrations ORDER BY id;"'
+)
+
+
+def _run_hook(payload: dict, log_path: Path):
+    """Feed `payload` to the hook's main() via stdin, with LOG_PATH pointed at
+    `log_path`. Returns (exit_code, stdout_json, stderr_text)."""
+    hook.LOG_PATH = log_path
+    old_stdin = sys.stdin
+    sys.stdin = io.StringIO(json.dumps(payload))
+    out_buf, err_buf = io.StringIO(), io.StringIO()
+    try:
+        with contextlib.redirect_stdout(out_buf), contextlib.redirect_stderr(err_buf):
+            rc = hook.main()
+    finally:
+        sys.stdin = old_stdin
+    stdout_text = out_buf.getvalue().strip()
+    stdout_json = json.loads(stdout_text.splitlines()[-1]) if stdout_text else {}
+    return rc, stdout_json, err_buf.getvalue()
+
+
+# ── 1. the incident, reproduced verbatim ────────────────────────────────────
+
+def test_incident_docker_run_detached_id_echo():
+    """1x container ID echoed bare by `docker run -d`; the sha256: digest
+    line right above it is already excluded by the existing regex (proving
+    scan() itself needs no change)."""
+    command = (
+        'docker run -d --name test-pg -p 5544:5432 '
+        '-e POSTGRES_PASSWORD=localtest postgres:16 2>&1; echo "RUN_EXIT:$?"'
+    )
+    hex_digest = "8badf00d" * 8
+    hex_echo = "deadc0de" * 8
+    output = (
+        "Unable to find image 'postgres:16' locally\n"
+        "16: Pulling from library/postgres\n"
+        f"Digest: sha256:{hex_digest}\n"
+        "Status: Downloaded newer image for postgres:16\n"
+        f"{hex_echo}\n"
+        "RUN_EXIT:0\n"
+    )
+    hits = scan(output)
+    assert dict(hits).get("hex-256bit-secret") == 1, (
+        f"expected exactly 1 hex-256bit-secret hit (digest line already "
+        f"excluded by the sha256: lookbehind), got {hits}"
+    )
+    remaining, suppressed = filter_tool_output_false_positives(hits, output, command)
+    assert remaining == [], f"expected all suppressed, got remaining={remaining}"
+    assert suppressed == [("hex-256bit-secret", 1, "docker-cli-id-echo")], suppressed
+
+
+def test_incident_drizzle_15_rows():
+    """15x drizzle migration-hash psql rows, all suppressed."""
+    command = _DRIZZLE_CMD
+    lines = [" id |  hash  | created_at", "----+--------+------------"]
+    for i in range(1, 16):
+        hex_i = f"{i:064x}"
+        lines.append(f"  {i} | {hex_i} | 1782448308{i:03d}")
+    lines.append("(15 rows)")
+    output = "\n".join(lines) + "\n"
+    hits = scan(output)
+    assert dict(hits).get("hex-256bit-secret") == 15, hits
+    remaining, suppressed = filter_tool_output_false_positives(hits, output, command)
+    assert remaining == [], f"expected all suppressed, got remaining={remaining}"
+    assert suppressed == [("hex-256bit-secret", 15, "drizzle-migration-hash")], suppressed
+
+
+# ── 2. negative controls (must still fire) ──────────────────────────────────
+
+def test_negative_export_secret_plain_still_fires():
+    command = "./deploy.sh"
+    hexv = "cafebabe" * 8
+    output = f"export SECRET={hexv}"
+    hits = scan(output)
+    remaining, suppressed = filter_tool_output_false_positives(hits, output, command)
+    assert remaining == hits, f"expected unchanged, got {remaining}"
+    assert suppressed == []
+
+
+def test_negative_export_secret_inside_drizzle_output_still_fires():
+    """The __drizzle_migrations command marker does NOT blanket-suppress —
+    only lines actually shaped like a migration row get reclassified."""
+    command = _DRIZZLE_CMD
+    hex_1 = f"{1:064x}"
+    hex_2 = f"{2:064x}"
+    hex_z = "deadbeef" * 8
+    output = (
+        f"  1 | {hex_1} | 1782448308040\n"
+        f"  2 | {hex_2} | 1782448308041\n"
+        f"export SECRET={hex_z}\n"
+    )
+    hits = scan(output)
+    assert dict(hits).get("hex-256bit-secret") == 3, hits
+    remaining, suppressed = filter_tool_output_false_positives(hits, output, command)
+    assert remaining == [("hex-256bit-secret", 1)], f"expected exactly 1 remaining, got {remaining}"
+    assert suppressed == [("hex-256bit-secret", 2, "drizzle-migration-hash")], suppressed
+
+
+def test_negative_bare_hex_without_context_still_fires():
+    """openssl output IS a real secret — no docker/drizzle context at all."""
+    command = "openssl rand -hex 32"
+    hexv = "deadbeef" * 8
+    hits = scan(hexv)
+    remaining, suppressed = filter_tool_output_false_positives(hits, hexv, command)
+    assert remaining == hits, f"expected unchanged, got {remaining}"
+    assert suppressed == []
+
+
+def test_negative_docker_exec_not_id_echo():
+    """`docker exec` is deliberately absent from the allowlist — its stdout
+    is arbitrary program output that can contain a real secret."""
+    command = "docker exec app printenv SECRET_KEY"
+    hexv = "deadbeef" * 8
+    hits = scan(hexv)
+    remaining, suppressed = filter_tool_output_false_positives(hits, hexv, command)
+    assert remaining == hits, f"expected unchanged, got {remaining}"
+    assert suppressed == []
+
+
+def test_negative_docker_run_foreground_not_id_echo():
+    """`docker run` without -d/--detach is foreground — its stdout is
+    arbitrary program output, not an ID echo."""
+    command = "docker run --rm img generate-key"
+    hexv = "deadbeef" * 8
+    hits = scan(hexv)
+    remaining, suppressed = filter_tool_output_false_positives(hits, hexv, command)
+    assert remaining == hits, f"expected unchanged, got {remaining}"
+    assert suppressed == []
+
+
+# ── 3. docker allowlist positive coverage ───────────────────────────────────
+
+def test_docker_stop_rm_id_echo_suppressed():
+    command = "docker stop 5e2f && docker rm 5e2f"
+    hexv = "deadbeef" * 8
+    hits = scan(hexv)
+    remaining, suppressed = filter_tool_output_false_positives(hits, hexv, command)
+    assert remaining == []
+    assert suppressed == [("hex-256bit-secret", 1, "docker-cli-id-echo")], suppressed
+
+
+# ── 4. drizzle shape coverage ────────────────────────────────────────────────
+
+def test_drizzle_expanded_display_and_bare_column():
+    command = _DRIZZLE_CMD
+    hexv = "deadbeef" * 8
+    for output in (f"hash | {hexv}", hexv):
+        hits = scan(output)
+        remaining, suppressed = filter_tool_output_false_positives(hits, output, command)
+        assert remaining == [], f"expected suppressed for {output!r}, got {remaining}"
+        assert suppressed == [("hex-256bit-secret", 1, "drizzle-migration-hash")], (output, suppressed)
+
+
+# ── 5. other patterns pass through untouched ────────────────────────────────
+
+def test_other_patterns_pass_through_untouched():
+    command = "docker run -d --name x postgres:16"
+    hexv = "deadbeef" * 8
+    hits = [("postgres-url-password", 1), ("hex-256bit-secret", 1)]
+    remaining, suppressed = filter_tool_output_false_positives(hits, hexv, command)
+    assert remaining == [("postgres-url-password", 1)], remaining
+    assert suppressed == [("hex-256bit-secret", 1, "docker-cli-id-echo")], suppressed
+
+
+# ── 6. scrub layer proof (the filter did not weaken scan/redact) ───────────
+
+def test_scrub_layer_stays_aggressive():
+    hexv = "deadbeef" * 8
+    text = f"  1 | {hexv} | 1782448308040"
+    redacted, hit_names = redact(text)
+    assert "hex-256bit-secret" in hit_names, hit_names
+    assert "[REDACTED-hex-256bit]" in redacted, redacted
+    assert hexv not in redacted, "raw hex survived redact()"
+
+
+# ── 7. empty command ─────────────────────────────────────────────────────────
+
+def test_empty_command_no_filtering():
+    hexv = "deadbeef" * 8
+    hits = [("hex-256bit-secret", 1)]
+    remaining, suppressed = filter_tool_output_false_positives(hits, hexv, "")
+    assert remaining == hits
+    assert suppressed == []
+
+
+# ── 8. integration: the real hook end-to-end ────────────────────────────────
+
+def test_hook_end_to_end_all_suppressed():
+    hex_digest = "8badf00d" * 8
+    hex_echo = "deadc0de" * 8
+    payload = {
+        "session_id": "t",
+        "tool_input": {"command": "docker run -d --name x postgres:16"},
+        "tool_response": {"stdout": f"Digest: sha256:{hex_digest}\n{hex_echo}\n"},
+    }
+    with tempfile.TemporaryDirectory() as tmp:
+        log_path = Path(tmp) / "secret-detection-log.jsonl"
+        rc, stdout_json, _stderr = _run_hook(payload, log_path)
+        assert rc == 0
+        assert stdout_json.get("suppressOutput") is True, stdout_json
+        assert "hookSpecificOutput" not in stdout_json, stdout_json
+
+        entries = [json.loads(line) for line in log_path.read_text().splitlines()]
+        assert len(entries) == 1, entries
+        entry = entries[0]
+        assert entry["alert_suppressed"] is True, entry
+        assert entry["hits"] == [], entry
+        assert entry["fp_suppressed"] == [
+            {"pattern": "hex-256bit-secret", "count": 1, "reason": "docker-cli-id-echo"}
+        ], entry
+
+
+def test_hook_end_to_end_mixed_still_alerts():
+    hex_1 = f"{1:064x}"
+    hex_2 = f"{2:064x}"
+    hex_z = "cafebabe" * 8
+    payload = {
+        "session_id": "t",
+        "tool_input": {"command": _DRIZZLE_CMD},
+        "tool_response": {
+            "stdout": (
+                f"  1 | {hex_1} | 1782448308040\n"
+                f"  2 | {hex_2} | 1782448308041\n"
+                f"export SECRET={hex_z}\n"
+            )
+        },
+    }
+    with tempfile.TemporaryDirectory() as tmp:
+        log_path = Path(tmp) / "secret-detection-log.jsonl"
+        rc, stdout_json, _stderr = _run_hook(payload, log_path)
+        assert rc == 0
+        ctx = stdout_json.get("hookSpecificOutput", {}).get("additionalContext", "")
+        assert "SECRETS DETECTED" in ctx, stdout_json
+        assert "hex-256bit-secret×1" in ctx, stdout_json
+
+        entries = [json.loads(line) for line in log_path.read_text().splitlines()]
+        assert len(entries) == 1, entries
+        entry = entries[0]
+        assert entry["hits"] == [{"pattern": "hex-256bit-secret", "count": 1}], entry
+        assert entry["fp_suppressed"] == [
+            {"pattern": "hex-256bit-secret", "count": 2, "reason": "drizzle-migration-hash"}
+        ], entry
+        assert entry["alert_suppressed"] is False, entry
+
+
+def main() -> None:
+    tests = [v for k, v in sorted(globals().items())
+             if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  [OK] {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"  [FAIL] {t.__name__}: {e}")
+        except Exception as e:  # noqa: BLE001 — surface any error as a failure
+            failed += 1
+            print(f"  [ERROR] {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    if failed:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -341,6 +341,7 @@ PY_DIRECT=(
   tests/test_instinct.py
   hooks/test_live_session_reap.py
   hooks/test_relocation_orphan_reclaim.py
+  hooks/test_secret_patterns_fp_filter.py
 )
 dormant_py=()
 while IFS= read -r -d '' f; do


### PR DESCRIPTION
The secret detector fired 16 false positives in one legitimate database-migration verification session — the bare container ID echoed by `docker run -d`, and 15 drizzle migration content-hashes printed by a `__drizzle_migrations` query.

This adds `filter_tool_output_false_positives` to `secret_patterns` and wires it only into `detect-secrets-in-bash-output`: `hex-256bit-secret` matches are suppressed only when the command context proves a content-addressed ID (a detached docker lifecycle echo, or a drizzle migrations query) AND the match line has the ID shape. `scan` / `redact` and the scrub / corpus-scan layers keep full aggression; suppressed hits are still audit-logged with a reason. A planted `export SECRET=<hex>` inside the same outputs still alarms — negative controls in the new suite prove both directions, and `docker exec` / `inspect` / foreground `run` are deliberately not allowlisted.

`hooks/test_secret_patterns_fp_filter.py` (14 cases) is registered in the `PY_DIRECT` gate of `scripts/ci.sh` (its dormancy invariant fails loud on unregistered tests); a plain-English changelog entry is included; also fixes the stale `redact-bash-secrets` consumer name in the `secret_patterns` module docstring.

Authored and verified by an AI agent on the maintainer's machine (full `scripts/ci.sh` gate green locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)