### PR TITLE
feat(hookify-rules): universal delegated-task-needs-source guard

### DIFF
--- a/templates/hookify-rules/README.md
+++ b/templates/hookify-rules/README.md
@@ -45,6 +45,7 @@ Your message when this rule triggers.
 | `public-repo-firewall` | block | Personal names/data leaking into public repos |
 | `dangerous-rm` | block | `rm -rf` commands without confirmation |
 | `warn-filesystem-walk-without-bounded-read` | warn | Recursive Python content walkers missing the shared bounded read |
+| `warn-delegated-task-needs-source` | warn | Delegated to-do (`[owner:: …]`) with no `[[link]]` or URL to its brief/source |
 
 ## Authoring guide and regression harness
 

--- a/templates/hookify-rules/hookify.warn-delegated-task-needs-source.local.md
+++ b/templates/hookify-rules/hookify.warn-delegated-task-needs-source.local.md
@@ -1,0 +1,26 @@
+---
+name: warn-delegated-task-needs-source
+enabled: true
+event: file
+action: warn
+conditions:
+  - field: file_path
+    operator: regex_match
+    pattern: '(to-?dos?|tasks?|delegation|backlog)[^/]*\.md$'
+  - field: content
+    operator: regex_match
+    pattern: '- \[ \](?:(?!\[\[|https?://|\n).)*\[owner::\s*[^\]]+\](?:(?!\[\[|https?://|\n).)*(?=\n|$)'
+---
+
+**Delegated task without a self-contained source.** This line has an `[owner::]` (you are handing it to someone) but no `[[wikilink]]` or URL pointing to the brief, source, or deliverable.
+
+A task that routes the assignee back to a person for the input ("ask Sam for the link", "pídele el doc a la manager") creates a dependency chain: they ask, you forget, the task dies. Every delegated task should be executable by someone with no access to you.
+
+**Minimum Viable Delegation** — each delegated task line should carry at least one link to:
+- a brief or playbook,
+- the source doc (list, tracker, spec), or
+- where the deliverable goes.
+
+Then check the four corners: **Source** (where the input lives), **Location** (where the output goes), **Shape** (what "done" looks like), **Channel** (how to report back). If any is missing, add it before filing.
+
+*Scope:* fires on to-do / task / delegation / backlog files, on any `[owner:: …]` line with no link. Customize the filename pattern or owner field for your vault, or set `action: block` if you want it enforced hard. This is the generic version of a delegated-task-quality rule; the specific names, paths, and tools stay in your own vault.


### PR DESCRIPTION
Adds a universal, opt-in hookify template rule to `templates/hookify-rules/`.

**What it catches:** a delegated to-do line — one with an `[owner:: …]` field — that has no `[[wikilink]]` or URL pointing to its brief, source, or deliverable. Routing the assignee back to a person for the input creates a dependency chain that quietly dies. The rule nudges toward Minimum Viable Delegation (Source / Location / Shape / Channel).

**Generic by construction:** name-agnostic owner field, bilingual-aware guidance, honors both wikilinks and URLs as valid sources, scoped to to-do / task / delegation / backlog files. No project- or person-specific content.

**Verified:** fire/silent across 7 cases against the real hookify engine (name variants incl. accented, wikilink + URL negatives, non-task-file + no-owner negatives). Local CI-parity gate green (marker 380b2980).

🤖 Generated with [Claude Code](https://claude.com/claude-code)