### PR TITLE
feat(hookify-rules): auto-activate warn-delegated-task-needs-source + integration test

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -170,6 +170,7 @@ INTEGRATION_TESTS=(
   test_resource_aware_session_close
   test_cloud_sync_guard
   test_cloud_safe_file_walkers
+  test_delegated_task_needs_source
   test_cloud_sync_offer
   test_worktree_on_vault_guard
   test_machinery_sidecar

--- a/scripts/install-hooks-user-level.py
+++ b/scripts/install-hooks-user-level.py
@@ -47,6 +47,7 @@ import argparse
 import json
 import os
 import re
+import shutil
 import sys
 import time
 from datetime import datetime
@@ -744,6 +745,119 @@ def link_agent_memory_into_vault(vault_path: str, quiet: bool) -> None:
             print(result.stderr, file=sys.stderr)
 
 
+def _hookify_templates_dir(hooks_template_path: Path) -> Path:
+    """The shipped hookify-rule templates live beside hooks.json at the repo root."""
+    return hooks_template_path.resolve().parent / "templates" / "hookify-rules"
+
+
+def activate_default_hookify_rules(
+    templates_dir: Path,
+    config_dir: Path,
+    *,
+    dry_run: bool,
+    quiet: bool,
+    fail_on_missing: bool,
+) -> int:
+    """Copy the activate-by-default hookify rule templates into config_dir (~/.claude).
+
+    Reproducible activation for substrate rules that should fire on every install
+    (warn-delegated-task-needs-source). Without this a rule template merged into
+    the repo only fires on a machine where someone hand-copied it — the
+    DEPLOYED-not-COMMITTED-not-WORKING gap for hookify rules.
+
+    Contract:
+      - templates/hookify-rules/activation.json's 'default' list names the rules
+        that auto-activate; everything else is opt-in (manual cp).
+      - COPY-IF-ABSENT: an existing destination is never overwritten, so a user's
+        customized rule (the README tells them to customize) survives re-install
+        and the daily update run.
+      - Fail-loud under fail_on_missing ONLY when the manifest PROMISES a
+        default template that is not on disk (governed-set drift: the manifest
+        claims a rule ships, but it does not). A missing or unreadable manifest
+        is treated as "feature unavailable" and skipped, never fatal, so a
+        partial or older checkout still installs its hooks. Outside
+        fail_on_missing a missing default template only warns; rule activation
+        never blocks the core hooks install unless asked to fail closed on a
+        broken promise.
+
+    Returns 0 normally, 1 only under fail_on_missing when the manifest names a
+    default template that is missing on disk.
+    """
+    manifest_path = templates_dir / "activation.json"
+    if not manifest_path.is_file():
+        # No manifest: this checkout predates the activation feature (or is a
+        # minimal fixture). Activation is additive, so skip and never block the
+        # hooks install -- even under --fail-on-missing, which is about missing
+        # hook SCRIPTS, not this optional feature. Fail-loud is reserved for a
+        # manifest that PROMISES a default template it does not ship (below).
+        if not quiet:
+            print(
+                f"Hookify rules: no activation manifest at {manifest_path}; "
+                "skipping activation.",
+                file=sys.stderr,
+            )
+        return 0
+
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as e:
+        if not quiet:
+            print(
+                f"Hookify rules: could not read activation manifest {manifest_path}: "
+                f"{e}; skipping activation.",
+                file=sys.stderr,
+            )
+        return 0
+
+    default_rules = list(manifest.get("default", []))
+    copied: list[str] = []
+    already: list[str] = []
+    missing: list[str] = []
+    for name in default_rules:
+        src = templates_dir / name
+        if not src.is_file():
+            missing.append(name)
+            continue
+        dest = config_dir / name
+        if dest.exists():
+            already.append(name)
+            continue
+        if not dry_run:
+            try:
+                config_dir.mkdir(parents=True, exist_ok=True)
+                shutil.copyfile(src, dest)
+            except OSError as e:
+                # A filesystem error copying one rule must not abort the core
+                # hooks install (activation is best-effort). Warn and move on.
+                if not quiet:
+                    print(f"  WARNING: could not activate {name}: {e}", file=sys.stderr)
+                continue
+        copied.append(name)
+
+    if missing and fail_on_missing:
+        print(
+            "ERROR: hookify activation manifest names default template(s) missing "
+            f"on disk: {', '.join(missing)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not quiet:
+        verb = "Would activate" if dry_run else "Activated"
+        print(
+            f"Hookify rules: {verb} {len(copied)} default rule(s), "
+            f"{len(already)} already present in {config_dir}"
+        )
+        marker = "~" if dry_run else "+"
+        for name in copied:
+            print(f"  {marker} {name}")
+    if missing and not quiet:
+        for name in missing:
+            print(f"  WARNING: default template missing, skipped: {name}", file=sys.stderr)
+
+    return 0
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--dry-run", action="store_true")
@@ -827,6 +941,23 @@ def main() -> int:
                     print(f"Backup at {backup}")
             return 0
         return 2
+
+    # === activate default hookify rules (reproducible activation) ===
+    # Independent of the settings-merge below: copies the activate-by-default rule
+    # templates into ~/.claude so a rule merged into the repo actually fires on a
+    # fresh machine (not only where someone hand-copied it). Runs on every install
+    # invocation — even when the hooks are already in sync — so the two concerns
+    # (settings.json wiring vs rule-file presence) can never drift. Copy-if-absent,
+    # so it never clobbers a user's customized rule.
+    rc = activate_default_hookify_rules(
+        _hookify_templates_dir(hooks_template_path),
+        settings_path.parent,
+        dry_run=args.dry_run,
+        quiet=args.quiet,
+        fail_on_missing=args.fail_on_missing,
+    )
+    if rc != 0:
+        return rc
 
     # === install / update path ===
     merged, summary = merge_hooks(existing, template)

--- a/templates/hookify-rules/README.md
+++ b/templates/hookify-rules/README.md
@@ -12,6 +12,23 @@ These are example rules for the [hookify plugin](https://github.com/anthropics/c
 3. Customize the patterns and messages for your context
 4. Rules are active immediately, no restart needed
 
+## Automatic activation
+
+Most templates here are opt-in: they do nothing until you run the `cp` command
+above. A small activate-by-default subset is different. The installer
+(`scripts/install-hooks-user-level.py`, which `bootstrap.sh` runs) copies that
+subset into `~/.claude/` on every install, so those rules fire on a fresh machine
+with no manual step.
+
+Which templates auto-activate is declared in [`activation.json`](activation.json).
+The `default` list is copied on install; everything in `opt_in` stays manual. The
+copy is copy-if-absent, so if you have already customized a rule in `~/.claude/`,
+re-installing never overwrites your version.
+
+Every `hookify.*.local.md` in this directory must be classified in exactly one of
+those two lists. Adding a template without classifying it (or listing one that does
+not exist) fails the CI test `tests/integration/test_delegated_task_needs_source.sh`.
+
 ## Rule types
 
 - **block**: Prevents the operation entirely. Use for hard rules (wrong facts, personal data leaks)
@@ -45,7 +62,7 @@ Your message when this rule triggers.
 | `public-repo-firewall` | block | Personal names/data leaking into public repos |
 | `dangerous-rm` | block | `rm -rf` commands without confirmation |
 | `warn-filesystem-walk-without-bounded-read` | warn | Recursive Python content walkers missing the shared bounded read |
-| `warn-delegated-task-needs-source` | warn | Delegated to-do (`[owner:: …]`) with no `[[link]]` or URL to its brief/source |
+| `warn-delegated-task-needs-source` | warn | Delegated to-do (`[owner:: …]`) with no `[[link]]` or URL to its brief/source. **Auto-activated on install** (see [Automatic activation](#automatic-activation)). |
 
 ## Authoring guide and regression harness
 

--- a/templates/hookify-rules/activation.json
+++ b/templates/hookify-rules/activation.json
@@ -1,0 +1,18 @@
+{
+  "description": "Which hookify rule templates the ai-brain-starter installer (scripts/install-hooks-user-level.py, invoked by bootstrap.sh) auto-activates by copying into ~/.claude/. 'default' rules are copied on every install, copy-if-absent so a user's customized copy is never overwritten. 'opt_in' rules stay documentation-only until the user copies them by hand (see README.md). EVERY hookify.*.local.md in this directory MUST appear in exactly one list; an unclassified template, a duplicate, or an entry naming a missing file fails tests/integration/test_delegated_task_needs_source.sh. This is the one declaration for the governed set: add a template and classify it in the same change.",
+  "default": [
+    "hookify.warn-delegated-task-needs-source.local.md"
+  ],
+  "opt_in": [
+    "hookify.block-malformed-mcp-json.local.md",
+    "hookify.compress-claude-docs.local.md",
+    "hookify.dangerous-rm.local.md",
+    "hookify.fact-check-template.local.md",
+    "hookify.public-repo-firewall.local.md",
+    "hookify.voice-no-em-dash.local.md",
+    "hookify.voice-no-exclamation.local.md",
+    "hookify.warn-claude-call-without-cache.local.md",
+    "hookify.warn-filesystem-walk-without-bounded-read.local.md",
+    "hookify.warn-rotation-push-on-local-only-leak.local.md"
+  ]
+}

--- a/tests/integration/test_delegated_task_needs_source.sh
+++ b/tests/integration/test_delegated_task_needs_source.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# Reproducible-activation + firing-contract gate for the
+# warn-delegated-task-needs-source hookify rule template. Two halves, each with
+# negative controls, mirroring test_cloud_safe_file_walkers.sh:
+#
+#   A. FIRING CONTRACT - extract the rule's two regex conditions from the shipped
+#      template and run them the way the hookify engine does: re.IGNORECASE +
+#      regex.search, all conditions ANDed (see the plugin's compile_regex +
+#      "all conditions must match"). Proves it fires on a to-do / task /
+#      delegation / backlog file with an [owner:: X] line and no [[link]]/URL;
+#      stays silent when a wikilink or URL is on the line, on a non-task
+#      filename, on an unowned line, and on a checked box; and is name-agnostic
+#      (accented + CJK owner names fire). The IGNORECASE mirror is load-bearing:
+#      the real file is "Team To-dos.md" (capital T) and the pattern is lowercase
+#      to-?dos?, so a case-sensitive test would wrongly read the rule as dead.
+#
+#   B. ACTIVATION - a rule is only useful if it reaches a fresh machine. Proves
+#      activation.json classifies every template exactly once (the one
+#      declaration for the governed set), the rule is in the `default`
+#      (auto-activate) list, and the REAL installer copies the default rule (and
+#      NOT an opt-in one) into a throwaway ~/.claude, preserves a user's
+#      customized copy (copy-if-absent), and fails loud under --fail-on-missing
+#      when the manifest names a template that is not on disk.
+#
+# Stdlib python3 + bash only (no PyYAML, no network, no git). Tmpdir on exit.
+# Run: bash tests/integration/test_delegated_task_needs_source.sh  (0 = pass)
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+RULE="$REPO_ROOT/templates/hookify-rules/hookify.warn-delegated-task-needs-source.local.md"
+INSTALLER="$REPO_ROOT/scripts/install-hooks-user-level.py"
+HOOKS_JSON="$REPO_ROOT/hooks.json"
+DEFAULT_RULE="hookify.warn-delegated-task-needs-source.local.md"
+OPT_IN_RULE="hookify.fact-check-template.local.md"
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS + 1)); echo "PASS  $1"; }
+bad() { FAIL=$((FAIL + 1)); echo "FAIL  $1 :: ${2:-}"; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# ---- A. FIRING CONTRACT ------------------------------------------------------
+echo "=== A. firing contract (regex mirrors hookify: IGNORECASE + search, ANDed) ==="
+
+# A0: rule file contract (name / event / action + the two condition fields).
+if [ -f "$RULE" ] \
+   && grep -q '^name: warn-delegated-task-needs-source$' "$RULE" \
+   && grep -q '^event: file$' "$RULE" \
+   && grep -q '^action: warn$' "$RULE" \
+   && grep -q 'field: file_path' "$RULE" \
+   && grep -q 'field: content' "$RULE"; then
+  ok "rule file contract (name/event/action + file_path & content conditions)"
+else
+  bad "rule file contract" "missing name/event/action or a condition field"
+fi
+
+# A1: positive + negative firing cases, driven off the SHIPPED patterns. Extract
+# both single-quoted YAML patterns with stdlib only (associate each pattern with
+# the most recent `field:`), then run the engine's IGNORECASE + AND semantics.
+if python3 - "$RULE" <<'PY'
+import re, sys
+from pathlib import Path
+
+lines = Path(sys.argv[1]).read_text(encoding="utf-8").splitlines()
+pats, field = {}, None
+for ln in lines:
+    m = re.match(r"\s*-?\s*field:\s*(\S+)", ln)
+    if m:
+        field = m.group(1); continue
+    m = re.match(r"\s*pattern:\s*'(.*)'\s*$", ln)
+    if m and field:
+        pats[field] = m.group(1).replace("''", "'"); field = None
+assert "file_path" in pats and "content" in pats, f"extracted only {sorted(pats)}"
+
+# hookify compile_regex() uses re.IGNORECASE; a rule matches only when ALL of its
+# conditions do (logical AND).
+file_re = re.compile(pats["file_path"], re.IGNORECASE)
+content_re = re.compile(pats["content"], re.IGNORECASE)
+def fires(path, content):
+    return bool(file_re.search(path)) and bool(content_re.search(content))
+
+# Non-ASCII owner names are injected from escapes so this file stays pure ASCII
+# while still proving genuinely accented + CJK names fire (the name-agnostic claim).
+NAMES = {"<ACCENT>": "Jos\u00e9 Garc\u00eda", "<UMLAUT>": "Zo\u00eb M\u00fcller", "<CJK>": "\u7530\u4e2d"}
+def sub(s):
+    for k, v in NAMES.items():
+        s = s.replace(k, v)
+    return s
+
+cases = [
+  # (path, content, expect_fire, label)
+  ("Team To-dos.md",     "- [ ] Call the vendor [owner:: Sam] [area:: ops]",            True,  "todo file + owner, no link -> FIRE"),
+  ("Sprint tasks.md",    "- [ ] Draft the brief [owner:: Alex]",                        True,  "tasks file -> FIRE"),
+  ("delegation.md",      "- [ ] Ship the deck [owner:: Robin]",                         True,  "delegation file -> FIRE"),
+  ("Product backlog.md", "- [ ] Wire the API [owner:: Jordan]",                         True,  "backlog file -> FIRE"),
+  ("todos.md",           "- [ ] Revisar el documento [owner:: <ACCENT>]",              True,  "accented owner -> FIRE (name-agnostic)"),
+  ("tasks.md",           "- [ ] Review [owner:: <UMLAUT>]",                             True,  "diaeresis owner -> FIRE (name-agnostic)"),
+  ("tasks.md",           "- [ ] Review [owner:: <CJK>]",                                True,  "CJK owner -> FIRE (name-agnostic)"),
+  ("Team To-dos.md",     "- [ ] Call vendor [owner:: Sam] see [[Vendor Brief]]",        False, "owner + wikilink -> SILENT"),
+  ("backlog.md",         "- [ ] Ship copy [owner:: Casey] https://example.com/brief",  False, "owner + https URL -> SILENT"),
+  ("delegation.md",      "- [ ] Ship copy [owner:: Casey] http://example.com/b",       False, "owner + http URL -> SILENT"),
+  ("Strategy Notes.md",  "- [ ] Do the thing [owner:: Sam]",                            False, "non-task filename -> SILENT (filename gate)"),
+  ("Team To-dos.md",     "- [ ] Call vendor [area:: ops]",                              False, "no owner -> SILENT"),
+  ("Team To-dos.md",     "- [x] Done [owner:: Sam]",                                    False, "checked box -> SILENT (open tasks only)"),
+  ("Team To-dos.md",     "- [ ] Task A [owner:: Sam]\n- [ ] Task B [owner:: Alex] [[Brief]]",  True,  "per-line: an unlinked line fires even when a sibling has a link"),
+  ("Team To-dos.md",     "- [ ] Task A [owner:: Sam] [[BriefA]]\n- [ ] Task B [owner:: Alex] https://ex.co", False, "every owner line linked -> SILENT"),
+]
+mismatches = [lbl for (p, c, exp, lbl) in cases if fires(p, sub(c)) is not exp]
+if mismatches:
+    print("MISMATCH: " + " | ".join(mismatches), file=sys.stderr)
+    sys.exit(1)
+print(f"{len(cases)} firing cases matched the shipped patterns")
+PY
+then ok "firing cases match shipped patterns (positive + negative controls)"
+else bad "firing cases" "a case disagreed with the shipped regex (see MISMATCH above)"; fi
+
+# ---- B. ACTIVATION -----------------------------------------------------------
+echo "=== B. activation (manifest governs the set; the REAL installer copies default) ==="
+
+# B1: manifest classifies every template exactly once, no dangling entry, no
+# duplicate, and the rule is in the default (auto-activate) list.
+if python3 - "$REPO_ROOT" <<'PY'
+import json, sys
+from pathlib import Path
+
+tdir = Path(sys.argv[1]) / "templates" / "hookify-rules"
+manifest = json.loads((tdir / "activation.json").read_text(encoding="utf-8"))
+default = list(manifest.get("default", []))
+opt_in = list(manifest.get("opt_in", []))
+on_disk = {p.name for p in tdir.glob("hookify.*.local.md")}
+classified = default + opt_in
+declared = set(classified)
+
+problems = []
+dup = {n for n in declared if classified.count(n) > 1}
+if dup:
+    problems.append(f"listed more than once: {sorted(dup)}")
+dangling = declared - on_disk
+if dangling:
+    problems.append(f"manifest names non-existent template(s): {sorted(dangling)}")
+unclassified = on_disk - declared
+if unclassified:
+    problems.append(f"template(s) on disk not classified in the manifest: {sorted(unclassified)}")
+if "hookify.warn-delegated-task-needs-source.local.md" not in default:
+    problems.append("warn-delegated-task-needs-source is not in the default (auto-activate) list")
+if problems:
+    print(" ; ".join(problems), file=sys.stderr)
+    sys.exit(1)
+print(f"manifest clean: {len(default)} default + {len(opt_in)} opt_in = {len(on_disk)} templates, partitioned")
+PY
+then ok "manifest classifies every template exactly once; rule is a default"
+else bad "manifest completeness" "see stderr above"; fi
+
+# B2: the REAL installer copies the default rule into a throwaway ~/.claude and
+# leaves the opt-in templates alone.
+H1="$TMP/home1"; mkdir -p "$H1/.claude"
+HOME="$H1" python3 "$INSTALLER" --hooks-source "$HOOKS_JSON" \
+  --settings "$H1/.claude/settings.json" --quiet >/dev/null 2>&1
+if [ -f "$H1/.claude/$DEFAULT_RULE" ]; then
+  ok "installer activated the default rule into ~/.claude"
+else
+  bad "default rule not activated" "$H1/.claude/$DEFAULT_RULE absent after install"
+fi
+if [ -f "$H1/.claude/$OPT_IN_RULE" ]; then
+  bad "opt-in rule wrongly activated" "$OPT_IN_RULE was copied but is opt-in"
+else
+  ok "installer left the opt-in rule (fact-check-template) alone"
+fi
+
+# B3: copy-if-absent - a user's customized copy is never overwritten on re-install.
+H2="$TMP/home2"; mkdir -p "$H2/.claude"
+printf '%s\n' "CUSTOMIZED BY USER - do not clobber" > "$H2/.claude/$DEFAULT_RULE"
+HOME="$H2" python3 "$INSTALLER" --hooks-source "$HOOKS_JSON" \
+  --settings "$H2/.claude/settings.json" --quiet >/dev/null 2>&1
+if grep -q "CUSTOMIZED BY USER" "$H2/.claude/$DEFAULT_RULE"; then
+  ok "copy-if-absent: a user's customized rule survives re-install"
+else
+  bad "copy-if-absent" "the user's customized rule was overwritten"
+fi
+
+# B4: idempotent - a second install into the same home exits 0 and keeps one copy.
+HOME="$H1" python3 "$INSTALLER" --hooks-source "$HOOKS_JSON" \
+  --settings "$H1/.claude/settings.json" --quiet >/dev/null 2>&1
+rc_second=$?
+count_default=$(find "$H1/.claude" -maxdepth 1 -name "$DEFAULT_RULE" | wc -l | tr -d ' ')
+if [ "$rc_second" -eq 0 ] && [ "$count_default" = "1" ]; then
+  ok "idempotent: second install exits 0 and keeps exactly one copy"
+else
+  bad "idempotent" "rc=$rc_second, copies=$count_default"
+fi
+
+# B5: NEGATIVE CONTROL - a guard earns trust only by failing on the thing it
+# catches. Point the installer at a manifest whose default names a missing
+# template and pass --fail-on-missing: it must exit nonzero AND say why.
+FAKE="$TMP/fakerepo"; mkdir -p "$FAKE/templates/hookify-rules"
+cp "$HOOKS_JSON" "$FAKE/hooks.json"
+cat > "$FAKE/templates/hookify-rules/activation.json" <<'JSON'
+{ "default": ["hookify.does-not-exist.local.md"], "opt_in": [] }
+JSON
+H3="$TMP/home3"; mkdir -p "$H3/.claude"
+ERR3="$TMP/err3.log"
+HOME="$H3" python3 "$INSTALLER" --hooks-source "$FAKE/hooks.json" \
+  --settings "$H3/.claude/settings.json" --fail-on-missing --quiet >/dev/null 2>"$ERR3"
+rc_missing=$?
+if [ "$rc_missing" -ne 0 ] && grep -qi "activation manifest names default template" "$ERR3"; then
+  ok "fail-loud: --fail-on-missing exits nonzero and names the missing default template"
+else
+  bad "fail-loud negative control" "rc=$rc_missing; stderr: $(cat "$ERR3")"
+fi
+
+echo
+echo "=== summary: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes the reproducible-activation + substrate-test gap for the
`warn-delegated-task-needs-source` hookify rule (shipped in #342).

## Why

The template only fired where someone had hand-copied it into `~/.claude`.
Nothing in `bootstrap.sh` or `install-hooks-user-level.py` activated it, so on a
fresh machine the rule was absent (DEPLOYED-not-COMMITTED-not-WORKING for
substrate hookify rules), and it had no committed test.

## Activation

- `templates/hookify-rules/activation.json` is the one declaration classifying
  every `hookify.*.local.md` as `default` (auto-copied on install) or `opt_in`
  (manual `cp`). Only `warn-delegated-task-needs-source` is `default`; the voice
  rules, the `fact-check-template` stub, and `public-repo-firewall` stay opt-in
  so a fresh install never imposes them.
- `install-hooks-user-level.py` (run by `bootstrap.sh`) copies the `default` set
  into `~/.claude` on every install, copy-if-absent so a user's customized rule
  is never clobbered. Fail-loud under `--fail-on-missing` only when the manifest
  promises a `default` template it does not ship; a missing or unreadable
  manifest is skipped, never fatal, so older or partial checkouts still install
  their hooks.

## Test

`tests/integration/test_delegated_task_needs_source.sh`, wired into
`scripts/ci.sh`:

- **Firing contract**: drives the rule's two shipped regexes the way the engine
  does (`re.IGNORECASE` + `search`, conditions ANDed) across 15 positive/negative
  cases. Fires on a to-do / task / delegation / backlog file with an
  `[owner:: X]` line and no `[[link]]`/URL; silent with a wikilink or URL on the
  line, on a non-task filename, an unowned line, or a checked box; name-agnostic
  (accented + CJK owners). The `IGNORECASE` mirror is load-bearing: the real file
  is `Team To-dos.md` (capital T) and the pattern is lowercase.
- **Activation**: the manifest partitions every template exactly once and lists
  the rule as `default`; the real installer copies the default rule (not an
  opt-in one) into a sandbox `~/.claude`, preserves a customized copy, is
  idempotent, and fails loud under `--fail-on-missing` (negative control).

Local `ci-test` is green (`bash scripts/ci.sh`: 82 integration tests +
py_compile + shellcheck + unit suites). Personal-data scrub, open-core-boundary,
and template-purity all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
