### PR TITLE
perf(ci): collapse security-audit's 4-job fan-out, ship the Actions spend meter

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -12,7 +12,36 @@ name: security-audit
 # written by hand. Generated gates carry an "Auto-managed by" marker on
 # line 2; this file omits it, so the tooling leaves it alone.
 #
-# No untrusted input is interpolated into any run: step.
+# ONE JOB, NOT FOUR (MYC-3419)
+# ----------------------------
+# GitHub bills every JOB a one-minute minimum. This gate used to run an
+# `npm-audit` job plus a three-way `pip-audit` matrix: four jobs, each doing
+# 16-28 seconds of work (their own checkout, their own interpreter setup, their
+# own `pip install pip-audit`) and each paying a full billed minute. Measured
+# over 40 real runs with scripts/actions-spend-report.py, that was 20 billed
+# minutes of which 13 were pure rounding - the second-worst offender in the repo
+# after lint.yml. One runner, one checkout, one toolchain install now covers all
+# four audits.
+#
+# THE MATRIX'S `fail-fast: false` SEMANTICS ARE PRESERVED, deliberately: every
+# sub-project is still audited even when an earlier one has a finding, so one
+# vulnerability never hides the next. That is what the `fail` accumulator does.
+#
+# WHY ONE STEP AND NOT SEVERAL. The obvious way to keep "audit everything, then
+# fail" across separate steps is `continue-on-error: true` plus a final step
+# that converts the outcomes back into an exit code. That was rejected: it makes
+# the gate's teeth removable: delete or mis-edit that one trailing step and this
+# workflow reports vulnerabilities and still goes green. Here the audits share a
+# single step whose exit status IS the verdict, so there is no separate gate to
+# lose. Each sub-audit runs in a `set -e` subshell and contributes to `fail`.
+#
+# JOB NAME IS A CONTRACT: branch protection matches required checks by job NAME
+# (MYC-3418 will mark this one required). `dependency audit (npm + pip)` is the
+# final name - do not rename it, and add new ecosystems as sub-audits inside the
+# step below rather than as new jobs.
+#
+# No untrusted input is interpolated into any run: step - this workflow
+# references no event-context expressions at all.
 
 on:
   pull_request:
@@ -35,56 +64,78 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  npm-audit:
-    # scripts/whatsapp is the only npm sub-project. Threshold is `high`:
-    # high + critical fail the build; moderate and low stay with
-    # Dependabot PRs so the gate is signal, not noise.
+  audit:
+    name: dependency audit (npm + pip)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: 20
-      - name: npm audit (scripts/whatsapp)
-        working-directory: scripts/whatsapp
-        run: |
-          if [ ! -f package-lock.json ] && [ ! -f npm-shrinkwrap.json ]; then
-            npm install --package-lock-only --ignore-scripts
-          fi
-          npm audit --audit-level=high
-
-  pip-audit:
-    # One job per Python sub-project (services + skills). fail-fast is
-    # off so every sub-project is audited even when one has a finding.
-    # pip-audit reads the OSV / PyPI advisory database; a genuinely
-    # unfixable advisory can be waived with `--ignore-vuln <GHSA-id>`
-    # plus a justifying comment, never by deleting this gate.
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        dir:
-          - services/health-mcp
-          - services/memory-api
-          - skills/nano-banana
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: '3.11'
-      - name: pip-audit (${{ matrix.dir }})
-        working-directory: ${{ matrix.dir }}
+
+      - name: audit every sub-project (npm + pip)
         run: |
-          python -m pip install --quiet pip-audit
-          if [ -f requirements.txt ]; then
-            pip-audit --requirement requirements.txt
-          elif [ -f pyproject.toml ]; then
-            python -c "import sys,tomllib; sys.stdout.write(chr(10).join(tomllib.load(open('pyproject.toml','rb')).get('project',{}).get('dependencies',[])))" > /tmp/security-audit-deps.txt
-            if [ -s /tmp/security-audit-deps.txt ]; then
-              pip-audit --requirement /tmp/security-audit-deps.txt
-            else
-              echo "security-audit: pyproject.toml declares no [project.dependencies]; nothing to audit."
+          set -u
+          fail=0
+
+          # ---- npm sub-project -------------------------------------------
+          # scripts/whatsapp is the only one. Threshold is `high`: high +
+          # critical fail the build; moderate and low stay with Dependabot PRs
+          # so the gate is signal, not noise.
+          echo "::group::npm audit (scripts/whatsapp)"
+          (
+            set -e
+            cd scripts/whatsapp
+            if [ ! -f package-lock.json ] && [ ! -f npm-shrinkwrap.json ]; then
+              npm install --package-lock-only --ignore-scripts
             fi
-          else
-            echo "security-audit: no requirements.txt or pyproject.toml; nothing to audit."
+            npm audit --audit-level=high
+          ) || fail=1
+          echo "::endgroup::"
+
+          # ---- python sub-projects ---------------------------------------
+          # Fail CLOSED if the auditor itself cannot be installed: a gate that
+          # silently skips is vacuous exactly when it is least able to protect.
+          if ! python -m pip install --quiet pip-audit; then
+            echo "::error::pip-audit failed to install - this gate cannot run and must not pass vacuously."
+            exit 1
           fi
