### PR TITLE
feat(hooks): activate the anti-fabrication guard family + gate landed-state claims

### DIFF
--- a/hooks.json
+++ b/hooks.json
@@ -76,6 +76,17 @@
             "type": "command",
             "command": "if [ -f ~/.claude/skills/ai-brain-starter/hooks/verify-session-close-cascade.py ]; then [PYTHON] ~/.claude/skills/ai-brain-starter/hooks/verify-session-close-cascade.py; else echo '{\"continue\":true,\"suppressOutput\":true}'; fi",
             "statusMessage": "Verifying session-close cascade (advisory unless the cascade is installed)..."
+          },
+          {
+            "_comment": "Anti-fabrication family. Blocks a close that asserts a verification result (deploy / HTTP status / commit / push / PR opened-or-merged) with no tool call in the session that sourced it from the system of record, or that names a hook/rule as having fired when that name is in no tool error. Wired if/then/else (NOT '|| echo') so a real block (the JSON decision) reaches Claude Code instead of being masked. Bypass: FAB_VERIFY_CHECK_BYPASS=1 / FAB_HOOK_CHECK_BYPASS=1.",
+            "type": "command",
+            "command": "if [ -f ~/.claude/skills/ai-brain-starter/hooks/check-fabricated-verification.py ]; then [PYTHON] ~/.claude/skills/ai-brain-starter/hooks/check-fabricated-verification.py; else echo '{\"continue\":true,\"suppressOutput\":true}'; fi",
+            "statusMessage": "Checking closing claims against tool evidence..."
+          },
+          {
+            "type": "command",
+            "command": "if [ -f ~/.claude/skills/ai-brain-starter/hooks/check-fabricated-hook-attribution.py ]; then [PYTHON] ~/.claude/skills/ai-brain-starter/hooks/check-fabricated-hook-attribution.py; else echo '{\"continue\":true,\"suppressOutput\":true}'; fi",
+            "statusMessage": "Checking hook attributions against fire evidence..."
           }
         ]
       }
@@ -106,6 +117,11 @@
           {
             "type": "command",
             "command": "[PYTHON] ~/.claude/skills/ai-brain-starter/hooks/warn-journal-saved-without-context.py 2>/dev/null || echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"allow\"}}'"
+          },
+          {
+            "_comment": "Warn-only. One Bash call chaining git commit/push, gh pr create/merge or gh release after '&&' AND piping to tail/head: '&&' short-circuits, so a truncated tail shows the FAILING step's error text while the agent infers the earlier steps landed. Bypass: CHAINED_STATE_CMD_BYPASS=1.",
+            "type": "command",
+            "command": "[PYTHON] ~/.claude/skills/ai-brain-starter/hooks/warn-chained-state-command-truncated.py 2>/dev/null || echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"allow\"}}'"
           }
         ]
       },

--- a/hooks/check-fabricated-hook-attribution.py
+++ b/hooks/check-fabricated-hook-attribution.py
@@ -1,5 +1,15 @@
 #!/usr/bin/env python3
-"""Stop hook. Block claims like "[X] hook fired" when X is not in recent hookify-blocks.log.
+"""Stop hook. Block claims like "[X] hook fired" when X can't be verified.
+
+Two verification sources — a claim passes if EITHER confirms it:
+  1. hookify-blocks.log — for hookify RULES (they log there as **[name]**).
+  2. This turn's transcript tool errors — for STANDALONE Python hooks, which
+     never touch hookify-blocks.log but DO appear verbatim in the tool error as
+     a `.../hooks/<name>.py` path. Only NON-assistant records (tool results,
+     system) count, so the model can't self-verify by writing the path itself.
+
+Without source 2 the guard false-flags every truthful attribution to a
+standalone hook, and a guard that punishes honesty gets uninstalled.
 
 Bypass: FAB_HOOK_CHECK_BYPASS=1.
 """
@@ -48,18 +58,21 @@ def main() -> None:
     if not claimed:
         sys.exit(0)
     recent = _recent_rule_names()
+    fired_standalone = _standalone_hook_evidence(transcript_path, WINDOW_SEC)
     fabricated = sorted(
-        c for c in claimed if not _matches_any(c, recent)
+        c for c in claimed
+        if not _matches_any(c, recent) and not _matches_any(c, fired_standalone)
     )
     if not fabricated:
         sys.exit(0)
     msg = (
-        f"Hook attribution check: assistant claims {fabricated} fired, but no matching "
-        f"rule name appears in ~/.claude/hookify-blocks.log within last "
-        f"{WINDOW_SEC // 60} minutes. Recent fires: "
-        f"{sorted(recent) or 'none'}. Either quote the verbatim rule name from the actual "
-        f"tool error in this turn, or say 'a hookify rule blocked this' without naming a "
-        f"specific rule. Bypass for forensic discussion: FAB_HOOK_CHECK_BYPASS=1."
+        f"Hook attribution check: assistant claims {fabricated} fired, but that name is "
+        f"neither in ~/.claude/hookify-blocks.log nor present as a `.../hooks/<name>.py` "
+        f"path in this turn's tool errors, within the last {WINDOW_SEC // 60} minutes. "
+        f"Recent hookify fires: {sorted(recent) or 'none'}; standalone-hook fires: "
+        f"{sorted(fired_standalone) or 'none'}. Either quote the verbatim rule/hook name "
+        f"from the actual tool error in this turn, or say 'a hook blocked this' without "
+        f"naming a specific one. Bypass for forensic discussion: FAB_HOOK_CHECK_BYPASS=1."
     )
     print(json.dumps({"decision": "block", "reason": msg}))
     sys.exit(0)
@@ -137,6 +150,42 @@ def _recent_rule_names() -> set:
                 msg_field = "\t".join(parts[4:])
                 m = re.search(r"\*\*\[([a-z0-9][a-z0-9_-]*)\]\*\*", msg_field)
                 if m:
+                    names.add(m.group(1).lower())
+    except Exception:
+        return set()
+    return names
+
+
+def _standalone_hook_evidence(transcript_path: str, window_sec: int) -> set:
+    """Base-names of STANDALONE hooks that actually fired this turn, detected by
+    a `.../hooks/<name>.py` token in a NON-assistant transcript record (tool
+    result / system). Standalone hooks never write to hookify-blocks.log, so
+    this is the second verification source. Assistant records are skipped so the
+    model can't self-verify by writing the path in its own message."""
+    names: set = set()
+    cutoff = time.time() - window_sec
+    path_re = re.compile(r"/hooks/([a-z0-9][a-z0-9_-]*)\.py")
+    try:
+        with open(transcript_path) as f:
+            for line in f:
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if rec.get("type") == "assistant":
+                    continue
+                ts = rec.get("timestamp")
+                if isinstance(ts, str):
+                    try:
+                        rec_ts = datetime.datetime.fromisoformat(
+                            ts.replace("Z", "+00:00")
+                        ).timestamp()
+                        if rec_ts < cutoff:
+                            continue
+                    except ValueError:
+                        pass
+                blob = json.dumps(rec.get("message", rec))
+                for m in path_re.finditer(blob):
                     names.add(m.group(1).lower())
     except Exception:
         return set()

