### PR TITLE
fix(skills): convert host-tool install paths to the {SKILL_DIR} token (MYC-3227)

### DIFF
--- a/skills/diagnose/SKILL.md
+++ b/skills/diagnose/SKILL.md
@@ -31,6 +31,8 @@ output_shape:
 
 # /diagnose
 
+> **`{SKILL_DIR}`** = this skill's own folder (locally: the directory this SKILL.md lives in; a served brain substitutes the real absolute path before you read this). Shared starter files live at the repo root two levels up: `{SKILL_DIR}/../..`. If a path does not resolve, name the missing file and stop — never guess another location.
+
 Tells you whether your second brain is healthy.
 
 ## Why
@@ -47,22 +49,22 @@ Most "Claude is broken" reports trace to one of:
 
 ## What to do
 
-1. Find the script. On the maintainer machine: `~/Desktop/ai-brain-starter/scripts/diagnose.sh`. On an end-user install: `~/.claude/skills/ai-brain-starter/scripts/diagnose.sh`.
+1. Find the script: `{SKILL_DIR}/../../scripts/diagnose.sh` (the starter repo root sits two levels above this skill's folder on every install shape).
 
 2. Run it. Pick the right one for the platform:
 
    **Mac / Linux:**
    ```bash
-   bash ~/.claude/skills/ai-brain-starter/scripts/diagnose.sh
+   bash "{SKILL_DIR}/../../scripts/diagnose.sh"
    # or pass an explicit vault:
-   bash ~/.claude/skills/ai-brain-starter/scripts/diagnose.sh "/path/to/vault"
+   bash "{SKILL_DIR}/../../scripts/diagnose.sh" "/path/to/vault"
    ```
 
    **Windows:**
    ```powershell
-   pwsh ~/.claude/skills/ai-brain-starter/scripts/diagnose.ps1
+   pwsh "{SKILL_DIR}/../../scripts/diagnose.ps1"
    # or:
-   pwsh ~/.claude/skills/ai-brain-starter/scripts/diagnose.ps1 -Vault "C:\path\to\vault"
+   pwsh "{SKILL_DIR}/../../scripts/diagnose.ps1" -Vault "C:\path\to\vault"
    ```
 
    By default it uses `$VAULT_PATH` if set, else the current directory.
@@ -86,7 +88,7 @@ Most "Claude is broken" reports trace to one of:
 | 7 | Vault is a git repo | - | Recommend `git init` for snapshot history |
 | 8 | All .ps1 have BOM, no em dashes, parse clean | Fix the parser error | Add BOM and strip em dashes (see SKILL.md notes) |
 | 9 | MCP config valid JSON | Fix the JSON | No MCPs registered (fine if intentional) |
-| 10 | ai-brain-starter up to date with origin/main | Re-clone | git pull in ~/.claude/skills/ai-brain-starter |
+| 10 | ai-brain-starter up to date with origin/main | Re-clone | git pull in the starter root (`{SKILL_DIR}/../..`) |
 | 10b | No scheduled-task name collides with a skill; cron-only tasks `_`-prefixed | - | Rename per docs/MAINTENANCE.md |
 | 11 | Vault on a local disk, not a consumer cloud-sync root | Move it local (docs/CLOUD_SYNC.md) | Could not evaluate the path |
 | 12 | Vault has an off-machine backup | Set one up: `bash scripts/vault-backup.sh setup` (docs/BACKUP.md) | Backup configured but no snapshot yet |

--- a/skills/evolve/SKILL.md
+++ b/skills/evolve/SKILL.md
@@ -6,6 +6,8 @@ trigger: /evolve
 
 # /evolve — promote a cluster of instincts into a structure
 
+> **`{SKILL_DIR}`** = this skill's own folder (locally: the directory this SKILL.md lives in; a served brain substitutes the real absolute path before you read this). Shared starter files live at the repo root two levels up: `{SKILL_DIR}/../..`. If a path does not resolve, name the missing file and stop — never guess another location.
+
 When many related, high-confidence instincts pile up in one domain, that is a
 signal to promote them into ONE reusable structure instead of leaving them as
 loose memories. `/evolve` finds those clusters deterministically and drafts a
@@ -17,7 +19,7 @@ structures: Commands / Skills / Agents." Reimplemented clean per license-hygiene
 ## Step 1 — run the clusterer (deterministic, zero LLM cost)
 
 ```bash
-python3 ~/.claude/skills/ai-brain-starter/scripts/instinct.py evolve
+python3 "{SKILL_DIR}/../../scripts/instinct.py" evolve
 ```
 
 It groups every instinct by inferred `domain`, computes each cluster's median

--- a/skills/for-my-team/SKILL.md
+++ b/skills/for-my-team/SKILL.md
@@ -7,6 +7,8 @@ argument-hint: "[no arguments — fully conversational]"
 
 # /for-my-team
 
+> **`{SKILL_DIR}`** = this skill's own folder (locally: the directory this SKILL.md lives in; a served brain substitutes the real absolute path before you read this). Shared starter files live at the repo root two levels up: `{SKILL_DIR}/../..`. If a path does not resolve, name the missing file and stop — never guess another location.
+
 Help the user understand what the team version of this brain looks like, what it costs them to build it themselves, and what their options are.
 
 ## Why this skill exists
@@ -37,7 +39,7 @@ The vault should have ai-brain-starter installed. Find the for-teams folder:
 ls ~/Desktop/ai-brain-starter/for-teams/
 
 # End-user install:
-ls ~/.claude/skills/ai-brain-starter/for-teams/
+ls "{SKILL_DIR}/../../for-teams/"
 ```
 
 If it is missing, tell the user their install is incomplete and offer to re-run bootstrap. Do not improvise the team content from memory.

--- a/skills/graphify/SKILL.md
+++ b/skills/graphify/SKILL.md
@@ -7,6 +7,8 @@ argument-hint: "[subfolder path to process, e.g. Notes/ or Journals/ — for ver
 
 # /graphify
 
+> **`{SKILL_DIR}`** = this skill's own folder (locally: the directory this SKILL.md lives in; a served brain substitutes the real absolute path before you read this). If a path does not resolve, name the missing file and stop — never guess another location.
+
 Turn any folder of files into a navigable knowledge graph with community detection, an honest audit trail, and three outputs: interactive HTML, GraphRAG-ready JSON, and a plain-language GRAPH_REPORT.md.
 
 > ⚡ **Before running on a corpus larger than ~50 files, READ [OPTIMIZATIONS.md](./OPTIMIZATIONS.md).** The wrapper scripts in `scripts/` (dedupe, regex preflight, word-balanced chunking, label canonicalization, cache integration) typically cut LLM token cost by 80–92% and produce a higher-quality graph. The single most important step is calling `graphify_canonicalize.py --cache` after merging — without it, the next `--update` run repays the entire cost. Skip these wrappers and a 1,500-file vault will burn ~10M LLM tokens for the same graph that costs ~1M with them.
@@ -204,7 +206,7 @@ If a typed-relationship extractor is available, run it in parallel with Part A a
 # Locate the shipped script; PATH fallback for users who installed it standalone.
 WIRE_SCRIPT=""
 for candidate in \
-    "$HOME/.claude/skills/graphify/scripts/wire_typed_relationships.py" \
+    "{SKILL_DIR}/scripts/wire_typed_relationships.py" \
     "$HOME/.claude/plugins/graphify/scripts/wire_typed_relationships.py" \
     "./scripts/wire_typed_relationships.py"; do
     if [ -f "$candidate" ]; then

--- a/skills/ingest-github/SKILL.md
+++ b/skills/ingest-github/SKILL.md
@@ -6,6 +6,8 @@ argument-hint: "<owner/repo> [--days N]"
 
 # ingest-github: GitHub-to-vault connector
 
+> **`{SKILL_DIR}`** = this skill's own folder (locally: the directory this SKILL.md lives in; a served brain substitutes the real absolute path before you read this). If a path does not resolve, name the missing file and stop — never guess another location.
+
 Ingests recent GitHub repository activity into the vault as markdown the graphify pipeline can read and the rest of the AI Brain Starter substrate (decision log, session-close cascade, hooks) can act on.
 
 This is the second connector in the ingest-* pattern. Adding the next external source means writing a new normalizer, not a new architecture.
@@ -48,7 +50,7 @@ If the MCP is connected but the token lacks repo read scope, the call returns 40
 
 ## Invocation
 
-The skill is a thin orchestrator. The actual normalization runs in Python at `~/.claude/skills/ingest-github/ingest.py` (or the public-repo path). The skill assembles the GitHub MCP tool calls, hands the raw payloads to `ingest.py` as JSON on stdin, and the script writes the file.
+The skill is a thin orchestrator. The actual normalization runs in Python at `{SKILL_DIR}/ingest.py`. The skill assembles the GitHub MCP tool calls, hands the raw payloads to `ingest.py` as JSON on stdin, and the script writes the file.
 
 When invoked:
 

--- a/skills/ingest-youtube/SKILL.md
+++ b/skills/ingest-youtube/SKILL.md
@@ -5,6 +5,8 @@ description: Use when the user says /ingest-youtube <url-or-channel> [--days N],
 
 # ingest-youtube — YouTube-to-vault connector
 
+> **`{SKILL_DIR}`** = this skill's own folder (locally: the directory this SKILL.md lives in; a served brain substitutes the real absolute path before you read this). If a path does not resolve, name the missing file and stop — never guess another location.
+
 Ingests YouTube transcripts into the vault as markdown the graphify pipeline can read and the rest of the AI Brain Starter substrate (decision log, session-close cascade, hooks) can act on.
 
 Same connector pattern as `ingest-github`: adding a new source means a new normalizer, not a new architecture.
@@ -45,7 +47,7 @@ Do NOT use for:
 
 ## Invocation
 
-The skill is a thin orchestrator. The actual ingestion runs in Python at `~/.claude/skills/ingest-youtube/ingest.py`.
+The skill is a thin orchestrator. The actual ingestion runs in Python at `{SKILL_DIR}/ingest.py`.
 
 When invoked:
 

--- a/skills/instinct-export/SKILL.md
+++ b/skills/instinct-export/SKILL.md
@@ -6,6 +6,8 @@ trigger: /instinct-export
 
 # /instinct-export — portable instinct pack out
 
+> **`{SKILL_DIR}`** = this skill's own folder (locally: the directory this SKILL.md lives in; a served brain substitutes the real absolute path before you read this). Shared starter files live at the repo root two levels up: `{SKILL_DIR}/../..`. If a path does not resolve, name the missing file and stop — never guess another location.
+
 Turns your confidence-scored instincts into a portable, evidence-backed YAML
 pack. The unit of sharing is the instinct: `id / trigger / confidence / domain
 / source_repo` plus an `action` and `evidence` body.
@@ -17,11 +19,11 @@ Reimplemented clean per license-hygiene.
 
 ```bash
 # current project's instincts + globals, only confidence >= 0.70, to a file
-python3 ~/.claude/skills/ai-brain-starter/scripts/instinct.py export \
+python3 "{SKILL_DIR}/../../scripts/instinct.py" export \
   --min-confidence 0.70 --out ~/instinct-pack.yaml
 
 # everything regardless of project scope
-python3 ~/.claude/skills/ai-brain-starter/scripts/instinct.py export --all --out ~/all.yaml
+python3 "{SKILL_DIR}/../../scripts/instinct.py" export --all --out ~/all.yaml
 ```
 
 Flags:

--- a/skills/instinct-import/SKILL.md
+++ b/skills/instinct-import/SKILL.md
@@ -6,6 +6,8 @@ trigger: /instinct-import
 
 # /instinct-import — portable instinct pack in (confidence-gated)
 
+> **`{SKILL_DIR}`** = this skill's own folder (locally: the directory this SKILL.md lives in; a served brain substitutes the real absolute path before you read this). Shared starter files live at the repo root two levels up: `{SKILL_DIR}/../..`. If a path does not resolve, name the missing file and stop — never guess another location.
+
 Merges another harness's or teammate's instinct pack into your vault WITHOUT
 clobbering your own hard-won instincts. The merge rule is confidence-gated.
 
@@ -15,13 +17,13 @@ Equal-or-lower-confidence import is skipped." Reimplemented clean.
 ## Always dry-run first
 
 ```bash
-python3 ~/.claude/skills/ai-brain-starter/scripts/instinct.py import PACK.yaml --dry-run
+python3 "{SKILL_DIR}/../../scripts/instinct.py" import PACK.yaml --dry-run
 ```
 
 Read the planned `add` / `update` / `skip` lines. Then apply:
 
 ```bash
-python3 ~/.claude/skills/ai-brain-starter/scripts/instinct.py import PACK.yaml
+python3 "{SKILL_DIR}/../../scripts/instinct.py" import PACK.yaml
 ```
 
 ## Merge rules

--- a/skills/patterns/SKILL.md
+++ b/skills/patterns/SKILL.md
@@ -6,6 +6,8 @@ trigger: /patterns
 
 # /patterns — Instinct Engine
 
+> **`{SKILL_DIR}`** = this skill's own folder (locally: the directory this SKILL.md lives in; a served brain substitutes the real absolute path before you read this). Shared starter files live at the repo root two levels up: `{SKILL_DIR}/../..`. If a path does not resolve, name the missing file and stop — never guess another location.
+
 You are extracting signal before it evaporates. This skill scans recent sessions and surfaces what's hardening into real insight, then proposes concrete captures.
 
 Run this after a weekly review, after a heavy journaling session, or whenever the user says "I keep noticing..." or "this keeps coming up."
@@ -89,9 +91,9 @@ If a weekly review was just run, its output is already in context — use that, 
 
 If the Instinct Engine is installed, a `PreToolUse` hook has logged EVERY tool call this session to `~/.claude/instinct/observations.jsonl`. Read that ledger instead of reconstructing the session from the transcript — it is the 100%-capture source, not a ~50-80% reconstruction.
 
-- **Apply decay first:** `python3 ~/.claude/skills/ai-brain-starter/scripts/instinct.py decay` (erodes instincts unseen past the grace window so confidence stays honest).
+- **Apply decay first:** `python3 "{SKILL_DIR}/../../scripts/instinct.py" decay` (erodes instincts unseen past the grace window so confidence stays honest).
 - **Friction (Trigger 1) with evidence:** count repeated `action` values per `session` in the ledger. 5+ of the same `action` to reach one outcome = a friction pattern backed by hard counts, not a vibe.
-- **Current standings:** `python3 ~/.claude/skills/ai-brain-starter/scripts/instinct.py report --limit 30` lists instincts by effective confidence and flags stale ones.
+- **Current standings:** `python3 "{SKILL_DIR}/../../scripts/instinct.py" report --limit 30` lists instincts by effective confidence and flags stale ones.
 
 If the engine is NOT installed, fall back to the in-context conversation review below.
 
@@ -135,7 +137,7 @@ After the user confirms, execute all approved captures in one pass:
 - **CLAUDE.md rule** → add to the relevant section, sync to any other CLAUDE.md files
 - **Concept note** → create in the concept folder, add wikilinks
 - **Skill improvement** → note it clearly: "This should be baked into [skill name] — flag for next update"
-- **Confidence update (self-improving memory)** → when this run confirms an existing instinct held (it fired again, uncorrected), run `python3 ~/.claude/skills/ai-brain-starter/scripts/instinct.py reinforce <slug>`. When the user corrected one, run `... correct <slug>`. That bidirectional update is what makes the library self-improving instead of append-only. See `docs/instinct-engine.md`. When a domain accumulates many high-confidence instincts, run `/evolve` to propose promoting the cluster into a dedicated skill.
+- **Confidence update (self-improving memory)** → when this run confirms an existing instinct held (it fired again, uncorrected), run `python3 "{SKILL_DIR}/../../scripts/instinct.py" reinforce <slug>`. When the user corrected one, run `... correct <slug>`. That bidirectional update is what makes the library self-improving instead of append-only. See `docs/instinct-engine.md`. When a domain accumulates many high-confidence instincts, run `/evolve` to propose promoting the cluster into a dedicated skill.
 
 ---
 

--- a/skills/second-brain-mapping/SKILL.md
+++ b/skills/second-brain-mapping/SKILL.md
@@ -7,6 +7,8 @@ argument-hint: "[--metadata-only | --insights-only | --dry-run | --sample [N] | 
 
 # /second-brain-mapping
 
+> **`{SKILL_DIR}`** = this skill's own folder (locally: the directory this SKILL.md lives in; a served brain substitutes the real absolute path before you read this). Shared starter files live at the repo root two levels up: `{SKILL_DIR}/../..`. If a path does not resolve, name the missing file and stop — never guess another location.
+
 Your vault is a database. This skill makes it queryable.
 
 ## What it does
@@ -197,7 +199,7 @@ stat -f "%Sm" "$(pwd)/graphify-out/graph.json" 2>/dev/null || echo "Last graph: 
 
 Then ask: **"Run graphify on this corpus? y/N"**
 
-If yes, invoke `/graphify --update`. Read `~/.claude/skills/graphify/SKILL.md` first. On success, stamp `phase_2_graphify`.
+If yes, invoke `/graphify --update`. Read the graphify skill's own SKILL.md first (`{SKILL_DIR}/../graphify/SKILL.md` — sibling skill folder, resolves in both local and served installs). On success, stamp `phase_2_graphify`.
 
 **Cost framing (do not misquote):** the token estimate is real, but on a Claude Max/Pro subscription graphify's semantic extraction runs through subagents (no per-token dollar charge) and ~80% of edges come from zero-LLM deterministic passes — so the marginal dollar cost is effectively **$0**. Only quote dollars if the user is on metered API billing. Never let a paid-API figure talk a subscription user out of a rebuild — that inverts the whole point of maximum context.
 

--- a/skills/security-snapshot/SKILL.md
+++ b/skills/security-snapshot/SKILL.md
@@ -35,6 +35,8 @@ output_shape:
     summary_grade: overall hygiene grade (A through F) printed to stdout
 ---
 
+> **`{SKILL_DIR}`** = this skill's own folder (locally: the directory this SKILL.md lives in; a served brain substitutes the real absolute path before you read this). Shared starter files live at the repo root two levels up: `{SKILL_DIR}/../..`. If a path does not resolve, name the missing file and stop — never guess another location.
+
 When the user types /security-snapshot [domain] or asks for a security check on a prospect, run the security snapshot generator and deliver a client-ready report.
 
 ## Why this skill exists
@@ -44,7 +46,7 @@ Prospects rarely have budget for a full security audit upfront, but they will re
 ## Command
 
 ```bash
-python3 "$HOME/.claude/skills/ai-brain-starter/scripts/security-snapshot.py" <domain> --company "<Display Name>"
+python3 "{SKILL_DIR}/../../scripts/security-snapshot.py" <domain> --company "<Display Name>"
 ```
 
 The script ships with the starter repo. Output goes to `$SNAPSHOTS_DIR` if set, otherwise `$VAULT_ROOT/security-snapshots/` if `VAULT_ROOT` is set, otherwise a `security-snapshots/` folder next to wherever you run the command from. It takes 60-180 seconds because SSL Labs is slow. The script prints the saved report path to stdout and progress to stderr.

--- a/skills/setup-vault-types/SKILL.md
+++ b/skills/setup-vault-types/SKILL.md
@@ -36,6 +36,8 @@ output_shape:
 
 # /setup-vault-types
 
+> **`{SKILL_DIR}`** = this skill's own folder (locally: the directory this SKILL.md lives in; a served brain substitutes the real absolute path before you read this). Shared starter files live at the repo root two levels up: `{SKILL_DIR}/../..`. If a path does not resolve, name the missing file and stop — never guess another location.
+
 Figure out which doc types belong in this vault, then wire the right extractors.
 
 ## Why
@@ -110,7 +112,7 @@ For each checked type, symlink its extractor into the vault's `scripts/extractor
 
 ```bash
 VAULT="$(vault-root)"
-STARTER="$HOME/.claude/skills/ai-brain-starter"  # or wherever it's installed
+STARTER="{SKILL_DIR}/../.."  # the starter repo root, two levels above this skill's folder
 for type in ${SELECTED_TYPES[@]}; do
   ln -sf "$STARTER/scripts/extractors/$type.py" "$VAULT/scripts/extractors/$type.py"
 done

--- a/skills/sunday-review/SKILL.md
+++ b/skills/sunday-review/SKILL.md
@@ -5,6 +5,8 @@ description: 'Use when the user asks for the weekly meta-review or Sunday wrap-u
 
 # /sunday-review — weekly meta-orchestrator
 
+> **`{SKILL_DIR}`** = this skill's own folder (locally: the directory this SKILL.md lives in; a served brain substitutes the real absolute path before you read this). Shared starter files live at the repo root two levels up: `{SKILL_DIR}/../..`. If a path does not resolve, name the missing file and stop — never guess another location.
+
 You are running the Sunday meta-review. This skill doesn't reinvent the existing weekly skills — it orchestrates them in the right sequence, surfaces the cross-cutting signal, and produces ONE clean note instead of N independent reports.
 
 ## Order of operations
@@ -23,7 +25,7 @@ Invoke `/patterns`. It scans recent sessions, journals, and decisions for harden
 
 Run:
 ```bash
-python3 ~/.claude/skills/ai-brain-starter/scripts/vault-hygiene.py --quiet
+python3 "{SKILL_DIR}/../../scripts/vault-hygiene.py" --quiet
 ```
 
 It writes a fresh report to `⚙️ Meta/Vault Hygiene.md`. Capture: how many broken wikilinks, empty notes, stale notes, duplicate concepts.
@@ -32,7 +34,7 @@ It writes a fresh report to `⚙️ Meta/Vault Hygiene.md`. Capture: how many br
 
 Run:
 ```bash
-python3 ~/.claude/skills/ai-brain-starter/scripts/check-claude-md-drift.py --quiet
+python3 "{SKILL_DIR}/../../scripts/check-claude-md-drift.py" --quiet
 ```
 
 It writes a report to `⚙️ Meta/CLAUDE-md drift.md`. Capture: any dormant people, archived projects, broken links, or old codifications that need review.
@@ -121,7 +123,7 @@ Engram-inspired (`mem_capture_passive`) — scans the past week's session transc
 
 Run:
 ```bash
-python3 ~/.claude/skills/ai-brain-starter/scripts/closed-loop-week-report.py \
+python3 "{SKILL_DIR}/../../scripts/closed-loop-week-report.py" \
   --vault-root "$VAULT_ROOT" --days 7
 ```
 
@@ -157,7 +159,7 @@ Source: panel synthesis (Schneier + Charity Majors + Patrick Collison + DHH-diss
 
 Run:
 ```bash
-python3 ~/.claude/skills/ai-brain-starter/scripts/decision-retrospective.py --apply-prompt
+python3 "{SKILL_DIR}/../../scripts/decision-retrospective.py" --apply-prompt
 ```
 
 This surfaces decisions older than 90 days with empty Outcome and appends review-ready prompts to `⚙️ Meta/Decision Retrospective.md`. Capture: how many stale decisions need their Outcome filled in.
@@ -166,8 +168,8 @@ This surfaces decisions older than 90 days with empty Outcome and appends review
 
 Run:
 ```bash
-python3 ~/.claude/skills/ai-brain-starter/scripts/skill-usage-report.py
-python3 ~/.claude/skills/ai-brain-starter/scripts/curate-skills-surface.py --top 5 --days 7
+python3 "{SKILL_DIR}/../../scripts/skill-usage-report.py"
+python3 "{SKILL_DIR}/../../scripts/curate-skills-surface.py" --top 5 --days 7
 ```
 
 Capture: the 3 most-used skills this week + any skills that haven't been used in 30+ days (dormant — candidates for pruning or re-promoting).


### PR DESCRIPTION
## Summary

Converts every host-tool install path (`~/.claude/skills/...`, `$HOME/.claude/skills/...`) in 13 SKILL.md bodies to the `{SKILL_DIR}` token contract. `{SKILL_DIR}` is inert text: a served brain (Mycelium runtime) substitutes the real absolute path; a local install resolves it as the directory the SKILL.md itself lives in. An unsubstituted token degrades to a visible literal, never a silent wrong path.

Three conversion classes:
- **Repo-root scripts** (`diagnose`, `evolve`, `for-my-team`, `instinct-export`, `instinct-import`, `patterns`, `security-snapshot`, `setup-vault-types`, `sunday-review`, `second-brain-mapping`): `{SKILL_DIR}/../..` — the starter repo root sits two levels above any skill's own folder.
- **Own-dir files** (`graphify`, `ingest-github`, `ingest-youtube`): `{SKILL_DIR}` — the script lives inside the skill's own folder.
- **Cross-skill traversal** (`second-brain-mapping` → `graphify`): `{SKILL_DIR}/../graphify/SKILL.md` — sibling skill folder, resolves the same way in both local and served installs.

Each converted file gets a one-line blockquote right after its frontmatter (and after the H1 title where one opens the file) explaining what `{SKILL_DIR}` means and instructing to stop and name the missing file rather than guess a location if a path doesn't resolve.

## Verification

- `grep -rn "\.claude/skills" skills/*/SKILL.md` → zero lines.
- Every one of the 13 converted files has `{SKILL_DIR}` count ≥ 2.
- Personal-data scrub over `git diff origin/main..HEAD`: checked for Adelaida, Diaz-Roa, Onde, Sergio, Sneider, Alfonso, Panorama, Diana, Paola, Beverly, Natalia, Silvia, Nelly, Colombia, Bogotá/Bogota, Accenture, adelaidadiaz-roa, adelaida@ (word-boundary) — clean, no matches.
- `python3 scripts/check-template-purity.py <13 files>` → `template-purity OK: 13 public-bound file(s) are template-pure.`
- Local `ci-test` full gate (py_compile, integration tests, scripts/ + hooks/ unit suites, shellcheck, phase-doc, utf8 console guard) → GREEN, sha-keyed marker written for this commit.

## Test plan

- [x] Zero remaining `.claude/skills` references in `skills/*/SKILL.md`
- [x] Template-purity gate green
- [x] Full local ci-test gate green
- [x] Scrub check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)