+
+          # pip-audit reads the OSV / PyPI advisory database. A genuinely
+          # unfixable advisory can be waived with `--ignore-vuln <GHSA-id>` plus
+          # a justifying comment, never by deleting this gate. The loop keeps
+          # going after a finding - the matrix's fail-fast: false behavior.
+          for d in services/health-mcp services/memory-api skills/nano-banana; do
+            echo "::group::pip-audit ($d)"
+            (
+              set -e
+              cd "$d"
+              if [ -f requirements.txt ]; then
+                pip-audit --requirement requirements.txt
+              elif [ -f pyproject.toml ]; then
+                # A fresh temp file per sub-project. The old matrix gave each
+                # dir its own runner, so a fixed /tmp path was safe; sharing one
+                # runner, a fixed path would let one project's dependency list
+                # leak into the next project's audit.
+                deps="$(mktemp)"
+                python -c "import sys,tomllib; sys.stdout.write(chr(10).join(tomllib.load(open('pyproject.toml','rb')).get('project',{}).get('dependencies',[])))" > "$deps"
+                if [ -s "$deps" ]; then
+                  pip-audit --requirement "$deps"
+                else
+                  echo "security-audit: pyproject.toml declares no [project.dependencies]; nothing to audit."
+                fi
+              else
+                echo "security-audit: no requirements.txt or pyproject.toml; nothing to audit."
+              fi
+            ) || fail=1
+            echo "::endgroup::"
+          done
+
+          if [ "$fail" != 0 ]; then
+            echo "::error::dependency audit reported at least one vulnerability - see the grouped output above for which sub-project."
+            exit 1
+          fi
+          echo "All dependency audits passed (npm + 3 Python sub-projects)."

--- a/.github/workflows/windows-install.yml
+++ b/.github/workflows/windows-install.yml
@@ -34,6 +34,34 @@ name: windows-install
 #     and logged inside bootstrap (try/catch) and bootstrap still exits 0, so it
 #     is caught by the explicit post-assertion on settings.json hooks.
 #
+# WHY THIS RUNS ON EVERY CHANGE, AND IS NOT GATED (MYC-3419)
+# ----------------------------------------------------------
+# This is the repo's most expensive check per run: windows-latest bills at a 2x
+# multiplier, so its ~1m45s of work costs 4 billed minutes, and it was 14% of
+# the repo's entire Actions bill over the 40 runs measured with
+# scripts/actions-spend-report.py. That is deliberate, not an oversight:
+#
+#   * It is not the rounding class the rest of that audit targets. Only 2 of its
+#     20 measured minutes were per-job floor waste - the other 18 are real
+#     compute. A single-job workflow has no fan-out to consolidate away.
+#   * A relevance gate has no honest predicate here. This job seeds the runner
+#     with THIS checkout and runs bootstrap.ps1 end-to-end, so it exercises
+#     phases/*.md (the installer reads them), scripts/, hooks.json and skills/ -
+#     very nearly the whole tree. Any "Windows-irrelevant" path list narrow
+#     enough to be safe would almost never fire, and one drawn wider would
+#     silently stop testing the install that a real outage (PR #254) exists to
+#     protect.
+#   * Splitting a cheap Linux relevance job in front of it would make this
+#     check SKIP rather than post. Branch protection matches required checks by
+#     name (MYC-3418 will require this one), and a skipped required check is the
+#     classic way to deadlock every open PR. An in-job early exit would keep the
+#     check posting, but still pays the Windows floor at 2x, so it buys little.
+#
+# The real lever is `merge_group`: proving the predicted merge once instead of
+# every intermediate push. That is deliberately sequenced AFTER MYC-3418, because
+# today this repo's merge queue validates nothing, so moving there now would mean
+# the Windows install is effectively ungated.
+#
 # No GitHub event data is interpolated into any run: block (no event-context
 # expressions anywhere in this workflow).
 

