### PR TITLE
feat(auto-update): surface a clone that stopped pulling + share the lock reclaim

### DIFF
--- a/hooks/_lib/dev_repo_scan.py
+++ b/hooks/_lib/dev_repo_scan.py
@@ -26,6 +26,19 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import NamedTuple, Optional
 
+# Abandoned-git-lock reclaim (MYC-3175), shared with the install-clone updater.
+# Fail-open: a missing sibling must never break the scan.
+try:
+    from .git_locks import reclaim_stale_git_locks
+except ImportError:  # loaded as a plain module (not a package), the common case
+    try:
+        import sys as _sys
+        _sys.path.insert(0, str(Path(__file__).resolve().parent))
+        from git_locks import reclaim_stale_git_locks
+    except Exception:  # pragma: no cover - heal is best-effort
+        def reclaim_stale_git_locks(_repo):
+            return []
+
 
 SOURCE_EXT_RE = re.compile(
     r"\.(py|ts|tsx|js|jsx|go|rs|java|rb|php|c|cpp|h|hpp|swift|kt|scala)$"
@@ -895,6 +908,13 @@ def execute_hub_refresh(
         return res
 
     upstream = f"origin/{fresh.default_branch}"
+    # Reclaim an abandoned index.lock first (MYC-3175). A crashed git strands it
+    # and then EVERY ff here fails forever, so the hub silently rots while the
+    # report keeps calling it merely "behind" — the same permanent freeze the
+    # install clone hit. Conservative: only an old, unheld lock is removed.
+    reclaimed = reclaim_stale_git_locks(state.repo)
+    if reclaimed:
+        res["reclaimed_locks"] = reclaimed
     rc, _out, err = _git(state.repo, "merge", "--ff-only", upstream)
     res["ok"] = rc == 0
     res["applied"] = rc == 0

--- a/hooks/_lib/git_locks.py
+++ b/hooks/_lib/git_locks.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Reclaim ABANDONED git lock files. The canonical implementation (MYC-3175).
+
+A git process killed mid-operation strands `.git/index.lock`. From then on every
+operation that takes the index lock — `pull`, `merge --ff-only`, `checkout` —
+fails with "Unable to create index.lock". Nothing self-heals, so a managed clone
+silently stops updating while looking perfectly healthy: a valid repo at a valid
+commit. Observed live 2026-07-20: a 0-byte index.lock dated Jul 17 had failed
+every pull for 3 days, unnoticed.
+
+ONE implementation, every consumer that fast-forwards a managed clone:
+  * scripts/ai-brain-auto-update.py  — the install clone
+  * hooks/_lib/dev_repo_scan.py      — the ~/dev hub fleet
+A second copy would rot the moment one is fixed; that is the same
+deployed!=committed drift class this exists to prevent.
+
+CONSERVATIVE BY CONSTRUCTION. Removing a lock a live git holds corrupts the
+repo, so a lock is reclaimed only when BOTH hold:
+  * older than ABS_STALE_GIT_LOCK_AGE_SEC (default 3600). No real git operation
+    holds an index lock for an hour; a live one clears in seconds.
+  * not held by any live process, per lsof. Where lsof is unavailable the age
+    test alone decides — and on Windows the unlink itself raises PermissionError
+    while a process holds the file, a stronger check than lsof needing no code.
+
+Stdlib only. Never raises: a failure to heal must never break the caller.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from pathlib import Path
+
+# Locks that block a fast-forward. Others (config.lock, packed-refs.lock) are
+# held so briefly that an abandoned one is not a realistic freeze source.
+GIT_LOCK_NAMES = ("index.lock", "HEAD.lock", "shallow.lock")
+DEFAULT_MIN_AGE_SEC = 3600.0
+
+
+def git_dir(repo: Path) -> "Path | None":
+    """The real .git directory, WITHOUT shelling out to git — which is exactly
+    what a stuck lock can break. Handles `.git` as a directory (normal clone)
+    and as a `gitdir:` pointer FILE (linked worktree)."""
+    dot = Path(repo) / ".git"
+    try:
+        if dot.is_dir():
+            return dot
+        if dot.is_file():
+            txt = dot.read_text(encoding="utf-8", errors="replace").strip()
+            if txt.startswith("gitdir:"):
+                p = Path(txt.split(":", 1)[1].strip())
+                return p if p.is_absolute() else (Path(repo) / p).resolve()
+    except OSError:
+        return None
+    return None
+
+
+def lock_is_held(lock: Path) -> "bool | None":
+    """True if a LIVE process holds the lock, False if provably not, None if we
+    cannot tell (lsof absent). Unknown stays unknown — never downgraded to
+    False — so the caller falls back to the age test rather than assuming safe.
+    """
+    try:
+        r = subprocess.run(["lsof", "-t", str(lock)],
+                           capture_output=True, text=True, timeout=5)
+        return bool(r.stdout.strip())
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+
+
+def reclaim_stale_git_locks(repo: Path) -> list:
+    """Remove abandoned git locks in `repo`. Returns the names reclaimed (for
+    surfacing), never raises. See module docstring for the safety contract."""
+    try:
+        min_age = float(os.environ.get("ABS_STALE_GIT_LOCK_AGE_SEC",
+                                       str(DEFAULT_MIN_AGE_SEC)))
+    except (ValueError, TypeError):
+        min_age = DEFAULT_MIN_AGE_SEC
+    gd = git_dir(repo)
+    if gd is None:
+        return []
+    reclaimed = []
+    for name in GIT_LOCK_NAMES:
+        lock = gd / name
+        try:
+            if not lock.is_file():
+                continue
+            if (time.time() - lock.stat().st_mtime) <= min_age:
+                continue  # recent -> assume a real concurrent git operation
+            if lock_is_held(lock) is True:
+                continue  # a live process owns it; never stomp it
+            lock.unlink()
+            reclaimed.append(name)
+        except OSError:
+            # Windows raises PermissionError while the file is genuinely held.
+            # Leaving it alone is the correct, safe outcome.
+            continue
+    return reclaimed

--- a/hooks/surface-deployed-hooks-behind.py
+++ b/hooks/surface-deployed-hooks-behind.py
@@ -74,6 +74,7 @@ import importlib.util
 import json
 import os
 import sys
+import time
 from pathlib import Path
 
 MAX_LISTED = 12
@@ -361,15 +362,63 @@ def _drift_message() -> str | None:
     return _build_message(missing, retired)
 
 
+def _stale_pull_message() -> "str | None":
+    """MYC-3175: surface a clone that has not SUCCESSFULLY pulled in a long time.
+
+    The third instance of this file's class, one artifact further out. The
+    updater stamps `.ai-brain-starter-last-successful-pull` only when it has
+    confirmed the clone current with origin. `.ai-brain-starter-last-update`
+    keeps moving on every ATTEMPT, so a permanently-blocked clone looks busy;
+    only the gap between the two reveals it.
+
+    Why not "behind origin": a clone that cannot fetch cannot learn it is
+    behind, so the obvious signal is exactly the one the failure suppresses.
+    Elapsed-time-since-success needs no network and cannot be under-reported.
+
+    Silent unless the stamp EXISTS and is older than ABS_STALE_PULL_DAYS
+    (default 21 — three update intervals, so one or two missed cycles never
+    nag). A missing stamp is a pre-seed install, not a freeze. A pinned install
+    opted out. Any error -> None (fail open)."""
+    state = Path(
+        os.environ.get("ABS_UPDATE_STATE_DIR")
+        or (Path(os.environ.get("ABS_SETTINGS_JSON")).parent
+            if os.environ.get("ABS_SETTINGS_JSON")
+            else Path.home() / ".claude")
+    )
+    try:
+        if (state / ".ai-brain-starter-pinned").exists():
+            return None
+        stamp = state / ".ai-brain-starter-last-successful-pull"
+        if not stamp.is_file():
+            return None  # never seeded yet; not evidence of a freeze
+        days = float(os.environ.get("ABS_STALE_PULL_DAYS", "21"))
+        age_days = (time.time() - stamp.stat().st_mtime) / 86400.0
+        if age_days <= days:
+            return None
+        return (
+            f"[ai-brain-starter] This copy has not successfully updated in "
+            f"{int(age_days)} days. It still CHECKS for updates, so nothing looks "
+            "broken — but every attempt has been failing, which means new fixes "
+            "(including guard and security fixes) are not reaching this machine. "
+            "Most often a crashed git left a lock behind, or the checkout has "
+            "local edits blocking a fast-forward. Diagnose with: "
+            "cd ~/.claude/skills/ai-brain-starter && git status && git pull --ff-only"
+        )
+    except Exception:
+        return None
+
+
 def main() -> None:
     try:
         json.load(sys.stdin)
     except Exception:
         pass
-    # Two fail-open checks under one "update check" surface: deployed hooks behind
-    # (this file's original job) + skill content behind (MYC-3076). Emit whichever
-    # fired; both, separated, if both; silent if neither.
-    parts = [m for m in (_drift_message(), _skill_drift_message()) if m]
+    # Three fail-open checks under one "update check" surface: deployed hooks
+    # behind (this file's original job) + skill content behind (MYC-3076) + the
+    # clone itself no longer pulling (MYC-3175). Emit whichever fired, separated;
+    # silent if none. Same hook, so SessionStart fan-out stays flat (MYC-2348).
+    parts = [m for m in (_drift_message(), _skill_drift_message(),
+                         _stale_pull_message()) if m]
     _emit("\n\n".join(parts) if parts else None)
 
 

--- a/scripts/ai-brain-auto-update.py
+++ b/scripts/ai-brain-auto-update.py
@@ -82,83 +82,26 @@ def _reclaim_stale_lock(lock: Path) -> None:
         pass
 
 
-GIT_LOCK_NAMES = ("index.lock", "HEAD.lock", "shallow.lock")
-
-
-def _git_dir(repo: Path) -> "Path | None":
-    """The real .git directory, WITHOUT shelling out to git (which is exactly
-    what a stuck lock can break). `.git` is a directory in a normal clone and a
-    `gitdir:` pointer FILE in a linked worktree."""
-    dot = repo / ".git"
-    try:
-        if dot.is_dir():
-            return dot
-        if dot.is_file():
-            txt = dot.read_text(encoding="utf-8", errors="replace").strip()
-            if txt.startswith("gitdir:"):
-                p = Path(txt.split(":", 1)[1].strip())
-                return p if p.is_absolute() else (repo / p).resolve()
-    except OSError:
-        return None
-    return None
-
-
-def _lock_is_held(lock: Path) -> "bool | None":
-    """True if a LIVE process holds the lock, False if provably not, None if we
-    cannot tell (no lsof). Never guesses True->False: unknown stays unknown, and
-    the caller then falls back to the age test alone."""
-    try:
-        r = subprocess.run(["lsof", "-t", str(lock)],
-                           capture_output=True, text=True, timeout=5)
-        return bool(r.stdout.strip())
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-
-
-def _reclaim_stale_git_locks(repo: Path) -> list:
-    """Remove ABANDONED git lock files, which otherwise block every future pull
-    FOREVER (MYC-3175, the 3rd mechanism of the MYC-1988 install-clone-freeze
-    class). Same reasoning as _reclaim_stale_lock above, applied to git's own
-    locks: a git process killed mid-operation strands `.git/index.lock`, and
-    from then on EVERY `git pull` fails with "Unable to create index.lock".
-    Nothing self-heals, so the install silently stops receiving updates —
-    including guard and security fixes.
-
-    Deliberately conservative; removing a lock a live git holds would corrupt
-    the repo. A lock is reclaimed ONLY when BOTH hold:
-      * older than ABS_STALE_GIT_LOCK_AGE_SEC (default 1h). No git operation
-        holds an index lock for an hour; a real one clears in seconds.
-      * not held by any live process, per lsof. When lsof is unavailable the
-        age test alone decides — and on Windows the unlink itself raises
-        PermissionError while a process holds the file, which is a stronger
-        check than lsof and needs no extra code.
-
-    Returns the names reclaimed (for surfacing), never raises.
-    """
-    try:
-        min_age = float(os.environ.get("ABS_STALE_GIT_LOCK_AGE_SEC", "3600"))
-    except ValueError:
-        min_age = 3600.0
-    gitdir = _git_dir(repo)
-    if gitdir is None:
+# Abandoned-git-lock reclaim (MYC-3175). ONE canonical implementation in
+# hooks/_lib/git_locks.py, shared with the ~/dev hub fleet — a second copy would
+# rot the moment one is fixed. Fail-open: a missing _lib must never break the
+# updater, which is the thing that would repair it.
+try:
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks" / "_lib"))
+    from git_locks import reclaim_stale_git_locks as _reclaim_stale_git_locks
+except Exception:  # pragma: no cover - heal is best-effort, never load-bearing
+    def _reclaim_stale_git_locks(_repo):
         return []
-    reclaimed = []
-    for name in GIT_LOCK_NAMES:
-        lock = gitdir / name
-        try:
-            if not lock.is_file():
-                continue
-            if (time.time() - lock.stat().st_mtime) <= min_age:
-                continue  # recent -> assume a real concurrent git operation
-            if _lock_is_held(lock) is True:
-                continue  # a live process owns it; never stomp it
-            lock.unlink()
-            reclaimed.append(name)
-        except OSError:
-            # Windows raises PermissionError while the file is genuinely held.
-            # Leaving it alone is the correct, safe outcome.
-            continue
-    return reclaimed
+
+
+def _stamp(path: Path) -> None:
+    """Record 'this happened now'. Never raises — a stamp failure must not
+    break the update it is only observing."""
+    try:
+        path.touch()
+        os.utime(path, None)
+    except OSError:
+        pass
 
 
 def _install_fix_cmd() -> str:
@@ -173,6 +116,13 @@ def run() -> None:
     skill = _skill_dir()
     pin = state / ".ai-brain-starter-pinned"
     last = state / ".ai-brain-starter-last-update"
+    # Distinct from `last`, and the distinction IS the signal (MYC-3175).
+    # `last` records that an ATTEMPT happened; this records that the clone was
+    # confirmed CURRENT with origin. A frozen clone keeps stamping `last`
+    # forever while this one stops moving — the only reliable freeze signal,
+    # since "behind origin" is precisely what a clone that cannot fetch
+    # under-reports.
+    last_ok = state / ".ai-brain-starter-last-successful-pull"
     lock = state / ".ai-brain-starter-update.lock"
     interval_days = float(os.environ.get("ABS_UPDATE_INTERVAL_DAYS", "6"))
     deploy_timeout = float(os.environ.get("ABS_UPDATE_DEPLOY_TIMEOUT", "120"))
@@ -197,6 +147,12 @@ def run() -> None:
     try:
         try:
             last.touch()  # claim this interval up-front (matches prior behavior)
+            # Seed the success stamp on the FIRST run so staleness is measured
+            # from real data. Without a seed, a clone that never once pulled
+            # successfully would have no stamp to age — and the freeze it is
+            # meant to catch would be the exact case that stays invisible.
+            if not last_ok.exists():
+                last_ok.touch()
         except OSError:
             pass
 
@@ -236,6 +192,10 @@ def run() -> None:
         except (subprocess.TimeoutExpired, OSError):
             silent()
         if not head or head == origin:
+            # Confirmed current with origin: the fetch reached the remote and
+            # HEAD matches it. That is a SUCCESSFUL pull for freeze-detection
+            # purposes even though nothing moved.
+            _stamp(last_ok)
             # Surface a heal even when there is nothing to pull. This is the
             # case that was invisible before: the clone had been frozen for
             # days by a stranded lock, and going silent here would hide both
@@ -286,6 +246,10 @@ def run() -> None:
                     "main (or your preferred strategy).")
         except (subprocess.TimeoutExpired, OSError):
             silent()
+
+        # The ff-only merge succeeded: fetched from origin and moved HEAD onto
+        # it. Every emit_ctx above exits, so reaching here means a real pull.
+        _stamp(last_ok)
 
         try:
             log = _git(["log", "--oneline", f"{head}..HEAD"], skill)

--- a/scripts/test_stale_git_lock_reclaim.py
+++ b/scripts/test_stale_git_lock_reclaim.py
@@ -37,9 +37,27 @@ import time
 from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
-spec = importlib.util.spec_from_file_location("abs_au", HERE / "ai-brain-auto-update.py")
-au = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(au)
+
+# The reclaim is CANONICAL in hooks/_lib/git_locks.py and shared with the ~/dev
+# hub fleet (MYC-3175 item 4), so test it there — testing a consumer's private
+# copy is what lets two copies drift apart unnoticed.
+_gl_spec = importlib.util.spec_from_file_location(
+    "abs_git_locks", HERE.parent / "hooks" / "_lib" / "git_locks.py")
+au = importlib.util.module_from_spec(_gl_spec)
+sys.modules["abs_git_locks"] = au
+_gl_spec.loader.exec_module(au)
+# The public names, aliased to the private ones this suite was written against.
+au._reclaim_stale_git_locks = au.reclaim_stale_git_locks
+au._git_dir = au.git_dir
+au._lock_is_held = au.lock_is_held
+
+# The updater must still REACH the canonical reclaim — the import could silently
+# fall through to its fail-open stub and every heal would quietly stop happening.
+_au_spec = importlib.util.spec_from_file_location(
+    "abs_au", HERE / "ai-brain-auto-update.py")
+_au = importlib.util.module_from_spec(_au_spec)
+sys.modules["abs_au"] = _au
+_au_spec.loader.exec_module(_au)
 
 PASS = 0
 FAIL = 0
@@ -200,6 +218,16 @@ try:
         bad("9. tunable", f"exists={lock.exists()} returned={got}")
 finally:
     del os.environ["ABS_STALE_GIT_LOCK_AGE_SEC"]
+
+# --- 10. the updater is WIRED to the canonical reclaim, not its fail-open stub -
+# Without this the import could silently fall through and every heal would stop
+# happening, with all nine cases above still green (they test the lib directly).
+if getattr(_au, "_reclaim_stale_git_locks", None) is not None and \
+        _au._reclaim_stale_git_locks.__doc__ == au.reclaim_stale_git_locks.__doc__:
+    ok("10. ai-brain-auto-update resolves the CANONICAL reclaim (not the stub)")
+else:
+    bad("10. updater wiring",
+        "the updater fell back to its fail-open stub — heals would silently stop")
 
 print()
 print(f"=== summary: {PASS} passed, {FAIL} failed ===")

--- a/scripts/test_stale_pull_surface.py
+++ b/scripts/test_stale_pull_surface.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Controls for the stale-successful-pull surface + the shared lock reclaim.
+
+MYC-3175 items 2 and 4.
+
+ITEM 2 — surface pull FAILURE, not staleness. The updater stamps
+`.ai-brain-starter-last-successful-pull` only when it has confirmed the clone
+current with origin. `.ai-brain-starter-last-update` keeps moving on every
+ATTEMPT, so a permanently-blocked clone looks busy; only the gap reveals it.
+"Behind origin" is useless here — a clone that cannot fetch cannot learn it is
+behind, so the obvious signal is the one the failure suppresses.
+
+ITEM 4 — ONE reclaim implementation, shared by every consumer that
+fast-forwards a managed clone (the install clone + the ~/dev hub fleet). A
+second copy would rot the moment one is fixed.
+
+  1. a fresh success stamp is SILENT
+  2. a stamp older than the threshold FIRES        <- the catch
+  3. a MISSING stamp is silent (pre-seed install, not a freeze)
+  4. a pinned install is silent even when stale (advertised opt-out)
+  5. threshold is env-tunable
+  6. the message names the diagnosis command
+  7. the updater SEEDS the stamp on its first run
+  8. the updater ADVANCES the stamp on a real successful pull
+  9. the updater does NOT advance it when the pull fails  <- the whole point
+ 10. dev_repo_scan imports the SAME reclaim (one implementation, not a copy)
+
+Stdlib + git only. Exit 0 = all pass.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SURFACER = ROOT / "hooks" / "surface-deployed-hooks-behind.py"
+UPDATER = ROOT / "scripts" / "ai-brain-auto-update.py"
+
+PASS = 0
+FAIL = 0
+
+
+def ok(label):
+    global PASS
+    PASS += 1
+    print(f"PASS  {label}")
+
+
+def bad(label, why):
+    global FAIL
+    FAIL += 1
+    print(f"FAIL  {label} :: {why}")
+
+
+def surfacer_out(state: Path, extra_env=None) -> str:
+    env = {**os.environ,
+           "ABS_UPDATE_STATE_DIR": str(state),
+           "ABS_SETTINGS_JSON": str(state / "settings.json"),
+           "ABS_SKILL_DIR": str(state / "noskill")}
+    env.update(extra_env or {})
+    r = subprocess.run([sys.executable, str(SURFACER)], input="{}",
+                       capture_output=True, text=True, env=env, timeout=60)
+    try:
+        d = json.loads(r.stdout or "{}")
+    except json.JSONDecodeError:
+        return ""
+    return d.get("hookSpecificOutput", {}).get("additionalContext", "")
+
+
+def mkstate(tmp: Path, name: str, age_days=None, pinned=False) -> Path:
+    s = tmp / name
+    s.mkdir(parents=True, exist_ok=True)
+    (s / "settings.json").write_text("{}")
+    if age_days is not None:
+        stamp = s / ".ai-brain-starter-last-successful-pull"
+        stamp.touch()
+        t = time.time() - age_days * 86400
+        os.utime(stamp, (t, t))
+    if pinned:
+        (s / ".ai-brain-starter-pinned").touch()
+    return s
+
+
+TMP = Path(tempfile.mkdtemp())
+
+# --- 1-6: the surface -------------------------------------------------------
+out = surfacer_out(mkstate(TMP, "fresh", age_days=2))
+ok("1. fresh success stamp (2d) is silent") if "not successfully updated" not in out \
+    else bad("1. fresh", out[:150])
+
+out = surfacer_out(mkstate(TMP, "stale", age_days=40))
+if "not successfully updated" in out and "40 days" in out:
+    ok("2. stale success stamp (40d) FIRES and names the age")
+else:
+    bad("2. stale", f"got: {out[:200]!r}")
+
+out = surfacer_out(mkstate(TMP, "nostamp"))
+ok("3. MISSING stamp is silent (pre-seed install, not a freeze)") \
+    if "not successfully updated" not in out else bad("3. missing", out[:150])
+
+out = surfacer_out(mkstate(TMP, "pinned", age_days=99, pinned=True))
+ok("4. pinned install is silent even at 99d (opt-out honored)") \
+    if "not successfully updated" not in out else bad("4. pinned", out[:150])
+
+out = surfacer_out(mkstate(TMP, "tunable", age_days=5),
+                   {"ABS_STALE_PULL_DAYS": "3"})
+ok("5. ABS_STALE_PULL_DAYS lowers the threshold") if "not successfully updated" in out \
+    else bad("5. tunable", f"got: {out[:150]!r}")
+
+out = surfacer_out(mkstate(TMP, "msg", age_days=40))
+ok("6. message names the diagnosis command") if "git pull --ff-only" in out \
+    else bad("6. message", out[:200])
+
+# --- 7-9: the updater's stamping -------------------------------------------
+env0 = {**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+
+
+def mkrepo(p: Path) -> Path:
+    subprocess.run(["git", "init", "-q", str(p)], check=True, env=env0)
+    (p / "f.txt").write_text("x")
+    subprocess.run(["git", "-C", str(p), "add", "f.txt"], check=True, env=env0)
+    subprocess.run(["git", "-C", str(p), "commit", "-qm", "init"], check=True, env=env0)
+    subprocess.run(["git", "-C", str(p), "branch", "-M", "main"], check=True, env=env0)
+    return p
+
+
+def run_updater(clone: Path, state: Path):
+    env = {**env0, "ABS_SKILL_DIR": str(clone), "ABS_UPDATE_STATE_DIR": str(state),
+           "ABS_UPDATE_INTERVAL_DAYS": "0"}
+    return subprocess.run([sys.executable, str(UPDATER)], capture_output=True,
+                          text=True, env=env, timeout=180)
+
+
+origin = mkrepo(TMP / "o1")
+clone = TMP / "c1"
+subprocess.run(["git", "clone", "-q", str(origin), str(clone)], check=True, env=env0)
+st = TMP / "s1"
+st.mkdir()
+run_updater(clone, st)
+stamp = st / ".ai-brain-starter-last-successful-pull"
+ok("7. updater SEEDS the success stamp on first run") if stamp.is_file() \
+    else bad("7. seed", "stamp absent after a run")
+
+# 8. advances on a real pull
+(origin / "new.txt").write_text("y")
+subprocess.run(["git", "-C", str(origin), "add", "new.txt"], check=True, env=env0)
+subprocess.run(["git", "-C", str(origin), "commit", "-qm", "second"], check=True, env=env0)
+old_t = time.time() - 10 * 86400
+os.utime(stamp, (old_t, old_t))
+run_updater(clone, st)
+if stamp.stat().st_mtime > old_t + 86400 and (clone / "new.txt").exists():
+    ok("8. updater ADVANCES the stamp on a real successful pull")
+else:
+    bad("8. advance", f"pulled={(clone/'new.txt').exists()} "
+                      f"advanced={stamp.stat().st_mtime > old_t + 86400}")
+
+# 9. does NOT advance when the pull is blocked  <- the signal's whole value
+origin2 = mkrepo(TMP / "o2")
+clone2 = TMP / "c2"
+subprocess.run(["git", "clone", "-q", str(origin2), str(clone2)], check=True, env=env0)
+(origin2 / "z.txt").write_text("z")
+subprocess.run(["git", "-C", str(origin2), "add", "z.txt"], check=True, env=env0)
+subprocess.run(["git", "-C", str(origin2), "commit", "-qm", "third"], check=True, env=env0)
+st2 = TMP / "s2"
+st2.mkdir()
+run_updater(clone2, st2)  # seed (this one legitimately pulls z.txt)
+stamp2 = st2 / ".ai-brain-starter-last-successful-pull"
+
+# Origin must be AHEAD again, or "no stamp advance" would be untestable: a clone
+# already current is CORRECTLY confirmed current, blocked working tree or not.
+(origin2 / "w.txt").write_text("w")
+subprocess.run(["git", "-C", str(origin2), "add", "w.txt"], check=True, env=env0)
+subprocess.run(["git", "-C", str(origin2), "commit", "-qm", "fourth"], check=True, env=env0)
+
+frozen_t = time.time() - 30 * 86400
+os.utime(stamp2, (frozen_t, frozen_t))
+# Block the ff the way a real user does: dirty a tracked file.
+(clone2 / "f.txt").write_text("locally edited")
+run_updater(clone2, st2)
+if (clone2 / "w.txt").exists():
+    bad("9. premise", "the pull was NOT blocked — fixture proves nothing")
+elif abs(stamp2.stat().st_mtime - frozen_t) < 60:
+    ok("9. blocked pull does NOT advance the stamp — the freeze stays visible")
+else:
+    bad("9. no-advance", "stamp advanced despite a blocked pull (signal is worthless)")
+
+# --- 10: one implementation, not a copy ------------------------------------
+def _load(name: str, path: Path):
+    """Register in sys.modules BEFORE exec: @dataclass resolves its class's
+    module there, and a missing entry crashes on Python 3.12+."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+m = _load("_drs", ROOT / "hooks" / "_lib" / "dev_repo_scan.py")
+gl = _load("_gl", ROOT / "hooks" / "_lib" / "git_locks.py")
+if getattr(m, "reclaim_stale_git_locks", None) is not None and \
+        m.reclaim_stale_git_locks.__doc__ == gl.reclaim_stale_git_locks.__doc__:
+    ok("10. dev_repo_scan uses the SAME canonical reclaim (no second copy)")
+else:
+    bad("10. shared impl", "dev_repo_scan does not resolve to hooks/_lib/git_locks")
+
+print()
+print(f"=== summary: {PASS} passed, {FAIL} failed ===")
+sys.exit(1 if FAIL else 0)


### PR DESCRIPTION
Completes MYC-3175. #353 fixed the one **known** freeze mechanism; these two make the class **self-reporting** and cover the second managed-clone surface.

## Item 2 — surface pull FAILURE, not staleness

The updater now stamps `.ai-brain-starter-last-successful-pull` only when it has **confirmed the clone current with origin** — the fetch reached the remote and HEAD matches it, whether or not anything moved.

The existing `.ai-brain-starter-last-update` keeps moving on every *attempt*, so a permanently-blocked clone looks busy. Only the gap between the two reveals it.

**"Behind origin" cannot do this job.** A clone that cannot fetch cannot learn it is behind — the obvious signal is precisely the one the failure suppresses. That is why the real machine sat frozen for 3 days while every check reported normally. Elapsed-time-since-*success* needs no network and cannot be under-reported.

Surfaced by the **existing** SessionStart drift hook rather than a new one, so fan-out stays flat under the footprint SLA (MYC-2348). It is the third instance of that hook's own class — deployed hooks behind, skill content behind, and now the clone itself no longer pulling — which is exactly where its docstring already points.

**No-nag design.** Silent unless the stamp exists and is older than `ABS_STALE_PULL_DAYS` (default 21 = three update intervals, so one or two missed cycles never nag). A *missing* stamp is a pre-seed install, not a freeze — but the updater seeds it on first run, so a clone that never once pulled successfully still ages into the signal instead of staying invisible forever. Pinned installs stay silent.

## Item 4 — one reclaim implementation, two real consumers

Extracted to `hooks/_lib/git_locks.py`, imported by both places that fast-forward a managed clone:

- `scripts/ai-brain-auto-update.py` — the install clone (79 lines of private copy deleted)
- `hooks/_lib/dev_repo_scan.py` — whose `merge --ff-only` over the `~/dev` hub fleet is blockable by the **identical** stranded lock

That second surface is real, not hypothetical (19 hubs on the maintainer machine), and would have rotted the same way. A second copy would drift the moment one was fixed — the same `deployed != committed` class this whole arc guards against.

## Controls

**10 new** in `scripts/test_stale_pull_surface.py`. The one that gives the signal its value: **a blocked pull must not advance the stamp**. That case initially failed — and it was my *fixture* that was wrong, not the code: by that point the clone was already current, so confirming "current" was correct behavior however dirty its tree. It now puts origin ahead first and asserts the premise (the pull was genuinely blocked) before checking the stamp, so it cannot pass vacuously.

`test_stale_git_lock_reclaim.py` now tests the **canonical module** rather than a consumer's private copy — testing a copy is what lets copies drift. Plus a new case asserting the updater resolves the real reclaim and **not its fail-open stub**: without it, the import could silently fall through, every heal would stop happening, and all nine other cases would stay green.

CI also caught this refactor breaking the earlier suite (it referenced a helper I had moved) — which is the gate doing its job.

Full `scripts/ci.sh` green: 304 files py_compile, 83 integration tests, 14 unit suites, shellcheck, phase-doc python, UTF-8 guard. Scrub clean, fail-closed.

## Still deliberately out

**MYC-2453** (cooldown stamped before the attempt, so any failure locks out retries for 6 days). Doing it properly needs nag-suppression state so a repeating failure does not warn hourly — a real UX design, not a line move. With the self-heal plus this signal, a freeze now repairs itself or announces itself; 2453 only affects how fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
