### PR TITLE
feat(hooks): warn when a reusable workflow asks for a permission its caller lacks

### DIFF
--- a/hooks.json
+++ b/hooks.json
@@ -162,6 +162,11 @@
           },
           {
             "type": "command",
+            "command": "[PYTHON] ~/.claude/skills/ai-brain-starter/hooks/warn-workflow-call-permission-elevation.py 2>/dev/null || echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"allow\"}}'",
+            "statusMessage": "Checking reusable-workflow permissions (callee cannot exceed caller)..."
+          },
+          {
+            "type": "command",
             "command": "[PYTHON] ~/.claude/skills/ai-brain-starter/hooks/warn-journal-saved-without-context.py 2>/dev/null || echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"allow\"}}'"
           }
         ]

--- a/hooks/warn-workflow-call-permission-elevation.py
+++ b/hooks/warn-workflow-call-permission-elevation.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""PreToolUse Write/Edit hook: warn when a GitHub Actions workflow edit would
+make a reusable workflow request a permission its caller never grants.
+
+THE CLASS. A called (reusable) workflow's GITHUB_TOKEN can only be DOWNGRADED
+from its caller's, never elevated. When a callee asks for a scope the caller
+does not grant, GitHub rejects the run at STARTUP: `startup_failure`, ZERO jobs,
+no annotation, no check-run, nothing readable from the API. Every gate in that
+pipeline silently stops running.
+
+WHY A HOOK AND NOT JUST A LINTER. `actionlint` exits 0 on a tree GitHub refuses
+to start -- it validates each file in isolation, and this defect lives in the
+RELATIONSHIP between two files. A callee is also perfectly valid on its own
+(standalone it IS the top-level grant, so it has no caller to exceed). The
+defect is invisible to every single-file check.
+
+WHY IT CHECKS BOTH DIRECTIONS. This is the part that matters, and the part a
+naive implementation gets wrong. The realistic way this bug is introduced is by
+editing the CALLEE -- someone adds `pull-requests: read` to a reusable workflow
+so one of its own jobs can read PR metadata. That edit is locally correct and
+locally green. It breaks a DIFFERENT file's pipeline. So this hook checks:
+
+  forward  -- the edited file is a CALLER: do its callees fit its grant?
+  reverse  -- the edited file is a CALLEE: do its CALLERS grant what it asks?
+
+A forward-only check would miss the exact edit that causes this in practice.
+
+THE TRAP IT ENCODES. Declaring a `permissions:` block is not additive. It
+replaces the default wholesale, so every scope you do NOT list becomes `none`.
+`permissions: {contents: write}` grants contents AND REVOKES EVERYTHING ELSE.
+A callee asking for any unlisted scope is therefore requesting an elevation,
+even though the caller looks strictly more privileged at a glance.
+
+WARN, NOT BLOCK. A workflow edit is not destructive and the consequence lands
+at release time, not now. This surfaces the problem at authoring time with the
+exact fix; a repo that wants a hard stop should also run the check in CI.
+
+Bypass: WORKFLOW_PERMS_BYPASS=1
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:  # PyYAML absent -> stay silent, never break the user's edit
+    sys.exit(0)
+
+# Token scopes are ordered: absent < read < write.
+LEVELS = {"none": 0, "read": 1, "write": 2}
+NAMES = {v: k for k, v in LEVELS.items()}
+
+
+def _level(value: object) -> int:
+    if isinstance(value, str) and value.lower() in LEVELS:
+        return LEVELS[value.lower()]
+    return 0
+
+
+def parse_permissions(node: object) -> dict | None:
+    """Normalise a `permissions:` node to {scope: level}.
+
+    None means the workflow/job declared nothing -> it inherits, which is never
+    an elevation. A DECLARED block is CLOSED: unlisted scopes are level 0.
+    """
+    if node is None:
+        return None
+    if isinstance(node, str):
+        token = node.lower()
+        if token == "read-all":
+            return {"*": LEVELS["read"]}
+        if token == "write-all":
+            return {"*": LEVELS["write"]}
+        return {"*": LEVELS["none"]}
+    if isinstance(node, dict):
+        return {str(k): _level(v) for k, v in node.items()}
+    return {"*": LEVELS["none"]}
+
+
+def granted(perms: dict | None, scope: str) -> int:
+    if perms is None:
+        return LEVELS["write"]
+    if "*" in perms:
+        return perms["*"]
+    return perms.get(scope, LEVELS["none"])
+
+
+def _load(text: str) -> dict | None:
+    try:
+        doc = yaml.safe_load(text)
+    except Exception:
+        return None
+    return doc if isinstance(doc, dict) else None
+
+
+def _read(path: Path) -> dict | None:
+    try:
+        return _load(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+def _call_edges(doc: dict) -> list[tuple[str, str, dict | None]]:
+    """[(job_id, callee_basename, job_level_permissions_or_None)] for local calls."""
+    out = []
+    jobs = doc.get("jobs")
+    if not isinstance(jobs, dict):
+        return out
+    for job_id, job in jobs.items():
+        if not isinstance(job, dict):
+            continue
+        uses = job.get("uses")
+        if not isinstance(uses, str) or not uses.startswith("./"):
+            continue
+        job_perms = parse_permissions(job["permissions"]) if "permissions" in job else None
+        out.append((str(job_id), Path(uses).name, job_perms))
+    return out
+
+
+def _violations(caller_name, caller_doc, callee_name, callee_doc):
+    """Elevations the caller->callee edge would take. [] if fine."""
+    found = []
+    requested = parse_permissions(callee_doc.get("permissions"))
+    if requested is None:
+        return found  # callee inherits; never an elevation
+    caller_default = parse_permissions(caller_doc.get("permissions"))
+    for job_id, target, job_perms in _call_edges(caller_doc):
+        if target != callee_name:
+            continue
+        effective = job_perms if job_perms is not None else caller_default
+        if effective is None:
+            continue  # caller never declares -> repo default, unresolvable here
+        for scope, want in sorted(requested.items()):
+            if want == LEVELS["none"]:
+                continue
+            have = granted(effective, scope)
+            if have < want:
+                found.append((job_id, scope, NAMES[want], NAMES[have], caller_name))
+    return found
+
+
+def main() -> int:
+    if os.environ.get("WORKFLOW_PERMS_BYPASS") == "1":
+        return 0
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0
+
+    tool = payload.get("tool_name") or ""
+    if tool not in ("Write", "Edit"):
+        return 0
+    ti = payload.get("tool_input") or {}
+    raw_path = ti.get("file_path") or ""
+    if not raw_path:
+        return 0
+
+    path = Path(raw_path)
+    if path.suffix not in (".yml", ".yaml"):
+        return 0
+    if path.parent.name != "workflows" or path.parent.parent.name != ".github":
+        return 0
+
+    # Resulting content of the edited file.
+    if tool == "Write":
+        new_text = ti.get("content") or ""
+    else:
+        try:
+            current = path.read_text(encoding="utf-8")
+        except Exception:
+            return 0
+        old, new = ti.get("old_string") or "", ti.get("new_string") or ""
+        if old and old not in current:
+            return 0
+        new_text = current.replace(old, new, 1) if old else current
+
+    edited = _load(new_text)
+    if not edited:
+        return 0
+
+    wf_dir = path.parent
+    siblings = {}
+    try:
+        for p in list(wf_dir.glob("*.yml")) + list(wf_dir.glob("*.yaml")):
+            if p.name == path.name:
+                continue
+            d = _read(p)
+            if d:
+                siblings[p.name] = d
+    except Exception:
+        return 0
+
+    problems = []
+
+    # FORWARD: the edited file is a caller.
+    for job_id, callee_name, _ in _call_edges(edited):
+        callee_doc = siblings.get(callee_name)
+        if callee_doc is None:
+            continue
+        problems += _violations(path.name, edited, callee_name, callee_doc)
+
+    # REVERSE: the edited file is a callee -- the realistic way this is born.
+    for sib_name, sib_doc in siblings.items():
+        if any(t == path.name for _, t, _ in _call_edges(sib_doc)):
+            problems += _violations(sib_name, sib_doc, path.name, edited)
+
+    if not problems:
+        return 0
+
+    seen, lines = set(), []
+    for job_id, scope, want, have, caller in problems:
+        key = (job_id, scope, caller)
+        if key in seen:
+            continue
+        seen.add(key)
+        lines.append(
+            f"  {caller}: job `{job_id}` -> callee requests `{scope}: {want}`, "
+            f"caller grants `{scope}: {have}`\n"
+            f"    fix: add `{scope}: {want}` to a `permissions:` block on job `{job_id}` in {caller}"
+        )
+
+    sys.stderr.write(
+        "WORKFLOW PERMISSION ELEVATION -- GitHub will refuse to START this workflow.\n"
+        "A called workflow's GITHUB_TOKEN can only be DOWNGRADED from its caller's.\n"
+        "The run returns startup_failure with ZERO jobs, no annotation and no\n"
+        "check-run, so every gate in that pipeline silently stops running.\n\n"
+        + "\n".join(lines)
+        + "\n\nNote: declaring `permissions:` REPLACES the default -- every scope you do\n"
+        "not list becomes `none`, so an unlisted scope in a callee is an elevation.\n"
+        "actionlint will not catch this; it lints each file in isolation.\n"
+        "Bypass: WORKFLOW_PERMS_BYPASS=1\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/warn-workflow-call-permission-elevation.test.sh
+++ b/hooks/warn-workflow-call-permission-elevation.test.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Negative controls for warn-workflow-call-permission-elevation.py.
+#
+# A gate earns trust only by failing on the thing it catches. The load-bearing
+# case is REVERSE (case 2): the real-world way this bug is born is editing the
+# CALLEE to add a permission, which breaks a DIFFERENT file's pipeline. A
+# forward-only implementation passes case 1 and silently fails case 2.
+set -uo pipefail
+
+HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/warn-workflow-call-permission-elevation.py"
+pass=0; fail=0
+
+check() { # name expect_warn actual_output
+  local name="$1" expect="$2" out="$3"
+  local got="quiet"
+  printf '%s' "$out" | grep -q 'WORKFLOW PERMISSION ELEVATION' && got="warn"
+  if [ "$got" = "$expect" ]; then
+    printf '  ok   %-58s (%s)\n' "$name" "$got"; pass=$((pass+1))
+  else
+    printf '  FAIL %-58s expected %s, got %s\n' "$name" "$expect" "$got"; fail=$((fail+1))
+    printf '%s\n' "$out" | sed 's/^/       /'
+  fi
+}
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+WF="$TMP/.github/workflows"; mkdir -p "$WF"
+
+CALLER_TIGHT='name: release
+on: {push: {tags: ["v*"]}}
+permissions:
+  contents: write
+jobs:
+  gate:
+    uses: ./.github/workflows/smoke.yml
+'
+CALLER_GRANTS='name: release
+on: {push: {tags: ["v*"]}}
+permissions:
+  contents: write
+jobs:
+  gate:
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: ./.github/workflows/smoke.yml
+'
+CALLEE_SAFE='name: smoke
+on: {workflow_call: null}
+permissions:
+  contents: read
+jobs:
+  w:
+    runs-on: ubuntu-latest
+    steps: [{run: echo hi}]
+'
+CALLEE_ELEVATED='name: smoke
+on: {workflow_call: null}
+permissions:
+  contents: read
+  pull-requests: read
+jobs:
+  w:
+    runs-on: ubuntu-latest
+    steps: [{run: echo hi}]
+'
+
+run_write() { # file_path content
+  printf '{"tool_name":"Write","tool_input":{"file_path":"%s","content":%s}}' \
+    "$1" "$(python3 -c 'import json,sys;print(json.dumps(sys.stdin.read()))' <<<"$2")" \
+    | python3 "$HOOK" 2>&1
+}
+
+# 1 FORWARD: writing a caller whose existing callee already asks for more.
+printf '%s' "$CALLEE_ELEVATED" > "$WF/smoke.yml"
+check "forward: caller written against elevated callee" warn \
+  "$(run_write "$WF/release.yml" "$CALLER_TIGHT")"
+
+# 2 REVERSE (the real incident shape): the caller is already on disk and fine;
+#   editing the CALLEE to add a scope breaks it. Forward-only misses this.
+printf '%s' "$CALLER_TIGHT" > "$WF/release.yml"
+rm -f "$WF/smoke.yml"
+check "reverse: callee edited to add an ungranted scope" warn \
+  "$(run_write "$WF/smoke.yml" "$CALLEE_ELEVATED")"
+
+# 3 POSITIVE: a correct per-job grant must stay quiet.
+printf '%s' "$CALLER_GRANTS" > "$WF/release.yml"
+check "caller grants it per-job -> quiet" quiet \
+  "$(run_write "$WF/smoke.yml" "$CALLEE_ELEVATED")"
+
+# 4 POSITIVE: a callee within the caller's grant must stay quiet.
+printf '%s' "$CALLER_TIGHT" > "$WF/release.yml"
+check "callee within caller's grant -> quiet" quiet \
+  "$(run_write "$WF/smoke.yml" "$CALLEE_SAFE")"
+
+# 5 SCOPE: a non-workflow file must never trigger it.
+check "non-workflow path ignored" quiet \
+  "$(run_write "$TMP/notes.yml" "$CALLEE_ELEVATED")"
+
+# 6 BYPASS honoured.
+printf '%s' "$CALLER_TIGHT" > "$WF/release.yml"
+check "bypass env honoured" quiet \
+  "$(WORKFLOW_PERMS_BYPASS=1 run_write "$WF/smoke.yml" "$CALLEE_ELEVATED")"
+
+# 7 Callee that declares NO permissions inherits -> never an elevation.
+check "callee with no permissions block -> quiet" quiet \
+  "$(run_write "$WF/smoke.yml" 'name: smoke
+on: {workflow_call: null}
+jobs:
+  w:
+    runs-on: ubuntu-latest
+    steps: [{run: echo hi}]
+')"
+
+# 8 Unparseable YAML must not break the user's edit.
+check "unparseable yaml -> quiet, never breaks the edit" quiet \
+  "$(run_write "$WF/smoke.yml" ':::not: [valid')"
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "warn-workflow-call-permission-elevation: ${pass}/${pass} passed"
+  exit 0
+fi
+echo "warn-workflow-call-permission-elevation: ${fail} FAILED, ${pass} passed"
+exit 1

--- a/scripts/install-hooks-user-level.py
+++ b/scripts/install-hooks-user-level.py
@@ -98,6 +98,11 @@ ABS_FINGERPRINTS = [
     "ai-brain-starter/hooks/block-secret-in-note.py",
     # Write-time template-purity guard (MYC-1765, structural isolation plane):
     "ai-brain-starter/hooks/block-populated-public-skill.py",
+    # Write-time reusable-workflow permission guard. A callee asking for a scope
+    # its caller never grants makes GitHub refuse to START the run:
+    # startup_failure, zero jobs, no annotation, no check-run. Single-file
+    # linters cannot see it — the defect lives BETWEEN two files.
+    "ai-brain-starter/hooks/warn-workflow-call-permission-elevation.py",
     # Context-budget measurer (always-loaded text layer; MYC-619):
     "ai-brain-starter/hooks/context-budget-measure.py",
     # Vault-in-worktree melt tripwire (3-channel detect; SessionStart + tool-time + dedup):
@@ -143,6 +148,7 @@ ABS_OWNED_BASENAMES = {
     "worktree-footprint-signal.py", "remediate-runaway-procs.py",
     "block-secret-in-note.py", "context-budget-measure.py",
     "block-populated-public-skill.py",
+    "warn-workflow-call-permission-elevation.py",
     "warn-vault-session-in-worktree.py", "warn-learning-to-tool-private-memory.py",
     "warn-stale-dev-checkout.py", "dev-hub-refresh-on-session-start.py",
     # Session-start context loaders (MYC-2359 UPS -> SessionStart relocation):


### PR DESCRIPTION
## The class

A called (reusable) workflow's `GITHUB_TOKEN` can only be **downgraded** from its caller's, never elevated. When a callee requests a scope the caller does not grant, GitHub rejects the run at **startup**: `startup_failure`, **zero jobs**, no annotation, no check-run, nothing readable from the API.

Every gate in that pipeline silently stops running. The first symptom is a failed release, days later.

## Why a hook, and why this is not lintable

`actionlint` exits **0** on a tree GitHub refuses to start. It validates each file in isolation, and this defect lives in the **relationship between two files**. The callee is also perfectly valid standalone — standalone it *is* the top-level grant, so there is no caller to exceed.

No single-file check can catch this. That is what makes it a good hook.

## It checks BOTH directions — this is the part that matters

The realistic way this bug is born is **editing the callee**: someone adds `pull-requests: read` to a reusable workflow so one of its own jobs can read PR metadata. That edit is locally correct, locally green, and breaks a *different* file's pipeline.

A forward-only implementation (does the edited file's callees fit its grant?) passes review and **silently misses the exact edit that causes this in practice**. So the hook also walks reverse edges — when the edited file is a callee, it checks every caller that references it.

The test suite encodes this: case 2 is the reverse case, and a forward-only implementation fails it.

## The trap it encodes

Declaring a `permissions:` block is **not additive**. It replaces the default wholesale, so every scope you do *not* list becomes `none`:

```yaml
permissions:
  contents: write     # grants contents AND REVOKES EVERYTHING ELSE
```

A callee asking for any unlisted scope is therefore requesting an elevation — even though the caller looks strictly *more* privileged at a glance.

## Warn, not block

A workflow edit is not destructive and the consequence lands at release time, not now. The hook surfaces the problem at authoring time with the exact fix:

```
release.yml: job `boot-smoke-gate` -> callee requests `pull-requests: read`,
                                      caller grants `pull-requests: none`
  fix: add `pull-requests: read` to a `permissions:` block on job
       `boot-smoke-gate` in release.yml
```

A repo wanting a hard stop should also run the equivalent check in CI.

## Negative controls — 8 cases, `hooks/warn-workflow-call-permission-elevation.test.sh`

| case | expect |
| --- | --- |
| forward: caller written against an elevated callee | warn |
| **reverse: callee edited to add an ungranted scope** | **warn** |
| caller grants it per-job | quiet |
| callee within the caller's grant | quiet |
| non-workflow path | quiet |
| bypass env honoured | quiet |
| callee declaring no `permissions:` (inherits) | quiet |
| unparseable YAML | quiet — never break the user's edit |

All 8 pass. PyYAML absent also exits silently rather than breaking an edit.

**Replayed against a real historical incident**, not just synthetic fixtures: taking a real pre-change tree where the callee asked only for `contents: read`, then writing the post-change callee that added `pull-requests: read`, the hook fires and names the precise remedy — at write time, before CI, before a release.

## Activation, not presence

Registered in `scripts/install-hooks-user-level.py` (both `ABS_FINGERPRINTS` and `ABS_OWNED_BASENAMES`) and wired in `hooks.json` under `PreToolUse` `Write|Edit|MultiEdit`, so a fresh install **activates** it. Verified: the wired command matches the ownership fingerprint, `hooks.json` parses, and the installer parses.

## Verified locally

- 8/8 negative controls pass.
- `bash -n` clean; `shellcheck -S warning` clean on the new test; `scripts/shellcheck.sh` clean over all 163 tracked `.sh`.
- Personal-data scrub and API-key scrub both clean on the staged diff.
- The diff to `install-hooks-user-level.py` is two list entries plus comments — no new regex, no new exception handling.

Bypass: `WORKFLOW_PERMS_BYPASS=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)