### PR TITLE
ci: run the required gates on merge_group so the queue validates the predicted merge (MYC-3418)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,6 +37,13 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # A required status check MUST also run inside the merge queue (MYC-3418).
+  # The queue exists to validate the PREDICTED merge; a required context with no
+  # `merge_group:` trigger never posts there, so the queue waits forever for a
+  # check that will never arrive. Both jobs in this file are required contexts.
+  # Pairs with the `cancel-in-progress` guard below, which already refuses to
+  # cancel a merge_group run — a cancelled run never reports either.
+  merge_group:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/open-core-boundary.yml
+++ b/.github/workflows/open-core-boundary.yml
@@ -10,6 +10,9 @@ on:
   pull_request:
   push:
     branches: [main]
+  # Required status check → must also run on the merge queue's predicted merge
+  # state, or the queue waits on a check that never posts (MYC-3418).
+  merge_group:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/template-purity.yml
+++ b/.github/workflows/template-purity.yml
@@ -16,6 +16,9 @@ on:
   pull_request:
   push:
     branches: [main]
+  # Required status check → must also run on the merge queue's predicted merge
+  # state, or the queue waits on a check that never posts (MYC-3418).
+  merge_group:
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Linear: MYC-3418

`main` carries an **active** ruleset (`16210085`: deletion, merge_queue, non_fast_forward) whose `required_status_checks` list is **empty**, and **no** workflow triggers on `merge_group`. Two independent holes:

1. **Nothing is required.** PR #386 merged with 26 green checks, all advisory. A PR with a red `ci gate` merges exactly as easily.
2. **The queue proves nothing.** The queue is live but with no `merge_group` trigger it never validates the predicted merge — the one thing a merge queue is for. Two PRs individually green and jointly broken merge cleanly.

This PR fixes (2), which must land *before* (1): a required context that never posts on `merge_group` makes the queue wait forever for a check that will never arrive.

Adds `merge_group:` to the three repo-owned gates that become required contexts:

| workflow | check-run name |
|---|---|
| `lint.yml` | `lint (static checks + guards)`, `ci gate (py_compile + unit + integration tests)` |
| `open-core-boundary.yml` | `boundary` |
| `template-purity.yml` | `purity` |

`personal-pii-scrub.yml` needs the same trigger but is **auto-managed** ("do not hand-edit") — a hand-added trigger there is reverted on the next daily pass, which is exactly the MYC-3412 class. Its `merge_group:` goes into the generator template instead and propagates from there.

### Doubt-pass

- **Concurrency is safe under `merge_group`.** `github.event.pull_request.number` is undefined on the queue, so the group falls back to `github.ref` = `refs/heads/gh-readonly-queue/main/pr-N-<sha>`, unique per queue entry. And `cancel-in-progress: ${{ github.event_name == 'pull_request' }}` is already false there. A cancelled `merge_group` run never reports, which deadlocks the queue the same way a missing trigger does — two independent protections, both verified.
- **No required job is `if:`-gated**, so every required context posts on both events. The two PR-scoped steps *inside* the `lint` job (`fetch base branch`, `private-context tokens`) stay `if: github.event_name == 'pull_request'` and simply skip in the queue — skipped steps do not fail a job, and the scan is correct to skip: a private-context token added by one PR cannot be created by merging it with another.
- **No workflow here is path-filtered**, so no required context can be un-postable on a PR that does not match.

Verified: `ci-test` green on the clean tree (318 files py_compile, 86 integration tests, 11 scripts, 8 hook suites, shellcheck, phase-doc, utf8 guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)