--- a/hooks/check-fabricated-verification.py
+++ b/hooks/check-fabricated-verification.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""Stop hook. Block fabricated VERIFICATION claims in the final assistant turn.
+
+An agent's closing message must not assert a state it never confirmed with a
+tool call. Three detectors, each fails OPEN (a guard that crash-blocks Stop is
+worse than the bug it catches). Evidence = NON-assistant transcript records
+(tool_result outputs) + the commands actually executed (tool_use inputs). The
+model cannot self-verify from its own prose.
+
+  A. ORPHAN EVIDENCE ID — a deploy/build/run-ID- or commit-SHA-shaped token,
+     presented inside backticks in a verification context, that appears in ZERO
+     executed commands AND ZERO tool outputs this session. A fabricated ID is,
+     by definition, nowhere in the evidence.
+
+  B. CLAIMED-CHECK-WITHOUT-TOOL — an HTTP/curl status claim with no HTTP-fetch
+     tool (curl/wget/httpie/WebFetch) executed, OR a deploy-confirmation claim
+     with no deploy command (netlify/fly/vercel/deploy.sh) executed.
+
+  C. EXTERNAL-STATE-LANDED — a claim that git/PR state has LANDED on a shared
+     surface (pushed / on origin / synced / PR opened / PR merged) with no
+     read of the system of record for that surface. "Committed" and "pushed"
+     are separate claims: a commit is local; only a remote read (`git
+     rev-parse origin/<branch>`, `git ls-remote`, `git fetch`) proves origin
+     moved, and only `gh pr view --json headRefOid,state` (or `gh pr
+     list`/`gh pr checks`) proves a PR exists or merged. This closes the
+     failure mode where a chained `git push && gh pr create` is truncated by
+     `tail`, an early step's gate-denial hides in the cut output, and the
+     agent reports the whole chain as landed from the mutating command alone
+     instead of reading the remote back.
+
+Forensic exemption: a match within +-110 chars of a negation/postmortem word
+(didn't, did not, never, no tool call, without running, fabricat, hallucinat,
+claim-before-verify, would have) is skipped, so honest writeups pass. A
+not-yet-happened match (will push, about to push, ready to push, once this is
+merged, need to push) is also skipped, so plans and TODOs pass.
+
+Bypass: FAB_VERIFY_CHECK_BYPASS=1.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+# Token shapes that name a concrete external artifact you can only know by
+# running something: git SHAs (7-40 hex), deploy/build IDs (>=8 hex or
+# hex-with-dashes), long numeric run IDs (>=8 digits).
+ID_TOKEN = re.compile(
+    r"`([0-9a-f]{7,40}|[0-9a-f]{8,}(?:-[0-9a-f]{4,}){1,}|\d{8,})`",
+    re.IGNORECASE,
+)
+# Verification context keywords near a cited ID.
+VERIFY_CTX = re.compile(
+    r"deploy|build|commit|sha|run\s*id|run\s*#|curl|http|readyz|verif|confirm"
+    r"|live|prod|green|merged|pushed|shipped|netlify|vercel|fly\b",
+    re.IGNORECASE,
+)
+# Negation / postmortem proximity -> forensic discussion, not a live claim.
+FORENSIC = re.compile(
+    r"did\s*n.t|didn.t|do\s*not|does\s*n.t|never|without\s+run|no\s+tool\s*call"
+    r"|fabricat|hallucinat|claim-before-verify|would\s+have|never\s+ran"
+    r"|not\s+actually|no\s+such\s+call|i\s+did\s+not\s+run",
+    re.IGNORECASE,
+)
+# Not-yet-happened proximity -> a plan/TODO or an explicit not-done statement,
+# not a landed-state claim. Scoped tight: an exemption only applies when EVERY
+# match of a claim sits near one of these, so a message that mixes "not pushed
+# yet" with a bare "it's pushed" still blocks.
+NOT_YET = re.compile(
+    r"\bwill\s+(?:push|merge|open|create)|\babout\s+to\s+|\bready\s+to\s+"
+    r"|\bneed(?:s|ed)?\s+to\s+|\blet\s+me\s+|\bonce\s+this\s+is\b"
+    r"|\bshould\s+(?:push|merge|open)|\bplan\s+to\s+|\bnext\s+i.?ll\b"
+    r"|\bgoing\s+to\s+(?:push|merge|open|create)"
+    r"|\bha(?:ve|s)\s*n.t\b|\bha(?:ve|s)\s+not\b|\bhavent\b"
+    r"|\bnot\s+(?:yet\s+)?(?:push|merg|open|creat)|\bstill\s+(?:un|not\s+)",
+    re.IGNORECASE,
+)
+
+# Detector B claim phrases -> the tool-evidence token that MUST be present.
+HTTP_CLAIM = re.compile(
+    r"\bcurl\b|\bHTTP/?\d?\s*200\b|\bHTTP\s+200\b|post-deploy\s+curl"
+    r"|curl\s+(?:confirms?|shows?|returns?)",
+    re.IGNORECASE,
+)
+HTTP_EVIDENCE = re.compile(r"curl|wget|httpie|webfetch|http/2|http/1", re.IGNORECASE)
+DEPLOY_CLAIM = re.compile(
+    r"netlify\s+deploy|deploy(?:ed|ment)?\s+(?:id|succeed|complete|live|to\s+prod)"
+    r"|post-deploy|fly\s+deploy|vercel\s+deploy",
+    re.IGNORECASE,
+)
+DEPLOY_EVIDENCE = re.compile(
+    r"netlify|deploy\.sh|fly\s+deploy|flyctl|vercel|\bnpx\s+netlify", re.IGNORECASE
+)
+# A CI-triggered deploy (merge -> deploy workflow) is VERIFIED by INSPECTING the
+# run, not by a local deploy command: `gh run view/list` of a deploy workflow, or
+# a CI run URL. Accepting it fixes the false-positive that flagged a real
+# `gh run view <deploy-run>` + `curl /readyz` verification as "no deploy ran".
+CI_RUN_EVIDENCE = re.compile(r"gh\s+run\b|gh_run|/actions/runs/", re.IGNORECASE)
+
+# Detector C claim phrases -> the READ-of-record that must have executed.
+# "Committed" is a local claim: the commit command itself (or a local log/
+# rev-parse read) is adequate evidence, since git commit either succeeds or
+# errors loudly.
+COMMITTED_CLAIM = re.compile(
+    r"\b(?:is|are|was|were|got|has\s+been|have\s+been)?\s*committed\b"
+    r"|\bthe\s+commit\s+(?:landed|is\s+in|is\s+there)\b"
+    r"|\bchanges?\s+(?:is|are)\s+committed\b",
+    re.IGNORECASE,
+)
+COMMITTED_EVIDENCE = re.compile(
+    r"git\s+commit\b|git\s+log\b|git\s+rev-parse\s+head\b|git\s+show\b",
+    re.IGNORECASE,
+)
+# "Pushed" / "on origin" / "synced" — only a REMOTE read counts. The mutating
+# `git push` command's own (possibly-truncated) output is explicitly NOT
+# accepted here — that is exactly the proxy that hid the incident.
+PUSHED_CLAIM = re.compile(
+    r"\bpushed\b|\bon\s+origin\b|\bup(?:-|\s)?to(?:-|\s)?date\s+with\s+origin\b"
+    r"|\bbranch\s+is\s+(?:live|updated)\s+on\s+(?:github|origin)\b"
+    r"|\bsynced?\s+(?:to|with)\s+origin\b|\borigin\s+(?:has|is)\s+(?:the|our)\s+"
+    r"(?:latest|commit)",
+    re.IGNORECASE,
+)
+PUSHED_EVIDENCE = re.compile(
+    r"git\s+ls-remote\b|git\s+fetch\b|git\s+rev-parse\s+origin/"
+    r"|git\s+log\s+origin/|git\s+diff\s+origin/|git\s+branch\s+-r\b"
+    r"|git\s+status\b.*origin",
+    re.IGNORECASE,
+)
+# "PR opened" / "PR merged" — only reading the PR back counts. `gh pr create`
+# / `gh pr merge` running is not evidence of success: a PreToolUse gate can
+# deny the call and the agent still narrates it as if it landed.
+PR_CLAIM = re.compile(
+    r"\bpr\s*#\s*\d+\b|\bpull\s+request\b|\bpr\s+(?:is\s+)?(?:opened|created|open|merged)\b"
+    r"|\bthe\s+pr\b[^.]{0,60}\b(?:contains|has|includes|carries)\b",
+    re.IGNORECASE,
+)
+PR_EVIDENCE = re.compile(
+    r"gh\s+pr\s+view\b|gh\s+pr\s+list\b|gh\s+pr\s+checks\b|gh\s+pr\s+status\b",
+    re.IGNORECASE,
+)
+MERGED_CLAIM = re.compile(
+    r"\bmerged\b|\bmerge\s+(?:complete|succeeded|landed|is\s+done)\b"
+    r"|\bit.?s\s+merged\b|\bon\s+main\b|\blanded\s+on\s+main\b",
+    re.IGNORECASE,
+)
+
+
+def _present(tok: str, blob: str) -> bool:
+    """True only if tok GENUINELY occurs in the evidence blob (already lowercased).
+
+    Plain substring matching let fabricated short SHAs through: in a hex-saturated
+    CI session a 7-char SHA prefix coincidentally appears inside some longer hash,
+    so `tok in blob` wrongly counts it present and Detector A skips it. A real
+    cited short SHA is a PREFIX of the full SHA in tool output, so for a hex token
+    we require it NOT be preceded by another hex digit: rejects the mid-string
+    coincidence `7887e83` inside `a7887e83bb`, keeps the legit `7887e83` ->
+    `7887e83a1b2c`. Numeric run-IDs must match on BOTH digit boundaries; dashed
+    deploy IDs match on the left hex/dash boundary.
+    """
+    t = tok.lower()
+    if t.isdigit():
+        pat = r"(?<!\d)" + re.escape(t) + r"(?!\d)"
+    elif re.fullmatch(r"[0-9a-f]+", t):
+        pat = r"(?<![0-9a-f])" + re.escape(t)
+    else:
+        pat = r"(?<![0-9a-f-])" + re.escape(t)
+    return re.search(pat, blob) is not None
+
+
+def main() -> None:
+    if os.environ.get("FAB_VERIFY_CHECK_BYPASS") == "1":
+        sys.exit(0)
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
+    if data.get("stop_hook_active"):
+        sys.exit(0)
+    tp = data.get("transcript_path", "")
+    if not tp or not Path(tp).exists():
+        sys.exit(0)
+
+    try:
+        last = _last_assistant_text(tp)
+        if not last:
+            sys.exit(0)
+        result_blob, command_blob = _evidence(tp)
+    except Exception:
+        sys.exit(0)
+
+    findings = []
+
+    # Detector A — orphan evidence ID
+    try:
+        for m in ID_TOKEN.finditer(last):
+            tok = m.group(1)
+            ctx = last[max(0, m.start() - 90): m.end() + 90]
+            if not VERIFY_CTX.search(ctx):
+                continue
+            if FORENSIC.search(last[max(0, m.start() - 110): m.end() + 110]):
+                continue
+            if _present(tok, result_blob) or _present(tok, command_blob):
+                continue
+            findings.append(
+                f"ID `{tok}` cited as verification evidence, but it appears in no "
+                f"tool output and no executed command this session"
+            )
+    except Exception:
+        pass
+
+    # Detector B — claimed check without the tool
+    try:
+        if HTTP_CLAIM.search(last) and not _forensic_whole(last, HTTP_CLAIM):
+            if not HTTP_EVIDENCE.search(result_blob) and not HTTP_EVIDENCE.search(command_blob):
+                findings.append(
+                    "an HTTP/curl status (e.g. 'curl confirms HTTP 200') is claimed, but no "
+                    "curl/wget/WebFetch ran this session"
+                )
+        if DEPLOY_CLAIM.search(last) and not _forensic_whole(last, DEPLOY_CLAIM):
+            deploy_verified = (
+                DEPLOY_EVIDENCE.search(command_blob)
+                or CI_RUN_EVIDENCE.search(command_blob)
+                or HTTP_EVIDENCE.search(command_blob)
+            )
+            if not deploy_verified:
+                findings.append(
+                    "a deploy was claimed (netlify/fly/vercel/post-deploy), but no deploy "
+                    "command, CI deploy-run inspection (gh run), or live HTTP check ran "
+                    "this session"
+                )
+    except Exception:
+        pass
+
+    # Detector C — external git/PR state claimed without a read of the record
+    try:
+        if COMMITTED_CLAIM.search(last) and not _claim_exempt(last, COMMITTED_CLAIM):
+            if not COMMITTED_EVIDENCE.search(command_blob):
+                findings.append(
+                    "the change is claimed COMMITTED, but no `git commit`/`git log`/"
+                    "`git rev-parse HEAD` ran this session — run `git log -1` and cite it, "
+                    "or drop the claim"
+                )
+        if PUSHED_CLAIM.search(last) and not _claim_exempt(last, PUSHED_CLAIM):
+            if not PUSHED_EVIDENCE.search(command_blob):
+                findings.append(
+                    "the branch is claimed PUSHED/on origin, but no read of the remote "
+                    "(`git rev-parse origin/<branch>`, `git ls-remote`, `git fetch`) ran this "
+                    "session — a `git push` command in the transcript is not itself proof; its "
+                    "output can be truncated or the push can fail silently mid-chain. Run "
+                    "`git rev-parse origin/<branch>` and cite the SHA, or say 'pushed, not yet "
+                    "confirmed on origin'"
+                )
+        if PR_CLAIM.search(last) and not _claim_exempt(last, PR_CLAIM):
+            if not PR_EVIDENCE.search(command_blob):
+                findings.append(
+                    "a PR is claimed opened/merged/containing specific commits, but no "
+                    "`gh pr view <n> --json headRefOid,state` (or `gh pr list`/`gh pr checks`) "
+                    "ran this session — `gh pr create` appearing in the transcript is not proof "
+                    "it succeeded (a PreToolUse gate can deny it and the command output still "
+                    "shows in a truncated tail). Run `gh pr view <n> --json headRefOid,state` "
+                    "and cite what it returns, or drop the claim"
+                )
+        elif MERGED_CLAIM.search(last) and not _claim_exempt(last, MERGED_CLAIM):
+            if not PR_EVIDENCE.search(command_blob):
+                findings.append(
+                    "work is claimed merged/landed on main, but no `gh pr view --json state` "
+                    "(or equivalent remote read) ran this session"
+                )
+    except Exception:
+        pass
+
+    if not findings:
+        sys.exit(0)
+
+    bullet = "\n".join(f"  - {f}" for f in sorted(set(findings)))
+    msg = (
+        "Fabricated-verification check blocked the close. In the final message:\n"
+        f"{bullet}\n\n"
+        "A verification claim must trace to a tool call IN THIS SESSION that read the SYSTEM "
+        "OF RECORD, not a local proxy: committed != pushed != PR-opened != merged, and a "
+        "mutating command's own (possibly truncated) output is not proof it succeeded — read "
+        "the remote back. Either (a) run the read now and cite the real result, or (b) "
+        "remove/qualify the claim ('committed locally, not yet pushed'; 'PR creation was "
+        "denied by a hook, work is not on origin'). Recording the failure in a session file is "
+        "not the fix; producing the evidence is.\n"
+        "Forensic writeups and not-yet-happened plans pass automatically. Hard bypass: "
+        "FAB_VERIFY_CHECK_BYPASS=1."
+    )
+    print(json.dumps({"decision": "block", "reason": msg}))
+    sys.exit(0)
+
+
+def _claim_exempt(text: str, claim_re: "re.Pattern") -> bool:
+    """True if every match of claim_re sits near a forensic negation or a
+    not-yet-happened marker (plan/TODO), so it isn't a live landed-state claim."""
+    matches = list(claim_re.finditer(text))
+    if not matches:
+        return False
+    for m in matches:
+        window = text[max(0, m.start() - 110): m.end() + 110]
+        if not (FORENSIC.search(window) or NOT_YET.search(window)):
+            return False
+    return True
+
+
+def _forensic_whole(text: str, claim_re: "re.Pattern") -> bool:
+    """True if EVERY claim-phrase match sits near a forensic/negation word."""
+    matches = list(claim_re.finditer(text))
+    if not matches:
+        return False
+    for m in matches:
+        if not FORENSIC.search(text[max(0, m.start() - 110): m.end() + 110]):
+            return False
+    return True
+
+
+def _last_assistant_text(transcript_path: str) -> str:
+    text = ""
+    with open(transcript_path) as f:
+        for line in f:
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if rec.get("type") != "assistant":
+                continue
+            content = rec.get("message", {}).get("content", [])
+            if not isinstance(content, list):
+                continue
+            parts = [
+                c.get("text", "")
+                for c in content
+                if isinstance(c, dict) and c.get("type") == "text"
+            ]
+            if parts:
+                text = "\n".join(parts)
+    return text
+
+
+def _evidence(transcript_path: str) -> "tuple[str, str]":
+    """(result_blob, command_blob) lowercased.
+
+    result_blob  = text of every tool_result (the ACTUAL outputs).
+    command_blob = every Bash tool_use command + url + tool names (what ran).
+    Neither draws from assistant free-text, so the model can't self-verify.
+    """
+    results = []
+    commands = []
+    with open(transcript_path) as f:
+        for line in f:
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            content = rec.get("message", {}).get("content", [])
+            if not isinstance(content, list):
+                continue
+            for c in content:
+                if not isinstance(c, dict):
+                    continue
+                t = c.get("type")
+                if t == "tool_result":
+                    results.append(_flatten(c.get("content", "")))
+                elif t == "tool_use":
+                    commands.append(str(c.get("name", "")))
+                    inp = c.get("input", {})
+                    if isinstance(inp, dict):
+                        commands.append(str(inp.get("command", "")))
+                        commands.append(str(inp.get("url", "")))
+    return ("\n".join(results).lower(), "\n".join(commands).lower())
+
+
+def _flatten(content) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        out = []
+        for c in content:
+            if isinstance(c, dict):
+                out.append(c.get("text", "") or "")
+            else:
+                out.append(str(c))
+        return "\n".join(out)
+    return str(content)
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/test_check_fabricated_verification.py
+++ b/hooks/test_check_fabricated_verification.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Negative + positive controls for check-fabricated-verification.py.
+
+A guard earns trust only by FAILING on the thing it catches. The anchor case is
+a real incident: one chained Bash call ran
+`git add … && git commit … && git push origin <branch> && gh pr create …`,
+a PreToolUse gate DENIED `gh pr create`, `&&` killed the chain, and the only
+output read was `tail -3` — the gate's error text. The close then reported the
+commit and push as landed and named a PR as containing every fix. Ground truth:
+the changes were uncommitted, origin was two commits behind, and the PR's head
+carried fewer fixes than claimed.
+
+Cases 1-4 are that incident and its siblings (the guard must FIRE).
+Cases 5-11 are honest reports, forensic writeups and plans (must stay SILENT).
+Cases 12-14 cover the pre-existing detectors so this suite also locks them.
+
+Stdlib only. Exit 0 = all pass.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HOOK = Path(__file__).resolve().parent / "check-fabricated-verification.py"
+
+PASS = 0
+FAIL = 0
+
+
+def _transcript(final_text: str, commands=(), results=()) -> str:
+    """Build a transcript: tool_use commands + tool_result outputs, then the
+    final assistant message. Assistant text is never evidence — by design."""
+    lines = []
+    for i, cmd in enumerate(commands):
+        lines.append(json.dumps({
+            "type": "assistant",
+            "message": {"content": [
+                {"type": "tool_use", "name": "Bash", "id": f"t{i}",
+                 "input": {"command": cmd}}
+            ]},
+        }))
+    for out in results:
+        lines.append(json.dumps({
+            "type": "user",
+            "message": {"content": [{"type": "tool_result", "content": out}]},
+        }))
+    lines.append(json.dumps({
+        "type": "assistant",
+        "message": {"content": [{"type": "text", "text": final_text}]},
+    }))
+    return "\n".join(lines) + "\n"
+
+
+def run(final_text: str, commands=(), results=(), env=None):
+    """Returns (blocked: bool, reason: str)."""
+    with tempfile.TemporaryDirectory() as td:
+        tp = Path(td) / "transcript.jsonl"
+        tp.write_text(_transcript(final_text, commands, results), encoding="utf-8")
+        payload = json.dumps({"transcript_path": str(tp)})
+        proc = subprocess.run(
+            [sys.executable, str(HOOK)],
+            input=payload, capture_output=True, text=True,
+            env=env,
+        )
+    out = (proc.stdout or "").strip()
+    if not out:
+        return False, ""
+    try:
+        d = json.loads(out)
+    except json.JSONDecodeError:
+        return False, ""
+    return d.get("decision") == "block", d.get("reason", "")
+
+
+def expect_block(label: str, final_text: str, commands=(), results=(), must_say=None):
+    global PASS, FAIL
+    blocked, reason = run(final_text, commands, results)
+    if not blocked:
+        FAIL += 1
+        print(f"FAIL  {label} :: guard did NOT fire")
+        return
+    if must_say and must_say.lower() not in reason.lower():
+        FAIL += 1
+        print(f"FAIL  {label} :: fired but message lacks {must_say!r}")
+        return
+    PASS += 1
+    print(f"PASS  {label}")
+
+
+def expect_silent(label: str, final_text: str, commands=(), results=()):
+    global PASS, FAIL
+    blocked, reason = run(final_text, commands, results)
+    if blocked:
+        FAIL += 1
+        print(f"FAIL  {label} :: false positive -- {reason[:160]}")
+        return
+    PASS += 1
+    print(f"PASS  {label}")
+
+
+# --- THE INCIDENT ------------------------------------------------------------
+# One chained call; the gate denied `gh pr create`; only `tail -3` was read.
+INCIDENT_CMD = (
+    "git add src/ && git commit -m 'fix' && git push origin feature-branch "
+    "&& gh pr create --title x --body y | tail -3"
+)
+INCIDENT_TAIL = "error: hook denied gh pr create (see runbook)"
+
+expect_block(
+    "1. incident: 'pushed' claimed, only the mutating chain ran, tail-truncated",
+    "All 16 fixes are committed and pushed to origin. PR #144 contains every one of them.",
+    commands=[INCIDENT_CMD],
+    results=[INCIDENT_TAIL],
+    must_say="rev-parse origin",
+)
+
+expect_block(
+    "2. 'pushed' with a bare git push and no remote read",
+    "Done. The branch is pushed and up to date on origin.",
+    commands=["git push origin my-branch"],
+    results=["Everything up-to-date"],
+    must_say="not itself proof",
+)
+
+expect_block(
+    "3. PR claimed open after `gh pr create` alone (no `gh pr view`)",
+    "Opened PR #144 with all the review fixes.",
+    commands=["gh pr create --title x --body y"],
+    results=["https://github.com/o/r/pull/144"],
+    must_say="gh pr view",
+)
+
+expect_block(
+    "4. 'merged / on main' with no remote read at all",
+    "The work is merged and on main now.",
+    commands=["git status"],
+    results=["nothing to commit"],
+)
+
+expect_block(
+    "4b. 'committed' claimed with no git command whatsoever",
+    "The changes are committed.",
+    commands=["ls -la"],
+    results=["a.txt"],
+    must_say="git log",
+)
+
+# --- HONEST / CLEAN PATH -----------------------------------------------------
+expect_silent(
+    "5. honest report: push CONFIRMED by reading origin back",
+    "Pushed. `git rev-parse origin/my-branch` returns 875b87e, matching local HEAD.",
+    commands=["git push origin my-branch", "git rev-parse origin/my-branch"],
+    results=["Everything up-to-date", "875b87e2c1a4f9b3d5e6a7c8901234567890abcd"],
+)
+
+expect_silent(
+    "6. honest report: PR state read back with gh pr view",
+    "PR #144 is open; head is 875b87e per `gh pr view`.",
+    commands=["gh pr create --title x", "gh pr view 144 --json headRefOid,state"],
+    results=["created", '{"headRefOid":"875b87e2c1a4f9b3","state":"OPEN"}'],
+)
+
+expect_silent(
+    "7. honest scoping: committed locally, explicitly NOT pushed",
+    "Committed locally. I have not pushed yet -- origin is unchanged.",
+    commands=["git commit -m fix"],
+    results=["[main abc1234] fix"],
+)
+
+expect_silent(
+    "8. forensic writeup of the incident (negation nearby)",
+    "I said it was pushed, but I never ran a remote read and the push did not "
+    "actually happen -- the chain died at the gate. That is the fabrication.",
+    commands=["cat notes.md"],
+    results=["..."],
+)
+
+expect_silent(
+    "9. a plan, not a claim ('will push', 'about to open')",
+    "Next I'll push the branch and then open a PR once CI is green.",
+    commands=["git status"],
+    results=["clean"],
+)
+
+expect_silent(
+    "10. no external-state claim at all",
+    "Refactored the parser and added two tests. Both pass locally.",
+    commands=["pytest -q"],
+    results=["2 passed"],
+)
+
+expect_silent(
+    "11. merge confirmed via gh pr view",
+    "Merged -- `gh pr view 144 --json state` reports MERGED.",
+    commands=["gh pr merge 144 --squash", "gh pr view 144 --json state"],
+    results=["merged", '{"state":"MERGED"}'],
+)
+
+# --- PRE-EXISTING DETECTORS (regression lock) --------------------------------
+expect_block(
+    "12. detector B: HTTP 200 claimed, no curl/WebFetch ran",
+    "Post-deploy curl confirms HTTP 200 on the live URL.",
+    commands=["git log -1"],
+    results=["commit abc"],
+)
+
+expect_block(
+    "13. detector A: orphan deploy ID cited as evidence",
+    "Deploy `6a191f3a284445cfd3ad5902` completed and the site is live.",
+    commands=["git status"],
+    results=["clean"],
+)
+
+expect_silent(
+    "14. detector B clean: curl actually ran",
+    "curl on /readyz returned HTTP 200.",
+    commands=["curl -s -o /dev/null -w '%{http_code}' https://example.test/readyz"],
+    results=["200"],
+)
+
+# --- BYPASS ------------------------------------------------------------------
+import os  # noqa: E402
+
+_env = dict(os.environ, FAB_VERIFY_CHECK_BYPASS="1")
+_blocked, _ = run(
+    "All 16 fixes are committed and pushed to origin. PR #144 contains every one.",
+    commands=[INCIDENT_CMD], results=[INCIDENT_TAIL], env=_env,
+)
+if _blocked:
+    FAIL += 1
+    print("FAIL  15. FAB_VERIFY_CHECK_BYPASS=1 :: still blocked")
+else:
+    PASS += 1
+    print("PASS  15. FAB_VERIFY_CHECK_BYPASS=1 disables the guard")
+
+print()
+print(f"=== summary: {PASS} passed, {FAIL} failed ===")
+sys.exit(1 if FAIL else 0)

