### PR TITLE
fix(drift): the claim surface must not lie about its own coverage (MYC-2070)

### DIFF
--- a/hooks/_lib/dev_repo_scan.py
+++ b/hooks/_lib/dev_repo_scan.py
@@ -1420,6 +1420,7 @@ class ClaimBranch:
     subject: str               # tip commit subject — tells finished from mid-edit
     tree: str                  # tip tree sha, for identical-content dedupe
     promoted_by: str           # "ticket-id" | "volume"
+    branch_class: str = ""     # BranchClass — content-vs-origin verdict, not ref topology
     duplicates: list = field(default_factory=list)  # sibling branch names, same tree
 
 
@@ -1591,12 +1592,47 @@ def _claim_branches_for_repo(
         except ValueError:
             unpushed = 0
 
+        # `--not --remotes` reads LOCAL remote-tracking refs, which only exist for
+        # branches the repo's fetch refspec actually covers. A repo cloned
+        # single-branch (`+refs/heads/main:refs/remotes/origin/main` — what
+        # `git clone --single-branch` leaves behind) never gets a tracking ref for
+        # ANY topic branch, so every one of them reads as "backed up nowhere"
+        # forever. Measured on a real fleet: 15 of 56 repos were in that state,
+        # and one flagged branch was provably on origin — `ls-remote` returned the
+        # identical sha while the count still said 1 unpushed. Claiming
+        # un-backed-up work that is in fact safe is the cry-wolf direction, and a
+        # false one sits in the same list as the real ones and dilutes them.
+        # So before asserting the strongest claim this surface makes, confirm it
+        # against the SYSTEM OF RECORD. Bounded: runs only for the handful of
+        # branches that already passed every cheap filter above.
+        if unpushed:
+            rc_ls, ls_out, _ = _git(repo, "ls-remote", "--heads", "origin", branch, timeout=10)
+            if rc_ls == 0 and ls_out.strip():
+                remote_sha = ls_out.split()[0]
+                rc_tip, tip, _ = _git(repo, "rev-parse", ref)
+                if rc_tip == 0 and tip.strip() == remote_sha:
+                    unpushed = 0  # identical on origin: pushed, tracking ref just absent
+
+        # Is this branch's CONTENT already on origin, just not under this ref?
+        # Without this the surface cannot tell a stale iteration of SHIPPED work
+        # from genuinely unmerged work, and both read as "claimed and stranded".
+        # Squash-merges guarantee the confusing shape — the tip is never an
+        # ancestor of the default branch — so "differs from main" was never
+        # evidence of anything on a merge-queue repo. classify_branch already
+        # answers it; it simply was not asked.
+        try:
+            cls = classify_branch(repo, branch, default)
+        except Exception:
+            cls = BranchClass.UNKNOWN
+        if cls in REAPABLE_CLASSES:
+            continue  # content provably on origin -> shipped, not a stranded claim
+
         entry = ClaimBranch(
             repo=repo.name, branch=branch, ticket=ticket,
             state=ClaimState.UNPUSHED if unpushed else ClaimState.PUSHED_NO_PR,
             commits=ahead, age_hours=age_hours,
             subject=_clean_subject(raw_subject), tree=tree,
-            promoted_by=promoted_by,
+            promoted_by=promoted_by, branch_class=cls,
         )
         (found if unpushed else pushed_pending).append(entry)
 
@@ -1643,6 +1679,7 @@ def collect_claim_bearing(
     max_workers: int = 8,
     now_ts: Optional[float] = None,
     budget_sec: Optional[float] = None,
+    stats: Optional[dict] = None,
 ) -> list:
     """Stranded claim-bearing branches across the fleet, oldest first.
 
@@ -1651,19 +1688,31 @@ def collect_claim_bearing(
     code. Parallel + read-only; any repo that errors contributes nothing rather
     than failing the scan.
 
-    HARD WALL-CLOCK BUDGET (CLAIM_BRANCH_BUDGET_SEC, default 15s). The algorithm
+    HARD WALL-CLOCK BUDGET (CLAIM_BRANCH_BUDGET_SEC, default 45s). The algorithm
     is fast now, but "fast on this fleet today" is not a guarantee — repo count
     and branch count only grow, and a hung `gh` on a flaky network answers to no
     algorithm. Past the deadline the scan stops and returns what it has. Partial
     output is the right failure mode for a surfacer: a hook that overruns is
     killed and reports NOTHING, which is indistinguishable from a clean fleet and
     is exactly the silent coverage loss this whole surface exists to prevent.
+
+    A truncated scan SAYS SO. Pass `stats` (a dict) to receive
+    {"truncated": bool, "repos": int}; the caller renders it. Without it, hitting
+    the budget silently drops repos while the banner still reads as a complete
+    answer — measured on a real fleet, 29 entries reported when the true count
+    was 109, with nothing in the output to tell the two apart. A cap nobody can
+    see is the same bug class this surface exists to catch, one level up.
     """
     if not repos:
         return []
     if budget_sec is None:
         try:
-            budget_sec = float(os.environ.get("CLAIM_BRANCH_BUDGET_SEC", 15.0))
+            # 45s, sized off a MEASURED complete scan (29.9s over 56 repos / 109
+            # entries). The first value chosen (15s) silently truncated EVERY
+            # real run — it reported 29 entries when the true count was 109, with
+            # nothing in the output distinguishing the two. Sized under the
+            # caller's cache, not under a single session's patience.
+            budget_sec = float(os.environ.get("CLAIM_BRANCH_BUDGET_SEC", 45.0))
         except (TypeError, ValueError):
             budget_sec = 15.0
     deadline = time.time() + budget_sec if budget_sec > 0 else None
@@ -1696,13 +1745,34 @@ def collect_claim_bearing(
     except Exception:
         results = [_one(r) for r in repos]
 
+    if stats is not None:
+        stats["repos"] = len(repos)
+        # Overrunning the deadline is the only way coverage is dropped here, so
+        # it is also the only thing the caller has to be told about.
+        stats["truncated"] = bool(deadline and time.time() > deadline)
+
     flat: list = []
     for r in results:
         flat.extend(r)
     return sorted(flat, key=lambda e: (-e.age_hours, e.repo, e.branch))
 
 
-def format_claim_section(entries: list, limit: int = 10) -> Optional[str]:
+def _partial_scan_notice() -> str:
+    """Emitted whenever the budget cut the scan short and nothing else would be
+    said. "No claims found" and "I ran out of time looking" are different
+    answers, and only one of them is safe to act on."""
+    return (
+        "[claimed-work-stranded]\n\n"
+        "⚠ PARTIAL SCAN — the claim-bearing branch scan hit its time budget "
+        "before finishing, so coverage is INCOMPLETE. No claim-bearing branches "
+        "were confirmed either way; this is NOT a clean result. Re-run for full "
+        "coverage with a larger `CLAIM_BRANCH_BUDGET_SEC`."
+    )
+
+
+def format_claim_section(
+    entries: list, limit: int = 10, truncated: bool = False
+) -> Optional[str]:
     """The headlined claim-bearing block, or None when there is nothing to say.
 
     TICKET-BEARING branches are headlined individually; VOLUME-promoted ones are
@@ -1717,27 +1787,41 @@ def format_claim_section(entries: list, limit: int = 10) -> Optional[str]:
     classify a RELIC properly, and this surfacer deliberately does not try.
     """
     if not entries:
-        return None
+        # A scan that ran out of budget before finding anything is NOT a clean
+        # fleet, and must not render as one.
+        return _partial_scan_notice() if truncated else None
     ticketed = [e for e in entries if e.ticket]
     volume_only = [e for e in entries if not e.ticket]
     if not ticketed:
         # Nothing claimed against a tracked issue. The volume-only set is the
-        # reaper's job, and it is not worth a banner of its own.
-        return None
+        # reaper's job and is not worth a banner of its own -- UNLESS the scan
+        # was cut short, in which case "no claims found" is an artifact of the
+        # budget rather than a finding, and silence would be a silent cap.
+        return _partial_scan_notice() if truncated else None
 
     n = len(ticketed)
     plural = "es" if n != 1 else ""
+    at_least = "at least " if truncated else ""
     lines = [
         "[claimed-work-stranded]",
         "",
         (
-            f"{n} branch{plural} carry CLAIMED work against a tracked issue that no "
-            f"other session can act on. A fresh session's default path is to write it "
-            f"AGAIN from scratch; the cost is duplicated judgment, not lost bytes. "
-            f"Check here BEFORE starting work on any ticket named below."
+            f"{at_least}{n} branch{plural} carry CLAIMED work against a tracked issue "
+            f"that no other session can act on. A fresh session's default path is to "
+            f"write it AGAIN from scratch; the cost is duplicated judgment, not lost "
+            f"bytes. Check here BEFORE starting work on any ticket named below."
         ),
         "",
     ]
+    if truncated:
+        lines += [
+            (
+                "⚠ PARTIAL — the scan hit its time budget, so this list is INCOMPLETE "
+                "and the count is a floor, not a total. Re-run with a larger "
+                "`CLAIM_BRANCH_BUDGET_SEC` for full coverage."
+            ),
+            "",
+        ]
     for e in ticketed[:limit]:
         who = e.ticket or f"unnamed, {e.commits} commits"
         if e.state == ClaimState.UNPUSHED:

--- a/hooks/test_claim_surface_honesty.py
+++ b/hooks/test_claim_surface_honesty.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Behavior controls for the claim-bearing surface's HONESTY properties.
+
+The surface names branches whose work is claimed against a tracked issue but
+invisible to every other session. Three ways it can lie, each measured on a real
+fleet before this test existed:
+
+  * SILENT TRUNCATION — it carries a wall-clock budget, and when the budget
+    fired it dropped repos while the banner still read as a complete answer.
+    29 entries reported when the true count was 109, nothing in the output to
+    tell them apart. "No claims found" and "I ran out of time looking" are
+    different answers and only one is safe to act on.
+  * FALSE "BACKED UP NOWHERE" — `--not --remotes` reads LOCAL tracking refs,
+    which a single-branch clone never creates for a topic branch. 15 of 56 repos
+    were in that state; a branch provably on origin (identical sha via
+    `ls-remote`) still counted as unpushed. A false loss-risk sits in the same
+    list as the real ones and dilutes them.
+  * SHIPPED WORK REPORTED AS STRANDED — squash-merges guarantee the tip is never
+    an ancestor of the default branch, so ref topology always says "ahead" even
+    for work that landed hours ago.
+
+Each fix must not blunt the guard, so every case is paired with its inverse: the
+genuinely-truncated / genuinely-unpushed / genuinely-unmerged case must still
+fire. A one-directional test would pass for a surface that reports nothing.
+
+Run: python3 hooks/test_claim_surface_honesty.py
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _lib import dev_repo_scan as drs  # noqa: E402
+
+OLD = "2020-01-01T00:00:00"
+
+
+def git(repo, *args, **kw):
+    return subprocess.run(["git", "-C", str(repo), *args],
+                          capture_output=True, text=True, **kw)
+
+
+def make_repo(root: Path) -> Path:
+    """A repo with a real bare origin, so pushed-vs-unpushed is genuine."""
+    repo, remote = root / "repo", root / "origin.git"
+    repo.mkdir(parents=True, exist_ok=True)
+    assert git(remote, "init", "-q", "--bare", str(remote)).returncode == 0 or True
+    subprocess.run(["git", "init", "-q", "--bare", str(remote)],
+                   capture_output=True, check=True)
+    git(repo, "init", "-q", "-b", "main")
+    git(repo, "config", "user.email", "t@example.com")
+    git(repo, "config", "user.name", "t")
+    (repo / "f.txt").write_text("base\n", encoding="utf-8")
+    git(repo, "add", "f.txt")
+    env = dict(os.environ, GIT_AUTHOR_DATE=OLD, GIT_COMMITTER_DATE=OLD)
+    git(repo, "commit", "-q", "-m", "base", env=env)
+    git(repo, "remote", "add", "origin", str(remote))
+    assert git(repo, "push", "-q", "-u", "origin", "main").returncode == 0, "push failed"
+    git(repo, "remote", "set-head", "origin", "main")
+    return repo
+
+
+def add_branch(repo: Path, branch: str, *, push: bool, subject="work") -> None:
+    git(repo, "checkout", "-q", "-b", branch, "main")
+    (repo / "f.txt").write_text(f"change-{branch}\n", encoding="utf-8")
+    git(repo, "add", "f.txt")
+    env = dict(os.environ, GIT_AUTHOR_DATE=OLD, GIT_COMMITTER_DATE=OLD)
+    git(repo, "commit", "-q", "-m", subject, env=env)
+    if push:
+        assert git(repo, "push", "-q", "origin", branch).returncode == 0, "push failed"
+    git(repo, "checkout", "-q", "main")
+
+
+def scan(repo: Path, *, pr_heads=None, budget=None):
+    """(section, stats). pr_heads=None keeps the real fail-closed gh lookup."""
+    if pr_heads is not None:
+        drs.fetch_pr_head_branches = lambda _repo: frozenset(pr_heads)
+    stats: dict = {}
+    kw = {"stats": stats}
+    if budget is not None:
+        kw["budget_sec"] = budget
+    entries = drs.collect_claim_bearing([repo], **kw)
+    section = drs.format_claim_section(entries, truncated=bool(stats.get("truncated")))
+    return section or "", stats, entries
+
+
+def main() -> int:
+    import tempfile
+    failures = []
+
+    def check(cond, msg):
+        if not cond:
+            failures.append(msg)
+
+    real_pr_lookup = drs.fetch_pr_head_branches
+
+    # [1] truncation is VISIBLE, never a silent cap.
+    with tempfile.TemporaryDirectory() as td:
+        repo = make_repo(Path(td))
+        add_branch(repo, "claude/myc-9999-fixture", push=False)
+        section, stats, _ = scan(repo, budget=0.001)
+        check(stats.get("truncated") is True, "a starved scan did not record truncated")
+        check("PARTIAL" in section,
+              "SILENT CAP: a budget-starved scan rendered as a complete answer")
+
+    # [2] a COMPLETE scan must not cry partial (the inverse — no cry-wolf).
+    drs.fetch_pr_head_branches = real_pr_lookup
+    with tempfile.TemporaryDirectory() as td:
+        repo = make_repo(Path(td))
+        add_branch(repo, "claude/myc-9999-fixture", push=False)
+        section, stats, _ = scan(repo)
+        check(not stats.get("truncated"), "a complete scan reported truncated")
+        check("PARTIAL" not in section, "a complete scan falsely claimed partial coverage")
+        check("MYC-9999" in section, "a complete scan lost the finding entirely")
+
+    # [3] single-branch clone: a branch ON origin is not called backed-up-nowhere.
+    with tempfile.TemporaryDirectory() as td:
+        repo = make_repo(Path(td))
+        add_branch(repo, "claude/myc-9999-pushed", push=True)
+        git(repo, "config", "--unset-all", "remote.origin.fetch")
+        git(repo, "config", "--add", "remote.origin.fetch",
+            "+refs/heads/main:refs/remotes/origin/main")
+        git(repo, "update-ref", "-d", "refs/remotes/origin/claude/myc-9999-pushed")
+        section, _, _ = scan(repo, pr_heads={"claude/myc-9999-pushed"})
+        check("UNPUSHED" not in section,
+              "FALSE 'backed up nowhere' for a branch provably on origin")
+
+    # [4] genuinely unpushed under the SAME narrow refspec must still fire.
+    drs.fetch_pr_head_branches = real_pr_lookup
+    with tempfile.TemporaryDirectory() as td:
+        repo = make_repo(Path(td))
+        add_branch(repo, "claude/myc-9999-really-unpushed", push=False)
+        git(repo, "config", "--unset-all", "remote.origin.fetch")
+        git(repo, "config", "--add", "remote.origin.fetch",
+            "+refs/heads/main:refs/remotes/origin/main")
+        section, _, _ = scan(repo)
+        check("UNPUSHED" in section,
+              "remote-confirmation swallowed a GENUINELY unpushed branch")
+
+    # [5] squash-merged work is not a stranded claim.
+    with tempfile.TemporaryDirectory() as td:
+        repo = make_repo(Path(td))
+        add_branch(repo, "claude/myc-9999-shipped", push=False)
+        git(repo, "checkout", "-q", "main")
+        git(repo, "merge", "-q", "--squash", "claude/myc-9999-shipped")
+        env = dict(os.environ, GIT_AUTHOR_DATE=OLD, GIT_COMMITTER_DATE=OLD)
+        git(repo, "commit", "-q", "-m", "squash-land (MYC-9999)", env=env)
+        assert git(repo, "push", "-q", "origin", "main").returncode == 0
+        section, _, _ = scan(repo)
+        check("MYC-9999" not in section,
+              "a squash-merged branch still reads as claimed-and-stranded")
+
+    # [6] a NOT-merged branch under identical conditions must still fire.
+    with tempfile.TemporaryDirectory() as td:
+        repo = make_repo(Path(td))
+        add_branch(repo, "claude/myc-9999-not-shipped", push=False)
+        section, _, _ = scan(repo)
+        check("MYC-9999" in section,
+              "the content check swallowed genuinely unmerged work")
+
+    if failures:
+        print("FAILED — claim-surface honesty:")
+        for f in failures:
+            print(f"  ✗ {f}")
+        return 1
+    print("OK - claim surface: truncation visible (and no false partial), "
+          "remote-confirmed unpushed (and real loss-risk still fires), "
+          "shipped work excluded (and unmerged work still fires)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -364,6 +364,7 @@ PY_DIRECT=(
   hooks/test_warn_chained_state_command.py
   hooks/test_footprint_aggregate_bloat.py
   hooks/test_unpushed_drift_surface.py
+  hooks/test_claim_surface_honesty.py
 )
 dormant_py=()
 while IFS= read -r -d '' f; do

--- a/scripts/dev-drift-report.py
+++ b/scripts/dev-drift-report.py
@@ -174,8 +174,11 @@ def _render() -> None:
     if cached is not None:
         claim_section, n_unpushed_claims = cached
     else:
-        claims = collect_claim_bearing(repos)
-        claim_section = format_claim_section(claims)
+        scan_stats: dict = {}
+        claims = collect_claim_bearing(repos, stats=scan_stats)
+        claim_section = format_claim_section(
+            claims, truncated=bool(scan_stats.get("truncated"))
+        )
         n_unpushed_claims = sum(1 for c in claims if c.state == ClaimState.UNPUSHED)
         _claim_cache_write(claim_section, n_unpushed_claims)
 


### PR DESCRIPTION
## Why

PR #381 brought the claim-bearing branch surface into the public lib, but from a snapshot taken **before three honesty fixes landed downstream**. Consuming that snapshot byte-identical — correct per *canonical holds the best version* — therefore regressed the surface on every install. This puts the best version in canonical, where it belongs.

## Three ways it could lie, each measured on a real 56-repo fleet

**1. Silent truncation.** It carries a wall-clock budget. When the budget fired it dropped repos while the banner still read as a complete answer — **29 entries reported when the true count was 109**, with nothing in the output to tell the two apart. A cap nobody can see is the same bug class this surface exists to catch, one level up.

`collect_claim_bearing(stats=...)` now reports `{"truncated", "repos"}`; the banner says "at least N" plus a PARTIAL warning. The no-findings path is covered too — *"no claims found"* and *"I ran out of time looking"* are different answers and only one is safe to act on.

**2. False "backed up nowhere".** `--not --remotes` reads **local** tracking refs, which a single-branch clone (`+refs/heads/main:refs/remotes/origin/main`) never creates for a topic branch. **15 of 56 repos** were in that state, and a branch provably on origin — identical sha via `ls-remote` — still counted as unpushed. A false loss-risk sits in the same list as the real ones and dilutes them.

Before asserting the strongest claim this surface makes, it now confirms against the system of record. Bounded: runs only for branches that already passed every cheap filter.

**3. Shipped work reported as stranded.** Squash-merges guarantee the tip is never an ancestor of the default branch, so ref topology always says "ahead" even for work that landed hours ago. `classify_branch` already answered this and was simply never asked; `TRUE_MERGED` / `SQUASH_MERGED_STALE` now drop out.

## Budget default

15s → **45s**, sized off a *measured* complete scan (29.9s over 56 repos / 109 entries) rather than a guess. The old default truncated every real run.

## Verification

New control `hooks/test_claim_surface_honesty.py`, 6 cases. Every fix is **paired with its inverse**, so a fix cannot pass by reporting nothing:

| Fix | Inverse that must still fire |
|---|---|
| truncation visible | a complete scan must NOT claim partial |
| remote-confirmed unpushed | a genuinely unpushed branch must still fire |
| shipped work excluded | genuinely unmerged work must still fire |

Proven by **reverting each of the three independently** — A, B and C each go RED alone — then restoring to green:

```
REVERT A -> ✗ a starved scan did not record truncated
            ✗ SILENT CAP: a budget-starved scan rendered as a complete answer
REVERT B -> ✗ FALSE 'backed up nowhere' for a branch provably on origin
REVERT C -> ✗ a squash-merged branch still reads as claimed-and-stranded
RESTORED -> exit 0
```

Personal-data scrub + API-key scan clean on the staged diff; fleet specifics and repo names genericized for the public repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)