### PR TITLE
close: hand `/goal clear` back to the user when a goal outlives the session

### DIFF
--- a/hooks/detect-closing-signal.py
+++ b/hooks/detect-closing-signal.py
@@ -25,6 +25,9 @@ Behavior contract:
     list, recently-touched-files list, session-file shell pre-build)
   - Returns additionalContext that injects all of the above plus the cascade
     instructions inline (no separate rule-file read needed)
+  - Adds Phase 4b when this session set a `/goal`: that installs a
+    session-scoped Stop hook which would block the close, and only the user
+    can run `/goal clear`
   - Skips entirely if session is trivial (<5 user messages, no captures detected)
   - Fails open: any error returns empty context, never blocks the user
 
@@ -517,6 +520,78 @@ def count_user_messages(transcript_path: str | None) -> int:
     return count
 
 
+# /goal renders in the transcript as a client-side command record:
+#   <command-name>/goal</command-name> ... <command-args>CONDITION</command-args>
+# Bare `/goal` (no args) is a status query; `/goal clear` clears. Anything else
+# sets the condition.
+_GOAL_CMD = "<command-name>/goal</command-name>"
+_GOAL_ARGS_RE = re.compile(r"<command-args>(.*?)</command-args>", re.DOTALL)
+
+
+def _record_text(rec: dict) -> str:
+    """Flatten a transcript record's message content to plain text."""
+    msg = rec.get("message")
+    if not isinstance(msg, dict):
+        return ""
+    content = msg.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "".join(
+            blk.get("text", "") for blk in content if isinstance(blk, dict)
+        )
+    return ""
+
+
+def active_session_goal(transcript_path: str | None) -> str | None:
+    """Return the condition of a /goal still set on this session, else None.
+
+    `/goal <condition>` installs a session-scoped Stop hook that blocks stopping
+    until the condition holds, so a goal that is still set will fight a
+    deliberate close: the cascade finishes, Stop fires, the goal hook blocks,
+    and the model is re-invoked with nothing left to do.
+
+    The condition lives only in Claude Code's in-memory session state — there is
+    no goal state file — so the transcript is the sole readable record. Replay
+    the /goal invocations in order and keep the last one that SET a goal.
+
+    Blind spot, handled model-side: a goal auto-clears once its condition is
+    met, and that leaves no transcript marker. So a True here means "a goal was
+    set and never explicitly cleared", NOT "a goal is definitely still live".
+    The injected phase tells the model to stay silent when the condition was in
+    fact met — nagging after success is the one case the harness rules out.
+    """
+    if not transcript_path:
+        return None
+    p = Path(transcript_path)
+    if not p.is_file():
+        return None
+    goal: str | None = None
+    try:
+        with p.open("r", encoding="utf-8") as f:
+            for line in f:
+                if _GOAL_CMD not in line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                text = _record_text(rec)
+                if _GOAL_CMD not in text:
+                    continue  # matched inside some other field, not a command
+                m = _GOAL_ARGS_RE.search(text)
+                args = (m.group(1).strip() if m else "")
+                if not args:
+                    continue  # bare /goal is a status query
+                if args.lower() == "clear":
+                    goal = None
+                else:
+                    goal = args
+    except OSError:
+        return None
+    return goal
+
+
 def list_decisions_with_empty_outcome(meta_dir: Path) -> list[str]:
     """Return relative paths of Decisions/ files where Outcome: is blank."""
     decisions_dir = meta_dir / "Decisions"
@@ -624,6 +699,7 @@ def build_injected_context(
     pending_outcomes: list[str],
     is_trivial: bool,
     is_ambiguous: bool,
+    goal_condition: str | None = None,
 ) -> str:
     """Compose the system block injected into the model's context.
 
@@ -631,11 +707,14 @@ def build_injected_context(
     inline so the model doesn't need to read a separate rule file.
     """
     if is_trivial:
+        # A live /goal blocks stopping regardless of how small the session was,
+        # so the goal note survives the skip-if-trivial rule.
         return (
             f"SESSION CLOSE detected (signal: {matched!r}, confidence: {confidence}). "
             f"This session is trivial (<5 user messages). Per the skip rule, "
             f"skip the cascade and just say a clean goodbye. The Stop hook will "
             f"still log a timestamp."
+            + _goal_clear_block(goal_condition, trivial=True)
         )
 
     if is_ambiguous:
@@ -660,9 +739,46 @@ def build_injected_context(
         + _full_cascade_block(
             timestamp_human, timestamp_file, worktree, vault_root,
             meta_dir, session_file, decisions_dir, captures_file,
-            pending_outcomes,
+            pending_outcomes, goal_condition,
         )
     )