--- a/scripts/actions-spend-report.py
+++ b/scripts/actions-spend-report.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""actions-spend-report.py - measure where a repo's billed Actions minutes go.
+
+WHY THIS EXISTS
+---------------
+`ci-cost-audit.py` is a STATIC auditor: it reads workflow YAML and flags shapes
+known to waste money (no concurrency group, ungated macOS, a merge-queue
+deadlocking cancel-in-progress). It cannot tell you what the bill actually IS,
+so it cannot tell you whether a fix moved the burn rate - and a cost gate is
+unproven until the burn rate moves.
+
+This script is the dynamic half. It reads the Actions **jobs** API for the last
+N runs and reports billed minutes per workflow, using GitHub's own billing rule:
+
+    billed_minutes = ceil(job_seconds / 60) * runner_multiplier
+
+That per-job ROUNDING is the point. A workflow that fans out 14 jobs which each
+finish in 4 seconds bills 14 minutes, not 1. The gap between billed minutes and
+real compute is reported here as `floor-waste`: money paid for rounding rather
+than for work. A wide fan-out of very short jobs is what empties an Actions
+budget - not slow tests.
+
+USAGE
+-----
+    python3 scripts/actions-spend-report.py --repo owner/name
+    python3 scripts/actions-spend-report.py --repo owner/name --runs 40
+    python3 scripts/actions-spend-report.py --repo owner/name --workflow lint --per-job
+    python3 scripts/actions-spend-report.py --repo owner/name --json
+
+Requires the `gh` CLI, authenticated (`gh auth status`). No token is read,
+stored, or printed by this script - every API call goes through `gh api`.
+
+Re-run it with the SAME --runs before and after a CI change and post both
+tables: that before/after IS the proof the change worked.
+"""
+import argparse
+import json
+import math
+import subprocess
+import sys
+from collections import defaultdict
+
+# Keep this CLI printable on a Windows cp1252 console (scripts/check-utf8-stdout.py).
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+    except (AttributeError, ValueError):
+        pass
+
+# GitHub's published per-minute multipliers, keyed by the runner label a job
+# reports. A job billed at 2x that finishes in 61 seconds costs FOUR minutes.
+# https://docs.github.com/billing/managing-billing-for-github-actions
+MULTIPLIERS = (
+    ("macos", 10),
+    ("windows", 2),
+    ("ubuntu", 1),
+    ("linux", 1),
+    ("self-hosted", 0),  # self-hosted minutes are not billed by GitHub
+)
+DEFAULT_MULTIPLIER = 1
+
+
+def runner_multiplier(labels):
+    """Map a job's runner labels to GitHub's billing multiplier."""
+    joined = " ".join(labels or []).lower()
+    for token, mult in MULTIPLIERS:
+        if token in joined:
+            return mult
+    return DEFAULT_MULTIPLIER
+
+
+def gh_api(path, paginate=False):
+    """Call `gh api <path>` and return parsed JSON. Fails loud, never silently."""
+    cmd = ["gh", "api", path]
+    if paginate:
+        cmd.append("--paginate")
+    try:
+        out = subprocess.run(cmd, capture_output=True, text=True, check=True).stdout
+    except FileNotFoundError:
+        sys.exit("error: the `gh` CLI is not installed. See https://cli.github.com/")
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or "").strip()
+        sys.exit("error: gh api %s failed:\n  %s" % (path, stderr))
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError as exc:
+        sys.exit("error: gh api %s returned unparseable JSON: %s" % (path, exc))
+
+
+def job_seconds(job):
+    """Wall-clock seconds GitHub bills this job for, from its own timestamps."""
+    started, completed = job.get("started_at"), job.get("completed_at")
+    if not started or not completed:
+        return 0.0
+    # Timestamps are RFC3339 Zulu. Parse without a dependency and without
+    # datetime.fromisoformat's pre-3.11 refusal of a trailing 'Z'.
+    import datetime
+
+    fmt = "%Y-%m-%dT%H:%M:%SZ"
+    try:
+        t0 = datetime.datetime.strptime(started, fmt)
+        t1 = datetime.datetime.strptime(completed, fmt)
+    except ValueError:
+        return 0.0
+    return max(0.0, (t1 - t0).total_seconds())
+
+
+def collect(repo, run_limit, workflow_filter):
+    """Return (per-workflow totals, per-job totals, runs actually counted)."""
+    runs_doc = gh_api(
+        "repos/%s/actions/runs?per_page=%d" % (repo, min(run_limit, 100))
+    )
+    runs = runs_doc.get("workflow_runs", [])[:run_limit]
+
+    by_workflow = defaultdict(
+        lambda: {"billed": 0, "real": 0.0, "jobs": 0, "runs": set()}
+    )
+    by_job = defaultdict(lambda: {"billed": 0, "real": 0.0, "jobs": 0})
+    counted = 0
+
+    for run in runs:
+        wf = run.get("name") or "(unnamed)"
+        if workflow_filter and workflow_filter.lower() not in wf.lower():
+            continue
+        jobs_doc = gh_api(
+            "repos/%s/actions/runs/%s/jobs?per_page=100" % (repo, run["id"])
+        )
+        jobs = jobs_doc.get("jobs", [])
+        if not jobs:
+            continue
+        counted += 1
+        for job in jobs:
+            # A skipped job never occupies a runner and is never billed.
+            if job.get("conclusion") == "skipped":
+                continue
+            secs = job_seconds(job)
+            mult = runner_multiplier(job.get("labels"))
+            billed = math.ceil(secs / 60.0) * mult if secs > 0 else 0
+            real = (secs / 60.0) * mult
+
+            w = by_workflow[wf]
+            w["billed"] += billed
+            w["real"] += real
+            w["jobs"] += 1
+            w["runs"].add(run["id"])
+
+            key = (wf, job.get("name") or "(unnamed)")
+            j = by_job[key]
+            j["billed"] += billed
+            j["real"] += real
+            j["jobs"] += 1
+
+    return by_workflow, by_job, counted
+
+
+def render(by_workflow, by_job, counted, repo, show_jobs):
+    total_billed = sum(w["billed"] for w in by_workflow.values())
+    total_real = sum(w["real"] for w in by_workflow.values())
+    waste = total_billed - total_real
+
+    print("Actions spend - %s" % repo)
+    print("method: jobs API, billed = ceil(job_seconds/60) x runner multiplier")
+    print("sample: %d runs\n" % counted)
+
+    head = "%-32s %10s %6s %6s %12s" % (
+        "workflow",
+        "billed-min",
+        "jobs",
+        "share",
+        "floor-waste",
+    )
+    print(head)
+    print("-" * len(head))
+    ordered = sorted(by_workflow.items(), key=lambda kv: -kv[1]["billed"])
+    for name, w in ordered:
+        share = (w["billed"] / total_billed * 100) if total_billed else 0
+        print(
+            "%-32s %10d %6d %5.0f%% %11dm"
+            % (name[:32], w["billed"], w["jobs"], share, round(w["billed"] - w["real"]))
+        )
+    print("-" * len(head))
+    pct = (waste / total_billed * 100) if total_billed else 0
+    print(
+        "%-32s %10d %6s %6s %11dm  (%.0f%% of billed is rounding, not compute)"
+        % ("TOTAL", total_billed, "", "", round(waste), pct)
+    )
+
+    if show_jobs:
+        print("\nper-job breakdown")
+        jhead = "%-24s %-40s %10s %6s %12s" % (
+            "workflow",
+            "job",
+            "billed-min",
+            "runs",
+            "floor-waste",
+        )
+        print(jhead)
+        print("-" * len(jhead))
+        for (wf, jn), j in sorted(by_job.items(), key=lambda kv: -kv[1]["billed"]):
+            print(
+                "%-24s %-40s %10d %6d %11dm"
+                % (wf[:24], jn[:40], j["billed"], j["jobs"], round(j["billed"] - j["real"]))
+            )
+
+    return total_billed, waste, pct
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Measure billed GitHub Actions minutes per workflow."
+    )
+    ap.add_argument("--repo", required=True, help="owner/name")
+    ap.add_argument("--runs", type=int, default=40, help="how many recent runs (default 40)")
+    ap.add_argument("--workflow", default="", help="only this workflow (substring match)")
+    ap.add_argument("--per-job", action="store_true", help="also break down by job name")
+    ap.add_argument("--json", action="store_true", dest="as_json", help="machine-readable output")
+    ap.add_argument(
+        "--fail-over-waste",
+        type=float,
+        default=None,
+        metavar="PCT",
+        help="exit 1 if floor waste exceeds this percent of billed minutes",
+    )
+    args = ap.parse_args()
+
+    by_workflow, by_job, counted = collect(args.repo, args.runs, args.workflow)
+    if not counted:
+        sys.exit("error: no runs with jobs found for %s (check --repo / --workflow)" % args.repo)
+
+    if args.as_json:
+        payload = {
+            "repo": args.repo,
+            "runs_sampled": counted,
+            "workflows": {
+                name: {
+                    "billed_minutes": w["billed"],
+                    "real_minutes": round(w["real"], 2),
+                    "floor_waste_minutes": round(w["billed"] - w["real"], 2),
+                    "jobs": w["jobs"],
+                    "runs": len(w["runs"]),
+                }
+                for name, w in by_workflow.items()
+            },
+        }
+        total_billed = sum(w["billed"] for w in by_workflow.values())
+        total_real = sum(w["real"] for w in by_workflow.values())
+        payload["total_billed_minutes"] = total_billed
+        payload["total_floor_waste_minutes"] = round(total_billed - total_real, 2)
+        payload["floor_waste_pct"] = (
+            round((total_billed - total_real) / total_billed * 100, 1) if total_billed else 0
+        )
+        print(json.dumps(payload, indent=2))
+        pct = payload["floor_waste_pct"]
+    else:
+        _, _, pct = render(by_workflow, by_job, counted, args.repo, args.per_job)
+
+    if args.fail_over_waste is not None and pct > args.fail_over_waste:
+        sys.exit(
+            "\nFAIL: floor waste %.0f%% exceeds the --fail-over-waste ceiling of %.0f%%"
+            % (pct, args.fail_over_waste)
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Follow-on to #387 (lint.yml consolidation). Same bug class: `COST-FROM-JOB-FANOUT-NOT-COMPUTE`. GitHub bills per **job**, rounded up to a whole minute, times the runner multiplier — never per workflow.

### Measured before (40 real runs, jobs API)

```
workflow          billed-min  jobs  share  floor-waste
lint                      74    69    50%          58m
security-audit            20    20    14%          13m
windows-install           20     5    14%           2m
TOTAL                    148              rounding waste 91m (61%)
```

### 1. `security-audit`: 4 jobs → 1

An `npm-audit` job plus a three-way `pip-audit` matrix. Four jobs doing 16-28s of work each, every one paying its own checkout, interpreter setup, `pip install pip-audit`, and billed minute. **13 of its 20 minutes were rounding, not compute.**

The matrix's `fail-fast: false` semantics are preserved deliberately — every sub-project is still audited even when an earlier one has a finding, so one vulnerability never hides the next.

**Deliberately not built with `continue-on-error:` + a trailing outcome-to-exit-code step.** That construction makes the gate's teeth removable: delete or mis-edit that one step and the workflow reports vulnerabilities and still goes green. Here the audits share a single step whose exit status *is* the verdict, so there is no separate gate to lose.

The accumulator was **executed against injected failures** before shipping, not just read:

| case | later audits still ran | verdict |
|---|---|---|
| npm fails, pip clean | yes (all) | RED |
| npm clean, pip fails | yes (all) | RED |
| all clean | yes (all) | GREEN |

### 2. `scripts/actions-spend-report.py` — the meter

`ci-cost-audit.py` is a *static* auditor: it reads workflow YAML and flags shapes known to waste money, but it cannot tell you what the bill **is**, so it cannot tell you whether a fix moved the burn rate. This reads the Actions jobs API and reports billed minutes per workflow using GitHub's own rule, `ceil(seconds/60) * multiplier`, plus the gap between billed and real time. Every table in this PR is its output.

### 3. `windows-install` — ungated, on purpose

It is the priciest check per run (2x multiplier), but only 2 of its 20 minutes were floor waste; the rest is real compute, and a single-job workflow has no fan-out to remove. It also has no honest relevance predicate: it runs `bootstrap.ps1` end-to-end against this checkout, touching `phases/`, `scripts/`, `hooks.json` and `skills/`. Gating it behind a separate Linux job would make the check **skip** rather than post — the classic way to deadlock required checks. `ci-cost-audit.py` recommends exactly this remedy for such a job. Now a comment, so it stops reading as an oversight.

### Job names are a contract

`dependency audit (npm + pip)` is final. Branch protection matches by job **name**, and MYC-3418 will mark these required — so the names are decided once, here, rather than fought twice. Verified (with a positive control on the search) that nothing outside the workflow referenced the old `npm-audit` / `pip-audit (…)` names.

### Not addressed, deliberately

8 workflows fire on both `push` and `pull_request`, billing an identical tree twice. Dropping `push:` is only safe once the required-PR path genuinely validates, so it waits on MYC-3418.

### Verification

- `ci-test` GREEN (canon): 321 files py_compiled, 86 integration tests, 11 `scripts/` + 10 `hooks/tests` unit suites, shellcheck, phase-doc python, utf8 console guard
- `ci-cost-audit.py --fail-on high` clean
- Public-repo personal-data + API-key scrub clean

Context: MYC-3419 (this completes items 2, 4 and 5; item 1 shipped in #387; item 3 deferred).
