### PR TITLE
fix(whatsapp): rename-contacts Swift compile error + robust Contacts-access failure

### DIFF
--- a/scripts/whatsapp/rename-contacts.py
+++ b/scripts/whatsapp/rename-contacts.py
@@ -50,7 +50,8 @@ if not WA_DIR.exists():
 # ── Export contacts from macOS Contacts via Swift ─────────────────────────────
 
 SWIFT = """
-import Contacts, Foundation
+import Contacts
+import Foundation
 let store = CNContactStore()
 let keys = [CNContactGivenNameKey, CNContactFamilyNameKey,
             CNContactOrganizationNameKey, CNContactPhoneNumbersKey] as [CNKeyDescriptor]
@@ -63,7 +64,19 @@ do {
         if name.isEmpty { return }
         for ph in c.phoneNumbers { out += "\\(name)\\t\\(ph.value.stringValue)\\n" }
     }
-} catch { fputs("Error: \\(error)\\n", stderr); exit(1) }
+} catch {
+    // An ad-hoc `swift` script has no app bundle / NSContactsUsageDescription, so
+    // macOS cannot show a consent prompt and TCC attributes access to the parent
+    // (your terminal). Report an access failure distinctly (exit 2) so the caller
+    // can guide the user precisely, instead of matching a locale-dependent string.
+    let status = CNContactStore.authorizationStatus(for: .contacts)
+    if status != .authorized {
+        fputs("CONTACTS_ACCESS_UNAVAILABLE status=\\(status.rawValue)\\n", stderr)
+        exit(2)
+    }
+    fputs("Error: \\(error)\\n", stderr)
+    exit(1)
+}
 print(out, terminator: "")
 """
 
@@ -75,12 +88,20 @@ with tempfile.NamedTemporaryFile(suffix=".swift", mode="w", delete=False) as f:
 result = subprocess.run(["swift", swift_path], capture_output=True, text=True)
 os.unlink(swift_path)
 
+if result.returncode == 2 or "CONTACTS_ACCESS_UNAVAILABLE" in result.stderr:
+    print("\nCould not read Contacts: macOS has not granted Contacts access to this step.")
+    print("This step runs an ad-hoc Swift script, which has no app bundle for macOS to")
+    print("attach a Contacts permission to, so it cannot show you an access prompt. Fix:")
+    print("  1. Open System Settings > Privacy & Security > Contacts")
+    print("  2. Enable access for the terminal app you ran this from (Terminal, iTerm, ...)")
+    print("  3. Re-run this script.")
+    print("If access is already enabled and it still fails, this macOS version blocks")
+    print("ad-hoc scripts from Contacts; the WhatsApp files keep their phone-number names")
+    print("and the rest of the export is unaffected.")
+    sys.exit(1)
+
 if result.returncode != 0:
-    err = result.stderr.strip()
-    print(f"\nCould not read Contacts: {err}")
-    if "Access Denied" in err:
-        print("\nFix: System Settings › Privacy & Security › Contacts")
-        print("     Enable access for Terminal, then re-run.")
+    print(f"\nCould not read Contacts: {result.stderr.strip()}")
     sys.exit(1)
 
 # ── Phone → name lookup ───────────────────────────────────────────────────────


### PR DESCRIPTION
Two macOS bugs in `scripts/whatsapp/rename-contacts.py`, both hit by every fresh install (surfaced from a Second Brain 30X participant run).

## Bug 1: Swift compile error (breaks for everyone)

The emitted Swift opened with `import Contacts, Foundation`. Swift has no comma-separated import, so `swift` errors with `consecutive statements on a line must be separated by ';'` and the step fails to compile before it reads a single contact. Confirmed with the real compiler (Swift 6.3). Fixed by splitting into two `import` lines.

## Bug 2: ad-hoc Swift can't obtain Contacts access, and failed near-silently

An ad-hoc `swift script.swift` has no app bundle and no `NSContactsUsageDescription`, so macOS TCC has nothing to attach a Contacts grant to and cannot show a consent prompt. The old code only recognized denial by matching the literal string `Access Denied` in stderr, which is locale- and version-fragile.

Now the Swift reads `CNContactStore.authorizationStatus` on failure and exits `2` with a stable `CONTACTS_ACCESS_UNAVAILABLE` marker; the Python maps that to a precise, actionable message (grant Contacts to the terminal app you ran it from, then re-run) rather than a near-silent failure. The tool works when the terminal has access and fails loud + clear when it does not.

## Verification

Ran the actually-emitted Swift (string-literal evaluated exactly as the script emits it) on macOS 26 / Swift 6.3: it compiles, interpolates correctly, and reads contacts (authorized path). `py_compile` + full `ci.sh` gate green; the change also removes a non-ASCII `print()`.

## Not in this PR

Making it prompt automatically (a proper signed `.app` bundle with `NSContactsUsageDescription`) is a follow-up — it needs on-machine TCC verification (a real consent click) that can't be done in CI. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
