### PR TITLE
TEMPORARY: negative control for MYC-3418 (do not merge)

### DIFF
--- a/tests/negative_control_myc3418.py
+++ b/tests/negative_control_myc3418.py
@@ -1,0 +1,4 @@
+# TEMPORARY negative control for MYC-3418. Deliberately unparseable so the
+# `ci gate` required status check goes RED, proving branch protection now
+# BLOCKS the merge. Deleted as soon as the block is observed.
+def broken(:


### PR DESCRIPTION
Negative control required by MYC-3418's Done= clause: open a PR with a deliberately failing required check and confirm the merge is BLOCKED.

`tests/negative_control_myc3418.py` is deliberately unparseable, so `ci gate (py_compile + unit + integration tests)` goes RED.

Expected: `mergeStateStatus: BLOCKED` and `gh pr merge` refused. Before this ticket the same PR would have merged, because the active ruleset required nothing.

This PR is closed and its branch deleted as soon as the block is observed. Do not merge.