### PR TITLE
fix(drift): stop crying wolf on single-branch clones, count the current branch, look before deleting

### DIFF
--- a/hooks/_lib/dev_repo_scan.py
+++ b/hooks/_lib/dev_repo_scan.py
@@ -366,10 +366,17 @@ def find_unpushed_local_commits(
         branch_names: list[str] = []
         for ref in refs.split(","):
             ref = ref.strip()
-            if not ref or ref.startswith("tag:") or ref.startswith("HEAD"):
+            if not ref or ref.startswith("tag:"):
                 continue
+            # Unwrap BEFORE the bare-HEAD skip. These were the other way round,
+            # so `HEAD -> claude/my-branch` hit the startswith("HEAD") skip and
+            # the unwrap was DEAD CODE — the branch you are CURRENTLY ON was
+            # never counted. That is the branch most likely to be carrying your
+            # work, so both surfaces under-reported by exactly it.
             if ref.startswith("HEAD -> "):
                 ref = ref[len("HEAD -> "):]
+            elif ref.startswith("HEAD"):
+                continue  # bare detached-HEAD decoration, no branch name
             if ref.startswith("origin/") or ref.startswith("upstream/"):
                 continue
             branch_names.append(ref)
@@ -1139,6 +1146,72 @@ def discover_primary_repos(
     return sorted(set(by_common.values()))
 
 
+def has_full_fetch_refspec(repo: Path) -> bool:
+    """True when this repo fetches ALL branches, not just one.
+
+    A single-branch clone (`git clone --single-branch`, `gh repo clone` of a
+    large repo, most CI checkouts) carries
+    `+refs/heads/main:refs/remotes/origin/main`. `git fetch` then updates
+    origin/main and NOTHING else, so every OTHER branch has no local
+    remote-tracking ref no matter how thoroughly it was pushed.
+
+    That matters because every backup check here is `git log <ref> --not
+    --remotes`, which asks "is this commit reachable from a LOCAL remote-
+    tracking ref". On a narrow clone the honest answer to "is this pushed" is
+    NOT "no" — it is "this repo cannot tell you locally". Reporting the first
+    when the truth is the second is cry-wolf by construction, on a clone shape
+    that is completely normal. Measured live: two repos reported 1 un-backed-up
+    commit each; `git ls-remote` showed both commits sitting on origin.
+    """
+    rc, out, _ = _git(repo, "config", "--get-regexp", r"^remote\..*\.fetch$")
+    if rc != 0 or not out.strip():
+        return False
+    return any("refs/heads/*" in line for line in out.splitlines())
+
+
+def narrow_refspec_repos(repos: list) -> list:
+    """Repos whose local backup state is UNVERIFIABLE (single-branch clones).
+
+    Surfaced separately with a one-command remedy rather than folded into the
+    drift count — "I cannot tell" is a different message from "your work is at
+    risk", and conflating them is what makes a banner ignorable.
+    """
+    out = []
+    for r in repos:
+        r = Path(r)
+        try:
+            if repo_has_any_remote_ref(r) and not has_full_fetch_refspec(r):
+                out.append(r)
+        except OSError:
+            continue
+    return out
+
+
+def format_narrow_refspec_section(repos: list, limit: int = 6) -> str:
+    """One advisory block, or "" when every repo can verify itself."""
+    if not repos:
+        return ""
+    lines = [
+        "[unverifiable-backup-state]",
+        "",
+        (f"{len(repos)} repo(s) are single-branch clones, so whether their "
+         f"branches are pushed CANNOT be determined locally — `git fetch` only "
+         f"updates one branch. Their branches are NOT reported as at-risk above, "
+         f"because the honest answer is \"unknown\", not \"unbacked\"."),
+        "",
+    ]
+    for r in repos[:limit]:
+        lines.append(f"- `{Path(r).name}`")
+    if len(repos) > limit:
+        lines.append(f"- ... and {len(repos) - limit} more")
+    lines += [
+        "",
+        "**Fix (per repo, one time):** "
+        "`git remote set-branches origin '*' && git fetch origin`",
+    ]
+    return "\n".join(lines)
+
+
 def repo_has_any_remote_ref(repo: Path) -> bool:
     """True if the repo has at least one remote-tracking ref (a known backup).
 
@@ -1274,10 +1347,17 @@ def _count_topic_branches_with_unpushed(repo: Path, default: Optional[str]) -> i
     for line in out.splitlines():
         for ref in line.split(","):
             ref = ref.strip()
-            if not ref or ref.startswith("tag:") or ref.startswith("HEAD"):
+            if not ref or ref.startswith("tag:"):
                 continue
+            # Unwrap BEFORE the bare-HEAD skip. These were the other way round,
+            # so `HEAD -> claude/my-branch` hit the startswith("HEAD") skip and
+            # the unwrap was DEAD CODE — the branch you are CURRENTLY ON was
+            # never counted. That is the branch most likely to be carrying your
+            # work, so both surfaces under-reported by exactly it.
             if ref.startswith("HEAD -> "):
                 ref = ref[len("HEAD -> "):]
+            elif ref.startswith("HEAD"):
+                continue  # bare detached-HEAD decoration, no branch name
             if ref.startswith("origin/") or ref.startswith("upstream/"):
                 continue
             if default and ref == default:
@@ -1299,6 +1379,18 @@ def _repo_drift(repo: Path, min_age_minutes: int) -> tuple[list, int]:
         entry = _no_remote_repo_drift(repo, min_age_minutes)
         return ([entry] if entry else []), 0
     default = detect_default_branch(repo)
+    if not has_full_fetch_refspec(repo):
+        # Single-branch clone: `--not --remotes` cannot distinguish "unpushed"
+        # from "never fetched", so every claim it would make here is a coin
+        # flip. Report nothing; narrow_refspec_repos() surfaces the repo with
+        # the one-command fix instead. The DEFAULT branch is the one exception
+        # — it IS in the narrow refspec, so its answer is still trustworthy.
+        g: list = []
+        if default:
+            n_def = _unpushed_count_on_ref(repo, default, min_age_minutes)
+            if n_def > 0:
+                g.append((repo.name, default, n_def, BranchClass.GENUINE_UNIQUE))
+        return g, 0
     g: list = []
     if default:
         n_def = _unpushed_count_on_ref(repo, default, min_age_minutes)

--- a/hooks/_lib/dev_repo_scan.py
+++ b/hooks/_lib/dev_repo_scan.py
@@ -1162,10 +1162,20 @@ def has_full_fetch_refspec(repo: Path) -> bool:
     when the truth is the second is cry-wolf by construction, on a clone shape
     that is completely normal. Measured live: two repos reported 1 un-backed-up
     commit each; `git ls-remote` showed both commits sitting on origin.
+
+    FAIL-SAFE DIRECTION. A False from this function SUPPRESSES drift warnings
+    for the repo, so it must require POSITIVE evidence of a narrow refspec —
+    never merely the absence of evidence. A timed-out or failed `git config`
+    would otherwise silently switch off a safety warning for a repo that might
+    genuinely be holding un-backed-up work. So: narrow ONLY when git answered
+    cleanly AND what it returned lacks `refs/heads/*`; every failure mode reads
+    as full (warnings stay on).
     """
     rc, out, _ = _git(repo, "config", "--get-regexp", r"^remote\..*\.fetch$")
     if rc != 0 or not out.strip():
-        return False
+        # Could not read the config (timeout, permissions, no fetch refspec at
+        # all). Unknown -> do NOT suppress.
+        return True
     return any("refs/heads/*" in line for line in out.splitlines())
 
 

--- a/hooks/test_narrow_refspec_falsealarm.py
+++ b/hooks/test_narrow_refspec_falsealarm.py
@@ -108,6 +108,19 @@ def main() -> int:
               "a normal clone was read as single-branch — this would suppress "
               "REAL un-backed-up findings, the dangerous direction")
 
+        # --- a FAILED config read must NOT suppress --------------------------
+        # False here switches OFF drift warnings for a repo. It must require
+        # positive evidence of a narrow refspec, never the absence of evidence:
+        # a timed-out `git config` silently disabling a safety warning is how a
+        # repo holding real un-backed-up work goes unreported.
+        real_git = drs._git
+        drs._git = lambda repo, *a, **k: (99, "", "timeout") if a and a[0] == "config" else real_git(repo, *a, **k)
+        unreadable = drs.has_full_fetch_refspec(narrow)
+        drs._git = real_git
+        check(unreadable is True,
+              "an UNREADABLE git config was treated as a narrow refspec — a "
+              "transient failure would silently suppress drift warnings")
+
         # --- the narrow repo is NOT counted as risk --------------------------
         repos = drs.discover_primary_repos()
         check({p.name for p in repos} == {"narrow", "full"},

--- a/hooks/test_narrow_refspec_falsealarm.py
+++ b/hooks/test_narrow_refspec_falsealarm.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""A single-branch clone must not be reported as un-backed-up work.
+
+Every backup check in dev_repo_scan is `git log <ref> --not --remotes`, which
+asks "is this commit reachable from a LOCAL remote-tracking ref". On a
+single-branch clone (`+refs/heads/main:refs/remotes/origin/main` — what
+`git clone --single-branch`, `gh repo clone` of a big repo, and most CI
+checkouts produce) `git fetch` updates origin/main and nothing else. So every
+branch except the default has no tracking ref, no matter how thoroughly it was
+pushed, and the check answers "unpushed" when the truth is "this repo cannot
+tell you locally".
+
+Found live: two repos each reported 1 un-backed-up commit; `git ls-remote`
+showed both commits sitting on origin. 13 of 56 repos on that machine — 23% of
+the fleet — had the narrow refspec, so this was not an edge case.
+
+"Unknown" and "at risk" are different messages. Merging them is exactly the
+cry-wolf failure MYC-683 exists to prevent, so the fix reports the repo in its
+own advisory with a one-command remedy instead of inflating the risk count.
+
+Run: python3 hooks/test_narrow_refspec_falsealarm.py
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+HOOKS = Path(__file__).resolve().parent
+sys.path.insert(0, str(HOOKS))
+
+
+def git(repo, *args, **kw):
+    return subprocess.run(["git", "-C", str(repo), *args],
+                          capture_output=True, text=True, **kw)
+
+
+def main() -> int:
+    failures = []
+
+    def check(cond, msg):
+        if not cond:
+            failures.append(msg)
+
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        dev = tmp / "code"
+        dev.mkdir()
+        os.environ["ABS_DEV_ROOT"] = str(dev)
+        import _lib.dev_repo_scan as drs
+        importlib.reload(drs)
+        drs.CONFIG_PATH = tmp / "cfg.json"
+
+        old = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(time.time() - 3 * 86400))
+        env = dict(os.environ, GIT_AUTHOR_DATE=old, GIT_COMMITTER_DATE=old)
+
+        # An origin holding BOTH main and a topic branch — i.e. the topic branch
+        # really is backed up.
+        origin = tmp / "origin.git"
+        origin.mkdir()
+        git(origin, "init", "-q", "--bare")
+
+        seed = tmp / "seed"
+        seed.mkdir()
+        git(seed, "init", "-q", "-b", "main")
+        git(seed, "config", "user.email", "t@example.com")
+        git(seed, "config", "user.name", "t")
+        (seed / "a.txt").write_text("a", encoding="utf-8")
+        git(seed, "add", "a.txt")
+        git(seed, "commit", "-q", "-m", "base", env=env)
+        git(seed, "remote", "add", "origin", str(origin))
+        git(seed, "push", "-q", "origin", "main")
+        git(seed, "checkout", "-q", "-b", "claude/topic")
+        (seed / "b.txt").write_text("b", encoding="utf-8")
+        git(seed, "add", "b.txt")
+        git(seed, "commit", "-q", "-m", "pushed topic work", env=env)
+        git(seed, "push", "-q", "origin", "claude/topic")
+
+        # NARROW clone: only main is fetched.
+        narrow = dev / "narrow"
+        assert git(tmp, "clone", "-q", "--single-branch", "--branch", "main",
+                   str(origin), str(narrow)).returncode == 0, "narrow clone failed"
+        git(narrow, "config", "user.email", "t@example.com")
+        git(narrow, "config", "user.name", "t")
+        # The topic branch exists locally (checked out from the pushed one) but
+        # has NO tracking ref, because the refspec never fetches it.
+        git(narrow, "fetch", "-q", "origin", "claude/topic:claude/topic")
+
+        # FULL clone with a genuinely unpushed branch — the true positive that
+        # must keep firing, so the fix cannot be "suppress everything".
+        full = dev / "full"
+        assert git(tmp, "clone", "-q", str(origin), str(full)).returncode == 0
+        git(full, "config", "user.email", "t@example.com")
+        git(full, "config", "user.name", "t")
+        git(full, "checkout", "-q", "-b", "claude/never-pushed")
+        (full / "c.txt").write_text("c", encoding="utf-8")
+        git(full, "add", "c.txt")
+        git(full, "commit", "-q", "-m", "genuinely unpushed", env=env)
+
+        # --- the refspec discriminator itself --------------------------------
+        check(not drs.has_full_fetch_refspec(narrow),
+              "a --single-branch clone was read as fetching all branches")
+        check(drs.has_full_fetch_refspec(full),
+              "a normal clone was read as single-branch — this would suppress "
+              "REAL un-backed-up findings, the dangerous direction")
+
+        # --- the narrow repo is NOT counted as risk --------------------------
+        repos = drs.discover_primary_repos()
+        check({p.name for p in repos} == {"narrow", "full"},
+              f"discovery unexpected: {sorted(p.name for p in repos)}")
+
+        genuine, n_topic = drs.collect_drift(repos)
+        fired = {r for r, _b, _n, _c in genuine}
+        check("narrow" not in fired,
+              "a single-branch clone whose branch IS on origin was reported as "
+              "un-backed-up work — the false alarm this closes")
+        # Measure the NARROW repo's own contribution. The fleet total is
+        # legitimately 1 here — the full clone really does carry an unpushed
+        # branch — so asserting on the total would conflate the two repos.
+        _g_narrow, n_topic_narrow = drs._repo_drift(narrow, 24 * 60)
+        check(n_topic_narrow == 0,
+              f"the narrow clone's PUSHED topic branch was counted as drift "
+              f"(its n_topic={n_topic_narrow}); fleet total was {n_topic}")
+
+        # --- the true positive still fires -----------------------------------
+        raw = drs._count_topic_branches_with_unpushed(full, "main")
+        check(raw >= 1,
+              "a genuinely unpushed branch on a FULL clone stopped being "
+              "counted — the fix over-suppressed")
+
+        # --- and the repo is surfaced, with a remedy -------------------------
+        narrow_repos = drs.narrow_refspec_repos(repos)
+        check([p.name for p in narrow_repos] == ["narrow"],
+              f"narrow_refspec_repos returned {[p.name for p in narrow_repos]}")
+        section = drs.format_narrow_refspec_section(narrow_repos)
+        check("narrow" in section, "the advisory does not name the repo")
+        check("set-branches" in section,
+              "the advisory carries no remedy — a warning without a fix is noise")
+        check("unknown" in section.lower(),
+              "the advisory does not say the state is UNKNOWN; it must not read "
+              "as a risk claim")
+        check(drs.format_narrow_refspec_section([]) == "",
+              "a healthy fleet still emitted the advisory")
+
+    if failures:
+        print("FAILED — narrow-refspec false alarm:")
+        for f in failures:
+            print(f"  ✗ {f}")
+        return 1
+    print("OK - narrow refspec: single-branch clone not counted as risk, real "
+          "unpushed work still fires, repo surfaced with a one-command remedy")
+    return 0
+
+
+if __name__ == "__main__":
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
+    sys.exit(main())

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -365,6 +365,7 @@ PY_DIRECT=(
   hooks/test_footprint_aggregate_bloat.py
   hooks/test_unpushed_drift_surface.py
   hooks/test_claim_surface_honesty.py
+  hooks/test_narrow_refspec_falsealarm.py
 )
 dormant_py=()
 while IFS= read -r -d '' f; do

--- a/scripts/dev-drift-report.py
+++ b/scripts/dev-drift-report.py
@@ -65,6 +65,8 @@ try:
         discover_primary_repos,
         fetch_repos_capped,
         format_claim_section,
+        format_narrow_refspec_section,
+        narrow_refspec_repos,
     )
 except Exception as _exc:  # a lib older than this script -> fail LOUD, never silent
     print(f"dev-drift-report: _lib/dev_repo_scan.py is missing or older than this "
@@ -165,6 +167,12 @@ def _render() -> None:
 
     genuine, n_topic = collect_drift(repos)
 
+    # Repos that CANNOT verify their own backup state (single-branch clones).
+    # Reported as its own advisory instead of being counted as risk: "unknown"
+    # and "at risk" are different messages, and merging them is how a banner
+    # earns being ignored.
+    narrow_section = format_narrow_refspec_section(narrow_refspec_repos(repos))
+
     # MYC-3290: claim-bearing branches are promoted OUT of the suppressed count
     # and headlined individually. Computed before the early exits below, because
     # a fleet with zero lost-work risk can still be sitting on finished work no
@@ -188,7 +196,7 @@ def _render() -> None:
     n_topic = max(0, n_topic - n_unpushed_claims)
 
     if not genuine and not n_topic and not claim_section:
-        _emit()
+        _emit(narrow_section or None)
 
     delta = _delta_24h(len(genuine))
 
@@ -219,7 +227,8 @@ def _render() -> None:
             f"No high-risk un-backed-up drift (no repo missing a remote, no unpushed "
             f"work on a main branch).{topic_note}{stale_note}"
         )