--- a/hooks/test_warn_chained_state_command.py
+++ b/hooks/test_warn_chained_state_command.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Controls for warn-chained-state-command-truncated.py.
+
+Fires on the exact shape that hid the incident: a state-changing command
+chained after `&&` in one Bash call whose output is piped through tail/head.
+Warn-only, so the assertion is on the presence of the advisory message, and on
+the decision NEVER being a deny.
+
+Stdlib only. Exit 0 = all pass.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+HOOK = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                    "warn-chained-state-command-truncated.py")
+
+PASS = 0
+FAIL = 0
+
+
+def run(command: str, tool_name: str = "Bash", env=None):
+    payload = json.dumps({"tool_name": tool_name, "tool_input": {"command": command}})
+    proc = subprocess.run([sys.executable, HOOK], input=payload,
+                          capture_output=True, text=True, env=env)
+    out = (proc.stdout or "").strip()
+    if not out:
+        return None
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError:
+        return None
+
+
+def expect_warn(label: str, command: str):
+    global PASS, FAIL
+    d = run(command)
+    if not d:
+        FAIL += 1
+        print(f"FAIL  {label} :: no warning emitted")
+        return
+    decision = d.get("hookSpecificOutput", {}).get("permissionDecision")
+    if decision != "allow":
+        FAIL += 1
+        print(f"FAIL  {label} :: warn hook must never deny (got {decision!r})")
+        return
+    PASS += 1
+    print(f"PASS  {label}")
+
+
+def expect_silent(label: str, command: str, tool_name: str = "Bash"):
+    global PASS, FAIL
+    d = run(command, tool_name=tool_name)
+    if d:
+        FAIL += 1
+        print(f"FAIL  {label} :: false positive")
+        return
+    PASS += 1
+    print(f"PASS  {label}")
+
+
+# --- THE INCIDENT SHAPE ------------------------------------------------------
+expect_warn(
+    "1. the incident: add && commit && push && gh pr create | tail -3",
+    "git add src/ && git commit -m 'fix' && git push origin br "
+    "&& gh pr create --title x --body y | tail -3",
+)
+expect_warn(
+    "2. push after && piped to tail",
+    "npm test && git push origin main | tail -5",
+)
+expect_warn(
+    "3. gh pr merge after && piped to head",
+    "gh pr checks 144 && gh pr merge 144 --squash | head -2",
+)
+expect_warn(
+    "4. gh release create after && piped to tail",
+    "npm run build && gh release create v1.2.3 | tail -1",
+)
+
+# --- MUST NOT FIRE -----------------------------------------------------------
+expect_silent(
+    "5. chained push with NO truncation (full output visible)",
+    "npm test && git push origin main",
+)
+expect_silent(
+    "6. truncation but NO chaining (single command)",
+    "git log --oneline | tail -20",
+)
+expect_silent(
+    "7. state command FIRST, nothing inferred after it",
+    "git push origin main | tail -3",
+)
+expect_silent(
+    "8. read-only chain piped to tail",
+    "git fetch && git log --oneline | tail -5",
+)
+expect_silent(
+    "9. non-Bash tool",
+    "git add . && git push origin main | tail -3",
+    tool_name="Read",
+)
+
+# --- BYPASS ------------------------------------------------------------------
+_env = dict(os.environ, CHAINED_STATE_CMD_BYPASS="1")
+if run("git add . && git push origin br && gh pr create | tail -3", env=_env):
+    FAIL += 1
+    print("FAIL  10. CHAINED_STATE_CMD_BYPASS=1 :: still warned")
+else:
+    PASS += 1
+    print("PASS  10. CHAINED_STATE_CMD_BYPASS=1 disables the warn")
+
+print()
+print(f"=== summary: {PASS} passed, {FAIL} failed ===")
+sys.exit(1 if FAIL else 0)

