### PR TITLE
fix(ci): restore concurrency groups the generator was silently dropping (MYC-3412)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -4,6 +4,14 @@ name: dependabot-auto-merge
 on:
   pull_request:
     branches: [main]
+concurrency:
+  # A superseded push to the same PR cancels the in-flight run instead of
+  # billing it to completion. Scoped to pull_request ONLY: push / schedule runs
+  # are never cancelled (and if a merge queue is ever wired here, cancelling a
+  # queued group would deadlock it). Added by MYC-3180; moved into the
+  # generator by MYC-3412 so regeneration stops silently reverting it.
+  group: dependabot-auto-merge-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 permissions:
   pull-requests: write
   contents: write

--- a/.github/workflows/personal-pii-scrub.yml
+++ b/.github/workflows/personal-pii-scrub.yml
@@ -24,6 +24,15 @@ on:
     - cron: '0 12 * * 1'   # Mondays 12:00 UTC
   workflow_dispatch:
 
+concurrency:
+  # A superseded push to the same PR cancels the in-flight run instead of
+  # billing it to completion. Scoped to pull_request ONLY: push / schedule runs
+  # are never cancelled (and if a merge queue is ever wired here, cancelling a
+  # queued group would deadlock it). Added by MYC-3180; moved into the
+  # generator by MYC-3412 so regeneration stops silently reverting it.
+  group: personal-pii-scrub-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Two auto-managed commits (`a06d442`, `08cb804`) regenerated `dependabot-auto-merge.yml` and `personal-pii-scrub.yml` from `gh-harden-repos.sh`, which did not emit a `concurrency:` key — silently un-doing the group MYC-3180 had hand-landed on both files.

`scripts/ci-cost-audit.py` rates a PR-triggered workflow with no concurrency group **HIGH**, and the lint job gates on `--fail-on high` against the **predicted merge**. So every PR opened after those commits inherited the regressed workflows and went red on a check its own diff never touched. PR #384 is blocked exactly this way right now: its `ci gate` is green (25 SUCCESS) and this is the sole failure.

### What this PR does

Restores `concurrency:` on both files. `cancel-in-progress` stays scoped to `pull_request` only — cancelling a `merge_group` or push-to-main run means its required checks never report and the queue can never drain, which is why MYC-3180 used this exact conditional shape.

### Why it will not regress again

These bytes are rendered by the **fixed generator** — the same function the nightly cron calls — so the next auto-managed pass is a no-op here rather than a revert. The root fix landed in `gh-harden-repos.sh`:

- `emit_concurrency_block()` is now one source of truth, wired into all 8 renderers across three heredoc styles (unquoted, quoted, and one inside a `$( )` command substitution that takes a parse-inert placeholder — inlining there breaks `bash -n`).
- A fail-closed self-gate runs **before any repo is touched** (`--self-test` standalone): `bash -n`, render all 9 templates, a built-in concurrency assertion with no external dependency, then `ci-cost-audit.py --fail-on high` as a cross-check. An auditor that cannot parse YAML exits 0 on `unparsed`; that vacuous pass is detected and failed.

### Verification

| check | before | after |
|---|---|---|
| `ci-cost-audit.py --fail-on high` on this tree | 2 HIGH | **exit 0, clean** |
| both files under `yaml.safe_load` | — | parse, jobs intact |
| generator `--self-test` | — | green |
| generator negative controls | — | 6/6 fail as designed |

Bug class: GENERATOR-EMITS-WHAT-ITS-OWN-AUDITOR-FORBIDS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)