-        _emit(f"{claim_section}\n\n{base}" if claim_section else base)
+        parts = [x for x in (claim_section, base, narrow_section) if x]
+        _emit("\n\n".join(parts))
 
     n_no_remote = sum(1 for *_h, cls in genuine if cls == BranchClass.NO_REMOTE)
     lines = [
@@ -262,7 +271,8 @@ def _render() -> None:
         "close-loop: MYC-683 + MYC-1894 (`dev-repo-reaper.py` + weekly cron).",
     ]
     body = "\n".join(lines)
-    _emit(f"{claim_section}\n\n{body}" if claim_section else body)
+    parts = [x for x in (claim_section, body, narrow_section) if x]
+    _emit("\n\n".join(parts))
 
 
 def build_section() -> str:

--- a/scripts/test_auto_gc_default_on.py
+++ b/scripts/test_auto_gc_default_on.py
@@ -70,15 +70,41 @@ def main() -> int:
     # --- the reaper legs must APPLY, not dry-run ----------------------------
     # A GC pass that only ever plans is a GC pass that reclaims nothing, and it
     # looks healthy in the log either way.
-    for label in ("dev-repo-reaper", "dev-worktree-prune", "dev-hub-refresh"):
-        # The invocation names the run LABEL; the script path is a variable, so
-        # match the `run "<label>"` line rather than the filename.
+    # Non-destructive legs apply unconditionally: a fast-forward destroys
+    # nothing, so there is no reason to stage it.
+    line = next((ln for ln in maint.splitlines() if 'run "dev-hub-refresh"' in ln), "")
+    check("--apply" in line,
+          "dev-hub-refresh is invoked without --apply — it would plan forever "
+          "and refresh nothing, and a fast-forward has nothing to stage")
+
+    # The two DESTRUCTIVE legs are staged: report on run 1, apply from run 2.
+    # Deleting someone's git branches on day one, before they have seen what
+    # this pass does, is a trust event even when every deletion is provably
+    # safe and reversible.
+    for label in ("dev-repo-reaper", "dev-worktree-prune"):
         line = next((ln for ln in maint.splitlines()
                      if f'run "{label}"' in ln), "")
         check(line, f"no `run \"{label}\"` invocation in the daily pass")
