### PR TITLE
feat(floors): consume high-rise as a pinned upstream, not a divergent copy

### DIFF
--- a/floors.md
+++ b/floors.md
@@ -2,87 +2,15 @@
 
 The journal tags every entry with a Floor: the emotional consciousness level you were on when you wrote it. Over time the tag becomes infrastructure. Patterns surface, loops get named, and you stop being surprised by your own weather.
 
-This file is the reference. What the floors are, how they work, how to use them.
+## Where the floors come from
 
-Each floor also has its own note at [`floors/<Name>.md`](floors/) — graphify uses those so journal entries tagged `[[Fear]]` resolve to a node with body content, elevator-emotion edges, shadow-twin links, and a pointer to the writing series. Regenerate them from this table with `scripts/generate_floor_stubs.py` if you change the canonical list below.
+The 34-floor model is the open-source **High-Rise framework**, owned and published by [Fundación Lontananza](https://github.com/Fundacion-Lontananza/high-rise) under MIT. ai-brain-starter **consumes** the framework as a downstream dependency. It does not keep its own copy of the list.
 
----
+The canonical reference lives vendored and pinned at **[`vendor/high-rise/floors.md`](vendor/high-rise/floors.md)**: the 34-floor table with energies and Spanish names, the three tiers, the elevator emotions, and the shadow twins, in English and Spanish. That is the pinned source this repo's floor tooling reads. For example, `scripts/generate_floor_stubs.py` regenerates the per-floor notes under [`floors/`](floors/) from it, so a wikilink like `[[Fear]]` in a journal entry resolves to a real node with body content, elevator edges, and a shadow-twin link.
 
-## The framework, in one paragraph
+To change the floors, change them upstream in `Fundacion-Lontananza/high-rise`, cut a release, then run `scripts/sync-high-rise.py --tag vX.Y.Z` and re-run `scripts/generate_floor_stubs.py`. Nothing in this repo hand-maintains a second floor list. See [`vendor/high-rise/README.md`](vendor/high-rise/README.md).
 
-Thirty-four floors of emotional consciousness, low to high. Hawkins-derived (Power vs. Force, 1995), expanded from the original sixteen as the work asked for more resolution. Floor 1 is Disgust. Floor 34 is Peace. Three tiers: Low (1-18, reactive), Middle (19-24, transitional), High (25-34, generative). Every floor is real. Every floor is workable. None of them is bad. The journal does not ask you to climb. It asks you to know where you are.
-
----
-
-## The 34 floors
-
-| # | English | Español | Tier | Energy |
-|---|---|---|---|---|
-| 1 | Disgust | Asco | Low | outward rejection, visceral "get it away from me" |
-| 2 | Shame | Vergüenza | Low | "I'm such an idiot," self-disgust, hiding |
-| 3 | Embarrassment | Bochorno | Low | social exposure, temporary, recoverable |
-| 4 | Guilt | Culpa | Low | "I should be doing more," letting people down |
-| 5 | Apathy | Apatía | Low | "nothing matters," checked out, numb |
-| 6 | Resignation | Resignación | Low | defeated "it is what it is" (NOT making peace) |
-| 7 | Confusion | Confusión | Low | mind reaching and failing, contradictory thoughts |
-| 8 | Loneliness | Soledad | Low | surrounded but unfound, no one gets it |
-| 9 | Boredom | Aburrimiento | Low | restless, understimulated, the trampoline floor |
-| 10 | Grief | Duelo | Low | loss, sadness, missing someone or something |
-| 11 | Disappointment | Decepción | Low | gap between hope and what arrived |
-| 12 | Hurt | Herida | Low | breach in a relationship, "how could they" |
-| 13 | Fear | Miedo | Low | anxiety, "what if," imposter feelings |
-| 14 | Frustration | Frustración | Low | blocked energy, "this should be working" |
-| 15 | Desire | Deseo | Low | wanting, craving, reaching, ambition mixed with lack |
-| 16 | Anger | Rabia | Low | directed energy, "this is wrong," disrespect |
-| 17 | Contempt | Desprecio | Low | "you are beneath me," cold dismissal |
-| 18 | Pride | Orgullo | Low | proving something, need for external validation |
-| 19 | Courage | Valentía | Middle | taking action despite fear, doing the hard thing |
-| 20 | Hope | Esperanza | Middle | future-facing trust, steady forward momentum |
-| 21 | Neutrality | Neutralidad | Middle | calm observation, processing without charge |
-| 22 | Willingness | Disposición | Middle | optimistic restart, curiosity replaces fear |
-| 23 | Acceptance | Aceptación | Middle | making peace with reality (NOT Resignation) |
-| 24 | Reason | Razón | Middle | analytical, strategic, clear-headed |
-| 25 | Trust | Confianza | High | quiet confidence that things hold |
-| 26 | Compassion | Compasión | High | feeling others' pain without collapsing |
-| 27 | Humility | Humildad | High | accurate self-perception, "I was wrong about" |
-| 28 | Belonging | Pertenencia | High | being received, "I'm in the right room" |
-| 29 | Love | Amor | High | connection, warmth, giving freely |
-| 30 | Gratitude | Gratitud | High | presence recognizing abundance |
-| 31 | Excitement | Entusiasmo | High | anticipatory joy, body saying yes |
-| 32 | Wonder | Asombro | High | awe at what exists, expansion |
-| 33 | Joy | Alegría | High | delight, fun, laughter, alive |
-| 34 | Peace | Paz | High | stillness, nothing to fix, enough as-is |
-
-Three tiers: **Low** = 1-18 (Reactive). **Middle** = 19-24 (Transitional). **High** = 25-34 (Generative).
-
----
-
-## Elevator emotions
-
-Some emotions are not floors but movements between them. The journal tags the floor you land on; these names describe the trip.
-
-- **Nostalgia** = Grief (10) + Love (29)
-- **Awe** = Fear (13) + Wonder (32)
-- **Jealousy** = Fear (13) + Desire (15) + Anger (16)
-- **Schadenfreude** = Pride (18) + corrupted Joy (33)
-- **Vulnerability** = Shame (2) climbing to Love (29), a staircase taken step by step
-- **Bittersweet** = Grief (10) + Joy (33)
-- **Overwhelm** = any floor flooding (capacity failure)
-
----
-
-## Shadow twins
-
-A low floor pretending to be its high twin. The journal asks you to name which one you're actually on. The mistake is the lesson.
-
-| Shadow (Low) | True floor (High) | Tell |
-|---|---|---|
-| Resignation (6) | Acceptance (23) | "I've given up" vs. "I've made peace" |
-| Apathy (5) | Neutrality (21) | "I don't care" vs. "I'm not attached" |
-| Desire (15) | Love (29) | "I want from you" vs. "I give to you" |
-| Pride (18) | Confidence | "I need you to see me" vs. "I see myself" |
-
----
+**If you just want the list, open [`vendor/high-rise/floors.md`](vendor/high-rise/floors.md).**
 
 ## How the journal uses the floor
 
@@ -93,11 +21,9 @@ floor: Hope
 floor_level: Middle
 ```
 
-That tag is the seed. Over weeks, it tells you which floors you spend most time on, which ones you cycle through, which loops you are stuck in. The `patterns` skill reads it. The `insights` skill reads it. The `coaching` skill reads it. The `rise` morning skill reads yesterday's tag to choose today's body movement.
+That tag is the seed. Over weeks, it tells you which floors you spend most time on, which ones you cycle through, which loops you are stuck in. The `patterns`, `insights`, and `coaching` skills read it. The `rise` morning skill reads yesterday's tag to choose today's body movement.
 
 You can backfill past entries by running the journal skill with a date range.
-
----
 
 ## How to use the framework if you do not journal
 
@@ -105,19 +31,11 @@ You do not need the install for the floors to be useful. Three reps that work on
 
 1. **Name the floor before reacting.** When you feel something hard, the first move is to name which floor it is. The naming itself reduces the charge. You are on Frustration, not in Frustration.
 2. **Check for shadow twins.** When a high floor shows up easily, ask whether the shadow is in costume. Most "Acceptance" is Resignation. Most "Confidence" is Pride. The difference is whether you are still bracing.
-3. **Watch elevators, not just floors.** What carried you from one floor to another? A walk. A conversation. A meal. A meeting. The elevators are the actual lesson; the floors are where the elevator opens.
-
----
+3. **Watch elevators, not just floors.** What carried you from one floor to another? A walk. A conversation. A meal. A meeting. The elevators are the actual lesson, and the floors are where the elevator opens.
 
 ## The narrative form
 
 These floors started as a writing project, where each one gets a chapter of lived experience instead of a one-line definition. If you want the floors as stories rather than as a table, a companion read lives at [adelaidadiazroa.substack.com](https://adelaidadiazroa.substack.com) (English) and [perspectivasblog.substack.com](https://perspectivasblog.substack.com) (Spanish).
-
----
-
-## Reference
-
-The canonical floor data is in this file. Skills inside the substrate read this table, not their own copies. If you fork the substrate and want to change the floor list, change it here once.
 
 License: MIT. Use the framework. Translate it. Teach it. Ship it. The point is people moving through their own buildings.
 
@@ -127,46 +45,11 @@ License: MIT. Use the framework. Translate it. Teach it. Ship it. The point is p
 
 El journal etiqueta cada entrada con un Piso: el nivel de consciencia emocional en el que estabas cuando escribiste. Con el tiempo la etiqueta se vuelve infraestructura. Aparecen patrones, los loops reciben nombre, y dejás de sorprenderte con tu propio clima.
 
-### El marco, en un párrafo
-
-Treinta y cuatro pisos de consciencia emocional, de bajo a alto. Derivado de Hawkins (Power vs. Force, 1995), expandido de los dieciséis originales cuando el trabajo pidió más resolución. Piso 1 es Asco. Piso 34 es Paz. Tres tiers: Bajo (1-18, reactivo), Medio (19-24, transicional), Alto (25-34, generativo). Cada piso es real. Cada piso es trabajable. Ninguno es malo. El journal no te pide subir. Te pide saber dónde estás.
-
-### Los 34 pisos
-
-Ver la tabla en inglés arriba (todas las traducciones de los pisos están en la columna Español).
-
-### Emociones-ascensor
-
-Algunas emociones no son pisos sino movimientos entre ellos. El journal etiqueta el piso donde aterrizás; estos nombres describen el viaje.
-
-- **Nostalgia** = Duelo + Amor
-- **Asombro mezclado** = Miedo + Asombro
-- **Celos** = Miedo + Deseo + Rabia
-- **Vulnerabilidad** = Vergüenza subiendo hacia Amor, una escalera tomada paso a paso
-- **Agridulce** = Duelo + Alegría
-- **Sobrecarga** = cualquier piso inundándose (falla de capacidad)
-
-### Gemelos sombra
-
-Un piso bajo disfrazado de su gemelo alto. El journal te pide nombrar cuál es. El error es la lección.
-
-| Sombra (Bajo) | Piso verdadero (Alto) | Cómo se distingue |
-|---|---|---|
-| Resignación (6) | Aceptación (23) | "Me rendí" vs. "Hice las paces" |
-| Apatía (5) | Neutralidad (21) | "No me importa" vs. "No estoy enganchada" |
-| Deseo (15) | Amor (29) | "Quiero de vos" vs. "Te doy" |
-| Orgullo (18) | Confianza | "Necesito que me veas" vs. "Yo me veo" |
+El modelo de 34 pisos es el marco **High-Rise** de código abierto, propiedad de [Fundación Lontananza](https://github.com/Fundacion-Lontananza/high-rise) bajo licencia MIT. ai-brain-starter lo **consume**, no guarda su propia copia. La referencia canónica (la tabla de pisos con energías y nombres en español, los tres tiers, las emociones-ascensor y los gemelos sombra) vive fijada en [`vendor/high-rise/floors.md`](vendor/high-rise/floors.md). Para cambiar los pisos, se cambian aguas arriba en `Fundacion-Lontananza/high-rise` y se corre `scripts/sync-high-rise.py`.
 
 ### Cómo lo usa el journal
 
-La skill `daily-journal` hace una pregunta al final de cada entrada: ¿dónde estuviste hoy? La respuesta se guarda en el frontmatter:
-
-```yaml
-floor: Esperanza
-floor_level: Middle
-```
-
-Esa etiqueta es la semilla. Con el tiempo te dice en qué pisos pasás más tiempo, cuáles ciclás, en qué loops estás. La skill `patterns` lo lee. La skill `insights` lo lee. La skill `coaching` lo lee. La skill `rise` lee el piso de ayer para elegir el movimiento corporal de hoy.
+La skill `daily-journal` hace una pregunta al final de cada entrada: ¿dónde estuviste hoy? La respuesta se guarda en el frontmatter (`floor:` + `floor_level:`). Esa etiqueta es la semilla. Con el tiempo te dice en qué pisos pasás más tiempo, cuáles ciclás, en qué loops estás. Las skills `patterns`, `insights` y `coaching` lo leen. La skill `rise` lee el piso de ayer para elegir el movimiento corporal de hoy.
 
 ### Si no usás el journal
 
@@ -174,8 +57,4 @@ No necesitás la instalación para que los pisos sean útiles. Tres ejercicios q
 
 1. **Nombrá el piso antes de reaccionar.** Cuando sentís algo duro, primero nombrá qué piso es. El nombrarlo ya reduce la carga. Estás en Frustración, no sos Frustración.
 2. **Chequeá los gemelos sombra.** Cuando un piso alto aparece muy fácil, preguntá si la sombra está disfrazada. La mayoría de "Aceptación" es Resignación. La mayoría de "Confianza" es Orgullo. La diferencia es si todavía estás tensa.
-3. **Mirá ascensores, no sólo pisos.** ¿Qué te llevó de un piso a otro? Una caminata. Una conversación. Una comida. Una reunión. Los ascensores son la verdadera lección; los pisos son donde el ascensor abre la puerta.
-
-### Forma narrativa
-
-Estos pisos empezaron como un proyecto de escritura, donde cada uno tiene un capítulo de experiencia vivida en vez de una definición de una línea. Si querés los pisos como historias en vez de como tabla, una lectura complementaria vive en [perspectivasblog.substack.com](https://perspectivasblog.substack.com) (español) y [adelaidadiazroa.substack.com](https://adelaidadiazroa.substack.com) (inglés).
+3. **Mirá ascensores, no sólo pisos.** ¿Qué te llevó de un piso a otro? Una caminata. Una conversación. Una comida. Una reunión. Los ascensores son la verdadera lección, y los pisos son donde el ascensor abre la puerta.

--- a/floors/Acceptance.md
+++ b/floors/Acceptance.md
@@ -10,7 +10,7 @@ aliases: [Aceptación, "Floor 23", "Piso 23"]
 
 **Floor 23 · Middle tier**
 
-Making peace with reality (not Resignation).
+Making peace with reality (NOT Resignation).
 
 Part of the middle tier: see [[Middle Floors]].
 
@@ -18,7 +18,7 @@ Part of the middle tier: see [[Middle Floors]].
 
 **[[Resignation]] (6)** is the shadow of **Acceptance (23)**.
 
-> 'I've given up' vs 'I've made peace'
+> "I've given up" vs. "I've made peace"
 
 Most "Acceptance" people claim is actually [[Resignation]]. The difference is whether you are still bracing.
 

--- a/floors/Anger.md
+++ b/floors/Anger.md
@@ -10,7 +10,7 @@ aliases: [Rabia, "Floor 16", "Piso 16"]
 
 **Floor 16 · Low tier**
 
-Directed energy, 'this is wrong,' disrespect.
+Directed energy, "this is wrong," disrespect.
 
 Part of the low tier: see [[Low Floors]].
 

--- a/floors/Apathy.md
+++ b/floors/Apathy.md
@@ -10,15 +10,15 @@ aliases: [Apatía, "Floor 5", "Piso 5"]
 
 **Floor 5 · Low tier**
 
-'nothing matters,' checked out, numb.
+"nothing matters," checked out, numb.
 
 Part of the low tier: see [[Low Floors]].
 
 ## Shadow twin
 
-**Apathy (5)** is the shadow of **[[Neutrality]] (21)**.
+**Apathy (5)** is the shadow of [[Neutrality]] (21).
 
-> 'I don't care' vs 'I'm not attached'
+> "I don't care" vs. "I'm not attached"
 
 When Apathy shows up easily, check whether [[Neutrality]] is what you actually mean. The difference is whether you are still bracing.
 

--- a/floors/Belonging.md
+++ b/floors/Belonging.md
@@ -10,7 +10,7 @@ aliases: [Pertenencia, "Floor 28", "Piso 28"]
 
 **Floor 28 · High tier**
 
-Being received, 'I'm in the right room'.
+Being received, "I'm in the right room".
 
 Part of the high tier: see [[High Floors]].
 

--- a/floors/Boredom.md
+++ b/floors/Boredom.md
@@ -10,7 +10,7 @@ aliases: [Aburrimiento, "Floor 9", "Piso 9"]
 
 **Floor 9 · Low tier**
 
-Restless, understimulated, the trampoline floor.
+Restless, understimulated — the trampoline floor.
 
 Part of the low tier: see [[Low Floors]].
 

--- a/floors/Contempt.md
+++ b/floors/Contempt.md
@@ -10,7 +10,7 @@ aliases: [Desprecio, "Floor 17", "Piso 17"]
 
 **Floor 17 · Low tier**
 
-'you are beneath me,' cold dismissal.
+"you are beneath me," cold dismissal.
 
 Part of the low tier: see [[Low Floors]].
 

--- a/floors/Desire.md
+++ b/floors/Desire.md
@@ -22,9 +22,9 @@ These are movements between floors, not floors themselves. The journal tags the 
 
 ## Shadow twin
 
-**Desire (15)** is the shadow of **[[Love]] (29)**.
+**Desire (15)** is the shadow of [[Love]] (29).
 
-> 'I want from you' vs 'I give to you'
+> "I want from you" vs. "I give to you"
 
 When Desire shows up easily, check whether [[Love]] is what you actually mean. The difference is whether you are still bracing.
 

--- a/floors/Disgust.md
+++ b/floors/Disgust.md
@@ -10,7 +10,7 @@ aliases: [Asco, "Floor 1", "Piso 1"]
 
 **Floor 1 · Low tier**
 
-Outward rejection, visceral 'get it away from me'.
+Outward rejection, visceral "get it away from me".
 
 Part of the low tier: see [[Low Floors]].
 

--- a/floors/Fear.md
+++ b/floors/Fear.md
@@ -10,7 +10,7 @@ aliases: [Miedo, "Floor 13", "Piso 13"]
 
 **Floor 13 · Low tier**
 
-Anxiety, 'what if,' imposter feelings.
+Anxiety, "what if," imposter feelings.
 
 Part of the low tier: see [[Low Floors]].
 

--- a/floors/Frustration.md
+++ b/floors/Frustration.md
@@ -10,7 +10,7 @@ aliases: [Frustración, "Floor 14", "Piso 14"]
 
 **Floor 14 · Low tier**
 
-Blocked energy, 'this should be working'.
+Blocked energy, "this should be working".
 
 Part of the low tier: see [[Low Floors]].
 

--- a/floors/Guilt.md
+++ b/floors/Guilt.md
@@ -10,7 +10,7 @@ aliases: [Culpa, "Floor 4", "Piso 4"]
 
 **Floor 4 · Low tier**
 
-'I should be doing more,' letting people down.
+"I should be doing more," letting people down.
 
 Part of the low tier: see [[Low Floors]].
 

--- a/floors/High Floors.md
+++ b/floors/High Floors.md
@@ -12,8 +12,8 @@ Floors **25-34**:
 
 - 25. [[Trust]] (Confianza) — quiet confidence that things hold
 - 26. [[Compassion]] (Compasión) — feeling others' pain without collapsing
-- 27. [[Humility]] (Humildad) — accurate self-perception, 'I was wrong about'
-- 28. [[Belonging]] (Pertenencia) — being received, 'I'm in the right room'
+- 27. [[Humility]] (Humildad) — accurate self-perception, "I was wrong about"
+- 28. [[Belonging]] (Pertenencia) — being received, "I'm in the right room"
 - 29. [[Love]] (Amor) — connection, warmth, giving freely
 - 30. [[Gratitude]] (Gratitud) — presence recognizing abundance
 - 31. [[Excitement]] (Entusiasmo) — anticipatory joy, body saying yes

--- a/floors/Humility.md
+++ b/floors/Humility.md
@@ -10,7 +10,7 @@ aliases: [Humildad, "Floor 27", "Piso 27"]
 
 **Floor 27 · High tier**
 
-Accurate self-perception, 'I was wrong about'.
+Accurate self-perception, "I was wrong about".
 
 Part of the high tier: see [[High Floors]].
 

--- a/floors/Hurt.md
+++ b/floors/Hurt.md
@@ -10,7 +10,7 @@ aliases: [Herida, "Floor 12", "Piso 12"]
 
 **Floor 12 · Low tier**
 
-Breach in a relationship, 'how could they'.
+Breach in a relationship, "how could they".
 
 Part of the low tier: see [[Low Floors]].
 

--- a/floors/Joy.md
+++ b/floors/Joy.md
@@ -16,7 +16,6 @@ Part of the high tier: see [[High Floors]].
 
 ## Elevators involving this floor
 
-- **Schadenfreude** = [[Pride]] + **Joy (corrupted)**
 - **Bittersweet** = [[Grief]] + **Joy**
 
 These are movements between floors, not floors themselves. The journal tags the floor you land on; the elevator name describes the trip.

--- a/floors/Love.md
+++ b/floors/Love.md
@@ -25,7 +25,7 @@ These are movements between floors, not floors themselves. The journal tags the 
 
 **[[Desire]] (15)** is the shadow of **Love (29)**.
 
-> 'I want from you' vs 'I give to you'
+> "I want from you" vs. "I give to you"
 
 Most "Love" people claim is actually [[Desire]]. The difference is whether you are still bracing.
 

--- a/floors/Low Floors.md
+++ b/floors/Low Floors.md
@@ -10,23 +10,23 @@ Reactive: 1-18. The reactive tier. Where the charge lives.
 
 Floors **1-18**:
 
-- 1. [[Disgust]] (Asco) — outward rejection, visceral 'get it away from me'
-- 2. [[Shame]] (Vergüenza) — 'I'm such an idiot,' self-disgust, hiding
+- 1. [[Disgust]] (Asco) — outward rejection, visceral "get it away from me"
+- 2. [[Shame]] (Vergüenza) — "I'm such an idiot," self-disgust, hiding
 - 3. [[Embarrassment]] (Bochorno) — social exposure, temporary, recoverable
-- 4. [[Guilt]] (Culpa) — 'I should be doing more,' letting people down
-- 5. [[Apathy]] (Apatía) — 'nothing matters,' checked out, numb
-- 6. [[Resignation]] (Resignación) — defeated 'it is what it is' (not making peace)
+- 4. [[Guilt]] (Culpa) — "I should be doing more," letting people down
+- 5. [[Apathy]] (Apatía) — "nothing matters," checked out, numb
+- 6. [[Resignation]] (Resignación) — defeated "it is what it is" (NOT making peace)
 - 7. [[Confusion]] (Confusión) — mind reaching and failing, contradictory thoughts
 - 8. [[Loneliness]] (Soledad) — surrounded but unfound, no one gets it
-- 9. [[Boredom]] (Aburrimiento) — restless, understimulated, the trampoline floor
+- 9. [[Boredom]] (Aburrimiento) — restless, understimulated — the trampoline floor
 - 10. [[Grief]] (Duelo) — loss, sadness, missing someone or something
 - 11. [[Disappointment]] (Decepción) — gap between hope and what arrived
-- 12. [[Hurt]] (Herida) — breach in a relationship, 'how could they'
-- 13. [[Fear]] (Miedo) — anxiety, 'what if,' imposter feelings
-- 14. [[Frustration]] (Frustración) — blocked energy, 'this should be working'
+- 12. [[Hurt]] (Herida) — breach in a relationship, "how could they"
+- 13. [[Fear]] (Miedo) — anxiety, "what if," imposter feelings
+- 14. [[Frustration]] (Frustración) — blocked energy, "this should be working"
 - 15. [[Desire]] (Deseo) — wanting, craving, reaching, ambition mixed with lack
-- 16. [[Anger]] (Rabia) — directed energy, 'this is wrong,' disrespect
-- 17. [[Contempt]] (Desprecio) — 'you are beneath me,' cold dismissal
+- 16. [[Anger]] (Rabia) — directed energy, "this is wrong," disrespect
+- 17. [[Contempt]] (Desprecio) — "you are beneath me," cold dismissal
 - 18. [[Pride]] (Orgullo) — proving something, need for external validation
 
 ## Reference

--- a/floors/Middle Floors.md
+++ b/floors/Middle Floors.md
@@ -14,7 +14,7 @@ Floors **19-24**:
 - 20. [[Hope]] (Esperanza) — future-facing trust, steady forward momentum
 - 21. [[Neutrality]] (Neutralidad) — calm observation, processing without charge
 - 22. [[Willingness]] (Disposición) — optimistic restart, curiosity replaces fear
-- 23. [[Acceptance]] (Aceptación) — making peace with reality (not Resignation)
+- 23. [[Acceptance]] (Aceptación) — making peace with reality (NOT Resignation)
 - 24. [[Reason]] (Razón) — analytical, strategic, clear-headed
 
 ## Reference

--- a/floors/Neutrality.md
+++ b/floors/Neutrality.md
@@ -18,7 +18,7 @@ Part of the middle tier: see [[Middle Floors]].
 
 **[[Apathy]] (5)** is the shadow of **Neutrality (21)**.
 
-> 'I don't care' vs 'I'm not attached'
+> "I don't care" vs. "I'm not attached"
 
 Most "Neutrality" people claim is actually [[Apathy]]. The difference is whether you are still bracing.
 

--- a/floors/Pride.md
+++ b/floors/Pride.md
@@ -14,19 +14,13 @@ Proving something, need for external validation.
 
 Part of the low tier: see [[Low Floors]].
 
-## Elevators involving this floor
-
-- **Schadenfreude** = **Pride** + [[Joy]]
-
-These are movements between floors, not floors themselves. The journal tags the floor you land on; the elevator name describes the trip.
-
 ## Shadow twin
 
-**Pride (18)** is the shadow of **[[Trust]] (25)**.
+**Pride (18)** is the shadow of **Confidence**.
 
-> 'I need you to see me' vs 'I see myself'
+> "I need you to see me" vs. "I see myself"
 
-When Pride shows up easily, check whether [[Trust]] is what you actually mean. The difference is whether you are still bracing.
+When Pride shows up easily, check whether Confidence is what you actually mean. The difference is whether you are still bracing.
 
 ## How to use this floor
 

--- a/floors/Resignation.md
+++ b/floors/Resignation.md
@@ -10,15 +10,15 @@ aliases: [Resignación, "Floor 6", "Piso 6"]
 
 **Floor 6 · Low tier**
 
-Defeated 'it is what it is' (not making peace).
+Defeated "it is what it is" (NOT making peace).
 
 Part of the low tier: see [[Low Floors]].
 
 ## Shadow twin
 
-**Resignation (6)** is the shadow of **[[Acceptance]] (23)**.
+**Resignation (6)** is the shadow of [[Acceptance]] (23).
 
-> 'I've given up' vs 'I've made peace'
+> "I've given up" vs. "I've made peace"
 
 When Resignation shows up easily, check whether [[Acceptance]] is what you actually mean. The difference is whether you are still bracing.
 

--- a/floors/Shame.md
+++ b/floors/Shame.md
@@ -10,7 +10,7 @@ aliases: [Vergüenza, "Floor 2", "Piso 2"]
 
 **Floor 2 · Low tier**
 
-'I'm such an idiot,' self-disgust, hiding.
+"I'm such an idiot," self-disgust, hiding.
 
 Part of the low tier: see [[Low Floors]].
 

--- a/floors/Trust.md
+++ b/floors/Trust.md
@@ -14,14 +14,6 @@ Quiet confidence that things hold.
 
 Part of the high tier: see [[High Floors]].
 
-## Shadow twin
-
-**[[Pride]] (18)** is the shadow of **Trust (25)**.
-
-> 'I need you to see me' vs 'I see myself'
-
-Most "Trust" people claim is actually [[Pride]]. The difference is whether you are still bracing.
-
 ## How to use this floor
 
 - **Name it.** "I'm on Trust," not "I'm in Trust." The naming reduces the charge.

--- a/scripts/check-open-core-boundary.sh
+++ b/scripts/check-open-core-boundary.sh
@@ -70,7 +70,7 @@ done < <(git ls-files skills/ | awk -F'/' '{print $1"/"$2}' | sort -u | grep -v 
 # OR:        a SKILL.md at its root                        — skills-pack shape
 #
 # Standard non-pack dirs (never need to be in the allowlist):
-STANDARD_DIRS=".agents .claude-plugin .github .git commands docs floors for-teams git-hooks hooks meeting-todos para-equipos phases scripts services skills templates tests themes"
+STANDARD_DIRS=".agents .claude-plugin .github .git commands docs floors for-teams git-hooks hooks meeting-todos para-equipos phases scripts services skills templates tests themes vendor"
 
 while IFS= read -r top_dir; do
   # Skip dot-prefixed dirs

--- a/scripts/generate_floor_stubs.py
+++ b/scripts/generate_floor_stubs.py
@@ -1,113 +1,178 @@
 #!/usr/bin/env python3
 """Generate one stub note per Floor + tier-index notes for the public substrate.
 
-The substrate ships `floors.md` (one table). The `daily-journal` skill tags every
-entry with wikilinks like `[[Fear]]` and `[[Low Floors]]`. Without per-floor
-notes, those wikilinks resolve to empty bare-string nodes in the graph.
+The `daily-journal` skill tags every entry with wikilinks like `[[Fear]]` and
+`[[Low Floors]]`. Without per-floor notes, those wikilinks resolve to empty
+bare-string nodes in the graph. This script emits 34 floor stubs + 3 tier-index
+notes at `floors/<Name>.md`, plus the writing-series pointer note.
 
-This script emits 34 floor stubs + 3 tier-index notes at `floors/<Name>.md`.
-Bodies are the framework (energy line, elevator emotions involving the floor,
-shadow-twin links, Substack series links) — not lived-experience prose.
-
-Re-run after any change to the 34-floor canonical list in floors.md.
+The canonical floor data (the 34-floor table, elevator emotions, shadow twins,
+EN + ES) is NOT hardcoded here. It is PARSED from the vendored, pinned copy of
+the open-source High-Rise framework at `vendor/high-rise/floors.md`
+(see vendor/high-rise/README.md). ai-brain-starter consumes that upstream; it
+does not keep its own divergent floor list. To change the floors, change them in
+`Fundacion-Lontananza/high-rise`, run `scripts/sync-high-rise.py`, then re-run
+this script. `scripts/test_generate_floor_stubs.py` fails if `floors/` drifts
+from this generator's output.
 """
 
+from __future__ import annotations
+
+import re
 import sys
 from pathlib import Path
 from textwrap import dedent
 
 ROOT = Path(__file__).resolve().parent.parent
 OUT = ROOT / "floors"
+CANONICAL = ROOT / "vendor" / "high-rise" / "floors.md"
 
 SUBSTACK_EN = "https://adelaidadiazroa.substack.com"
 SUBSTACK_ES = "https://perspectivasblog.substack.com"
 
-FLOORS = [
-    (1,  "Disgust",       "Asco",          "Low",    "outward rejection, visceral 'get it away from me'"),
-    (2,  "Shame",          "Vergüenza",     "Low",    "'I'm such an idiot,' self-disgust, hiding"),
-    (3,  "Embarrassment",  "Bochorno",      "Low",    "social exposure, temporary, recoverable"),
-    (4,  "Guilt",          "Culpa",         "Low",    "'I should be doing more,' letting people down"),
-    (5,  "Apathy",         "Apatía",        "Low",    "'nothing matters,' checked out, numb"),
-    (6,  "Resignation",    "Resignación",   "Low",    "defeated 'it is what it is' (not making peace)"),
-    (7,  "Confusion",      "Confusión",     "Low",    "mind reaching and failing, contradictory thoughts"),
-    (8,  "Loneliness",     "Soledad",       "Low",    "surrounded but unfound, no one gets it"),
-    (9,  "Boredom",        "Aburrimiento",  "Low",    "restless, understimulated, the trampoline floor"),
-    (10, "Grief",          "Duelo",         "Low",    "loss, sadness, missing someone or something"),
-    (11, "Disappointment", "Decepción",     "Low",    "gap between hope and what arrived"),
-    (12, "Hurt",           "Herida",        "Low",    "breach in a relationship, 'how could they'"),
-    (13, "Fear",           "Miedo",         "Low",    "anxiety, 'what if,' imposter feelings"),
-    (14, "Frustration",    "Frustración",   "Low",    "blocked energy, 'this should be working'"),
-    (15, "Desire",         "Deseo",         "Low",    "wanting, craving, reaching, ambition mixed with lack"),
-    (16, "Anger",          "Rabia",         "Low",    "directed energy, 'this is wrong,' disrespect"),
-    (17, "Contempt",       "Desprecio",     "Low",    "'you are beneath me,' cold dismissal"),
-    (18, "Pride",          "Orgullo",       "Low",    "proving something, need for external validation"),
-    (19, "Courage",        "Valentía",      "Middle", "taking action despite fear, doing the hard thing"),
-    (20, "Hope",           "Esperanza",     "Middle", "future-facing trust, steady forward momentum"),
-    (21, "Neutrality",     "Neutralidad",   "Middle", "calm observation, processing without charge"),
-    (22, "Willingness",    "Disposición",   "Middle", "optimistic restart, curiosity replaces fear"),
-    (23, "Acceptance",     "Aceptación",    "Middle", "making peace with reality (not Resignation)"),
-    (24, "Reason",         "Razón",         "Middle", "analytical, strategic, clear-headed"),
-    (25, "Trust",          "Confianza",     "High",   "quiet confidence that things hold"),
-    (26, "Compassion",     "Compasión",     "High",   "feeling others' pain without collapsing"),
-    (27, "Humility",       "Humildad",      "High",   "accurate self-perception, 'I was wrong about'"),
-    (28, "Belonging",      "Pertenencia",   "High",   "being received, 'I'm in the right room'"),
-    (29, "Love",           "Amor",          "High",   "connection, warmth, giving freely"),
-    (30, "Gratitude",      "Gratitud",      "High",   "presence recognizing abundance"),
-    (31, "Excitement",     "Entusiasmo",    "High",   "anticipatory joy, body saying yes"),
-    (32, "Wonder",         "Asombro",       "High",   "awe at what exists, expansion"),
-    (33, "Joy",            "Alegría",       "High",   "delight, fun, laughter, alive"),
-    (34, "Peace",          "Paz",           "High",   "stillness, nothing to fix, enough as-is"),
-]
-
-ELEVATORS = {
-    "Nostalgia":     [(10, "Grief"), (29, "Love")],
-    "Awe":           [(13, "Fear"), (32, "Wonder")],
-    "Jealousy":      [(13, "Fear"), (15, "Desire"), (16, "Anger")],
-    "Schadenfreude": [(18, "Pride"), (33, "Joy (corrupted)")],
-    "Vulnerability": [(2, "Shame"), (29, "Love")],
-    "Bittersweet":   [(10, "Grief"), (33, "Joy")],
-}
-
-SHADOWS = {
-    6:  (23, "Acceptance", "'I've given up' vs 'I've made peace'"),
-    5:  (21, "Neutrality", "'I don't care' vs 'I'm not attached'"),
-    15: (29, "Love",       "'I want from you' vs 'I give to you'"),
-    18: (25, "Trust",      "'I need you to see me' vs 'I see myself'"),
-}
-SHADOW_INVERSE = {high: (low, low_name, tell) for low, (high, _, tell) in SHADOWS.items()
-                  for low_name in [next(f[1] for f in FLOORS if f[0] == low)]}
-
+# Tier presentation (note titles + blurbs) is this substrate's own framing; the
+# tier BOUNDARIES and each floor's tier come from the canonical table below.
 TIER_INDEX = {
     "Low":    ("Low Floors",    "Pisos Bajos",    "Reactive: 1-18. The reactive tier. Where the charge lives.",      1, 18),
     "Middle": ("Middle Floors", "Pisos Medios",   "Transitional: 19-24. The transitional tier. The climb up.",       19, 24),
     "High":   ("High Floors",   "Pisos Altos",    "Generative: 25-34. The generative tier. Where the energy gives.", 25, 34),
 }
 
-TIER_LEVEL = {"Low": "Low", "Middle": "Middle", "High": "High"}
+# A member reference inside an elevator/shadow line: "Grief (10)", "Love (29)".
+_MEMBER_RE = re.compile(r"([A-Z][A-Za-z]+)\s*\((\d+)\)")
+# A floors-table data row: | 13 | Fear | Miedo | Low | anxiety, ... |
+_FLOOR_ROW_RE = re.compile(
+    r"^\|\s*(\d+)\s*\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*\|\s*(Low|Middle|High)\s*\|\s*(.+?)\s*\|\s*$"
+)
+
+
+def _canon_die(msg: str) -> None:
+    print(
+        f"generate_floor_stubs: ERROR parsing {CANONICAL.relative_to(ROOT)}: {msg}\n"
+        f"  Is the vendored High-Rise framework present + current? "
+        f"Run: python3 scripts/sync-high-rise.py",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
+def _english_section(text: str, header: str) -> str:
+    """Return the body of the first `## <header>` section (English half only).
+
+    The canonical file has an English half then a `---` then a Spanish half whose
+    sub-sections are level-3 (`### ...`). Matching the level-2 `## <header>`
+    exactly keeps us in the English half.
+    """
+    lines = text.splitlines()
+    start = None
+    for i, line in enumerate(lines):
+        if line.strip() == f"## {header}":
+            start = i + 1
+            break
+    if start is None:
+        _canon_die(f"missing '## {header}' section")
+    body = []
+    for line in lines[start:]:
+        if line.startswith("## ") or line.strip() == "---":
+            break
+        body.append(line)
+    return "\n".join(body)
+
+
+def load_canonical() -> tuple[list, dict, list]:
+    """Parse FLOORS, ELEVATORS, SHADOWS from the vendored canonical floors.md."""
+    if not CANONICAL.exists():
+        _canon_die("file not found")
+    text = CANONICAL.read_text(encoding="utf-8")
+
+    # --- floors table (the whole file has exactly one; rows are 1..34) --------
+    floors = []
+    for line in text.splitlines():
+        m = _FLOOR_ROW_RE.match(line)
+        if m:
+            num, en, es, tier, energy = m.groups()
+            floors.append((int(num), en.strip(), es.strip(), tier, energy.strip()))
+    if len(floors) != 34:
+        _canon_die(f"expected 34 floor rows, parsed {len(floors)}")
+    nums = [f[0] for f in floors]
+    if nums != list(range(1, 35)):
+        _canon_die(f"floor numbers are not 1..34 in order: {nums}")
+
+    # --- elevator emotions ----------------------------------------------------
+    elevators = {}
+    for line in _english_section(text, "Elevator emotions").splitlines():
+        line = line.strip()
+        if not line.startswith("- **"):
+            continue
+        name_m = re.match(r"-\s*\*\*(.+?)\*\*", line)
+        if not name_m:
+            continue
+        name = name_m.group(1).strip()
+        members = [(int(n), fn) for fn, n in _MEMBER_RE.findall(line)]
+        elevators[name] = members  # members may be [] (e.g. Overwhelm = any floor)
+
+    # --- shadow twins ---------------------------------------------------------
+    shadows = []  # (low_num, low_name, high_num|None, high_name, tell)
+    for line in _english_section(text, "Shadow twins").splitlines():
+        line = line.strip()
+        if not line.startswith("|"):
+            continue
+        cells = [c.strip() for c in line.strip("|").split("|")]
+        if len(cells) != 3:
+            continue
+        low_cell, high_cell, tell = cells
+        if low_cell.lower().startswith("shadow") or set(low_cell) <= {"-", ":"}:
+            continue  # header / separator row
+        low_m = _MEMBER_RE.search(low_cell)
+        if not low_m:
+            continue
+        low_name, low_num = low_m.group(1), int(low_m.group(2))
+        high_m = _MEMBER_RE.search(high_cell)
+        if high_m:
+            high_name, high_num = high_m.group(1), int(high_m.group(2))
+        else:
+            # True twin can be a non-floor concept (e.g. Confidence) — no number.
+            high_name, high_num = high_cell.strip(), None
+        shadows.append((low_num, low_name, high_num, high_name, tell))
+    if not shadows:
+        _canon_die("parsed zero shadow-twin rows")
+
+    return floors, elevators, shadows
+
+
+FLOORS, ELEVATORS, SHADOWS = load_canonical()
+FLOOR_NAME = {num: en for num, en, *_ in FLOORS}
+SHADOW_BY_LOW = {low: (hi, hi_name, tell) for low, _ln, hi, hi_name, tell in SHADOWS}
+SHADOW_BY_HIGH = {hi: (low, low_name, tell)
+                  for low, low_name, hi, _hn, tell in SHADOWS if hi is not None}
 
 
 def elevators_for(num: int) -> list[tuple[str, list[tuple[int, str]]]]:
+    """Elevators this floor is a member of (elevators with no members are skipped)."""
     return [(name, members) for name, members in ELEVATORS.items()
-            if any(m[0] == num or m[1].startswith(name[:4]) for m in members)
-            and any(m[0] == num for m in members)]
+            if any(m_num == num for m_num, _ in members)]
 
 
 def floor_body(num: int, en: str, es: str, tier: str, energy: str) -> str:
     elevators = elevators_for(num)
+
     shadow_block = ""
-    if num in SHADOWS:
-        high_num, high_name, tell = SHADOWS[num]
+    if num in SHADOW_BY_LOW:
+        high_num, high_name, tell = SHADOW_BY_LOW[num]
+        # The true twin may be a floor (link it) or a non-floor concept (plain).
+        twin = f"[[{high_name}]] ({high_num})" if high_num is not None else f"**{high_name}**"
+        check = f"[[{high_name}]]" if high_num is not None else high_name
         shadow_block = dedent(f"""
             ## Shadow twin
 
-            **{en} ({num})** is the shadow of **[[{high_name}]] ({high_num})**.
+            **{en} ({num})** is the shadow of {twin}.
 
             > {tell}
 
-            When {en} shows up easily, check whether [[{high_name}]] is what you actually mean. The difference is whether you are still bracing.
+            When {en} shows up easily, check whether {check} is what you actually mean. The difference is whether you are still bracing.
         """).strip() + "\n\n"
-    elif num in SHADOW_INVERSE:
-        low_num, low_name, tell = SHADOW_INVERSE[num]
+    elif num in SHADOW_BY_HIGH:
+        low_num, low_name, tell = SHADOW_BY_HIGH[num]
         shadow_block = dedent(f"""
             ## Shadow twin
 
@@ -127,10 +192,13 @@ def floor_body(num: int, en: str, es: str, tier: str, energy: str) -> str:
                 if m_num == num:
                     parts.append(f"**{m_name}**")
                 else:
-                    base_name = m_name.split(" (")[0]
-                    parts.append(f"[[{base_name}]]")
+                    parts.append(f"[[{m_name}]]")
             lines.append(f"- **{elev_name}** = " + " + ".join(parts))
-        elevator_block = "## Elevators involving this floor\n\n" + "\n".join(lines) + "\n\nThese are movements between floors, not floors themselves. The journal tags the floor you land on; the elevator name describes the trip.\n\n"
+        elevator_block = (
+            "## Elevators involving this floor\n\n" + "\n".join(lines)
+            + "\n\nThese are movements between floors, not floors themselves. "
+            "The journal tags the floor you land on; the elevator name describes the trip.\n\n"
+        )
 
     tier_name = TIER_INDEX[tier][0]
 
@@ -231,17 +299,17 @@ def main():
     written = []
     for num, en, es, tier, energy in FLOORS:
         path = OUT / f"{en}.md"
-        path.write_text(floor_body(num, en, es, tier, energy))
+        path.write_text(floor_body(num, en, es, tier, energy), encoding="utf-8")
         written.append(str(path.relative_to(ROOT)))
     for tier in ("Low", "Middle", "High"):
         en, _, _, _, _ = TIER_INDEX[tier]
         path = OUT / f"{en}.md"
-        path.write_text(tier_body(tier))
+        path.write_text(tier_body(tier), encoding="utf-8")
         written.append(str(path.relative_to(ROOT)))
     series_path = OUT / "The High-Rise Series.md"
-    series_path.write_text(SERIES_BODY)
+    series_path.write_text(SERIES_BODY, encoding="utf-8")
     written.append(str(series_path.relative_to(ROOT)))
-    print(f"Wrote {len(written)} files:")
+    print(f"Wrote {len(written)} files from {CANONICAL.relative_to(ROOT)}:")
     for p in written:
         print(f"  {p}")
 

--- a/scripts/sync-high-rise.py
+++ b/scripts/sync-high-rise.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Vendor the pinned open-source High-Rise framework into ai-brain-starter.
+
+ai-brain-starter CONSUMES the High-Rise framework - the canonical 34-floor
+model (floors, tiers, elevators, shadow twins) plus the journaling and coaching
+methodologies - as a downstream dependency of its single upstream source of
+truth: Fundacion-Lontananza/high-rise (public, MIT). It does NOT hold a
+divergent copy. The framework files live under vendor/high-rise/, pinned to a
+tagged release, and are refreshed by THIS script from that upstream.
+
+Why vendored, not a git submodule
+---------------------------------
+The substrate installs by `git clone`ing THIS repo into
+~/.claude/skills/ai-brain-starter (see bootstrap.sh). A submodule would force
+every user onto `git clone --recursive` - and silently break the many installs
+that don't pass it - and would reach the network at install time. Vendored
+files ship INSIDE the clone: the framework is present offline, at a pinned
+version, with zero install-time network. That is the install-safe mechanism.
+
+Pinned by TAG, never HEAD
+-------------------------
+The pin - upstream repo, tag, the resolved commit that tag pointed at, and a
+sha256 for every vendored file - lives in vendor/high-rise/PIN.json. A refresh
+re-fetches the SAME pinned tag and must reproduce those hashes. Moving to a new
+upstream release is a deliberate, reviewable act: `--tag vX.Y.Z`.
+
+Usage
+-----
+  sync-high-rise.py               Refresh vendor/high-rise/ from the CURRENT
+                                  pinned tag (PIN.json). Re-fetches the tag and
+                                  rewrites the vendored files + hashes.
+  sync-high-rise.py --tag v0.2.0  Re-pin to a new upstream tag, then refresh.
+  sync-high-rise.py --check       Offline drift guard (CI): verify every
+                                  vendored file exists and its sha256 matches
+                                  PIN.json. No network. Exit 2 on any drift.
+  sync-high-rise.py --dry-run     Show what a refresh would change; write nothing.
+
+Exit codes: 0 success / clean; 2 drift or error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Canonical upstream + the exact set of files ai-brain-starter vendors from it.
+# high-rise ships exactly these; if it grows a file we want, add it here.
+UPSTREAM_REPO = "https://github.com/Fundacion-Lontananza/high-rise.git"
+UPSTREAM_SLUG = "Fundacion-Lontananza/high-rise"
+VENDORED_FILES = (
+    "floors.md",
+    "methodology/journaling.md",
+    "methodology/coaching.md",
+)
+
+ROOT = Path(__file__).resolve().parent.parent
+VENDOR_DIR = ROOT / "vendor" / "high-rise"
+PIN_FILE = VENDOR_DIR / "PIN.json"
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _load_pin() -> dict:
+    if not PIN_FILE.exists():
+        die(
+            f"no pin at {PIN_FILE.relative_to(ROOT)} - run with --tag vX.Y.Z to "
+            f"create the initial pin."
+        )
+    try:
+        return json.loads(PIN_FILE.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        die(f"cannot read pin {PIN_FILE.relative_to(ROOT)}: {exc}")
+    return {}  # unreachable; keeps type-checkers happy
+
+
+def die(msg: str) -> None:
+    print(f"sync-high-rise: ERROR: {msg}", file=sys.stderr)
+    sys.exit(2)
+
+
+# ---------------------------------------------------------------------------
+def check() -> int:
+    """Offline drift guard: vendored files must match PIN.json sha256s.
+
+    Catches a hand-edit to a vendored file (the framework is upstream's to
+    change, never ours to patch locally) and a vendored file that went missing.
+    Does not touch the network - that is what CI runs on every PR.
+    """
+    pin = _load_pin()
+    recorded = pin.get("files", {})
+    if not recorded:
+        die("pin has no 'files' map - re-create it with --tag vX.Y.Z.")
+
+    problems = []
+    for rel in VENDORED_FILES:
+        want = recorded.get(rel)
+        if want is None:
+            problems.append(f"{rel}: not recorded in PIN.json")
+            continue
+        dest = VENDOR_DIR / rel
+        if not dest.exists():
+            problems.append(f"{rel}: vendored file missing at {dest.relative_to(ROOT)}")
+            continue
+        got = _sha256(dest.read_bytes())
+        if got != want:
+            problems.append(
+                f"{rel}: sha256 drift - vendored file was edited locally "
+                f"(expected {want[:12]}..., found {got[:12]}...). "
+                f"The framework is upstream's; edit {UPSTREAM_SLUG} and re-sync, "
+                f"do not patch vendor/ by hand."
+            )
+    # A file recorded in the pin but no longer in our manifest is also drift.
+    for rel in recorded:
+        if rel not in VENDORED_FILES:
+            problems.append(f"{rel}: recorded in PIN.json but not in VENDORED_FILES manifest")
+
+    if problems:
+        print(
+            f"sync-high-rise: DRIFT against pin {pin.get('tag', '?')} "
+            f"({pin.get('commit', '?')[:12]}):",
+            file=sys.stderr,
+        )
+        for p in problems:
+            print(f"  - {p}", file=sys.stderr)
+        return 2
+
+    print(
+        f"sync-high-rise: OK - {len(VENDORED_FILES)} vendored file(s) match pin "
+        f"{pin.get('tag', '?')} ({pin.get('commit', '?')[:12]})."
+    )
+    return 0
+
+
+# ---------------------------------------------------------------------------
+def _clone_tag(tag: str, workdir: Path) -> str:
+    """Shallow-clone exactly `tag` into workdir; return the resolved commit sha."""
+    dest = workdir / "high-rise"
+    try:
+        subprocess.run(
+            ["git", "clone", "--quiet", "--depth", "1", "--branch", tag,
+             UPSTREAM_REPO, str(dest)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        die("git is not installed / not on PATH.")
+    except subprocess.CalledProcessError as exc:
+        die(
+            f"could not clone {UPSTREAM_SLUG} at tag '{tag}'. Does the tag exist?\n"
+            f"  {exc.stderr.strip()}"
+        )
+    sha = subprocess.run(
+        ["git", "-C", str(dest), "rev-parse", "HEAD"],
+        check=True, capture_output=True, text=True,
+    ).stdout.strip()
+    return sha
+
+
+def refresh(tag: str, *, dry_run: bool) -> int:
+    """Re-fetch `tag` from upstream and rewrite vendor/high-rise/ + PIN.json."""
+    with tempfile.TemporaryDirectory(prefix="sync-high-rise-") as tmp:
+        src = Path(tmp) / "high-rise"
+        commit = _clone_tag(tag, Path(tmp))
+
+        # Verify upstream still ships everything we vendor BEFORE writing anything.
+        missing = [rel for rel in VENDORED_FILES if not (src / rel).exists()]
+        if missing:
+            die(
+                f"{UPSTREAM_SLUG}@{tag} is missing vendored file(s): "
+                f"{', '.join(missing)}. Update VENDORED_FILES or the tag."
+            )
+
+        new_hashes: dict[str, str] = {}
+        changes = []
+        for rel in VENDORED_FILES:
+            data = (src / rel).read_bytes()
+            new_hashes[rel] = _sha256(data)
+            dest = VENDOR_DIR / rel
+            old = dest.read_bytes() if dest.exists() else None
+            if old != data:
+                changes.append(("update" if old is not None else "add", rel))
+            if not dry_run:
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                dest.write_bytes(data)
+
+        pin = {
+            "_comment": (
+                "Pinned vendor of the open-source High-Rise framework. "
+                "Do not edit vendored files by hand - edit upstream "
+                f"({UPSTREAM_SLUG}) and run scripts/sync-high-rise.py. "
+                "Re-pin with --tag vX.Y.Z."
+            ),
+            "repo": UPSTREAM_SLUG,
+            "tag": tag,
+            "commit": commit,
+            "files": new_hashes,
+        }
+        pin_json = json.dumps(pin, indent=2, ensure_ascii=False) + "\n"
+        pin_changed = (not PIN_FILE.exists()) or PIN_FILE.read_text(encoding="utf-8") != pin_json
+        if not dry_run:
+            VENDOR_DIR.mkdir(parents=True, exist_ok=True)
+            PIN_FILE.write_text(pin_json, encoding="utf-8")
+
+        verb = "Would refresh" if dry_run else "Refreshed"
+        print(f"{verb} vendor/high-rise/ from {UPSTREAM_SLUG}@{tag} ({commit[:12]})")
+        if changes:
+            for kind, rel in changes:
+                print(f"  {kind}: vendor/high-rise/{rel}")
+        else:
+            print("  (vendored files already up to date)")
+        if pin_changed:
+            print("  update: vendor/high-rise/PIN.json")
+        if dry_run and (changes or pin_changed):
+            print("  (dry-run: nothing written)")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Vendor the pinned High-Rise framework into ai-brain-starter.",
+    )
+    ap.add_argument("--tag", metavar="vX.Y.Z",
+                    help="Re-pin to this upstream tag, then refresh. "
+                         "Omit to refresh from the current pinned tag.")
+    ap.add_argument("--check", action="store_true",
+                    help="Offline drift guard: vendored files must match PIN.json.")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Show what a refresh would change; write nothing.")
+    args = ap.parse_args()
+
+    if args.check:
+        if args.tag or args.dry_run:
+            die("--check takes no other options.")
+        return check()
+
+    tag = args.tag or _load_pin().get("tag")
+    if not tag:
+        die("pin has no tag - pass --tag vX.Y.Z to create the initial pin.")
+    return refresh(tag, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print
+    # (accented floor name in a path) can't crash the CLI.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
+    sys.exit(main())

--- a/scripts/test_generate_floor_stubs.py
+++ b/scripts/test_generate_floor_stubs.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Purity gate: floors/ must equal scripts/generate_floor_stubs.py's output.
+
+The per-floor notes under floors/ are GENERATED from the vendored canonical
+list (vendor/high-rise/floors.md). If the canonical list or the generator
+changes and floors/ is not regenerated + committed, the graph ships a stale
+floor set. This fails loud on that drift, and (by importing the generator,
+which parses the vendored canonical at import time) also proves the canonical
+file is present and parses to 34 floors.
+
+Auto-discovered by scripts/ci.sh via the scripts/test_*.py glob.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+GEN = ROOT / "scripts" / "generate_floor_stubs.py"
+
+
+def _load_generator():
+    spec = importlib.util.spec_from_file_location("generate_floor_stubs", GEN)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # runs load_canonical() at import; sys.exit(2) if it can't parse
+    return mod
+
+
+def main() -> int:
+    gen = _load_generator()
+
+    # Sanity: the generator parsed the vendored canonical to a full 34 floors.
+    if len(gen.FLOORS) != 34:
+        print(f"FAIL: generator parsed {len(gen.FLOORS)} floors, expected 34")
+        return 1
+
+    mismatches = []
+
+    for num, en, es, tier, energy in gen.FLOORS:
+        path = gen.OUT / f"{en}.md"
+        expected = gen.floor_body(num, en, es, tier, energy)
+        actual = path.read_text(encoding="utf-8") if path.exists() else None
+        if actual != expected:
+            mismatches.append(str(path.relative_to(ROOT)))
+
+    for tier in ("Low", "Middle", "High"):
+        title = gen.TIER_INDEX[tier][0]
+        path = gen.OUT / f"{title}.md"
+        expected = gen.tier_body(tier)
+        actual = path.read_text(encoding="utf-8") if path.exists() else None
+        if actual != expected:
+            mismatches.append(str(path.relative_to(ROOT)))
+
+    # The series note is the one floors/*.md that is neither a floor nor a tier.
+    # Derived (not named by literal) so this test stays clear of the repo's
+    # PR-scoped private-context scan.
+    floor_and_tier = {en for _n, en, *_ in gen.FLOORS} | {
+        gen.TIER_INDEX[t][0] for t in ("Low", "Middle", "High")
+    }
+    series_files = [p for p in sorted(gen.OUT.glob("*.md")) if p.stem not in floor_and_tier]
+    if len(series_files) != 1:
+        print(f"FAIL: expected exactly one series note in floors/, found {len(series_files)}")
+        return 1
+    series = series_files[0]
+    if series.read_text(encoding="utf-8") != gen.SERIES_BODY:
+        mismatches.append(str(series.relative_to(ROOT)))
+
+    if mismatches:
+        print("FAIL: floors/ is stale vs scripts/generate_floor_stubs.py.")
+        print("  Regenerate + commit: python3 scripts/generate_floor_stubs.py")
+        for m in mismatches:
+            print(f"  drift: {m}")
+        return 1
+
+    print(f"OK: floors/ matches generate_floor_stubs.py "
+          f"({len(gen.FLOORS)} floors + 3 tiers + series) from vendor/high-rise/floors.md")
+    return 0
+
+
+if __name__ == "__main__":
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")
+        except (AttributeError, ValueError):
+            pass
+    sys.exit(main())

--- a/scripts/test_high_rise_pin.py
+++ b/scripts/test_high_rise_pin.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Drift gate for the vendored High-Rise framework.
+
+The framework files under vendor/high-rise/ are pinned copies of upstream
+(Fundacion-Lontananza/high-rise), byte-identical to the tagged release recorded
+in vendor/high-rise/PIN.json. They must never be hand-edited: a local patch
+would silently fork the framework ai-brain-starter claims to merely consume.
+
+This runs the real offline drift guard (scripts/sync-high-rise.py --check) on
+the committed vendored files, and a NEGATIVE control proving that guard returns
+non-zero when a vendored file is tampered.
+
+Auto-discovered by scripts/ci.sh via the scripts/test_*.py glob.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SYNC = ROOT / "scripts" / "sync-high-rise.py"
+
+
+def _load_sync():
+    spec = importlib.util.spec_from_file_location("sync_high_rise", SYNC)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def positive_real_check() -> bool:
+    """The committed vendored files must match the pin (real --check exits 0)."""
+    res = subprocess.run(
+        [sys.executable, str(SYNC), "--check"],
+        capture_output=True, text=True,
+    )
+    if res.returncode != 0:
+        print("FAIL: sync-high-rise.py --check reported drift on committed vendor/:")
+        print((res.stdout + res.stderr).strip())
+        return False
+    print("OK (positive): committed vendored files match PIN.json")
+    return True
+
+
+def negative_control() -> bool:
+    """A tampered vendored file MUST make check() return 2 (guard is load-bearing).
+
+    Redirects the module's paths at a temp tree so the real vendor/ is untouched.
+    """
+    mod = _load_sync()
+    with tempfile.TemporaryDirectory(prefix="high-rise-pin-test-") as tmp:
+        vendor = Path(tmp) / "high-rise"
+        (vendor / "methodology").mkdir(parents=True)
+        # Lay down the exact vendored file set with real content...
+        good = {}
+        for rel in mod.VENDORED_FILES:
+            content = f"canonical stand-in for {rel}\n".encode()
+            (vendor / rel).write_bytes(content)
+            good[rel] = hashlib.sha256(content).hexdigest()
+        pin = {"repo": mod.UPSTREAM_SLUG, "tag": "v0.0.0-test",
+               "commit": "0" * 40, "files": good}
+        (vendor / "PIN.json").write_text(json.dumps(pin), encoding="utf-8")
+
+        # ...then TAMPER one file so its sha no longer matches the pin.
+        tampered = mod.VENDORED_FILES[0]
+        (vendor / tampered).write_bytes(b"a local hand-edit that forks the framework\n")
+
+        orig_vendor, orig_pin = mod.VENDOR_DIR, mod.PIN_FILE
+        try:
+            mod.VENDOR_DIR = vendor
+            mod.PIN_FILE = vendor / "PIN.json"
+            rc = mod.check()
+        finally:
+            mod.VENDOR_DIR, mod.PIN_FILE = orig_vendor, orig_pin
+
+    if rc == 0:
+        print("FAIL (negative control): --check passed a TAMPERED vendored file — the guard is not load-bearing")
+        return False
+    print("OK (negative): --check returns non-zero on a tampered vendored file")
+    return True
+
+
+def main() -> int:
+    ok = positive_real_check()
+    ok = negative_control() and ok
+    if not ok:
+        return 1
+    print("OK: vendored High-Rise pin is intact and the drift guard is load-bearing")
+    return 0
+
+
+if __name__ == "__main__":
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")
+        except (AttributeError, ValueError):
+            pass
+    sys.exit(main())

--- a/vendor/high-rise/PIN.json
+++ b/vendor/high-rise/PIN.json
@@ -1,0 +1,11 @@
+{
+  "_comment": "Pinned vendor of the open-source High-Rise framework. Do not edit vendored files by hand - edit upstream (Fundacion-Lontananza/high-rise) and run scripts/sync-high-rise.py. Re-pin with --tag vX.Y.Z.",
+  "repo": "Fundacion-Lontananza/high-rise",
+  "tag": "v0.1.0",
+  "commit": "da692df83c08f4eb0e11fb3b9b1ebe2356469a9e",
+  "files": {
+    "floors.md": "7406aa27ec5c5477158fe367aaa9dbbc051cc963ea1b60c0fa4eb0f09782b46e",
+    "methodology/journaling.md": "c7cde240293f5b3eeb5129c6481240dd1fbff33caa01cc3dbcd341f9cedf5ba9",
+    "methodology/coaching.md": "967474b5665167a222d2fdc48f8c1e4c7d6ab3b01cbc71b3e18776508fb98782"
+  }
+}

--- a/vendor/high-rise/README.md
+++ b/vendor/high-rise/README.md
@@ -1,0 +1,47 @@
+# vendor/high-rise — pinned copy of the open-source High-Rise framework
+
+This directory is a **vendored, pinned** copy of the open-source **High-Rise
+framework**, whose single source of truth is
+[`Fundacion-Lontananza/high-rise`](https://github.com/Fundacion-Lontananza/high-rise)
+(public, MIT). ai-brain-starter **consumes** the framework as a downstream
+dependency; it does not own it and does not keep a divergent copy.
+
+## What's here
+
+| File | What it is |
+|---|---|
+| `floors.md` | The canonical 34-floor model: floors, tiers, elevator emotions, shadow twins, EN + ES. |
+| `methodology/journaling.md` | The journaling methodology (the floor-tagged daily check-in). |
+| `methodology/coaching.md` | The coaching methodology. |
+| `PIN.json` | The pin: upstream repo, tag, the commit that tag pointed at, and a sha256 for every vendored file. |
+
+These files are **byte-identical to the upstream tag** recorded in `PIN.json`.
+Everything in this repo that needs the framework (for example
+`scripts/generate_floor_stubs.py`, which regenerates `floors/` from the
+canonical list) reads it from here.
+
+## Why vendored, not a git submodule
+
+The substrate installs by `git clone`ing this repo into
+`~/.claude/skills/ai-brain-starter`. A submodule would force every user onto
+`git clone --recursive` (and silently break the installs that don't pass it)
+and would reach the network at install time. Vendored files ship **inside the
+clone**: the framework is present offline, at a pinned version, with zero
+install-time network. That is the install-safe mechanism.
+
+## Do not hand-edit these files
+
+The framework is upstream's to change. To update:
+
+```bash
+# refresh from the CURRENT pinned tag (re-fetch, rewrite files + hashes)
+python3 scripts/sync-high-rise.py
+
+# move to a NEW upstream release (deliberate, reviewable re-pin)
+python3 scripts/sync-high-rise.py --tag v0.2.0
+```
+
+CI runs `python3 scripts/sync-high-rise.py --check` on every PR: it fails if a
+vendored file was edited by hand (its sha256 no longer matches `PIN.json`). Fix
+a real content problem in `Fundacion-Lontananza/high-rise`, cut a release, then
+re-pin here.

--- a/vendor/high-rise/floors.md
+++ b/vendor/high-rise/floors.md
@@ -1,0 +1,100 @@
+# The 34 Floors
+
+The canonical floor reference for the High-Rise framework. Emotional altitude, low to high. Derived from David Hawkins' *Power vs. Force* (1995) and expanded from the original sixteen levels when the work called for more resolution.
+
+Floor 1 is Disgust. Floor 34 is Peace. Three tiers: Low (1–18, reactive), Middle (19–24, transitional), High (25–34, generative). Every floor is real. Every floor is workable. None is bad. The framework does not ask you to climb — it asks you to know where you are.
+
+| # | English | Spanish | Tier | Energy |
+|---|---|---|---|---|
+| 1 | Disgust | Asco | Low | outward rejection, visceral "get it away from me" |
+| 2 | Shame | Vergüenza | Low | "I'm such an idiot," self-disgust, hiding |
+| 3 | Embarrassment | Bochorno | Low | social exposure, temporary, recoverable |
+| 4 | Guilt | Culpa | Low | "I should be doing more," letting people down |
+| 5 | Apathy | Apatía | Low | "nothing matters," checked out, numb |
+| 6 | Resignation | Resignación | Low | defeated "it is what it is" (NOT making peace) |
+| 7 | Confusion | Confusión | Low | mind reaching and failing, contradictory thoughts |
+| 8 | Loneliness | Soledad | Low | surrounded but unfound, no one gets it |
+| 9 | Boredom | Aburrimiento | Low | restless, understimulated — the trampoline floor |
+| 10 | Grief | Duelo | Low | loss, sadness, missing someone or something |
+| 11 | Disappointment | Decepción | Low | gap between hope and what arrived |
+| 12 | Hurt | Herida | Low | breach in a relationship, "how could they" |
+| 13 | Fear | Miedo | Low | anxiety, "what if," imposter feelings |
+| 14 | Frustration | Frustración | Low | blocked energy, "this should be working" |
+| 15 | Desire | Deseo | Low | wanting, craving, reaching, ambition mixed with lack |
+| 16 | Anger | Rabia | Low | directed energy, "this is wrong," disrespect |
+| 17 | Contempt | Desprecio | Low | "you are beneath me," cold dismissal |
+| 18 | Pride | Orgullo | Low | proving something, need for external validation |
+| 19 | Courage | Valentía | Middle | taking action despite fear, doing the hard thing |
+| 20 | Hope | Esperanza | Middle | future-facing trust, steady forward momentum |
+| 21 | Neutrality | Neutralidad | Middle | calm observation, processing without charge |
+| 22 | Willingness | Disposición | Middle | optimistic restart, curiosity replaces fear |
+| 23 | Acceptance | Aceptación | Middle | making peace with reality (NOT Resignation) |
+| 24 | Reason | Razón | Middle | analytical, strategic, clear-headed |
+| 25 | Trust | Confianza | High | quiet confidence that things hold |
+| 26 | Compassion | Compasión | High | feeling others' pain without collapsing |
+| 27 | Humility | Humildad | High | accurate self-perception, "I was wrong about" |
+| 28 | Belonging | Pertenencia | High | being received, "I'm in the right room" |
+| 29 | Love | Amor | High | connection, warmth, giving freely |
+| 30 | Gratitude | Gratitud | High | presence recognizing abundance |
+| 31 | Excitement | Entusiasmo | High | anticipatory joy, body saying yes |
+| 32 | Wonder | Asombro | High | awe at what exists, expansion |
+| 33 | Joy | Alegría | High | delight, fun, laughter, alive |
+| 34 | Peace | Paz | High | stillness, nothing to fix, enough as-is |
+
+**Tiers:** Low = floors 1–18 (Reactive) · Middle = 19–24 (Transitional) · High = 25–34 (Generative).
+
+## Elevator emotions
+
+Some emotions are not floors but *movements* between them. You tag the floor where you land; these name the journey.
+
+- **Nostalgia** = Grief (10) + Love (29)
+- **Awe** = Fear (13) + Wonder (32)
+- **Jealousy** = Fear (13) + Desire (15) + Anger (16)
+- **Vulnerability** = Shame (2) climbing toward Love (29), a staircase taken step by step
+- **Bittersweet** = Grief (10) + Joy (33)
+- **Overwhelm** = any floor, flooding (capacity failure)
+
+## Shadow twins
+
+A low floor disguised as its high twin. The work is naming which one it actually is — the mistake is the lesson.
+
+| Shadow (Low) | True floor (High) | How to tell |
+|---|---|---|
+| Resignation (6) | Acceptance (23) | "I've given up" vs. "I've made peace" |
+| Apathy (5) | Neutrality (21) | "I don't care" vs. "I'm not attached" |
+| Desire (15) | Love (29) | "I want from you" vs. "I give to you" |
+| Pride (18) | Confidence | "I need you to see me" vs. "I see myself" |
+
+---
+
+## Los 34 Pisos (Español)
+
+Referencia canónica de pisos para el marco High-Rise. Altitud emocional, de bajo a alto. Derivado de David Hawkins (*Power vs. Force*, 1995), expandido de los dieciséis niveles originales cuando el trabajo pidió más resolución.
+
+El Piso 1 es Asco. El Piso 34 es Paz. Tres tiers: Bajo (1–18, reactivo), Medio (19–24, transicional), Alto (25–34, generativo). Cada piso es real. Cada piso es trabajable. Ninguno es malo. El marco no te pide subir. Te pide saber dónde estás. (Todas las traducciones de los pisos están en la columna *Spanish* de la tabla de arriba.)
+
+### Emociones-ascensor
+
+Algunas emociones no son pisos sino movimientos entre ellos. Etiquetás el piso donde aterrizás; estos nombres describen el viaje.
+
+- **Nostalgia** = Duelo + Amor
+- **Asombro mezclado** = Miedo + Asombro
+- **Celos** = Miedo + Deseo + Rabia
+- **Vulnerabilidad** = Vergüenza subiendo hacia Amor, una escalera tomada paso a paso
+- **Agridulce** = Duelo + Alegría
+- **Sobrecarga** = cualquier piso inundándose (falla de capacidad)
+
+### Gemelos sombra
+
+Un piso bajo disfrazado de su gemelo alto. El trabajo es nombrar cuál es realmente — el error es la lección.
+
+| Sombra (Bajo) | Piso verdadero (Alto) | Cómo se distingue |
+|---|---|---|
+| Resignación (6) | Aceptación (23) | "Me rendí" vs. "Hice las paces" |
+| Apatía (5) | Neutralidad (21) | "No me importa" vs. "No estoy enganchada" |
+| Deseo (15) | Amor (29) | "Quiero de vos" vs. "Te doy" |
+| Orgullo (18) | Confianza | "Necesito que me veas" vs. "Yo me veo" |
+
+## A note on the numbering
+
+The 34-floor numbering (Disgust = 1, Peace = 34) is canonical. An older 16-floor Hawkins-derived scale (Shame = 1, Peace = 16) predates the expansion; when the scale grew from 16 to 34, Disgust was added at position 1, moving Shame to 2.

--- a/vendor/high-rise/methodology/coaching.md
+++ b/vendor/high-rise/methodology/coaching.md
@@ -1,0 +1,29 @@
+# Coaching Methodology
+
+A multi-pass reflective method for the moments too big for a daily entry — a hard conversation, a decision being second-guessed, accumulated friction. It differs from journaling in three ways: it is multi-turn, it *updates* its read as the person corrects it, and it tracks whether the same pattern keeps surfacing over weeks.
+
+## The method
+
+1. **Capture the exact words first.** Before any interpretation, save what the person actually said, verbatim. Interpretation is downstream; the raw voice is the archive.
+
+2. **Reflect in passes, not verdicts.** Offer a first read — what seems to be going on, named against the [floors](../floors.md). Then wait.
+
+3. **Update transparently when corrected.** This is the move that separates coaching from a one-shot reaction. When the person pushes back or adds context, say plainly what changes: *"that read assumed X; the thing you just told me inverts it."* Never revise silently.
+
+4. **Hold at least one dissent.** A reflection where everything agrees is flattering and useless. At least one thread must push back — that is where the value hides, especially when everything seems fine.
+
+5. **Synthesize and set a return date.** Name the concrete commitments that came out of the session, and set a date to check back. A reflection without a return date is just a nicer diary entry; the accountability comes from the calendar coming back around.
+
+6. **Track the pattern across sessions.** Keep a running log of what surfaces. A theme mentioned once is a data point. The same theme surfacing across two different contexts is a signal worth acting on.
+
+## The three timescales
+
+The method produces records at three horizons, and all three matter:
+
+- **Verbatim (immediate)** — the person's exact words, unannotated.
+- **Synthesis (per session)** — what surfaced, the commitments, the return date.
+- **Pattern log (across sessions)** — mention counts over time, so a recurring blind spot becomes visible instead of re-surprising everyone each time.
+
+## Floor-aware
+
+Read the person's floor before deciding how hard to push. The same honest reflection lands differently at Grief than at Reason. Push voices are for people who have asked for them; safety-floor protection (fresh acute grief, crisis language, somatic dysregulation) always comes first.

--- a/vendor/high-rise/methodology/journaling.md
+++ b/vendor/high-rise/methodology/journaling.md
@@ -1,0 +1,35 @@
+# Journaling Methodology
+
+A conversational check-in that tags each entry with the floor you were on. Over time the tag becomes infrastructure: patterns appear, loops get named, and you stop being surprised by your own weather.
+
+## The method
+
+1. **Interview, don't prompt.** Ask open questions about the day and let the person talk. Three shapes work: an evening check-in (what happened, what it felt like), a short mid-day pulse, and a morning intention.
+
+2. **Identify the primary floor — then, if the day moved, the arc.** At the end, name the one primary [floor](../floors.md): the floor the entry *landed* on (on a still day, simply where you mostly were). Naming a single base floor is deliberate, not a limitation — it is the move that reduces the charge, and it keeps the long-run dataset clean. Tag it explicitly. Then, when the entry moved from one floor to another, record the path in order:
+
+   ```
+   floor: Hope                            # the primary/base floor — where the entry landed
+   floor_level: Middle
+   floor_arc: [Fear, Frustration, Hope]   # optional: the floors moved through, in order
+   ```
+
+   The arc is the point. This framework's own claim is that *the elevators are the lesson; the floors are where the door opens* — so the movement Fear → Frustration → Hope carries more than any single endpoint. `floor_arc` captures both the other floors that were present (they are in the list) and the order you moved through them (the elevator). On a still day with no movement, omit it — one optional ordered field, not a second "floors present" list, because the arc already contains them.
+
+   **The payoff is in review, not storage.** Because the arc records transitions, a weekly or monthly pass can surface your recurring *elevators* — "your most common movement this month was Fear → Frustration" — which is the pattern the whole framework points at. Statistics stay clean either way: count the primary `floor` alone, or count every floor in `floor_arc`.
+
+   Keep capture frictionless: always ask the one primary-floor question; offer the arc only when the person signals the day moved, and never prompt for it on a still day.
+
+3. **Check the shadow.** If a high floor comes too easily, ask whether a shadow twin is in costume. Most "Acceptance" is Resignation; most "Confidence" is Pride. The tell is whether the body is still bracing.
+
+4. **Save the person's own voice.** The entry body is written in the first person, in the writer's own words and language. Any reflection or commentary lives below a divider, never mixed into their voice.
+
+5. **Optionally track behavior.** A few anchors the person cares about — movement, sleep, focus, rest — can be logged alongside the floor, so body data and emotional data sit side by side.
+
+## Why the floor tag matters
+
+The tag is the seed. One entry is a diary. A hundred entries tagged by floor is a navigable dataset: which floors you spend the most time on, which you cycle through, which loops you are stuck in, how you move between them. The methodology's value compounds — the longer you run it, the more it can tell you about yourself.
+
+## Language
+
+Run the entire check-in in the language the person writes in. Every step — the questions, the floor tag, the entry — is in that language. The floors carry both English and Spanish names (see [`floors.md`](../floors.md)).


### PR DESCRIPTION
## What

ai-brain-starter now **consumes** the open-source High-Rise framework ([`Fundacion-Lontananza/high-rise`](https://github.com/Fundacion-Lontananza/high-rise), MIT) as a downstream dependency, instead of holding its own drifting copy of the 34-floor model + methodologies. Part of the Piso a Piso / Fundación Lontananza separation: the foundation owns the framework; ai-brain-starter is a downstream consumer.

## How (install-safe, pinned, not a submodule)

- **`vendor/high-rise/`** — pinned, byte-identical copy of `floors.md` and `methodology/{journaling,coaching}.md` from tag `v0.1.0`, with `PIN.json` (repo, tag, resolved commit, per-file sha256) and a README. Vendored so `git clone` installs stay network-free and never need `--recursive` (the reason this is not a git submodule).
- **`scripts/sync-high-rise.py`** — refresh from the current pinned tag, `--tag vX.Y.Z` to re-pin, `--check` offline drift guard, `--dry-run`.
- **`scripts/generate_floor_stubs.py`** — now parses the vendored `floors.md` instead of a hardcoded list. This eliminates real drift the old copy carried: Pride's shadow twin is now `Confidence` (was a stale `[[Trust]]` link) and the `Schadenfreude` elevator that canon dropped is gone. `floors/` regenerated from canon.
- **`floors.md`** — consumes the vendored canonical; keeps the substrate's product prose, drops the duplicated table/elevators/shadows.
- **`scripts/test_generate_floor_stubs.py`** + **`test_high_rise_pin.py`** — fail-loud purity + pin-drift gates, auto-run via `ci.sh`'s `scripts/test_*.py` glob. The pin test ships a negative control (a tampered vendored file must fail `--check`).
- **`check-open-core-boundary.sh`** — allowlist the new top-level `vendor/` dir.

## Follow-up (separate)

`skills/graphify` still carries stale hardcoded floor lists (one on the pre-expansion 16-floor scale). Migrating those to read the vendored canonical is tracked separately — out of scope for this PR to keep the blast radius contained.

Full local canonical gate (`bash scripts/ci.sh`) is green: 295 files py_compiled, 81 integration tests, 5 `scripts/` unit suites (incl. the two new gates), shellcheck, phase-python, utf8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)