### PR TITLE
fix(installer): own observe-tool-calls + dedupe owned hooks

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -225,6 +225,10 @@ INTEGRATION_TESTS=(
   # FIRES — protection that is not actually there. Negative controls prove the
   # gate reddens on a bad operator, a bad field, and a stale allowlist entry.
   test_hookify_template_capabilities
+  # Owned-hook dedup (follow-up to the matcher-aware merge): a hook shipped under two
+  # matchers whose stored interpreter path drifted duplicated per matcher; proves owning
+  # observe-tool-calls + the dedupe pass collapse the drift copy and never touch user hooks.
+  test_installer_dedupes_owned_hooks
 )
 # ---- Gate-coverage invariant -------------------------------------------------
 # The list above is an explicit allow-list, and allow-lists rot: a new

--- a/scripts/install-hooks-user-level.py
+++ b/scripts/install-hooks-user-level.py
@@ -135,6 +135,12 @@ ABS_FINGERPRINTS = [
     "ai-brain-starter/hooks/check-fabricated-verification.py",
     "ai-brain-starter/hooks/check-fabricated-hook-attribution.py",
     "ai-brain-starter/hooks/warn-chained-state-command-truncated.py",
+    # Instinct-engine observer. Shipped under TWO PreToolUse matchers with a
+    # byte-identical command; OWNED so its dedup is by basename (matcher-scoped),
+    # not the literal command text. Without this, an interpreter-path drift (bare
+    # `python3` -> absolute shim-safe path) makes is_same_command's literal fallback
+    # miss and the matcher-aware merge APPENDS a second copy per matcher.
+    "ai-brain-starter/hooks/observe-tool-calls.py",
 ]
 
 # Path-divergence-robust matching: an ai-brain-starter hook may be wired at the
@@ -171,6 +177,9 @@ ABS_OWNED_BASENAMES = {
     # at ~/.claude/hooks/ dedups against the skill-path copy instead of doubling.
     "check-fabricated-verification.py", "check-fabricated-hook-attribution.py",
     "warn-chained-state-command-truncated.py",
+    # Instinct-engine observer, shipped under two matchers (dedup by basename so an
+    # interpreter-path change can't double it):
+    "observe-tool-calls.py",
 }
 
 # Hooks ai-brain-starter USED TO ship and has deliberately RETIRED. The
@@ -705,6 +714,51 @@ def relocate_moved_hooks(existing: dict, template: dict) -> tuple[dict, int]:
     return cleaned, removed
 
 
+def dedupe_owned_hooks(existing: dict) -> tuple[dict, int]:
+    """Collapse duplicate OWNED hooks that share the same (event, group, owned-script)
+    down to one, keeping the LAST occurrence (the freshest merge result).
+
+    merge_hooks() REPLACES a template hook in place only when is_same_command matches; for
+    an owned hook that match is by basename, but if a machine's stored command text drifts
+    in a way the owned-basename set still recognizes yet a SECOND stale copy already exists
+    in the group (e.g. an interpreter-path change from bare `python3` to an absolute
+    shim-safe path left two copies before this hook was owned), the replace touches only
+    the first and a duplicate persists. This pass is the idempotent cleanup that self-heals
+    such duplicates on the next install. Non-owned (user) hooks and DISTINCT owned hooks
+    are never touched. Groups emptied are dropped. Returns (cleaned, count_removed)."""
+    cleaned = json.loads(json.dumps(existing))
+    removed = 0
+    if "hooks" not in cleaned:
+        return cleaned, 0
+    for event, groups in list(cleaned["hooks"].items()):
+        new_groups = []
+        for g in groups:
+            hooks = g.get("hooks", [])
+            # Last index per owned-basename set within THIS group. Only owned hooks
+            # (non-empty key) are eligible; a user hook (empty key) is always kept.
+            last_idx: dict = {}
+            for i, h in enumerate(hooks):
+                key = frozenset(_owned_basenames(h.get("command", "")))
+                if key:
+                    last_idx[key] = i
+            kept = []
+            for i, h in enumerate(hooks):
+                key = frozenset(_owned_basenames(h.get("command", "")))
+                if key and last_idx.get(key) != i:
+                    removed += 1
+                    continue  # an earlier duplicate of an owned hook kept later in-group
+                kept.append(h)
+            if kept:
+                ng = dict(g)
+                ng["hooks"] = kept
+                new_groups.append(ng)
+        if new_groups:
+            cleaned["hooks"][event] = new_groups
+        else:
+            del cleaned["hooks"][event]
+    return cleaned, removed
+
+
 def backup_settings(settings_path: Path) -> Path | None:
     if not settings_path.is_file():
         return None