--- a/hooks/warn-chained-state-command-truncated.py
+++ b/hooks/warn-chained-state-command-truncated.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""PreToolUse(Bash) warn. One call chains a state-changing command after `&&`
+AND pipes the result through `tail`/`head`.
+
+That exact shape hides failure. `&&` short-circuits, so an early step's denial
+or error kills the rest of the chain — and `tail -3` then shows only the last
+few lines, which are the ERROR text of whichever step died. The agent reads a
+plausible-looking tail, infers every earlier step succeeded, and reports the
+whole chain as landed. Nothing in the visible output says otherwise.
+
+Warn only, never block: the shape is often legitimate (a long build piped to
+`tail` for brevity). The point is to make the agent read the exit status and
+re-read the remote instead of trusting the tail. The Stop-side guard
+(check-fabricated-verification.py, Detector C) is what actually enforces the
+read-of-record before a landed-state claim.
+
+Bypass: CHAINED_STATE_CMD_BYPASS=1.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+
+# State-changing commands whose success cannot be inferred from a truncated tail.
+STATE_CMD = re.compile(
+    r"\bgit\s+commit\b|\bgit\s+push\b|\bgh\s+pr\s+create\b|\bgh\s+pr\s+merge\b"
+    r"|\bgh\s+release\s+create\b|\bgit\s+tag\s+-\w*\s*\S|\bgh\s+api\s+.*-X\s*(?:POST|PATCH|PUT|DELETE)",
+    re.IGNORECASE,
+)
+# A truncating filter on the OUTPUT of the pipeline.
+TRUNCATE = re.compile(r"\|\s*(?:tail|head)\b", re.IGNORECASE)
+# `&&` chaining (not `&` backgrounding, not `||`).
+CHAIN = re.compile(r"(?<!&)&&(?!&)")
+
+
+def main() -> None:
+    if os.environ.get("CHAINED_STATE_CMD_BYPASS") == "1":
+        sys.exit(0)
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
+    if data.get("tool_name") != "Bash":
+        sys.exit(0)
+    cmd = ""
+    tin = data.get("tool_input")
+    if isinstance(tin, dict):
+        cmd = str(tin.get("command", ""))
+    if not cmd:
+        sys.exit(0)
+
+    if not CHAIN.search(cmd) or not TRUNCATE.search(cmd):
+        sys.exit(0)
+
+    # The state command must sit in a segment AFTER a `&&` — that is the one
+    # whose success gets inferred rather than observed.
+    segments = CHAIN.split(cmd)
+    if len(segments) < 2:
+        sys.exit(0)
+    hits = sorted({m.group(0).strip() for seg in segments[1:] for m in STATE_CMD.finditer(seg)})
+    if not hits:
+        sys.exit(0)
+
+    msg = (
+        "This one Bash call chains a state-changing command after `&&` and pipes the result "
+        f"through tail/head: {', '.join(hits)}.\n"
+        "`&&` short-circuits, so if an earlier step fails or a PreToolUse gate denies it, the "
+        "later steps NEVER RUN — and the truncated tail you read will be that failure's error "
+        "text, which looks like ordinary output. Do not infer the earlier steps succeeded.\n"
+        "Either split the chain into separate calls, or read the full output and then confirm "
+        "the end state from the system of record: `git rev-parse origin/<branch>` for a push, "
+        "`gh pr view <n> --json headRefOid,state` for a PR. Bypass: CHAINED_STATE_CMD_BYPASS=1."
+    )
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "allow",
+            "permissionDecisionReason": msg,
+        },
+        "systemMessage": msg,
+    }))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -212,6 +212,12 @@ INTEGRATION_TESTS=(
   # SessionStart repair restores an unprotected account (registration under both
   # matchers + vault preflight) and no-ops on a healthy one, with pos/neg controls.
   test_heal_journal_guard
+  # Anti-fabrication guard family (MYC-1017): proves a fresh install REGISTERS the
+  # Stop + PreToolUse guards, and that the SHIPPED wiring blocks the incident it
+  # exists for while passing an honest close. File presence is not the assertion —
+  # activation is (the family sat dormant in the repo precisely because nothing
+  # asserted registration).
+  test_installer_registers_fabrication_guards
 )
 # ---- Gate-coverage invariant -------------------------------------------------
 # The list above is an explicit allow-list, and allow-lists rot: a new
