### PR TITLE
fix(hooks): the workflow-permission guard warned on stderr, which the wiring discards

### DIFF
--- a/hooks/warn-workflow-call-permission-elevation.py
+++ b/hooks/warn-workflow-call-permission-elevation.py
@@ -35,6 +35,13 @@ WARN, NOT BLOCK. A workflow edit is not destructive and the consequence lands
 at release time, not now. This surfaces the problem at authoring time with the
 exact fix; a repo that wants a hard stop should also run the check in CI.
 
+THE WARNING GOES ON STDOUT. Every hooks.json command in this repo is wired as
+`<script> 2>/dev/null || echo <allow-json>` -- stderr is discarded by the shell
+before Claude Code ever reads it. A diagnostic written to stderr is therefore
+deployed, registered, green in its own tests, and MUTE in production. Case 9 of
+the test suite pins the channel, and the harness captures stdout only so the
+behavioural cases fail the same way production would.
+
 Bypass: WORKFLOW_PERMS_BYPASS=1
 """
 from __future__ import annotations
@@ -222,7 +229,7 @@ def main() -> int:
             f"    fix: add `{scope}: {want}` to a `permissions:` block on job `{job_id}` in {caller}"
         )
 
-    sys.stderr.write(
+    warning = (
         "WORKFLOW PERMISSION ELEVATION -- GitHub will refuse to START this workflow.\n"
         "A called workflow's GITHUB_TOKEN can only be DOWNGRADED from its caller's.\n"
         "The run returns startup_failure with ZERO jobs, no annotation and no\n"
@@ -233,6 +240,17 @@ def main() -> int:
         "actionlint will not catch this; it lints each file in isolation.\n"
         "Bypass: WORKFLOW_PERMS_BYPASS=1\n"
     )
+
+    # STDOUT, as hookSpecificOutput.additionalContext -- NOT stderr. Every
+    # hooks.json command in this repo ends in `2>/dev/null || echo <allow>`, so
+    # a hook that writes its diagnostic to stderr is registered, tested green,
+    # and PERMANENTLY SILENT in production. Only stdout survives the wiring.
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "additionalContext": warning,
+        }
+    }))
     return 0
 
 

--- a/hooks/warn-workflow-call-permission-elevation.test.sh
+++ b/hooks/warn-workflow-call-permission-elevation.test.sh
@@ -67,7 +67,7 @@ jobs:
 run_write() { # file_path content
   printf '{"tool_name":"Write","tool_input":{"file_path":"%s","content":%s}}' \
     "$1" "$(python3 -c 'import json,sys;print(json.dumps(sys.stdin.read()))' <<<"$2")" \
-    | python3 "$HOOK" 2>&1
+    | python3 "$HOOK" 2>/dev/null
 }
 
 # 1 FORWARD: writing a caller whose existing callee already asks for more.
@@ -114,6 +114,29 @@ jobs:
 # 8 Unparseable YAML must not break the user's edit.
 check "unparseable yaml -> quiet, never breaks the edit" quiet \
   "$(run_write "$WF/smoke.yml" ':::not: [valid')"
+
+# 9 EMISSION CHANNEL. Every hooks.json command in this repo ends in
+#   `2>/dev/null || echo <allow>`, so stderr is discarded before Claude Code
+#   sees it. A warning must therefore arrive on STDOUT as valid
+#   hookSpecificOutput.additionalContext JSON. run_write already captures
+#   stdout only (cases 1+2 are the behavioural half of this control); this
+#   asserts the payload SHAPE, so a revert to a bare stderr write -- or to
+#   plain unstructured text on stdout -- fails here instead of shipping mute.
+printf '%s' "$CALLER_TIGHT" > "$WF/release.yml"
+emit="$(run_write "$WF/smoke.yml" "$CALLEE_ELEVATED")"
+if printf '%s' "$emit" | python3 -c '
+import json,sys
+d = json.load(sys.stdin)
+ctx = d["hookSpecificOutput"]["additionalContext"]
+assert d["hookSpecificOutput"]["hookEventName"] == "PreToolUse", "wrong hookEventName"
+assert "WORKFLOW PERMISSION ELEVATION" in ctx, "diagnostic missing from additionalContext"
+' 2>/dev/null; then
+  printf '  ok   %-58s (%s)\n' "warns via stdout hookSpecificOutput JSON" "json"; pass=$((pass+1))
+else
+  printf '  FAIL %-58s %s\n' "warns via stdout hookSpecificOutput JSON" \
+    "stdout is not additionalContext JSON -- the wiring discards stderr, so this ships MUTE"
+  printf '%s\n' "$emit" | sed 's/^/       /'; fail=$((fail+1))
+fi
 
 echo
 if [ "$fail" -eq 0 ]; then


### PR DESCRIPTION
## The defect

The guard shipped in #365 (MYC-3243) is registered, deployed, and 8/8 green — and **has never been seen by anyone**.

It writes its entire diagnostic to `sys.stderr`. Every `hooks.json` command in this repo is wired as:

```
<script> 2>/dev/null || echo <allow-json>
```

The shell discards stderr before Claude Code reads it. The hook exits 0 with empty stdout, so the harness sees a clean allow. Registration was real; activation was not.

## Why the tests passed

The harness piped the hook with `2>&1`, merging stderr back into stdout. It proved the hook produces text *somewhere* — not that it produces text the harness will surface. That is the exact gap between DEPLOYED and WORKING.

## Negative control

Changing **only** the harness to capture stdout as the real wiring does, against the unmodified pre-fix hook:

```
FAIL forward: caller written against elevated callee    expected warn, got quiet
FAIL reverse: callee edited to add an ungranted scope   expected warn, got quiet
warn-workflow-call-permission-elevation: 2 FAILED, 6 passed
```

Both warn cases go silent — production behaviour, reproduced.

## The fix

- emit on stdout as `hookSpecificOutput.additionalContext`, the convention 20+ hooks here already use (`warn-stale-dev-checkout.py:260`)
- harness captures stdout only, so cases 1 and 2 fail the way production failed
- new **case 9** pins the emission channel structurally: a revert to stderr, or to unstructured stdout, fails here instead of shipping mute

After: `9/9 passed`.

## Class sweep

Checked all 47 wired hook scripts for the same shape (stderr-only diagnostic + `2>/dev/null` wiring + no block path): **zero further instances**. This was isolated.

Refs MYC-3246.

🤖 Generated with [Claude Code](https://claude.com/claude-code)