### PR TITLE
feat(ci): gate hookify templates against the official engine's capabilities

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -85,6 +85,22 @@ jobs:
       - name: run the meta-resolution guard
         run: bash scripts/check-meta-resolution.sh
 
+  hookify-capabilities:
+    name: hookify templates evaluable by the official engine
+    runs-on: ubuntu-latest
+    # We ship hookify rule templates for people to copy onto the OFFICIAL plugin
+    # (anthropics/claude-code -> plugins/hookify). That engine returns False for an
+    # operator it does not implement and None for a field it cannot resolve, so a
+    # template using a capability it lacks loads fine and SILENTLY NEVER FIRES -
+    # protection that is not actually there. This gate fails loud instead.
+    # No untrusted user input is referenced in any run: command.
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: run the hookify capability gate
+        run: python3 -S scripts/check-hookify-template-capabilities.py
+      - name: negative controls for the gate
+        run: bash tests/integration/test_hookify_template_capabilities.sh
+
   powershell:
     name: PowerShell parse (.ps1)
     runs-on: ubuntu-latest

--- a/scripts/check-hookify-template-capabilities.py
+++ b/scripts/check-hookify-template-capabilities.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Gate: every shipped hookify template must be evaluable by the OFFICIAL engine.
+
+Why this exists
+---------------
+We ship `templates/hookify-rules/hookify.*.local.md` for people to copy. They run
+the OFFICIAL hookify plugin (anthropics/claude-code -> plugins/hookify). That engine
+silently returns False for any operator it does not implement and None for any field
+it cannot resolve -- so a template using a capability the official engine lacks LOADS
+FINE AND NEVER FIRES. A safety rule that never fires is worse than no rule: it reads
+as protection that is not there.
+
+This gate fails loud at CI time instead. Bug class: SILENT-NO-OP-ON-UNEVALUABLE-SPEC.
+
+Capability sets below are transcribed from the official engine. Re-verify with:
+    git -C <claude-code> show origin/main:plugins/hookify/core/rule_engine.py
+Update them (and shrink KNOWN_UPSTREAM_GAPS) when upstream ships new capabilities.
+
+stdlib only, no PyYAML -- runs under `python3 -S`.
+"""
+import re
+import sys
+from pathlib import Path
+
+# --- OFFICIAL engine capabilities (anthropics/claude-code@main, plugins/hookify) ---
+# Source: rule_engine.py _check_condition (operators) + _extract_field (fields).
+OFFICIAL_OPERATORS = {
+    "regex_match", "contains", "equals", "not_contains", "starts_with", "ends_with",
+}
+OFFICIAL_FIELDS_BY_EVENT = {
+    "bash":   {"command"},
+    "file":   {"file_path", "new_text", "new_string", "old_text", "old_string", "content"},
+    "prompt": {"user_prompt"},
+    "stop":   {"reason", "transcript"},
+}
+OFFICIAL_FIELDS_BY_EVENT["all"] = set().union(*OFFICIAL_FIELDS_BY_EVENT.values())
+
+# Templates knowingly ahead of the official engine, each with the upstream fix in
+# flight. Keeps this gate GREEN today (never ship a known-red gate) while making the
+# debt visible. DELETE an entry when its PR ships -- the gate then enforces it.
+KNOWN_UPSTREAM_GAPS = {
+    "hookify.block-malformed-mcp-json.local.md":
+        "operator regex_not_match not in official engine "
+        "-- upstream fix: anthropics/claude-code#78715",
+    "hookify.warn-rotation-push-on-local-only-leak.local.md":
+        "event:prompt rules never fire on the official engine (payload key is "
+        "`prompt`, engine reads `user_prompt`) -- upstream fix: anthropics/claude-code#79873",
+}
+
+FM = re.compile(r"\A---\s*\n(.*?)\n---", re.S)
+
+
+def parse_template(path: Path):
+    """-> (event, [(field, operator), ...]). Regex frontmatter parse, stdlib only."""
+    m = FM.search(path.read_text(encoding="utf-8", errors="replace"))
+    if not m:
+        return None, []
+    fm = m.group(1)
+    ev_m = re.search(r"^event:\s*([A-Za-z_]+)", fm, re.M)
+    event = ev_m.group(1) if ev_m else None
+
+    conds = []
+    cond_m = re.search(r"^conditions:\s*\n(.*?)(?=\n[A-Za-z_]+:|\Z)", fm, re.M | re.S)
+    if cond_m:
+        for block in re.split(r"\n\s*-\s+", "\n" + cond_m.group(1)):
+            if not block.strip():
+                continue
+            f = re.search(r"\bfield:\s*(\S+)", block)
+            o = re.search(r"\boperator:\s*(\S+)", block)
+            if f:
+                # engine default when `operator:` is omitted is regex_match
+                conds.append((f.group(1), o.group(1) if o else "regex_match"))
+    return event, conds
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parent.parent
+    tdir = root / "templates" / "hookify-rules"
+    templates = sorted(tdir.glob("hookify.*.local.md"))
+    if not templates:
+        print(f"ERROR: no templates found under {tdir}", file=sys.stderr)
+        return 2
+
+    new_violations, known_hits, checked = [], [], 0
+    for t in templates:
+        event, conds = parse_template(t)
+        if event is None:
+            new_violations.append((t.name, "missing `event:` in frontmatter"))
+            continue
+        allowed_fields = OFFICIAL_FIELDS_BY_EVENT.get(event)
+        if allowed_fields is None:
+            new_violations.append((t.name, f"unknown event '{event}'"))
+            continue
+        for field, op in conds:
+            checked += 1
+            problems = []
+            if op not in OFFICIAL_OPERATORS:
+                problems.append(f"operator '{op}' not implemented by the official engine")
+            if field not in allowed_fields:
+                problems.append(
+                    f"field '{field}' not resolvable by the official engine for event '{event}'")
+            for p in problems:
+                if t.name in KNOWN_UPSTREAM_GAPS:
+                    known_hits.append((t.name, p))
+                else:
+                    new_violations.append((t.name, p))
+
+    print(f"hookify template capability gate: {len(templates)} templates, "
+          f"{checked} conditions checked against the official engine")
+
+    if known_hits:
+        print("\nKNOWN upstream gaps (allowlisted, fix in flight):")
+        seen = set()
+        for name, _ in known_hits:
+            if name not in seen:
+                seen.add(name)
+                print(f"  - {name}\n      {KNOWN_UPSTREAM_GAPS[name]}")
+
+    stale = sorted(set(KNOWN_UPSTREAM_GAPS) - {n for n, _ in known_hits})
+    if stale:
+        print("\nSTALE allowlist entries (no longer violating -- delete them):")
+        for n in stale:
+            print(f"  - {n}")
+        return 1
+
+    if new_violations:
+        print("\nFAIL: template(s) use capabilities the official engine lacks.")
+        print("These rules would load and SILENTLY NEVER FIRE for anyone who copies them.\n")
+        for name, why in new_violations:
+            print(f"  - {name}\n      {why}")
+        print("\nFix: rewrite the condition using an official capability, or land the "
+              "upstream fix and add an entry to KNOWN_UPSTREAM_GAPS citing the PR.")
+        return 1
+
+    print("\nOK: no new capability violations.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -218,6 +218,12 @@ INTEGRATION_TESTS=(
   # activation is (the family sat dormant in the repo precisely because nothing
   # asserted registration).
   test_installer_registers_fabrication_guards
+  # Hookify template capability gate (2026-07-18): the OFFICIAL engine returns
+  # False for an operator it does not implement and None for a field it cannot
+  # resolve, so a shipped template using either loads fine and SILENTLY NEVER
+  # FIRES — protection that is not actually there. Negative controls prove the
+  # gate reddens on a bad operator, a bad field, and a stale allowlist entry.
+  test_hookify_template_capabilities
 )
 # ---- Gate-coverage invariant -------------------------------------------------
 # The list above is an explicit allow-list, and allow-lists rot: a new

--- a/tests/integration/test_hookify_template_capabilities.sh
+++ b/tests/integration/test_hookify_template_capabilities.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Negative-control gate for scripts/check-hookify-template-capabilities.py.
+#
+# That gate exists because the OFFICIAL hookify engine silently returns False for
+# an operator it does not implement and None for a field it cannot resolve: a
+# template using a capability the official engine lacks LOADS FINE AND NEVER
+# FIRES. A safety rule that never fires reads as protection that is not there.
+#
+# A guard earns trust only by failing on the thing it catches, so this proves:
+#   1. GREEN on the real shipped templates (never ship a known-red gate).
+#   2. RED on an unsupported operator in a non-allowlisted template.
+#   3. RED on an unsupported field for the template's event.
+#   4. RED on a STALE allowlist entry (the debt ledger self-cleans when the
+#      upstream fix lands and the violation disappears).
+#   5. GREEN for an allowlisted template that still violates (fix in flight).
+#
+# Stdlib python3 + bash only (no PyYAML, no network, no git). Tmpdir on exit.
+# Run: bash tests/integration/test_hookify_template_capabilities.sh  (0 = pass)
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+GATE="$REPO_ROOT/scripts/check-hookify-template-capabilities.py"
+TPL_DIR="$REPO_ROOT/templates/hookify-rules"
+ALLOWLISTED="hookify.block-malformed-mcp-json.local.md"
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS + 1)); echo "PASS  $1"; }
+bad() { FAIL=$((FAIL + 1)); echo "FAIL  $1 :: ${2:-}"; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+[ -f "$GATE" ] || { echo "FAIL  gate script missing: $GATE"; exit 1; }
+
+# Build a throwaway repo layout the gate can resolve (script at <root>/scripts).
+stage() { # $1 = dest root
+  mkdir -p "$1/scripts" "$1/templates/hookify-rules"
+  cp "$GATE" "$1/scripts/"
+  cp "$TPL_DIR"/hookify.*.local.md "$1/templates/hookify-rules/"
+}
+
+run_gate() { python3 -S "$1/scripts/$(basename "$GATE")" 2>&1; }
+
+# --- 1. green on the real repo -------------------------------------------------
+if out="$(python3 -S "$GATE" 2>&1)"; then
+  ok "real shipped templates pass the gate (green baseline)"
+else
+  bad "real shipped templates pass the gate" "$(echo "$out" | tail -3)"
+fi
+
+# --- 2. red on an unsupported operator -----------------------------------------
+stage "$TMP/op"
+cat > "$TMP/op/templates/hookify-rules/hookify.zz-bad-operator.local.md" <<'EOF'
+---
+name: zz-bad-operator
+enabled: true
+event: file
+action: warn
+conditions:
+  - field: file_path
+    operator: regex_not_match
+    pattern: \.md$
+---
+should be caught
+EOF
+out="$(run_gate "$TMP/op")"; rc=$?
+if [ $rc -ne 0 ] && echo "$out" | grep -q "zz-bad-operator"; then
+  ok "unsupported operator in a new template is caught (exit $rc)"
+else
+  bad "unsupported operator is caught" "rc=$rc"
+fi
+
+# --- 3. red on an unsupported field --------------------------------------------
+stage "$TMP/fld"
+cat > "$TMP/fld/templates/hookify-rules/hookify.zz-bad-field.local.md" <<'EOF'
+---
+name: zz-bad-field
+enabled: true
+event: stop
+action: warn
+conditions:
+  - field: assistant_response
+    operator: contains
+    pattern: whatever
+---
+should be caught
+EOF
+out="$(run_gate "$TMP/fld")"; rc=$?
+if [ $rc -ne 0 ] && echo "$out" | grep -q "zz-bad-field"; then
+  ok "unsupported field for the event is caught (exit $rc)"
+else
+  bad "unsupported field is caught" "rc=$rc"
+fi
+
+# --- 4. red on a stale allowlist entry -----------------------------------------
+stage "$TMP/stale"
+rm -f "$TMP/stale/templates/hookify-rules/$ALLOWLISTED"
+out="$(run_gate "$TMP/stale")"; rc=$?
+if [ $rc -ne 0 ] && echo "$out" | grep -qi "stale"; then
+  ok "stale allowlist entry is caught (ledger self-cleans, exit $rc)"
+else
+  bad "stale allowlist entry is caught" "rc=$rc"
+fi
+
+# --- 5. allowlisted violation stays green --------------------------------------
+stage "$TMP/alw"
+out="$(run_gate "$TMP/alw")"; rc=$?
+if [ $rc -eq 0 ] && echo "$out" | grep -q "KNOWN upstream gaps"; then
+  ok "allowlisted in-flight violation reported but not fatal"
+else
+  bad "allowlisted violation stays green" "rc=$rc"
+fi
+
+echo
+echo "passed=$PASS failed=$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Why

We ship `templates/hookify-rules/*.local.md` for people to copy onto the **official** hookify plugin (`anthropics/claude-code` → `plugins/hookify`). That engine returns `False` for an operator it does not implement and `None` for a field it cannot resolve — so a template using either **loads fine and silently never fires**. A safety rule that never fires is worse than no rule: it reads as protection that isn't there.

An audit of the 11 shipped templates found **2 in exactly that state**:

| template | problem | upstream fix |
|---|---|---|
| `block-malformed-mcp-json` | `operator: regex_not_match` isn't in the official engine | [anthropics/claude-code#78715](https://github.com/anthropics/claude-code/pull/78715) |
| `warn-rotation-push-on-local-only-leak` | `event: prompt` rules never fire (payload key is `prompt`, engine reads `user_prompt`) | [anthropics/claude-code#79873](https://github.com/anthropics/claude-code/pull/79873) |

Nothing in CI could catch this, so it stayed invisible.

## What

- `scripts/check-hookify-template-capabilities.py` — validates every shipped template's operators + fields against the official engine's capability sets. Stdlib only, runs under `python3 -S`.
- `KNOWN_UPSTREAM_GAPS` allowlist — keeps the gate **green today** (never ship a known-red gate) while making the debt visible. Each entry cites its upstream PR, and the gate reports a **STALE** entry once the fix lands, so the ledger self-cleans.
- Wired as a `lint.yml` job and registered in `scripts/ci.sh` `INTEGRATION_TESTS` (the governed set's one declaration).

## Negative controls

`tests/integration/test_hookify_template_capabilities.sh` — a guard earns trust only by failing on what it catches:

```
PASS  real shipped templates pass the gate (green baseline)
PASS  unsupported operator in a new template is caught (exit 1)
PASS  unsupported field for the event is caught (exit 1)
PASS  stale allowlist entry is caught (ledger self-cleans, exit 1)
PASS  allowlisted in-flight violation reported but not fatal
```

`ci-test` green: 306 py_compile + 84 integration tests + shellcheck + all gates.

Bug class: SILENT-NO-OP-ON-UNEVALUABLE-SPEC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