@@ -343,6 +349,8 @@ PY_DIRECT=(
   hooks/test_live_session_reap.py
   hooks/test_relocation_orphan_reclaim.py
   hooks/test_secret_patterns_fp_filter.py
+  hooks/test_check_fabricated_verification.py
+  hooks/test_warn_chained_state_command.py
 )
 dormant_py=()
 while IFS= read -r -d '' f; do

--- a/scripts/install-hooks-user-level.py
+++ b/scripts/install-hooks-user-level.py
@@ -116,6 +116,14 @@ ABS_FINGERPRINTS = [
     # matchers each; the matcher-aware merge above keeps both copies.
     "ai-brain-starter/hooks/warn-journal-saved-without-context.py",
     "ai-brain-starter/scripts/heal-journal-guard.py",
+    # Anti-fabrication guard family (MYC-1017). These target a MODEL-GENERAL bug
+    # class — an agent asserting a verification result or a hook attribution it
+    # never sourced from evidence — so they belong in the substrate, ACTIVATED
+    # here. Shipping the files without registering them is ARTIFACT-WITHOUT-
+    # ACTIVATION: guards present on disk, dormant in behavior.
+    "ai-brain-starter/hooks/check-fabricated-verification.py",
+    "ai-brain-starter/hooks/check-fabricated-hook-attribution.py",
+    "ai-brain-starter/hooks/warn-chained-state-command-truncated.py",
 ]
 
 # Path-divergence-robust matching: an ai-brain-starter hook may be wired at the
