### PR TITLE
perf(hooks): fast-path the fabrication guard + wire fleet fire telemetry

### DIFF
--- a/hooks/check-fabricated-hook-attribution.py
+++ b/hooks/check-fabricated-hook-attribution.py
@@ -24,6 +24,15 @@ import sys
 import time
 from pathlib import Path
 
+# Fire telemetry (MYC-285). Fail-open: a missing _lib must never break the
+# guard or its tests.
+try:
+    sys.path.insert(0, str(Path(__file__).resolve().parent / "_lib"))
+    from guard_telemetry import log_fire
+except Exception:  # pragma: no cover - telemetry is never load-bearing
+    def log_fire(*_a, **_k):
+        return
+
 WINDOW_SEC = 600
 LOG_PATH = Path.home() / ".claude" / "hookify-blocks.log"
 
@@ -41,6 +50,7 @@ CLAIM_PATTERNS = [
 
 def main() -> None:
     if os.environ.get("FAB_HOOK_CHECK_BYPASS") == "1":
+        log_fire("check-fabricated-hook-attribution", status="bypassed")
         sys.exit(0)
     try:
         data = json.load(sys.stdin)
@@ -74,6 +84,8 @@ def main() -> None:
         f"from the actual tool error in this turn, or say 'a hook blocked this' without "
         f"naming a specific one. Bypass for forensic discussion: FAB_HOOK_CHECK_BYPASS=1."
     )
+    log_fire("check-fabricated-hook-attribution", status="blocked",
+             names=",".join(fabricated))
     print(json.dumps({"decision": "block", "reason": msg}))
     sys.exit(0)
 

--- a/hooks/check-fabricated-verification.py
+++ b/hooks/check-fabricated-verification.py
@@ -45,6 +45,16 @@ import re
 import sys
 from pathlib import Path
 
+# Fire telemetry (MYC-285). Fail-open: a missing _lib must never break the
+# guard or its tests. Without this the guard is invisible to the fleet report —
+# we could not tell whether it ever fires, or is being bypassed in the field.
+try:
+    sys.path.insert(0, str(Path(__file__).resolve().parent / "_lib"))
+    from guard_telemetry import log_fire
+except Exception:  # pragma: no cover - telemetry is never load-bearing
+    def log_fire(*_a, **_k):
+        return
+
 # Token shapes that name a concrete external artifact you can only know by
 # running something: git SHAs (7-40 hex), deploy/build IDs (>=8 hex or
 # hex-with-dashes), long numeric run IDs (>=8 digits).
@@ -173,6 +183,7 @@ def _present(tok: str, blob: str) -> bool:
 
 def main() -> None:
     if os.environ.get("FAB_VERIFY_CHECK_BYPASS") == "1":
+        log_fire("check-fabricated-verification", status="bypassed")
         sys.exit(0)
     try:
         data = json.load(sys.stdin)
@@ -187,6 +198,15 @@ def main() -> None:
     try:
         last = _last_assistant_text(tp)
         if not last:
+            sys.exit(0)
+        # Cheap gate before the expensive read. Every detector requires a match
+        # in `last`; with no claim of any kind there, `findings` is provably
+        # empty, so parsing the whole transcript for evidence is pure waste.
+        # Stop fires once per turn and a long session's transcript reaches tens
+        # of MB, so skipping the second full parse on the common (no-claim) turn
+        # is most of this guard's cost. Behavior is unchanged by construction:
+        # this is the disjunction of the detectors' own entry conditions.
+        if not _has_any_claim(last):
             sys.exit(0)
         result_blob, command_blob = _evidence(tp)
     except Exception:
@@ -290,8 +310,26 @@ def main() -> None:
         "Forensic writeups and not-yet-happened plans pass automatically. Hard bypass: "
         "FAB_VERIFY_CHECK_BYPASS=1."
     )
+    log_fire("check-fabricated-verification", status="blocked", findings=len(set(findings)))
     print(json.dumps({"decision": "block", "reason": msg}))
     sys.exit(0)