+
+
+def _goal_clear_block(goal_condition: str | None, trivial: bool = False) -> str:
+    """Tail block telling the model to hand `/goal clear` back to the user.
+
+    Empty string when this session never set a goal — no goal, no nag.
+    """
+    if not goal_condition:
+        return ""
+    cond = " ".join(goal_condition.split())
+    if len(cond) > 160:
+        cond = cond[:157] + "..."
+    if trivial:
+        instruction = "End your goodbye with one plain line asking them to type:"
+    else:
+        instruction = (
+            'Add one plain line to the PHASE 4 summary, after "Anything I '
+            'missed?", asking them to type:'
+        )
+    return f"""
+
+PHASE 4b — CLEAR THE SESSION GOAL (fires only because this session set one):
+  Goal on record: "{cond}"
+
+`/goal` installed a session-scoped Stop hook that blocks stopping until that
+condition holds. A close is a deliberate EARLY stop, so unless the condition is
+actually met the goal hook will block this close and re-invoke you with nothing
+left to do — the loop the user is trying to end.
+
+You CANNOT clear it yourself: `/goal` is a client-side command with no tool
+behind it. Only the user can. {instruction}
+
+  /goal clear
+
+EXCEPTION — if the goal's condition was genuinely MET this session, it already
+auto-cleared. Say nothing. Telling the user to clear a goal that succeeded is
+the one case the harness explicitly rules out."""
 
 
 def _full_cascade_block(
@@ -675,6 +791,7 @@ def _full_cascade_block(
     decisions_dir: Path,
     captures_file: Path,
     pending_outcomes: list[str],
+    goal_condition: str | None = None,
 ) -> str:
     """The reusable cascade-instruction block."""
     pending = ", ".join(pending_outcomes) if pending_outcomes else "(none)"
@@ -863,7 +980,7 @@ off M items[, broadcast to <workspaces> if Phase 1.8 fired]. Anything I
 missed?"
 
 Then say goodbye in the user's primary language, warm, no machinery
-narration."""
+narration.{_goal_clear_block(goal_condition)}"""
 
 
 def main() -> int:
@@ -1016,6 +1133,7 @@ def main() -> int:
             pending_outcomes=pending_outcomes,
             is_trivial=is_trivial,
             is_ambiguous=is_ambiguous,
+            goal_condition=active_session_goal(transcript_path),
         )
         emit_context(context)
         log_debug(f"injected context for {confidence} signal in {int((time.time() - start) * 1000)}ms")

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -133,6 +133,7 @@ INTEGRATION_TESTS=(
   test_verify_real_hooksjson_healthy_install
   test_detect_closing_signal_worktree
   test_detect_closing_signal_repo_aware_vault
+  test_detect_closing_signal_goal_clear
   test_closing_claim_shared
   test_meta_resolver
   test_meta_resolution_guard

--- a/templates/rules/session-close.md
+++ b/templates/rules/session-close.md
@@ -72,6 +72,10 @@ All edits in parallel. No read-write ping-pong. No tool-call narration.
 
 Tell the user plainly what you saved: "Saved to your vault: N decisions, M to-dos, the belief shift about Y. Anything I missed?" Then a warm goodbye in their language. No machinery, no phase names, no file paths unless they ask.
 
+**If this session set a `/goal`, add one line: ask them to type `/goal clear`.** `/goal` installs a session-scoped Stop hook that blocks stopping until its condition holds, so at a deliberate close it blocks the close and re-invokes you with nothing left to do. You cannot clear it — `/goal` is a client-side command with no tool behind it — so the instruction has to go back to the user. The detector injects this as **Phase 4b** when it sees a `/goal` that was never cleared; you do not have to look for it yourself.
+
+**The one exception:** a goal whose condition was actually met auto-cleared already. Say nothing then. Telling someone to clear a goal that succeeded is noise.
+
 ## Phase 4 — Automatic finalization (the Stop hook — you do nothing)
 
 Runs after your turn with zero involvement from you, and silently from the user's view:

--- a/tests/integration/test_detect_closing_signal_goal_clear.sh
+++ b/tests/integration/test_detect_closing_signal_goal_clear.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Test: detect-closing-signal.py emits PHASE 4b (/goal clear) when — and only
+# when — this session has a /goal still set.
+#
+# Why: `/goal <condition>` installs a session-scoped Stop hook that blocks
+# stopping until the condition holds. At a deliberate close that hook fights the
+# cascade: the model finishes, Stop fires, the goal blocks it, and the model is
+# re-invoked with nothing left to do. Only the user can run `/goal clear` (it is
+# a client-side command with no tool behind it), so the cascade has to hand the
+# instruction back to them.
+#
+# The goal condition lives only in Claude Code's in-memory session state — there
+# is no goal state file — so detection replays the transcript's /goal command
+# records. That makes precision the whole ballgame, hence the negative controls:
+# a false PHASE 4b tells the user to clear a goal that is not there, and the
+# harness explicitly rules out nagging about /goal clear after success.
+#
+# Assertions:
+#   FIRES (PHASE 4b present):
+#     1. /goal set, never cleared, substantive session
+#     2. /goal set, trivial session (<5 user msgs) — a live goal blocks the
+#        close regardless of session size, so it survives the skip-if-trivial rule
+#     3. /goal set, cleared, then set again — last write wins
+#   DOES NOT FIRE (no PHASE 4b):
+#     4. no /goal anywhere in the transcript
+#     5. /goal set then explicitly cleared with `/goal clear`
+#     6. bare /goal with no args (that is a status query, not a set)
+#     7. prose that merely mentions "/goal clear" with no command record
+#        (precision control — this very repo's own commit messages do that)
+#
+# Self-contained: tmpdir fake vault + synthetic transcript, HOME redirected.
+# Exit 0 = pass, 1 = fail.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOK="$REPO_ROOT/hooks/detect-closing-signal.py"
+if [ ! -f "$HOOK" ]; then
+  echo "ERROR: $HOOK not found" >&2
+  exit 1
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+export HOME="$TMP/fake-home"
+mkdir -p "$HOME/.claude"
+
+VAULT="$TMP/vault"
+META="$VAULT/Meta"
+mkdir -p "$META/Sessions" "$META/Decisions"
+
+# Build a transcript from a list of user-message bodies.
+build_transcript() {
+  local out="$1"; shift
+  : > "$out"
+  for body in "$@"; do
+    python3 -c '
+import json, sys
+print(json.dumps({"type": "user",
+                  "message": {"role": "user", "content": sys.argv[1]}}))
+' "$body" >> "$out"
+  done
+}
+
+GOAL_SET='<command-name>/goal</command-name>
+            <command-message>goal</command-message>
+            <command-args>ship the release and keep every test green</command-args>'
+GOAL_CLEAR='<command-name>/goal</command-name>
+            <command-message>goal</command-message>
+            <command-args>clear</command-args>'
+GOAL_BARE='<command-name>/goal</command-name>
+            <command-message>goal</command-message>'
+GOAL_PROSE='add "/goal clear" to the session close cascade if the session started with "/goal"'
+
+# 5 filler messages keeps the session above the <5 skip-if-trivial threshold.
+FILLER=("work one" "work two" "work three" "work four" "work five")
+
+run_hook() {
+  local transcript="$1"
+  printf '{"prompt":%s,"session_id":"test-sid","cwd":%s,"transcript_path":%s}' \
+    "$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "close this session")" \
+    "$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$VAULT")" \
+    "$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$transcript")" \
+    | VAULT_ROOT="$VAULT" python3 "$HOOK"
+}
+
+failed=0
+
+assert_phase4b() {
+  local label="$1" transcript="$2" output
+  output="$(run_hook "$transcript")"
+  if ! echo "$output" | grep -q "PHASE 4b"; then
+    echo "FAIL [expected PHASE 4b]: $label" >&2
+    failed=1
+    return
+  fi
+  # The condition must be carried through, else the model cannot tell the user
+  # which goal it is talking about.
+  if ! echo "$output" | grep -q "keep every test green"; then
+    echo "FAIL [PHASE 4b present but condition missing]: $label" >&2
+    failed=1
+    return
+  fi
+  # It must hand the literal command back — that is the whole payload.
+  if ! echo "$output" | grep -q "/goal clear"; then
+    echo "FAIL [PHASE 4b present but no /goal clear command]: $label" >&2
+    failed=1
+    return
+  fi
+  echo "ok   [fires]     $label"
+}
+
+assert_no_phase4b() {
+  local label="$1" transcript="$2" output
+  output="$(run_hook "$transcript")"
+  # The cascade itself must still fire — this asserts the goal block is absent,
+  # not that the hook went silent.
+  if ! echo "$output" | grep -qE "SESSION CLOSE"; then
+    echo "FAIL [cascade did not fire at all]: $label" >&2
+    failed=1
+    return
+  fi
+  if echo "$output" | grep -q "PHASE 4b"; then
+    echo "FAIL [unexpected PHASE 4b]: $label" >&2
+    echo "  output: $output" >&2
+    failed=1
+    return
+  fi
+  echo "ok   [no-fire]   $label"
+}
+
+# 1. goal set, never cleared
+build_transcript "$TMP/t1.jsonl" "$GOAL_SET" "${FILLER[@]}"
+assert_phase4b "goal set, never cleared" "$TMP/t1.jsonl"
+
+# 2. goal set, trivial session (2 user messages, under the skip threshold)
+build_transcript "$TMP/t2.jsonl" "$GOAL_SET" "one bit of work"
+assert_phase4b "goal set, trivial session" "$TMP/t2.jsonl"
+
+# 3. set, cleared, set again — last write wins
+build_transcript "$TMP/t3.jsonl" \
+  '<command-name>/goal</command-name>
+            <command-args>an older goal</command-args>' \
+  "$GOAL_CLEAR" "$GOAL_SET" "${FILLER[@]}"
+assert_phase4b "set, cleared, set again" "$TMP/t3.jsonl"
+
+# 4. no goal at all
+build_transcript "$TMP/t4.jsonl" "${FILLER[@]}"
+assert_no_phase4b "no /goal in transcript" "$TMP/t4.jsonl"
+
+# 5. goal set then explicitly cleared
+build_transcript "$TMP/t5.jsonl" "$GOAL_SET" "${FILLER[@]}" "$GOAL_CLEAR"
+assert_no_phase4b "goal set then cleared" "$TMP/t5.jsonl"
+
+# 6. bare /goal (status query, no args)
+build_transcript "$TMP/t6.jsonl" "$GOAL_BARE" "${FILLER[@]}"
+assert_no_phase4b "bare /goal status query" "$TMP/t6.jsonl"
+
+# 7. prose mentioning /goal clear, no command record
+build_transcript "$TMP/t7.jsonl" "$GOAL_PROSE" "${FILLER[@]}"
+assert_no_phase4b "prose mentioning /goal, no command record" "$TMP/t7.jsonl"
+
+if [ "$failed" -ne 0 ]; then
+  echo "FAILED: detect-closing-signal /goal clear phase" >&2
+  exit 1
+fi
+echo "PASS: detect-closing-signal emits PHASE 4b only for a live /goal"