@@ -143,6 +151,10 @@ ABS_OWNED_BASENAMES = {
     "surface-deployed-hooks-behind.py",
     # Journal Step-0 context guard + its SessionStart self-heal (2026-07-07):
     "warn-journal-saved-without-context.py", "heal-journal-guard.py",
+    # Anti-fabrication guard family (MYC-1017). Basenames listed so a copy wired
+    # at ~/.claude/hooks/ dedups against the skill-path copy instead of doubling.
+    "check-fabricated-verification.py", "check-fabricated-hook-attribution.py",
+    "warn-chained-state-command-truncated.py",
 }
 
 # Hooks ai-brain-starter USED TO ship and has deliberately RETIRED. The

--- a/tests/integration/test_installer_registers_fabrication_guards.sh
+++ b/tests/integration/test_installer_registers_fabrication_guards.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# Fresh-install smoke for the anti-fabrication guard family (MYC-1017).
+#
+# The bug this closes is ARTIFACT-WITHOUT-ACTIVATION: the guards shipped into
+# the repo as FILES for months while `scripts/install-hooks-user-level.py` never
+# registered them, so every install got the files and none got the behavior.
+# File presence is therefore NOT the assertion — registration in the installed
+# settings.json is, plus proof the registered command actually executes.
+#
+# Asserts, by running the REAL installer against a sandboxed HOME:
+#   0. NEGATIVE CONTROL: a pre-install settings.json has NONE of the guards.
+#   1. check-fabricated-verification.py registered on Stop.
+#   2. check-fabricated-hook-attribution.py registered on Stop.
+#   3. warn-chained-state-command-truncated.py registered on PreToolUse.
+#   4. Every registered guard script EXISTS at the path the command names.
+#   5. END-TO-END: the registered Stop command, run verbatim on a transcript
+#      that reproduces the incident, BLOCKS.  <- activation actually works
+#   6. END-TO-END negative control: the same command on an honest transcript
+#      does NOT block.  <- no false positive on the shipped wiring
+#   7. Idempotent: a second install does not duplicate the entries.
+#
+# Stdlib python3 + bash only. No network, no git. Tmpdir removed on exit.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+INSTALLER="$REPO_ROOT/scripts/install-hooks-user-level.py"
+
+PASS=0; FAIL=0
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+ok()  { PASS=$((PASS + 1)); echo "PASS  $1"; }
+bad() { FAIL=$((FAIL + 1)); echo "FAIL  $1 :: $2"; }
+
+# A REAL interpreter, resolved absolutely. Bare `python3` may be the
+# trailofbits modern-python refuse-shim, which exit-1s on every invocation.
+PY=""
+for c in /opt/homebrew/bin/python3 /usr/bin/python3 /usr/local/bin/python3; do
+  [ -x "$c" ] && "$c" -c 'import sys' >/dev/null 2>&1 && { PY="$c"; break; }
+done
+if [ -z "$PY" ]; then
+  PY="$(command -v python3 || true)"
+  [ -n "$PY" ] && ! "$PY" -c 'import sys' >/dev/null 2>&1 && PY=""
+fi
+[ -z "$PY" ] && { echo "SKIP: no usable python3"; exit 0; }
+
+# A real install has the repo at ~/.claude/skills/ai-brain-starter. Seed it so
+# the paths baked into the hook commands resolve — that is what makes leg 5 a
+# genuine end-to-end activation proof rather than a string match.
+mkdir -p "$TMP/.claude/skills"
+cp -R "$REPO_ROOT" "$TMP/.claude/skills/ai-brain-starter"
+SETTINGS="$TMP/.claude/settings.json"
+echo '{}' > "$SETTINGS"
+
+GUARDS=(
+  check-fabricated-verification.py
+  check-fabricated-hook-attribution.py
+  warn-chained-state-command-truncated.py
+)
+
+# Emits the event name for each registered ai-brain-starter command containing $1.
+registered_events() {
+  "$PY" - "$SETTINGS" "$1" <<'PY'
+import json, sys
+settings, needle = sys.argv[1], sys.argv[2]
+try:
+    hooks = json.load(open(settings)).get("hooks", {})
+except Exception:
+    hooks = {}
+for event, blocks in hooks.items():
+    for blk in blocks:
+        for e in blk.get("hooks", []):
+            if needle in e.get("command", ""):
+                print(event)
+PY
+}
+
+echo "=== 0. NEGATIVE CONTROL: guards absent before install ==="
+pre_found=""
+for g in "${GUARDS[@]}"; do
+  [ -n "$(registered_events "$g")" ] && pre_found="$pre_found $g"
+done
+if [ -z "$pre_found" ]; then
+  ok "no fabrication guard registered pre-install (control holds)"
+else
+  bad "pre-install control" "guards already present:$pre_found — the test cannot prove activation"
+fi
+
+# Run the REAL installer against the sandboxed HOME.
+env -u CLAUDECODE HOME="$TMP" "$PY" "$INSTALLER" \
+  --hooks-source "$REPO_ROOT/hooks.json" --settings "$SETTINGS" --quiet >/dev/null 2>&1
+
+echo "=== 1-3. each guard registered on its event ==="
+check_event() { # $1=script  $2=expected event
+  local events
+  events="$(registered_events "$1")"
+  if echo "$events" | grep -qx "$2"; then
+    ok "$1 registered on $2"
+  else
+    bad "$1 on $2" "registered events: [${events//$'\n'/,}]"
+  fi
+}
+check_event check-fabricated-verification.py Stop
+check_event check-fabricated-hook-attribution.py Stop
+check_event warn-chained-state-command-truncated.py PreToolUse
+
+echo "=== 4. every registered guard script exists on disk ==="
+missing=""
+for g in "${GUARDS[@]}"; do
+  [ -f "$TMP/.claude/skills/ai-brain-starter/hooks/$g" ] || missing="$missing $g"
+done
+if [ -z "$missing" ]; then
+  ok "all guard scripts present at the registered path"
+else
+  bad "guard scripts on disk" "missing:$missing"
+fi
+
+# Pull the EXACT command string the installer wrote, so legs 5/6 execute the
+# shipped wiring (interpreter substitution, if/then/else form and all) rather
+# than a hand-built invocation that could diverge from it.
+STOP_CMD="$("$PY" - "$SETTINGS" <<'PY'
+import json, sys
+hooks = json.load(open(sys.argv[1])).get("hooks", {})
+for blk in hooks.get("Stop", []):
+    for e in blk.get("hooks", []):
+        c = e.get("command", "")
+        if "check-fabricated-verification.py" in c:
+            print(c)
+            break
+PY
+)"
+
+mk_transcript() { # $1=outfile  $2=final assistant text  $3=bash command that ran
+  "$PY" - "$1" "$2" "$3" <<'PY'
+import json, sys
+out, text, cmd = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(out, "w") as f:
+    f.write(json.dumps({"type": "assistant", "message": {"content": [
+        {"type": "tool_use", "name": "Bash", "id": "t0", "input": {"command": cmd}}]}}) + "\n")
+    f.write(json.dumps({"type": "user", "message": {"content": [
+        {"type": "tool_result", "content": "error: hook denied gh pr create"}]}}) + "\n")
+    f.write(json.dumps({"type": "assistant", "message": {"content": [
+        {"type": "text", "text": text}]}}) + "\n")
+PY
+}
+
+echo "=== 5. END-TO-END: shipped Stop wiring BLOCKS the incident ==="
+if [ -z "$STOP_CMD" ]; then
+  bad "stop command extracted" "no Stop command names check-fabricated-verification.py"
+else
+  mk_transcript "$TMP/incident.jsonl" \
+    "All 16 fixes are committed and pushed to origin. PR #144 contains every one of them." \
+    "git add . && git commit -m fix && git push origin br && gh pr create | tail -3"
+  out="$(echo "{\"transcript_path\":\"$TMP/incident.jsonl\"}" \
+        | env -u CLAUDECODE HOME="$TMP" bash -c "$STOP_CMD" 2>/dev/null)"
+  if echo "$out" | grep -q '"decision"[[:space:]]*:[[:space:]]*"block"'; then
+    ok "shipped wiring blocks a 'pushed / PR contains' claim with no remote read"
+  else
+    bad "shipped wiring blocks" "no block decision; got: ${out:0:200}"
+  fi
+fi
+
+echo "=== 6. END-TO-END negative control: honest close is NOT blocked ==="
+if [ -n "$STOP_CMD" ]; then
+  mk_transcript "$TMP/honest.jsonl" \
+    "Refactored the parser and added two tests. Both pass locally." \
+    "pytest -q"
+  out="$(echo "{\"transcript_path\":\"$TMP/honest.jsonl\"}" \
+        | env -u CLAUDECODE HOME="$TMP" bash -c "$STOP_CMD" 2>/dev/null)"
+  if echo "$out" | grep -q '"decision"[[:space:]]*:[[:space:]]*"block"'; then
+    bad "honest close passes" "shipped wiring false-positived: ${out:0:200}"
+  else
+    ok "honest close passes the shipped wiring"
+  fi
+fi
+
+echo "=== 7. idempotent: a second install does not duplicate ==="
+env -u CLAUDECODE HOME="$TMP" "$PY" "$INSTALLER" \
+  --hooks-source "$REPO_ROOT/hooks.json" --settings "$SETTINGS" --quiet >/dev/null 2>&1
+dupes=""
+for g in "${GUARDS[@]}"; do
+  n="$(registered_events "$g" | wc -l | tr -d ' ')"
+  [ "$n" -gt 1 ] && dupes="$dupes $g(x$n)"
+done
+if [ -z "$dupes" ]; then
+  ok "no duplicate registrations after re-install"
+else
+  bad "idempotent" "duplicated:$dupes"
+fi
+
+echo
+echo "=== summary: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Why

