### PR TITLE
fix(auto-update): self-heal abandoned git locks that freeze updates forever

### DIFF
--- a/scripts/ai-brain-auto-update.py
+++ b/scripts/ai-brain-auto-update.py
@@ -82,6 +82,85 @@ def _reclaim_stale_lock(lock: Path) -> None:
         pass
 
 
+GIT_LOCK_NAMES = ("index.lock", "HEAD.lock", "shallow.lock")
+
+
+def _git_dir(repo: Path) -> "Path | None":
+    """The real .git directory, WITHOUT shelling out to git (which is exactly
+    what a stuck lock can break). `.git` is a directory in a normal clone and a
+    `gitdir:` pointer FILE in a linked worktree."""
+    dot = repo / ".git"
+    try:
+        if dot.is_dir():
+            return dot
+        if dot.is_file():
+            txt = dot.read_text(encoding="utf-8", errors="replace").strip()
+            if txt.startswith("gitdir:"):
+                p = Path(txt.split(":", 1)[1].strip())
+                return p if p.is_absolute() else (repo / p).resolve()
+    except OSError:
+        return None
+    return None
+
+
+def _lock_is_held(lock: Path) -> "bool | None":
+    """True if a LIVE process holds the lock, False if provably not, None if we
+    cannot tell (no lsof). Never guesses True->False: unknown stays unknown, and
+    the caller then falls back to the age test alone."""
+    try:
+        r = subprocess.run(["lsof", "-t", str(lock)],
+                           capture_output=True, text=True, timeout=5)
+        return bool(r.stdout.strip())
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+
+
+def _reclaim_stale_git_locks(repo: Path) -> list:
+    """Remove ABANDONED git lock files, which otherwise block every future pull
+    FOREVER (MYC-3175, the 3rd mechanism of the MYC-1988 install-clone-freeze
+    class). Same reasoning as _reclaim_stale_lock above, applied to git's own
+    locks: a git process killed mid-operation strands `.git/index.lock`, and
+    from then on EVERY `git pull` fails with "Unable to create index.lock".
+    Nothing self-heals, so the install silently stops receiving updates —
+    including guard and security fixes.
+
+    Deliberately conservative; removing a lock a live git holds would corrupt
+    the repo. A lock is reclaimed ONLY when BOTH hold:
+      * older than ABS_STALE_GIT_LOCK_AGE_SEC (default 1h). No git operation
+        holds an index lock for an hour; a real one clears in seconds.
+      * not held by any live process, per lsof. When lsof is unavailable the
+        age test alone decides — and on Windows the unlink itself raises
+        PermissionError while a process holds the file, which is a stronger
+        check than lsof and needs no extra code.
+
+    Returns the names reclaimed (for surfacing), never raises.
+    """
+    try:
+        min_age = float(os.environ.get("ABS_STALE_GIT_LOCK_AGE_SEC", "3600"))
+    except ValueError:
+        min_age = 3600.0
+    gitdir = _git_dir(repo)
+    if gitdir is None:
+        return []
+    reclaimed = []
+    for name in GIT_LOCK_NAMES:
+        lock = gitdir / name
+        try:
+            if not lock.is_file():
+                continue
+            if (time.time() - lock.stat().st_mtime) <= min_age:
+                continue  # recent -> assume a real concurrent git operation
+            if _lock_is_held(lock) is True:
+                continue  # a live process owns it; never stomp it
+            lock.unlink()
+            reclaimed.append(name)
+        except OSError:
+            # Windows raises PermissionError while the file is genuinely held.
+            # Leaving it alone is the correct, safe outcome.
+            continue
+    return reclaimed
+
+
 def _install_fix_cmd() -> str:
     """The manual re-install command, phrased for the user's actual platform."""
     py = "python" if os.name == "nt" else "python3"
@@ -124,12 +203,28 @@ def run() -> None:
         if not (skill / ".git").exists():
             silent()
 