### PR DESCRIPTION
## The problem

`/goal <condition>` installs a **session-scoped Stop hook** that blocks stopping until the condition holds. That is exactly what you want mid-session, and exactly wrong at a deliberate close: the cascade finishes, Stop fires, the goal hook blocks it, and the model gets re-invoked with nothing left to do. The user typed "close this session" and the session will not close.

The model cannot break that loop. `/goal` is a client-side `local-jsx` command — there is no tool behind it. Only the user can type `/goal clear`.

## The change

`detect-closing-signal.py` replays the transcript's `/goal` command records and, when a goal was set and never cleared, appends **PHASE 4b** to the injected cascade with the condition quoted, so the close ends by handing that one line back to the user.

```
PHASE 4b — CLEAR THE SESSION GOAL (fires only because this session set one):
  Goal on record: "get v0.0.38 shipped and every CI check green"
...
You CANNOT clear it yourself: `/goal` is a client-side command with no tool
behind it. Only the user can. Add one plain line to the PHASE 4 summary, after
"Anything I missed?", asking them to type:

  /goal clear

EXCEPTION — if the goal's condition was genuinely MET this session, it already
auto-cleared. Say nothing. ...
```

## Why detection is transcript-side

The goal condition lives only in Claude Code's in-memory session state — there is no goal state file to read. The transcript's `<command-name>/goal</command-name>` + `<command-args>` records are the only readable trace, so the hook replays them: last write wins, `clear` clears, bare `/goal` is a status query rather than a set.