The anti-fabrication guards shipped into this repo as **files** and were never registered by `scripts/install-hooks-user-level.py`. Every install got the files; none got the behavior. Bug class **ARTIFACT-WITHOUT-ACTIVATION** — "we ship anti-fabrication guards" was true at the file level and false at the behavior level.

## What changed

**Activation.** `check-fabricated-verification.py` and `check-fabricated-hook-attribution.py` are now wired on `Stop`, and a new warn-only hook on `PreToolUse(Bash)`, via `hooks.json` plus the installer's owned-set. Registration — not file presence — is what the new smoke test asserts.

**New claim class: EXTERNAL-STATE-LANDED** (Detector C). A closing message asserting *committed / pushed / on origin / PR opened / PR merged / synced* now requires a tool call in that session that read the **system of record**, and the block message names the exact command that satisfies it:

| Claim | Evidence required |
|---|---|
| committed | `git log` / `git rev-parse HEAD` |
| pushed / on origin | `git rev-parse origin/<branch>` / `git ls-remote` / `git fetch` |
| PR opened / merged | `gh pr view <n> --json headRefOid,state` |

`committed` != `pushed` != `PR-opened` != `merged` — separate claims, separate evidence. A **mutating** command in the transcript is explicitly not accepted as proof it succeeded; only a read-back is.