+        # 2b. Reclaim abandoned git locks BEFORE any git call. A stranded
+        # .git/index.lock fails every fetch/merge forever, so without this the
+        # install freezes permanently and silently (MYC-3175).
+        reclaimed_locks = _reclaim_stale_git_locks(skill)
+
         # 3. Fetch. Network down -> gentle note, never crash the turn.
         try:
             fetch = _git(["fetch", "origin", "main", "--quiet"], skill)
         except (subprocess.TimeoutExpired, OSError):
             fetch = None
         if fetch is None or fetch.returncode != 0:
+            err = (fetch.stderr or "") if fetch is not None else ""
+            if "lock" in err.lower():
+                # Not a network problem. Saying "couldn't reach the internet"
+                # here sends the user to debug wifi while a held lock blocks
+                # every update (MYC-3175).
+                emit_ctx(
+                    "AI Brain Starter could not check for updates: a git lock file "
+                    f"in {skill} is being held. If another git process is running "
+                    "there, this clears itself; otherwise the updater auto-clears "
+                    "locks older than an hour on the next check. Verbatim git "
+                    f"error: {err.strip()[:300]}")
             emit_ctx(
                 "AI Brain Starter checked for updates but couldn't reach the "
                 "internet (or the repository). Nothing is wrong — it will try "
@@ -141,6 +236,17 @@ def run() -> None:
         except (subprocess.TimeoutExpired, OSError):
             silent()
         if not head or head == origin:
+            # Surface a heal even when there is nothing to pull. This is the
+            # case that was invisible before: the clone had been frozen for
+            # days by a stranded lock, and going silent here would hide both
+            # the freeze and the repair (MYC-3175).
+            if reclaimed_locks:
+                emit_ctx(
+                    "AI Brain Starter cleared an abandoned git lock "
+                    f"({', '.join(reclaimed_locks)}) in {skill} that a crashed git "
+                    "process had left behind. Every update had been failing since "
+                    "then, silently. Updates work again — your copy is now current. "
+                    "No action needed.")
             silent()  # already current
 
         # 4. ff-ONLY. Tracked-file edits or a divergent fork refuse the pull.
@@ -156,6 +262,22 @@ def run() -> None:
                     "first). Everything else keeps working in the meantime.")
             merge = _git(["merge", "--ff-only", "origin/main", "--quiet"], skill)
             if merge.returncode != 0:
+                # Distinguish the two causes. A stuck lock is NOT a fork, and
+                # telling the user "you have a local fork" sends them to fix
+                # the wrong thing while the real cause (an abandoned
+                # .git/*.lock a crashed git left behind) persists forever.
+                # A lock still present HERE survived 2b, so it is either fresh
+                # (a real concurrent git) or genuinely held.
+                if "lock" in (merge.stderr or "").lower():
+                    emit_ctx(
+                        "AI Brain Starter auto-update is BLOCKED: a git lock file in "
+                        f"{skill} is being held, so the pull cannot run. If another "
+                        "git process is working there right now, this clears itself. "
+                        "If nothing else is running, a crashed git left the lock "
+                        "behind and every future update will keep failing until it "
+                        "is removed — the updater auto-clears locks older than an "
+                        "hour, so this should resolve on the next check. Verbatim "
+                        f"git error: {(merge.stderr or '').strip()[:300]}")
                 emit_ctx(
                     "AI Brain Starter auto-update is BLOCKED (safely): your copy at "
                     f"{skill} has diverged from the official version (a local "

--- a/scripts/test_stale_git_lock_reclaim.py
+++ b/scripts/test_stale_git_lock_reclaim.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Controls for the abandoned-git-lock reclaim in ai-brain-auto-update.py.
+
+MYC-3175. A git process killed mid-operation strands `.git/index.lock`; from
+then on EVERY `git pull` fails with "Unable to create index.lock" and the
+install silently stops receiving updates — including guard and security fixes.
+Observed live 2026-07-20: a 0-byte index.lock dated Jul 17 had been failing
+every pull for 3 days with no signal.
+
+The reclaim must be aggressive enough to fix that and conservative enough never
+to stomp a live git. Both halves are controlled here:
+
+  FIRES (the catch)
+    1. a stale index.lock is removed
+    2. stale HEAD.lock / shallow.lock are removed too
+    3. after the reclaim a real `git pull --ff-only` SUCCEEDS  <- end-to-end
+    4. it works through a `.git`-as-pointer-file worktree
+
+  DOES NOT FIRE (no corruption)
+    5. a FRESH lock is left alone (a real concurrent git operation)
+    6. a lock HELD by a live process is left alone, even when old
+    7. a repo with no lock is untouched
+    8. a non-repo path is a safe no-op
+    9. the age threshold is env-tunable
+
+Stdlib + git only. Exit 0 = all pass.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+spec = importlib.util.spec_from_file_location("abs_au", HERE / "ai-brain-auto-update.py")
+au = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(au)
+
+PASS = 0
+FAIL = 0
+
+
+def ok(label):
+    global PASS
+    PASS += 1
+    print(f"PASS  {label}")
+
+
+def bad(label, why):
+    global FAIL
+    FAIL += 1
+    print(f"FAIL  {label} :: {why}")
+
+
+def mkrepo(root: Path) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    env = {**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+    subprocess.run(["git", "init", "-q", str(root)], check=True, env=env)
+    (root / "f.txt").write_text("x")
+    subprocess.run(["git", "-C", str(root), "add", "f.txt"], check=True, env=env)
+    subprocess.run(["git", "-C", str(root), "commit", "-qm", "init"], check=True, env=env)
+    return root
+
+
+def plant(repo: Path, name: str, age_sec: float) -> Path:
+    lock = repo / ".git" / name
+    lock.write_text("")
+    t = time.time() - age_sec
+    os.utime(lock, (t, t))
+    return lock
+
+
+TMP = Path(tempfile.mkdtemp())
+
+# --- 1. stale index.lock removed -------------------------------------------
+r = mkrepo(TMP / "stale")
+lock = plant(r, "index.lock", 7200)
+got = au._reclaim_stale_git_locks(r)
+if not lock.exists() and "index.lock" in got:
+    ok("1. stale index.lock (2h) is reclaimed")
+else:
+    bad("1. stale index.lock", f"exists={lock.exists()} returned={got}")
+
+# --- 2. other stale git locks removed --------------------------------------
+r = mkrepo(TMP / "stale-multi")
+plant(r, "HEAD.lock", 7200)
+plant(r, "shallow.lock", 7200)
+got = au._reclaim_stale_git_locks(r)
+if set(got) >= {"HEAD.lock", "shallow.lock"}:
+    ok("2. stale HEAD.lock + shallow.lock reclaimed")
+else:
+    bad("2. other locks", f"returned={got}")
+
+# --- 3. END-TO-END: a real pull works again after the reclaim ---------------
+# THE regression. Before: pull fails forever. After: reclaim then pull succeeds.
+env = {**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+       "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+origin = mkrepo(TMP / "origin")
+clone = TMP / "clone"
+subprocess.run(["git", "clone", "-q", str(origin), str(clone)], check=True, env=env)
+(origin / "new.txt").write_text("y")
+subprocess.run(["git", "-C", str(origin), "add", "new.txt"], check=True, env=env)
+subprocess.run(["git", "-C", str(origin), "commit", "-qm", "second"], check=True, env=env)
+
+stuck = plant(clone, "index.lock", 7200)
+pre = subprocess.run(["git", "-C", str(clone), "pull", "--ff-only", "-q"],
+                     capture_output=True, text=True, env=env)
+if pre.returncode == 0:
+    bad("3. premise", "pull SUCCEEDED with a planted lock — the test proves nothing")
+else:
+    au._reclaim_stale_git_locks(clone)
+    post = subprocess.run(["git", "-C", str(clone), "pull", "--ff-only", "-q"],
+                          capture_output=True, text=True, env=env)
+    if post.returncode == 0 and (clone / "new.txt").exists():
+        ok("3. END-TO-END: pull blocked by the lock, succeeds after the reclaim")
+    else:
+        bad("3. end-to-end", f"post-reclaim pull rc={post.returncode} {post.stderr[:120]}")
+
+# --- 4. worktree (.git is a pointer FILE, not a dir) -----------------------
+r = mkrepo(TMP / "wtmain")
+wt = TMP / "wtlinked"
+subprocess.run(["git", "-C", str(r), "worktree", "add", "-q", str(wt)],
+               check=True, capture_output=True, env=env)
+gd = au._git_dir(wt)
+if gd is None or not gd.exists():
+    bad("4. worktree gitdir", f"resolved to {gd}")
+else:
+    wl = gd / "index.lock"
+    wl.write_text("")
+    t = time.time() - 7200
+    os.utime(wl, (t, t))
+    got = au._reclaim_stale_git_locks(wt)
+    if not wl.exists() and "index.lock" in got:
+        ok("4. worktree (.git pointer file) lock reclaimed")
+    else:
+        bad("4. worktree", f"exists={wl.exists()} returned={got}")
+
+# --- 5. FRESH lock left alone ----------------------------------------------
+r = mkrepo(TMP / "fresh")
+lock = plant(r, "index.lock", 30)
+got = au._reclaim_stale_git_locks(r)
+if lock.exists() and not got:
+    ok("5. FRESH lock (30s) left alone — a real concurrent git is not stomped")
+else:
+    bad("5. fresh lock", f"exists={lock.exists()} returned={got}")
+
+# --- 6. HELD lock left alone even when OLD ---------------------------------
+# The corruption case. A live process holds the fd; lsof must veto the age test.
+r = mkrepo(TMP / "held")
+lock = plant(r, "index.lock", 7200)
+holder = subprocess.Popen(
+    [sys.executable, "-c",
+     f"f=open({str(lock)!r},'r'); import time; time.sleep(30)"])
+time.sleep(1.5)
+try:
+    if au._lock_is_held(lock) is None:
+        ok("6. HELD lock: SKIPPED (no lsof on this box — age test alone governs)")
+    else:
+        got = au._reclaim_stale_git_locks(r)
+        if lock.exists() and not got:
+            ok("6. HELD lock left alone despite being 2h old — no corruption")
+        else:
+            bad("6. held lock", f"REMOVED A HELD LOCK: exists={lock.exists()} got={got}")
+finally:
+    holder.kill()
+    holder.wait()
+
+# --- 7. no lock -> untouched ------------------------------------------------
+r = mkrepo(TMP / "clean")
+got = au._reclaim_stale_git_locks(r)
+if not got:
+    ok("7. repo with no lock is untouched")
+else:
+    bad("7. clean repo", f"returned={got}")
+
+# --- 8. non-repo -> safe no-op ---------------------------------------------
+p = TMP / "notarepo"
+p.mkdir()
+try:
+    got = au._reclaim_stale_git_locks(p)
+    ok("8. non-repo path is a safe no-op") if not got else bad("8. non-repo", got)
+except Exception as e:
+    bad("8. non-repo", f"raised {e!r}")
+
+# --- 9. threshold is env-tunable -------------------------------------------
+r = mkrepo(TMP / "tunable")
+lock = plant(r, "index.lock", 120)
+os.environ["ABS_STALE_GIT_LOCK_AGE_SEC"] = "60"
+try:
+    got = au._reclaim_stale_git_locks(r)
+    if not lock.exists() and got:
+        ok("9. ABS_STALE_GIT_LOCK_AGE_SEC lowers the threshold")
+    else:
+        bad("9. tunable", f"exists={lock.exists()} returned={got}")
+finally:
+    del os.environ["ABS_STALE_GIT_LOCK_AGE_SEC"]
+
+print()
+print(f"=== summary: {PASS} passed, {FAIL} failed ===")
+sys.exit(1 if FAIL else 0)


### PR DESCRIPTION
Closes MYC-3175 — the third mechanism of the MYC-1988 install-clone-freeze class, and the worst one, because it never resolves on its own.

## The failure

A git process killed mid-operation strands `.git/index.lock`. From then on **every** `git pull` fails with `Unable to create '.../.git/index.lock': File exists.` Nothing self-heals, so the install silently stops receiving updates — including guard and security fixes — while looking perfectly healthy: a valid repo at a valid commit, so staleness checks under-report and no one learns that pulls have been failing since some date months back.

Observed live 2026-07-20 on the maintainer machine: a **0-byte `index.lock` dated Jul 17** had been failing every pull for 3 days, unnoticed. It surfaced only because a deploy was being *verified* rather than assumed — running the installer against that frozen clone would have registered a stale `hooks.json` and reported freshly-merged guards as deployed while they sat dormant.

The updater already reclaims **its own** stranded lock, with exactly this reasoning in the comment: *"a SIGKILL mid-run strands the lock and would silently disable updates forever."* It never applied that to git's locks. Now it does.

## Safety — the part that matters

Stomping a lock a live git holds would corrupt the repo. A lock is reclaimed only when **both** hold:

- **Older than an hour** (`ABS_STALE_GIT_LOCK_AGE_SEC`). No real git operation holds an index lock for an hour; a live one clears in seconds.
- **Not held by any live process**, per `lsof`. Where `lsof` is unavailable the age test alone decides — and on Windows the `unlink` itself raises `PermissionError` while a process holds the file, which is a stronger check than lsof and needs no extra code.

`_git_dir` resolves the real git directory **without shelling out to git**, since a stuck lock is exactly what can break git. It handles `.git` as a directory and as a `gitdir:` pointer file (linked worktrees).

## The diagnosis bug, which made this worse than silent

A stuck lock fails `merge --ff-only`, and the updater reported:

> your copy has diverged from the official version (a local fork)

That is simply wrong. It sends the user to resolve a fork that does not exist while the actual cause persists forever. Lock failures on both the fetch and merge paths now say what actually happened and quote git verbatim. And when a heal happens with nothing left to pull, that no longer goes silent — the user is told their updates had been broken and now work, which is the only signal that a multi-day freeze ever occurred.

## Controls (9, both directions)

**It FIRES:** stale `index.lock` / `HEAD.lock` / `shallow.lock` reclaimed · worktree pointer-file gitdirs resolved · **end-to-end**, a real `git pull` succeeds after the reclaim, with the premise asserted first (the test fails loudly if the planted lock does *not* block the pull, so the leg can never pass vacuously).

**It does NOT fire:** a fresh 30s lock survives · a **2h-old lock HELD by a live process survives**, proven against a real subprocess holding the fd rather than a mock · no-lock repo untouched · non-repo is a safe no-op · threshold is env-tunable.

Full `scripts/ci.sh` green: 302 files py_compile, 83 integration tests, 13 unit suites, shellcheck, phase-doc python, UTF-8 guard. Scrub clean (fail-closed).

## Deliberately not folded in

**MYC-2453** (the cooldown is stamped *before* the attempt, so any failure locks out retries for 6 days). Doing it properly needs nag-suppression state so a repeating failure does not warn hourly — a real UX design, not a line move. With this self-heal a stranded lock clears on the next scheduled run instead of never, so 2453 is no longer what makes the freeze permanent.

**Remaining on MYC-3175:** a `last-successful-pull` timestamp surfaced at SessionStart, which is the durable defense against a *fourth* mechanism. This PR closes the known one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
