### PR TITLE
fix(hookify-templates): make block-malformed-mcp-json actually fire; label the inert prompt rule

### DIFF
--- a/scripts/check-hookify-template-capabilities.py
+++ b/scripts/check-hookify-template-capabilities.py
@@ -39,9 +39,9 @@ OFFICIAL_FIELDS_BY_EVENT["all"] = set().union(*OFFICIAL_FIELDS_BY_EVENT.values()
 # flight. Keeps this gate GREEN today (never ship a known-red gate) while making the
 # debt visible. DELETE an entry when its PR ships -- the gate then enforces it.
 KNOWN_UPSTREAM_GAPS = {
-    "hookify.block-malformed-mcp-json.local.md":
-        "operator regex_not_match not in official engine "
-        "-- upstream fix: anthropics/claude-code#78715",
+    # block-malformed-mcp-json is NOT listed: it was rewritten to an anchored
+    # negative lookahead inside a plain regex_match, so it now fires on the
+    # official engine today rather than waiting on anthropics/claude-code#78715.
     "hookify.warn-rotation-push-on-local-only-leak.local.md":
         "event:prompt rules never fire on the official engine (payload key is "
         "`prompt`, engine reads `user_prompt`) -- upstream fix: anthropics/claude-code#79873",

--- a/templates/hookify-rules/hookify.block-malformed-mcp-json.local.md
+++ b/templates/hookify-rules/hookify.block-malformed-mcp-json.local.md
@@ -8,8 +8,16 @@ conditions:
     operator: regex_match
     pattern: \.mcp\.json$
   - field: new_text
-    operator: regex_not_match
-    pattern: ^\s*\{[\s\S]*\}\s*$
+    operator: regex_match
+    pattern: '^(?!\s*\{[\s\S]*\}\s*$)'
 ---
+
+> Maintainer note: the second condition is an ANCHORED NEGATIVE LOOKAHEAD, not the
+> more readable `operator: regex_not_match`. That operator is not implemented by the
+> official hookify engine (unknown operator -> False -> this rule would load fine and
+> SILENTLY NEVER BLOCK). Do not "simplify" it back until upstream ships it
+> (anthropics/claude-code#78715). The `^` anchor is load-bearing: `re.search` scans
+> every position, so an unanchored lookahead would match later in the string and
+> wrongly fire on valid JSON.
 
 **`.mcp.json` content does not look like a complete JSON object.** Claude Code silently drops malformed MCP config files: every MCP server inside the file will stop loading with no warning. Common cause: orphaned blocks, stray braces, or content added outside the top-level `mcpServers` object. Fix the JSON structure (must open with `{` and close with matching `}`) before saving. Validate with `python3 -c "import json; json.load(open('<path>'))"`

--- a/templates/hookify-rules/hookify.warn-rotation-push-on-local-only-leak.local.md
+++ b/templates/hookify-rules/hookify.warn-rotation-push-on-local-only-leak.local.md
@@ -9,6 +9,14 @@ conditions:
     pattern: \b(rotate|rotation|rotated|rotating)\b
 ---
 
+> **KNOWN INERT on the official hookify plugin (as of 2026-07-18).** `event: prompt`
+> rules never fire there: Claude Code sends the submitted text under the payload key
+> `prompt`, but the engine reads `user_prompt` — so the field resolves empty and the
+> condition never matches. This is true for BOTH field spellings, so there is no
+> template-side workaround. Upstream fix in flight: anthropics/claude-code#79873.
+> Copy this rule for the threat model it documents; do not rely on it firing until
+> that PR ships. (Verified against the official engine, not a local fork.)
+
 **Before recommending secret rotation, check the leak vector.**
 
 The reflex when a secret-detection layer fires is "rotate the secret." That reflex is wrong when the leak is confined to surfaces the user already trusts. Rotation has real cost (broken integrations, downtime, attention churn); spend that budget on real exposure.

--- a/tests/integration/test_hookify_template_capabilities.sh
+++ b/tests/integration/test_hookify_template_capabilities.sh
@@ -22,7 +22,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 GATE="$REPO_ROOT/scripts/check-hookify-template-capabilities.py"
 TPL_DIR="$REPO_ROOT/templates/hookify-rules"
-ALLOWLISTED="hookify.block-malformed-mcp-json.local.md"
+ALLOWLISTED="hookify.warn-rotation-push-on-local-only-leak.local.md"
 
 PASS=0; FAIL=0
 ok()  { PASS=$((PASS + 1)); echo "PASS  $1"; }


### PR DESCRIPTION
## Why

PR #359 added a gate that found **2 of 11 shipped templates were INERT** on the official hookify engine, and allowlisted both while upstream fixes are in flight. But an allowlist documents a dead rule — it does not revive it. A rule file sitting in `templates/` **signals protection**; shipping one that cannot fire is a false affordance, and it's worse now that we know.

One of the two is fixable today without waiting on anyone. The other is not. This PR does both honestly.

## `block-malformed-mcp-json` — actually fires now

It used `operator: regex_not_match`, which the official engine does not implement (unknown operator → `False`), so the rule **loaded fine and never blocked a malformed `.mcp.json`**. Rewritten as an anchored negative lookahead inside a plain `regex_match` — the exact form our own authoring cheatsheet prescribes.

Verified end-to-end with **the shipped file** driven through **the official engine** (not a local fork):

```
PASS  valid .mcp.json          silent
PASS  malformed .mcp.json      BLOCK +deny
PASS  empty .mcp.json          BLOCK +deny
PASS  truncated open-brace     BLOCK +deny
PASS  trailing junk after }    BLOCK +deny
PASS  unrelated file           silent

control: OLD form, same engine, same malformed input -> silent  (it was dead)
```

Removed from `KNOWN_UPSTREAM_GAPS` (the gate's STALE check enforces that), and the negative-control suite now pins its allowlist fixture to the remaining entry instead of this one.

The `^` anchor is load-bearing: `re.search` scans every position, so an unanchored lookahead would match later in the string and wrongly fire on valid JSON. A maintainer note in the template says so, and says not to "simplify" it back to `regex_not_match` until [anthropics/claude-code#78715](https://github.com/anthropics/claude-code/pull/78715) ships.

## `warn-rotation-push-on-local-only-leak` — labelled, because it cannot be fixed here

It's an `event: prompt` rule, and prompt events **never fire on the official engine at all**: Claude Code sends the payload key `prompt` while the engine reads `user_prompt` — true for BOTH field spellings, so there is no template-side workaround. It keeps its allowlist entry and now carries a visible **KNOWN INERT** banner at the top of the body, so nobody copies it believing it protects them. Upstream fix: [anthropics/claude-code#79873](https://github.com/anthropics/claude-code/pull/79873).

## Checks

Gate green (1 remaining known gap), negative controls 5/5, `ci-test` green: 306 py_compile + 84 integration tests + shellcheck + all gates.

Fix what can be fixed. Label what cannot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