### The failure mode this closes

One Bash call chains `git add && git commit && git push && gh pr create` and pipes to `tail -3`. A PreToolUse gate denies the last step, `&&` kills the chain, and the visible tail is the gate's error text. Every earlier step's success then gets inferred from output that never described it — the close reports commit, push and PR as landed while the tree is dirty and origin is behind.

`warn-chained-state-command-truncated.py` flags that exact shape at the moment it is typed (warn-only, never denies).

### Attribution guard

`check-fabricated-hook-attribution.py` gains its second evidence source — standalone-hook paths appearing in this turn's tool errors — so activating it does not false-flag truthful attributions to hooks that never write to `hookify-blocks.log`. Activating the old single-source version would have punished honesty.

## Premise audit

- **Premise: the guards are dormant.** Verified by reading `scripts/install-hooks-user-level.py` on `origin/main` — neither guard appears in `ABS_FINGERPRINTS` or `ABS_OWNED_BASENAMES`, and neither appears in `hooks.json`'s `Stop` block. Not inferred.
- **Premise: `check-fabricated-verification.py` is absent from the substrate.** Verified — `find` over the repo returned only `check-fabricated-hook-attribution.py`.
- **Premise: extending beats a near-duplicate guard.** The existing file already owned the "claimed a check that never ran" class with two detectors; landed-state is the same class with a different evidence source, so it is a third detector in that file rather than a fourth hook.
- **Premise: the incident is reproducible as a fixture.** Verified — the transcript shape (mutating chain + truncated tail + landed claim) drives case 1 and the smoke's leg 5.

## Invariant checklist

- **No state machine or schema touched.** No migrations, no DDL, no columns, no uniqueness constraints, no defaults on approval/verification flags.
- **Fail-open is deliberate and preserved.** Every detector is individually wrapped; a crash in one disables that detector rather than blocking `Stop`. A guard that crash-blocks the close is worse than the bug it catches.
- **No silent no-op.** Each detector has positive controls in CI; a regression that stops it firing fails the suite rather than passing quietly.
- **Clean-checkout buildable.** No build output involved; the smoke copies the checkout into a sandboxed `HOME` and runs the real installer.
- **Idempotent.** Asserted directly — a second install adds no duplicate registrations.
- **One canonical source.** Guard content lives in `hooks/`; wiring lives in `hooks.json`; ownership lives in the installer's two lists. No second source for any of the three.
- **Blast radius.** Adding basenames to `ABS_OWNED_BASENAMES` means a user's own `~/.claude/hooks/check-fabricated-verification.py` is now deduped against the skill-path copy. That is the intended dedup behavior and the substrate version is a strict superset of the older private one.

## Adversarial review dispositions

1. **Regex evasion by paraphrase** ("it's live on the remote") — *accepted, documented.* A text guard raises the floor against the unwitting case; it is not a cryptographic gate.
2. **Session-wide evidence matching** — *accepted, documented.* A `git fetch` anywhere in the session satisfies a push claim about any branch. Per-branch correlation would need transcript-order analysis and buys little against an honest agent.
3. **Only the final assistant message is scanned** — *accepted, inherited design.* Scanning all messages would false-positive on mid-session narration.
4. **Over-broad negation exemption could defeat the guard** — *fixed.* `_claim_exempt` requires *every* match to sit near a negation or not-yet marker, so a message mixing "not pushed yet" with a bare "it's pushed" still blocks. Case 7 pins the honest side; cases 1-4 pin the blocking side.
5. **ReDoS on the new patterns** — *checked.* No nested quantifiers over overlapping alternations; all alternations are literal-anchored.

## Proof

- **Negative controls.** `hooks/test_check_fabricated_verification.py` (16 cases) reproduces the incident; `hooks/test_warn_chained_state_command.py` (10 cases) the command shape. Both cover honest reports, forensic writeups, plans and bypasses so the guards do not false-positive.
- **Load-bearing, not decorative.** Neutering Detector C's claim patterns fails **5 of 16** cases; with it, 0 fail. The pre-existing detectors stay green in both runs, so the neutering was surgical.
- **Fresh-install smoke.** `tests/integration/test_installer_registers_fabrication_guards.sh` runs the real installer against a sandboxed `HOME`, asserts the guards are absent beforehand (control), registered after, and then executes the **shipped Stop command verbatim**: it blocks the incident transcript and passes an honest close. Also asserts idempotency.
- Full `scripts/ci.sh` green locally: 300 files py_compile, 83 integration tests, 12 unit suites, shellcheck, phase-doc python, UTF-8 guard.

## Known limits (not claims)

- Evidence is matched **session-wide**, not per-branch.
- Only the **final** assistant message is scanned.
- A paraphrase outside the patterns evades it.

Bypasses: `FAB_VERIFY_CHECK_BYPASS=1`, `FAB_HOOK_CHECK_BYPASS=1`, `CHAINED_STATE_CMD_BYPASS=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
