### PR TITLE
fix(worktree-prune): stop ranking ~/.claude/hooks/ above canonical for worktree-reclaim.py

### DIFF
--- a/scripts/worktree-prune.sh
+++ b/scripts/worktree-prune.sh
@@ -27,11 +27,19 @@ LOG="$LOG_DIR/worktree-prune.log"
 SNAPSHOT_DIR="${SNAPSHOT_DIR:-$VAULT_ROOT/⚙️ Meta/Worktree Snapshots}"
 WT_DIR="${WT_DIR:-$VAULT_ROOT/.claude/worktrees}"
 SNAPSHOT_RETENTION_DAYS="${SNAPSHOT_RETENTION_DAYS:-30}"
-# Safe reclaim engine — first existing of: user hooks, skill install, alongside.
+# Safe reclaim engine — first existing of: alongside, skill install, legacy.
+# ORDER IS LOAD-BEARING. $SCRIPT_DIR first: worktree-reclaim.py is a sibling of
+# THIS script in scripts/, so that copy is always version-matched with the prune
+# logic invoking it. ~/.claude/hooks/ is LAST and legacy-only: no installer ever
+# writes worktree-reclaim.py there (it is a script, not a hook), so the only way
+# that path is populated is a hand-placed or stale copy. Ranking it FIRST meant
+# a stale copy silently shadowed canonical forever — observed live 2026-07-23.
+# Keep it in the chain so a machine that only has that copy still sweeps, but
+# never let it outrank canonical.
 RECLAIM=""
-for _c in "$HOME/.claude/hooks/worktree-reclaim.py" \
+for _c in "$SCRIPT_DIR/worktree-reclaim.py" \
           "$HOME/.claude/skills/ai-brain-starter/scripts/worktree-reclaim.py" \
-          "$SCRIPT_DIR/worktree-reclaim.py"; do
+          "$HOME/.claude/hooks/worktree-reclaim.py"; do
   [ -f "$_c" ] && RECLAIM="$_c" && break
 done
 mkdir -p "$(dirname "$LOG")"


### PR DESCRIPTION
## The defect

`worktree-reclaim.py` is a **script, not a hook**, and no installer ever writes it to `~/.claude/hooks/`. The only way that path gets populated is a hand-placed or stale copy — yet `scripts/worktree-prune.sh` ranked it **first** in its resolution chain.

That slot therefore existed exclusively to be shadowed by staleness. Observed live 2026-07-23: a stale copy there was winning over `scripts/worktree-reclaim.py`, and deleting it was what restored canonical resolution.

## The fix

Reordered to `$SCRIPT_DIR` → skill install → `~/.claude/hooks/` (legacy last).

`$SCRIPT_DIR` leads because `worktree-reclaim.py` is a sibling of `worktree-prune.sh` in `scripts/`, so that copy is always version-matched with the prune logic invoking it.

The legacy path **stays in the chain** rather than being dropped: a machine that only has that copy keeps sweeping instead of silently losing orphan cleanup. This changes the *preference*, not the *availability* — zero regression risk.

## Verified

All four resolution states exercised:

| state | expected | result |
|---|---|---|
| stale hooks copy + canonical present | canonical wins | pass |
| skill install only | skill wins | pass |
| legacy hooks copy only | still found | pass |
| nothing anywhere | falls through to existing WARN | pass |

`scripts/ci.sh` green (85 integration tests). `shellcheck -S warning` clean.

Follow-up to #371, same bug family: canonical must hold the best version, and a copy that no installer ships must never outrank it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
