### PR TITLE
docs: stop labelling the goal reminder "Phase 4b" in the shipped rule

### DIFF
--- a/templates/rules/session-close.md
+++ b/templates/rules/session-close.md
@@ -72,7 +72,7 @@ All edits in parallel. No read-write ping-pong. No tool-call narration.
 
 Tell the user plainly what you saved: "Saved to your vault: N decisions, M to-dos, the belief shift about Y. Anything I missed?" Then a warm goodbye in their language. No machinery, no phase names, no file paths unless they ask.
 
-**If this session set a `/goal`, add one line: ask them to type `/goal clear`.** `/goal` installs a session-scoped Stop hook that blocks stopping until its condition holds, so at a deliberate close it blocks the close and re-invokes you with nothing left to do. You cannot clear it — `/goal` is a client-side command with no tool behind it — so the instruction has to go back to the user. The detector injects this as **Phase 4b** when it sees a `/goal` that was never cleared; you do not have to look for it yourself.
+**If this session set a `/goal`, add one line: ask them to type `/goal clear`.** `/goal` installs a session-scoped Stop hook that blocks stopping until its condition holds, so at a deliberate close it blocks the close and re-invokes you with nothing left to do. This is the one part of the goodbye that is **not** automatic and cannot be: `/goal` is a client-side command with no tool behind it, so only the user can run it. You do not have to go looking — when the detector sees a `/goal` that was never cleared, it adds the reminder (and quotes the condition) to the close instructions it injects.
 
 **The one exception:** a goal whose condition was actually met auto-cleared already. Say nothing then. Telling someone to clear a goal that succeeded is noise.
 


### PR DESCRIPTION
docs: stop labelling the goal reminder "Phase 4b" in the shipped rule

The injected cascade and this template number their phases differently:

  hook      Phase 3 = Functional audit   Phase 4 = Final summary
  template  Phase 3 = Goodbye            Phase 4 = Automatic finalization
                                                   ("the Stop hook — you do nothing")

#400 added the goal reminder under the template's Phase 3 and called it
"Phase 4b", borrowing the hook's numbering. In THIS document Phase 4 is the
part that happens automatically with no involvement from the reader, so the
label implied the goal clears itself. It is the opposite: it is the one line of
the goodbye that only the user can act on.

Drop the cross-numbering label and say what is actually true — this part is not
automatic and cannot be, and the detector supplies the reminder so you do not
have to look for it.