**Known blind spot, handled deliberately.** A goal auto-clears once its condition is met, and that leaves no transcript marker. So detection means "a goal was set and never explicitly cleared", not "a goal is definitely live". Rather than paper over that, the phase carries the exception explicitly: a goal that succeeded already cleared itself, and the harness rules out telling the user to run `/goal clear` after success. That one judgment stays model-side, where the information actually is.

## Scope

- Survives the skip-if-trivial path — a live goal blocks any close, however small the session.
- No goal set → no injected block at all. No goal, no nag.
- Also documented in `templates/rules/session-close.md` under Phase 3 (Goodbye), since that is where the line lands.

## Tests

`tests/integration/test_detect_closing_signal_goal_clear.sh`, wired into `scripts/ci.sh` (the canonical gate, entry 12 of 87). 7 cases — 3 fire, 4 negative controls (no goal / explicitly cleared / bare `/goal` status query / prose that merely mentions `/goal clear` with no command record).

Precision is the whole ballgame here: a false PHASE 4b tells the user to clear a goal that is not there. So the test was verified against 4 mutants rather than trusted for being green:

| mutant | test result |
|---|---|
| detector always returns None | FAIL (3 fire cases) |
| `clear` ignored | FAIL (cleared-goal case) |
| bare `/goal` counted as a set | FAIL (status-query case) |
| condition dropped from injected text | FAIL (all 3 fire cases) |

Full gate green locally: `py_compile` 320 files on 3.9, 87 integration tests, 11 scripts suites, 10 hooks suites, shellcheck, phase-doc python, utf8 console guard.
