### PR TITLE
fix(whatsapp): rename-contacts fails with a sentence off-macOS, on zero contacts, and in its docstring

### DIFF
--- a/scripts/whatsapp/rename-contacts.py
+++ b/scripts/whatsapp/rename-contacts.py
@@ -7,9 +7,10 @@ This script cross-references macOS Contacts to rename them to real names
 and updates the frontmatter + message sender lines inside each file.
 
 Requirements:
-  - macOS
-  - Terminal must have Contacts permission:
-    System Settings › Privacy & Security › Contacts › Terminal (enable)
+  - macOS (contacts are read through Contacts.app via osascript; no Xcode needed)
+  - The app you run this from (Claude, Terminal, iTerm, ...) needs permission to
+    control Contacts. The first run shows a one-click prompt; to change it later:
+    System Settings › Privacy & Security › Automation › <that app> › Contacts
 
 Usage:
   VAULT_ROOT=/path/to/vault python3 rename-contacts.py
@@ -26,6 +27,16 @@ import subprocess
 import tempfile
 import argparse
 from pathlib import Path
+
+# macOS only: contacts are read through Contacts.app via osascript, which does not
+# exist elsewhere. Say so in a sentence instead of dying on a FileNotFoundError
+# traceback -- this repo installs on Windows too, and this step is optional.
+if sys.platform != "darwin":
+    print("rename-contacts.py runs on macOS only: it reads Contacts through "
+          f"Contacts.app via osascript (detected platform: {sys.platform}).")
+    print("The rest of the WhatsApp export is unaffected; chats just keep their "
+          "phone-number names.")
+    sys.exit(1)
 
 # ── Args ──────────────────────────────────────────────────────────────────────
 
@@ -144,6 +155,15 @@ for line in result.stdout.splitlines():
         phone_map[d[2:]] = name          # Colombia: without country code
 
 print(f"Loaded {len(phone_map):,} phone entries")
+
+# Zero entries means nothing can be renamed. Say why and stop, rather than
+# scanning every file to change nothing and leaving the user to guess.
+if not phone_map:
+    print("\nNo usable contacts came back, so no file can be renamed.")
+    print("Either the address book is empty, or Contacts returned no data. Check")
+    print("System Settings > Privacy & Security > Automation >")
+    print(f"{host_app()} > Contacts, then re-run.")
+    sys.exit(1)
 
 def lookup(digits: str) -> str | None:
     return (phone_map.get(digits)


### PR DESCRIPTION
Three remaining ways the Contacts step could confuse someone who is not on an already-granted Mac. Follows #358.

## 1. No platform guard
The script is macOS-only (Contacts.app via `osascript`), but this repo installs on Windows too. A Windows user got an uncaught `FileNotFoundError` traceback for `osascript`. It now exits 1 naming the detected platform and noting the rest of the export is unaffected.

## 2. Zero contacts silently renamed nothing
It printed `Loaded 0 phone entries`, then scanned every file to change nothing and left the user to guess. It now stops and points at the Automation row for the **real** host app.

## 3. Stale docstring
Requirements still said *"Terminal must have Contacts permission"* — which #358 made wrong twice over: the grant belongs to whichever app launched the script, and the gate is now **Automation**, not Contacts.

## Verified
- `py_compile`; full `ci.sh` gate green (83 integration tests).
- Guard controls in isolation: `win32` -> exit 1 naming the platform, `linux` -> exit 1, `darwin` -> does **not** trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)