+
+
+def _has_any_claim(text: str) -> bool:
+    """True if `text` could possibly trip ANY detector.
+
+    This is the exact disjunction of the detectors' entry conditions:
+      A -> ID_TOKEN            B -> HTTP_CLAIM | DEPLOY_CLAIM
+      C -> COMMITTED | PUSHED | PR | MERGED
+    Keep it in sync when adding a detector, or that detector goes dark. The
+    unit suite's blocking cases fail loudly if this ever under-matches, since
+    a claim that no longer reaches its detector stops being blocked.
+    """
+    for pat in (ID_TOKEN, HTTP_CLAIM, DEPLOY_CLAIM,
+                COMMITTED_CLAIM, PUSHED_CLAIM, PR_CLAIM, MERGED_CLAIM):
+        if pat.search(text):
+            return True
+    return False
 
 
 def _claim_exempt(text: str, claim_re: "re.Pattern") -> bool:

--- a/hooks/check_fab_shim.py
+++ b/hooks/check_fab_shim.py
@@ -1,0 +1,11 @@
+"""Loader: import the hyphenated guard module so tests can exercise its
+internal fast-path gate directly. Hyphens are not importable identifiers."""
+import importlib.util
+from pathlib import Path
+
+_spec = importlib.util.spec_from_file_location(
+    "_cfv", Path(__file__).resolve().parent / "check-fabricated-verification.py")
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+has_any_claim = _mod._has_any_claim

--- a/hooks/test_check_fabricated_verification.py
+++ b/hooks/test_check_fabricated_verification.py
@@ -237,6 +237,57 @@ else:
     PASS += 1
     print("PASS  15. FAB_VERIFY_CHECK_BYPASS=1 disables the guard")
 
+# --- FAST PATH: no-claim turns must skip the evidence read, without weakening ---
+# The guard early-exits before parsing the transcript when the final message
+# contains no claim at all. That is only safe if the gate is the exact
+# disjunction of the detectors' entry conditions. These pin both halves.
+import check_fab_shim as _shim  # noqa: E402  (loader below)
+
+for _label, _text, _want in [
+    ("16. fast-path gate lets a pushed-claim through to its detector",
+     "The branch is pushed and up to date on origin.", True),
+    ("17. fast-path gate lets a PR claim through", "PR #144 is open.", True),
+    ("18. fast-path gate lets a merged claim through", "The work is merged.", True),
+    ("19. fast-path gate lets a committed claim through", "The changes are committed.", True),
+    ("20. fast-path gate lets an HTTP claim through", "curl confirms HTTP 200.", True),
+    ("21. fast-path gate lets a cited ID through", "Deploy `6a191f3a2844` completed.", True),
+    ("22. fast-path gate skips a genuinely claim-free close",
+     "Refactored the parser and added two tests. Both pass locally.", False),
+]:
+    _got = _shim.has_any_claim(_text)
+    if _got == _want:
+        PASS += 1
+        print(f"PASS  {_label}")
+    else:
+        FAIL += 1
+        print(f"FAIL  {_label} :: gate returned {_got}, expected {_want}")
+
+# --- TELEMETRY: a block must be observable in the fleet log ---
+import tempfile as _tf, os as _os  # noqa: E402
+_td = _tf.mkdtemp()
+_log = _os.path.join(_td, "guard-fires.jsonl")
+_blocked, _ = run(
+    "All 16 fixes are committed and pushed to origin. PR #144 contains every one.",
+    commands=[INCIDENT_CMD], results=[INCIDENT_TAIL],
+    env=dict(_os.environ, GUARD_FIRES_LOG=_log),
+)
+if _blocked and _os.path.exists(_log) and "check-fabricated-verification" in open(_log).read():
+    PASS += 1
+    print("PASS  23. block emits guard-fire telemetry (fleet report can see it)")
+else:
+    FAIL += 1
+    print(f"FAIL  23. telemetry :: blocked={_blocked} log_exists={_os.path.exists(_log)}")
+
+_log2 = _os.path.join(_td, "bypass.jsonl")
+run("It is pushed.", commands=["git push"], results=["ok"],
+    env=dict(_os.environ, FAB_VERIFY_CHECK_BYPASS="1", GUARD_FIRES_LOG=_log2))
+if _os.path.exists(_log2) and "bypassed" in open(_log2).read():
+    PASS += 1
+    print("PASS  24. bypass is recorded as 'bypassed' (heeded-vs-bypassed math works)")
+else:
+    FAIL += 1
+    print("FAIL  24. bypass telemetry not recorded")
+
 print()
 print(f"=== summary: {PASS} passed, {FAIL} failed ===")
 sys.exit(1 if FAIL else 0)