@@ -996,6 +1050,10 @@ def main() -> int:
     # copy but never removed the stale old-event one). Without this a moved hook
     # fires on BOTH events on every existing install (MYC-2359).
     merged, moved_count = relocate_moved_hooks(merged, template)
+    # Collapse duplicate owned-hook copies that an interpreter-path drift left behind
+    # (a byte-changed command the owned-basename dedup recognizes only AFTER the hook is
+    # owned, so merge replaced the first copy but a second stale one persisted).
+    merged, deduped_count = dedupe_owned_hooks(merged)
 
     if not args.quiet:
         print(f"Merging into: {settings_path}")
@@ -1005,6 +1063,7 @@ def main() -> int:
         print(f"Updated:      {len(summary['updated'])} hook(s)")
         print(f"Retired:      {retired_count} stale hook(s) removed")
         print(f"Relocated:    {moved_count} moved-event stale copy(ies) removed")
+        print(f"Deduped:      {deduped_count} duplicate owned hook(s) removed")
         print(f"Preserved:    {len(set(summary['kept']))} non-ABS hook(s) untouched")
         if win_skipped:
             print(f"Skipped:      {len(win_skipped)} POSIX-only (bash) hook(s) not "
@@ -1023,10 +1082,12 @@ def main() -> int:
                 print(f"  - retire {retired_count} stale hook(s)")
             if moved_count:
                 print(f"  - relocate {moved_count} moved-event stale copy(ies)")
+            if deduped_count:
+                print(f"  - dedupe {deduped_count} duplicate owned hook(s)")
         return 0
 
     if not summary["added"] and not summary["updated"] and not retired_count \
-            and not moved_count:
+            and not moved_count and not deduped_count:
         if not args.quiet:
             print("\nAlready in sync. Nothing to write.")
         return 0

--- a/tests/integration/test_installer_dedupes_owned_hooks.sh
+++ b/tests/integration/test_installer_dedupes_owned_hooks.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# test_installer_dedupes_owned_hooks.sh - the installer collapses a duplicate OWNED-hook
+# copy and never touches a user's own hooks.
+#
+# The matcher-aware merge (which correctly registers a hook under every matcher it ships
+# under) exposed a latent class: an owned hook whose stored command text drifts (bare
+# `python3` -> absolute shim-safe interpreter) is not literally == the template command,
+# so on a machine that already carried a second stale copy the replace touched only the
+# first and a duplicate persisted. observe-tool-calls ships under two matchers and hit
+# exactly this. Fix = own it (dedup by basename) + a dedupe pass that self-heals machines
+# already carrying the duplicate.
+#
+# Controls (a guard earns trust only by FAILING/ACTING on the thing it catches):
+#   1. observe-tool-calls.py is OWNED (else basename dedup can't recognize the drift copy).
+#   2. NEGATIVE-ish: a group with two owned copies of the same script collapses to ONE,
+#      keeping the freshest (last) copy.
+#   3. POSITIVE: a user's own duplicate-looking hooks are left completely intact.
+#   4. END-TO-END: a fresh install of the REAL hooks.json wires observe under BOTH of its
+#      matchers, once each, and a re-run is idempotent (no dedup, no growth).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+export REPO_ROOT
+
+python3 <<'PY'
+import importlib.util, os, json, sys
+from pathlib import Path
+
+repo = os.environ["REPO_ROOT"]
+installer = repo + "/scripts/install-hooks-user-level.py"
+spec = importlib.util.spec_from_file_location("ih", installer)
+ih = importlib.util.module_from_spec(spec); spec.loader.exec_module(ih)
+
+def fail(msg):
+    print("FAIL:", msg); sys.exit(1)
+
+OBS = "observe-tool-calls.py"
+
+# 1. observe-tool-calls must be OWNED (the forward fix that prevents new duplicates).
+if OBS not in ih.ABS_OWNED_BASENAMES:
+    fail(f"{OBS} not in ABS_OWNED_BASENAMES - drift copies would not dedup by basename")
+print("PASS: observe-tool-calls.py is owned")
+
+# 2. A group with two owned copies of the same script (interpreter-path drift) collapses
+#    to ONE, keeping the LAST (freshest = the just-merged template form).
+dup = {"hooks": {"PreToolUse": [{"matcher": "X", "hooks": [
+    {"type": "command", "command": f"python3 ~/.claude/skills/ai-brain-starter/hooks/{OBS}"},
+    {"type": "command", "command": f"/opt/x/python3 ~/.claude/skills/ai-brain-starter/hooks/{OBS}"},
+]}]}}
+cleaned, removed = ih.dedupe_owned_hooks(dup)
+kept = [h["command"] for g in cleaned["hooks"]["PreToolUse"] for h in g["hooks"] if OBS in h["command"]]
+if not (removed == 1 and len(kept) == 1):
+    fail(f"owned dup not collapsed (removed={removed}, kept={len(kept)})")
+if "/opt/x/python3" not in kept[0]:
+    fail("dedupe did not keep the LAST (freshest) copy")
+print("PASS: duplicate owned hook collapsed to the freshest single copy (removed=1)")
+
+# 3. A user's OWN duplicate-looking hooks are never touched.
+user = {"hooks": {"PreToolUse": [{"matcher": "Bash", "hooks": [
+    {"type": "command", "command": "echo mine"},
+    {"type": "command", "command": "echo mine"},
+]}]}}
+_, r2 = ih.dedupe_owned_hooks(user)
+if r2 != 0:
+    fail(f"dedupe removed {r2} USER hook(s) - it must only touch owned hooks")
+print("PASS: user (non-owned) hooks left intact")
+
+# 4. END-TO-END over the REAL hooks.json: observe lands under BOTH matchers once each,
+#    and it self-heals an already-duplicated machine + is idempotent.
+tmpl = json.load(open(repo + "/hooks.json"))
+tmpl = ih.normalize_path_substitutions(tmpl, str(Path.home()))
+tmpl = ih.substitute_python_interpreter(tmpl)
+absinterp = ih._posix_python()
+
+def install(existing):
+    m, _ = ih.merge_hooks(existing, tmpl)
+    m, _ = ih.retire_stale_hooks(m)
+    m, _ = ih.relocate_moved_hooks(m, tmpl)
+    m, c = ih.dedupe_owned_hooks(m)
+    return m, c
+
+def obs_matchers(d):
+    return sorted(g.get("matcher") for g in d.get("hooks", {}).get("PreToolUse", [])
+                  for h in g.get("hooks", []) if OBS in h.get("command", ""))
+
+fresh, cf = install({})
+if len(obs_matchers(fresh)) != 2 or len(set(obs_matchers(fresh))) != 2:
+    fail(f"fresh install did not wire observe under 2 distinct matchers: {obs_matchers(fresh)}")
+if cf != 0:
+    fail(f"fresh install spuriously deduped {cf}")
+print("PASS: fresh install wires observe under both matchers, once each")
+
+# already-duplicated machine (bare + absolute copy per matcher): self-heals to one each.
+dmg = json.loads(json.dumps(tmpl))
+for g in dmg["hooks"]["PreToolUse"]:
+    extra = [dict(h, command=h["command"].replace(absinterp, "python3"))
+             for h in g["hooks"] if OBS in h.get("command", "")]
+    g["hooks"] = g["hooks"] + extra
+healed, ch = install(dmg)
+if len(obs_matchers(healed)) != 2 or ch < 2:
+    fail(f"damaged machine not healed: matchers={obs_matchers(healed)} deduped={ch}")
+print(f"PASS: already-duplicated machine self-heals to one per matcher (deduped={ch})")
+
+# idempotent: re-running install over a clean result changes nothing.
+again, ca = install(fresh)
+if len(obs_matchers(again)) != 2 or ca != 0:
+    fail(f"re-run not idempotent: matchers={obs_matchers(again)} deduped={ca}")
+print("PASS: re-run is idempotent (no growth, no dedup)")
+
+print("\nAll assertions passed. Owned-hook dedup collapses drift duplicates, keeps user hooks.")
+PY


### PR DESCRIPTION
Follow-up to #318's matcher-aware `merge_hooks`, fixing a latent duplication class it exposed.

## Why
`merge_hooks` REPLACES a template hook in place only when `is_same_command` matches. For an owned hook that match is by basename, but `observe-tool-calls` ships under two matchers and was **not owned**, so the match fell back to literal command text. When a machine's stored interpreter path drifts (bare `python3` to the absolute shim-safe path), the literal match misses and the matcher-aware merge **appends** a second copy per matcher instead of replacing.

## Fix
- **Own `observe-tool-calls.py`** (`ABS_FINGERPRINTS` + `ABS_OWNED_BASENAMES`) so its dedup is by basename, immune to interpreter-path drift. Prevents any *new* duplicate.
- **Add `dedupe_owned_hooks()`**, a pass after retire/relocate that collapses duplicate owned-hook copies sharing an (event, group, owned-script) key to the freshest one. **Self-heals** machines already carrying the duplicate on their next install. Non-owned (user) hooks and distinct owned hooks are never touched.

## Proof
`test_installer_dedupes_owned_hooks.sh`: owned dup collapses to the freshest single copy; user hooks stay intact; a fresh install wires `observe` under both matchers once each; an already-duplicated machine self-heals; a re-run is idempotent. Full `scripts/ci.sh` green: 310 files compile, 86 integration tests, shellcheck, phase-doc, utf8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
