### PR TITLE
fix(whatsapp): stop sync.mjs truncating history silently, and stop it staging chats into the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,11 @@ hooks/.secret-scan.lock
 # folder into this public substrate repo.
 /⚙️ Meta/
 /Meta/
+
+# Same hazard, WhatsApp export side: scripts/whatsapp/sync.mjs defaults
+# VAULT_ROOT to two levels up from itself, which inside this repo resolves to
+# the REPO ROOT, not a vault. Running it without VAULT_ROOT set therefore writes
+# personal chat transcripts here. Credentials (baileys_auth/, baileys_store.json)
+# are already ignored; this covers the exported message content too, so a user
+# can never stage their own WhatsApp history into a public fork.
+/🤖 AI Chats/

--- a/scripts/whatsapp/sync.mjs
+++ b/scripts/whatsapp/sync.mjs
@@ -250,6 +250,10 @@ async function connect() {
   // ── History sync — fires in chunks; export when stream goes quiet for 5 s
   let historyDone = false
   let idleTimer   = null
+  // 0 = no history chunk has EVER arrived. Read by the connection-open fallback
+  // below so it can tell "this account emits no history" apart from "history is
+  // still streaming" (see the truncation note there).
+  let lastChunkAt = 0
 
   const scheduleIdleCheck = () => {
     if (idleTimer) clearTimeout(idleTimer)
@@ -263,6 +267,7 @@ async function connect() {
   }
 
   sock.ev.on('messaging-history.set', ({ chats, contacts, messages, isLatest }) => {
+    lastChunkAt = Date.now()
     mergeContacts(contacts || [])
     mergeMessages(messages || [])
 
@@ -295,14 +300,21 @@ async function connect() {
 
     if (connection === 'open') {
       console.log('\nConnected. Receiving history...\n')
-      // Fallback for already-synced sessions that emit no history events
+      // Fallback for already-synced sessions that emit NO history events at all.
+      // It must only fire in that case. It used to fire whenever history had not
+      // finished by 20s, but on a large account the `messaging-history.set`
+      // chunks are still streaming then, so it exported a PARTIAL history and
+      // exited 0 with no warning -- silent data loss the user could not see.
+      // When chunks are flowing, the 5s idle timer owns the exit instead: it
+      // waits for the stream to actually go quiet.
       setTimeout(() => {
-        if (!historyDone) {
-          historyDone = true
-          if (idleTimer) clearTimeout(idleTimer)
-          exportToVault(store)
-          process.exit(0)
-        }
+        if (historyDone) return
+        if (lastChunkAt !== 0) return   // history is streaming; let the idle timer finish it
+        historyDone = true
+        if (idleTimer) clearTimeout(idleTimer)
+        console.log('No history was sent for this session; exporting what is stored locally.')
+        exportToVault(store)
+        process.exit(0)
       }, 20_000)
     }
 


### PR DESCRIPTION
Audit of `scripts/whatsapp/sync.mjs`. Two live hazards fixed here; the root cause is reported on MYC-2614 rather than patched, for the reason below.

## 1. Silent history truncation (data loss)

On `connection: 'open'` a 20s timer fired `exportToVault` + `process.exit(0)` whenever history had not finished. On a large account the `messaging-history.set` chunks are **still streaming** at 20s, so it exported a **partial** history and exited `0` with no warning. The user believes the export is complete.

The fallback exists for accounts that emit *no* history events, so it now fires only when no chunk has ever arrived (`lastChunkAt === 0`), and says so. When chunks are flowing, the existing 5s idle timer owns the exit, which is what actually waits for the stream to go quiet.

## 2. Personal chats landed in the repo, unignored

`VAULT_ROOT` defaults to two levels up from `sync.mjs`, which **inside this repo resolves to the repo root, not a vault** (the comment claims three levels / a vault root, so this is a vendoring artifact). `git check-ignore` confirmed the export path was trackable: running without `VAULT_ROOT` wrote WhatsApp transcripts into a git working tree a user could stage and push from a public fork. Credentials (`baileys_auth/`, `baileys_store.json`) were already ignored; the exported **content** now is too, matching the existing *"never ship a user's vault folder into this public substrate repo"* block.

## Deliberately NOT patched here

This file is a **stale vendored fork** of `adelaidasofia/whatsapp-vault-sync`: this copy is v1.0.0 / 324 lines, canonical is v1.1.0 / 459 lines with Windows support, pairing-code auth, and live-refresh QR (MYC-3033, which shipped to the standalone repo but never to this vendored copy). Porting those in would perpetuate the duplicate, which *is* the bug. Reported on MYC-2614; the correct fix there is "every client runs canonical".

## Verified
- `node --check`; full `ci.sh` gate green (84 integration tests).
- `git check-ignore` now reports the export path IGNORED (was trackable).
- The fallback's decision logic asserted across all 4 states: no-history -> exports; **streaming -> does NOT export** (the bug); already-done -> no double export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)