--- a/hooks/warn-chained-state-command-truncated.py
+++ b/hooks/warn-chained-state-command-truncated.py
@@ -23,6 +23,16 @@ import json
 import os
 import re
 import sys
+from pathlib import Path
+
+# Fire telemetry (MYC-285). Fail-open: a missing _lib must never break the
+# guard or its tests.
+try:
+    sys.path.insert(0, str(Path(__file__).resolve().parent / "_lib"))
+    from guard_telemetry import log_fire
+except Exception:  # pragma: no cover - telemetry is never load-bearing
+    def log_fire(*_a, **_k):
+        return
 
 # State-changing commands whose success cannot be inferred from a truncated tail.
 STATE_CMD = re.compile(
@@ -38,6 +48,7 @@ CHAIN = re.compile(r"(?<!&)&&(?!&)")
 
 def main() -> None:
     if os.environ.get("CHAINED_STATE_CMD_BYPASS") == "1":
+        log_fire("warn-chained-state-command-truncated", status="bypassed")
         sys.exit(0)
     try:
         data = json.load(sys.stdin)
@@ -74,6 +85,8 @@ def main() -> None:
         "the end state from the system of record: `git rev-parse origin/<branch>` for a push, "
         "`gh pr view <n> --json headRefOid,state` for a PR. Bypass: CHAINED_STATE_CMD_BYPASS=1."
     )
+    log_fire("warn-chained-state-command-truncated", status="warned",
+             cmds=",".join(hits))
     print(json.dumps({
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",


### PR DESCRIPTION
Follow-up to #351, driven by measuring the shipped guards on real data rather than assuming they were fine.

## Perf: the Stop guard parsed a 50 MB transcript twice, every turn

`Stop` fires at every turn-end. The guard read the whole transcript once for the final assistant message and once again for evidence. Real transcripts on a working machine reach **50 MB** (1054 transcripts present; largest 50.6 MB).

Every detector requires a match in the final message. So when that message contains no claim at all — the overwhelmingly common turn — the second parse is provably dead work. `_has_any_claim` is the exact disjunction of the detectors' entry conditions and short-circuits before it.

**Measured, real 50 MB transcript, no-claim close: 159 ms → 86 ms (46% cut).**

Split of what remains: `_last_assistant_text` 72 ms (unavoidable — the final message is at EOF), `_evidence` 73 ms (now skipped on the common turn).

One honesty note on method: the first benchmark showed no improvement because the transcript I grabbed happened to end with a real "committed" claim, so the fast path correctly did *not* fire. The win only appears when you measure the case the optimization targets.

### The correctness risk, handled

A fast-path gate that drifts from the detectors silently disables them. Cases 16-22 pin it open for every claim shape (pushed / PR / merged / committed / HTTP / cited ID) and shut for a genuinely claim-free close, so a future detector added without extending the gate **fails the suite** instead of going dark.

## Telemetry: all three guards were invisible to the fleet report

`hooks/_lib/guard_telemetry.py` exists and other guards use it, but none of the three from #351 called it. MYC-285 built the guard-fleet report specifically so add/keep/prune decisions are data-driven — a guard outside it can't be shown to fire, or to be quietly bypassed.

Each guard now calls `log_fire` at its decision point using the shared taxonomy (`blocked` / `warned` / `bypassed`), fail-open through the existing helper. Cases 23-24 assert that a block and a bypass both land in the log.

This matters commercially: shipping a safety guard we cannot measure in the field is the same shape as shipping one that isn't activated.

## Proof

- 25/25 in `hooks/test_check_fabricated_verification.py` (was 16; +7 fast-path, +2 telemetry).
- Full `scripts/ci.sh` green: 301 files py_compile, 83 integration tests, 12 unit suites, shellcheck, phase-doc python, UTF-8 guard.
- Scrub clean, fail-closed (an empty diff now aborts rather than reading as clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
