### PR TITLE
fix(test): isolate sandbox HOME on Windows in heal-journal-guard test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,14 @@ HOME="$SANDBOX" EMAIL_GATE_BYPASS=1 PREFLIGHT_BYPASS=1 bash bootstrap.sh
 
 After the run, inspect `$SANDBOX/.claude/` to see what got created. To reset and re-test: `rm -rf "$SANDBOX"` and start over.
 
+**On Windows (Git Bash), export `USERPROFILE` alongside `HOME`.** `HOME` redirects bash and the POSIX tools, but Windows Python ignores it: since Python 3.8, `Path.home()` / `os.path.expanduser("~")` resolve against `USERPROFILE`, not `HOME` (CPython bpo-36264). So any Python the run invokes — hooks, installers, the self-heal scripts — still reads and writes your **real** `~/.claude` while your assertions look at the sandbox. Point both variables at the sandbox, Windows-spelling the path:
+
+```bash
+HOME="$SANDBOX" USERPROFILE="$(cygpath -w "$SANDBOX")" <command under test>
+```
+
+On macOS/Linux `cygpath` is absent and nothing reads `USERPROFILE`, so the exact same invocation is a no-op there — write it once, it works everywhere (`tests/integration/test_heal_journal_guard.sh` uses this pattern). Running the suite on Windows also needs a real `python3` on `PATH`: the Microsoft Store alias Windows ships fails with "Python was not found", so shim it once with a two-line script that `exec`s `py -3 "$@"`.
+
 **Two flags worth knowing for tests:**
 
 - `--dry-run` — shows what would be installed without making changes. Every install path respects this; if you add a new install step, wrap it in `do_cmd`, `git_clone_safe`, `claude_install_safe`, `claude_marketplace_safe`, or `pipx_install_safe` to keep dry-run actually dry.

--- a/tests/integration/test_heal_journal_guard.sh
+++ b/tests/integration/test_heal_journal_guard.sh
@@ -43,6 +43,16 @@ fi
 # --- build a throwaway account + vault ---------------------------------------
 FAKE_HOME="$(mktemp -d)"; TMPDIRS+=("$FAKE_HOME")
 FAKE_VAULT="$(mktemp -d)"; TMPDIRS+=("$FAKE_VAULT")
+# Sandboxing HOME alone does not isolate Windows Python: since 3.8,
+# ntpath.expanduser/Path.home() resolve against USERPROFILE and ignore HOME
+# (CPython bpo-36264), so the script under test would read/write the REAL
+# ~/.claude. Point USERPROFILE at the same sandbox, Windows-spelled where
+# cygpath exists (Git Bash). On Linux/macOS cygpath is absent and nothing
+# reads the extra variable, so the CI (ubuntu) run is unchanged.
+FAKE_HOME_NATIVE="$FAKE_HOME"
+if command -v cygpath >/dev/null 2>&1; then
+  FAKE_HOME_NATIVE="$(cygpath -w "$FAKE_HOME")"
+fi
 # The registered guard command resolves ~ against $HOME, so the guard script must
 # exist under the fake skill path for the "script on disk" health check to pass.
 mkdir -p "$FAKE_HOME/.claude/skills/ai-brain-starter/hooks"
@@ -55,11 +65,12 @@ mkdir -p "$FAKE_VAULT/⚙️ Meta/scripts" "$FAKE_VAULT/⚙️ Meta/Decisions" "
 printf '%s\n' '{"hooks": {}}' > "$FAKE_HOME/.claude/settings.json"
 
 run_heal() {  # runs the wired SessionStart path against the fake account
-  printf '%s' '{}' | env HOME="$FAKE_HOME" VAULT_ROOT="$FAKE_VAULT" \
-    HEAL_JOURNAL_GUARD_NO_COOLDOWN=1 python3 "$HEAL" 2>/dev/null
+  printf '%s' '{}' | env HOME="$FAKE_HOME" USERPROFILE="$FAKE_HOME_NATIVE" \
+    VAULT_ROOT="$FAKE_VAULT" HEAL_JOURNAL_GUARD_NO_COOLDOWN=1 python3 "$HEAL" 2>/dev/null
 }
 check_only() {  # read-only diagnosis; exit 1 on any gap
-  env HOME="$FAKE_HOME" VAULT_ROOT="$FAKE_VAULT" python3 "$HEAL" --check-only >/dev/null 2>&1
+  env HOME="$FAKE_HOME" USERPROFILE="$FAKE_HOME_NATIVE" VAULT_ROOT="$FAKE_VAULT" \
+    python3 "$HEAL" --check-only >/dev/null 2>&1
 }
 guard_matchers() {  # prints the sorted PreToolUse matchers the guard is registered under
   python3 - "$FAKE_HOME/.claude/settings.json" <<'PY'


### PR DESCRIPTION
## What

`tests/integration/test_heal_journal_guard.sh` sandboxes each run with
`HOME="$(mktemp -d)"`. That isolates bash and the POSIX tools, but not Windows
Python: since 3.8, `ntpath.expanduser` / `Path.home()` resolve `~` against
`USERPROFILE` and ignore `HOME` (CPython bpo-36264). So on Windows the script
under test (`scripts/heal-journal-guard.py`) read and wrote the developer's
**real** `~/.claude/settings.json` while the test asserted against the fake one.

Observed on Windows 11 / Python 3.12: 7/9 assertions passed; the two that
inspect `$FAKE_HOME/.claude/settings.json` — *guard both matchers* and
*idempotent registration* — failed with empty/0 because the fake settings never
received the registration. The run also left entries in the real `~/.claude`.

## Fix

Export `USERPROFILE` alongside `HOME` in `run_heal` and `check_only`, pointed at
the same sandbox and Windows-spelled with `cygpath -w` when available.

- **Linux/macOS:** `cygpath` is absent, so `USERPROFILE` is set to the same
  POSIX mktemp path and `posixpath.expanduser` never reads it. The ubuntu CI
  run is byte-identical.
- **Windows:** `USERPROFILE` now points at the sandbox, so `Path.home()`
  resolves there and the test writes/reads the fake settings as intended.

Also documents the `HOME`+`USERPROFILE` sandbox pattern (and the `py -3`
`python3` shim Windows needs) in `CONTRIBUTING.md`.

## Verification

- **Linux/macOS:** unchanged — the added env var is a no-op.
- **Windows 11 / Python 3.12 (Git Bash, python3→`py -3` shim):** the two
  isolation assertions now pass and the real `~/.claude` is left untouched.

Two other assertions (`--self-test`, positive `--check-only`) still fail on
Windows on their own, for an unrelated reason: `_GUARD_PATH_RE` in
`scripts/heal-journal-guard.py` doesn't match drive-letter (`C:\`) paths. That's
fixed by a companion Windows-compat change (drive-letter guard paths + CRLF
frontmatter normalization) tracked separately; with both applied the suite is
fully green (9/9) on Windows. This PR is intentionally scoped to the test
harness so it can land independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