-        check("--apply" in line,
-              f"{label} is invoked without --apply — it would plan forever and "
-              f"reclaim nothing")
+        check("$DESTRUCTIVE_MODE" in line,
+              f"{label} is hardwired instead of using $DESTRUCTIVE_MODE — it "
+              f"would delete on a client's very first run")
+        check("--apply" not in line,
+              f"{label} still carries a literal --apply")
+
+    # ...and the staging must ESCALATE, not stall forever: a marker banked after
+    # the first pass is what turns run 2 into an applying run. Without it the
+    # reclaim never happens and the machine still only gets fuller.
+    check("DESTRUCTIVE_MODE=\"--apply\"" in maint,
+          "no path sets DESTRUCTIVE_MODE to --apply — reclaim would never apply")
+    check("GC_SEEN_MARKER" in maint and "ABS_GC_APPLY_NOW" in maint,
+          "no first-report marker / no immediate-apply override")
+    marker_write = next((i for i, ln in enumerate(maint.splitlines())
+                         if "GC_SEEN_MARKER" in ln and "date -u" in ln), -1)
+    first_leg = next((i for i, ln in enumerate(maint.splitlines())
+                      if 'run "dev-repo-reaper"' in ln), -1)
+    check(marker_write > first_leg > 0,
+          "the first-report marker is banked BEFORE the legs run — a crashed "
+          "first pass would then escalate to delete on a run nobody saw")
 
     # --- OPT-OUT ONLY: no opt-in may gate the value -------------------------
     check("ABS_NO_AUTO_GC" in maint and "ABS_NO_AUTO_GC" in sched,

--- a/scripts/vault-daily-maintenance.sh
+++ b/scripts/vault-daily-maintenance.sh
@@ -233,6 +233,26 @@ RELOCWATCH="$SCRIPT_DIR/relocate-sweep.py"
 if [ "${ABS_NO_AUTO_GC:-0}" = "1" ]; then
   log "[auto-gc] SKIPPED - ABS_NO_AUTO_GC=1"
 else
+  # LOOK-BEFORE-DELETE (client trust). Reclaiming a regenerable CACHE needs no
+  # ceremony — nobody mourns a cache, and a fast-forward destroys nothing. But
+  # the two legs that DELETE a person's git branches and directories must not do
+  # that on day one, before they have ever seen what this pass does. Those two
+  # REPORT on the first run and APPLY from the second onward.
+  #
+  # This does NOT gate the VALUE behind an opt-in — that would leave the default
+  # install dirty forever, the bug MYC-2363 fixed. Nothing is asked of the user,
+  # no flag is needed, and the reclaim still arrives automatically: one cycle
+  # later for the destructive legs, with a report banked first.
+  # ABS_GC_APPLY_NOW=1 skips the dry first pass.
+  GC_SEEN_MARKER="$HOME/.claude/.auto-gc-first-report"
+  if [ -f "$GC_SEEN_MARKER" ] || [ "${ABS_GC_APPLY_NOW:-0}" = "1" ]; then
+    DESTRUCTIVE_MODE="--apply"
+  else
+    DESTRUCTIVE_MODE=""
+    log "[auto-gc] FIRST RUN — branch/worktree reclaim REPORTS ONLY this pass."
+    log "[auto-gc] Review below; the next run applies. Force now: ABS_GC_APPLY_NOW=1"
+  fi
+
   # 1. Vault scratch worktrees + orphan dirs + orphan branches + old snapshots.
   WTPRUNE="$SCRIPT_DIR/worktree-prune.sh"
   [ -f "$WTPRUNE" ] && VAULT_ROOT="$VAULT" run "worktree-prune" /bin/bash "$WTPRUNE"
@@ -250,13 +270,13 @@ else
   #    provably preserved on a remote; un-backed-up work is surfaced, never
   #    touched, and every deletion writes a recovery manifest.
   REAPER="$SCRIPT_DIR/dev-repo-reaper.py"
-  [ -f "$REAPER" ] && run "dev-repo-reaper" /usr/bin/env python3 "$REAPER" --apply
+  [ -f "$REAPER" ] && run "dev-repo-reaper" /usr/bin/env python3 "$REAPER" $DESTRUCTIVE_MODE
 
   # 4. Orphaned <dev-root>/<repo>-<slug> session worktrees (MYC-587/677).
   #    Nothing swept these before: the vault pruner deliberately excludes them.
   #    Dirty ones are snapshotted before removal; un-backed-up ones are kept.
   WTREAP="$SCRIPT_DIR/dev-worktree-prune.py"
-  [ -f "$WTREAP" ] && run "dev-worktree-prune" /usr/bin/env python3 "$WTREAP" --apply
+  [ -f "$WTREAP" ] && run "dev-worktree-prune" /usr/bin/env python3 "$WTREAP" $DESTRUCTIVE_MODE
 
   # 5. Bare ~/dev hub freshness — fast-forward the clean ones so a recon read is
   #    never weeks stale (MYC-677 STALE-BARE-CHECKOUT-READ). Dirty / diverged
@@ -269,6 +289,14 @@ else
 
   HUBREFRESH="$SCRIPT_DIR/dev-hub-refresh.py"
   [ -f "$HUBREFRESH" ] && run "dev-hub-refresh" /usr/bin/env python3 "$HUBREFRESH" --apply
+fi
+
+# Bank the first report so the NEXT pass applies. Written after the legs ran, so
+# a crashed first pass reports again rather than silently escalating to delete on
+# a run nobody ever saw.
+if [ "${ABS_NO_AUTO_GC:-0}" != "1" ] && [ -n "${GC_SEEN_MARKER:-}" ] && [ ! -f "$GC_SEEN_MARKER" ]; then
+  mkdir -p "$(dirname "$GC_SEEN_MARKER")" 2>/dev/null
+  date -u +%Y-%m-%dT%H:%M:%SZ > "$GC_SEEN_MARKER" 2>/dev/null
 fi
 
 close_mutex_release


### PR DESCRIPTION
Follow-up to #381, from **using** that PR on the real fleet rather than re-reading it.

## 1. A quarter of the fleet was crying wolf

Every backup check is `git log <ref> --not --remotes` — "is this reachable from a **local** remote-tracking ref". A `--single-branch` clone carries `+refs/heads/main:refs/remotes/origin/main`, so `git fetch` updates `origin/main` and nothing else, and every other branch looks unpushed **forever** no matter how thoroughly it was pushed.

Found live: two repos each reported 1 un-backed-up commit; `git ls-remote` showed both commits sitting on origin. **13 of 56 repos** on that machine had the narrow refspec.

"Unknown" and "at risk" are different messages, and merging them is exactly the cry-wolf failure MYC-683 exists to prevent. Those repos now get their own advisory with a one-command remedy instead of inflating the risk count. The default branch is exempt — it IS in the narrow refspec, so its answer stays trustworthy. The reaper needed no change: it can only reap what it can prove is on origin, so a narrow clone already fails safe toward preserving.

## 2. The `HEAD -> branch` unwrap was dead code, in both parsers

The bare-`HEAD` skip ran first, so `HEAD -> claude/my-branch` was skipped and the unwrap below never executed — **the branch you are currently on was never counted.** That is the branch most likely to be carrying your work. Predates #381 (came across with the port); caught because a new fixture happened to sit on the branch it was asserting about.

## 3. Look before deleting (client trust)

The daily GC ran `dev-repo-reaper --apply` and `dev-worktree-prune --apply` from the **first** pass, so a paid client's day-one install would delete their git branches and worktrees before they had ever seen what this pass does. Every deletion is provably safe and reversible via manifest, and it is still the wrong first impression.

Those two legs now **report on run 1, apply from run 2**. The marker is banked *after* the legs run, so a crashed first pass reports again rather than silently escalating to delete on a run nobody saw. Caches and fast-forwards still apply immediately — nobody mourns a cache.

This does **not** gate the value behind an opt-in (that would leave the default install dirty forever — the bug #381 fixed). Nothing is asked of the user, no flag is needed; reclaim just arrives one cycle later for the legs that delete. `ABS_GC_APPLY_NOW=1` applies immediately.

## 4. A failed refspec read must not suppress warnings

Pre-push doubt-pass on my own diff: `has_full_fetch_refspec()` returned `False` on any git failure, and `False` **suppresses** drift warnings. A transient `git config` failure would have silently disabled a safety warning on a repo possibly holding un-backed-up work. A suppression must require positive evidence, never the absence of it. Fixed and proven red.

## Verification

`scripts/ci.sh` green under **Python 3.9.6** (the version CI pins). Every control proven red before green. Beyond tests, the daily pass was run **end-to-end for the first time**: `EXIT=0`, 514s, first-run staging confirmed firing, marker banked, and the new advisory rendered with its remedy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
