### PR TITLE
ci(security-audit): add the merge_group trigger before the context becomes required

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -47,6 +47,17 @@ on:
   pull_request:
   push:
     branches: [main]
+  # A required status check MUST also run inside the merge queue (MYC-3418).
+  # The queue exists to validate the PREDICTED merge; a required context with no
+  # `merge_group:` trigger never posts there, so the queue waits forever for a
+  # check that will never arrive. The JOB NAME IS A CONTRACT note above says
+  # MYC-3418 will mark `dependency audit (npm + pip)` required, so this trigger
+  # has to be in place BEFORE that switch is flipped, not after - once the
+  # context is required, a missing trigger wedges every PR and reads as a queue
+  # bug rather than a missing line here. Pairs with the `cancel-in-progress`
+  # guard below, which already refuses to cancel a merge_group run (a cancelled
+  # run never reports either).
+  merge_group:
   schedule:
     - cron: '0 13 * * 1'   # Mondays 13:00 UTC
   workflow_dispatch:


### PR DESCRIPTION
## What

Adds `merge_group:` to `security-audit.yml`'s `on:` block. One file, 11 added lines, no job-name change.

## Why

`security-audit.yml` is the **only** one of this repo's five gate workflows missing the trigger:

| workflow | `merge_group:` |
|---|---|
| lint.yml | present |
| template-purity.yml | present |
| open-core-boundary.yml | present |
| personal-pii-scrub.yml | present |
| **security-audit.yml** | **absent** |

Its own header says the job name is a contract and that MYC-3418 will mark `dependency audit (npm + pip)` a required context:

> JOB NAME IS A CONTRACT: branch protection matches required checks by job NAME (MYC-3418 will mark this one required).

**A required context with no `merge_group:` trigger never posts inside the queue.** The queue then waits forever for a check that will never arrive — every PR wedged, and it presents as a merge-queue bug rather than a missing line in this file. The trigger has to be in place *before* that switch is flipped, not after.

## Safety

- **No job name changes.** `dependency audit (npm + pip)` is untouched, so the contract the header protects is intact.
- **Concurrency already handles it.** `cancel-in-progress: ${{ github.event_name == 'pull_request' }}` scopes cancellation to PRs only, so a queued group is never cancelled — cancelling one would deadlock the queue, and a cancelled run never reports either.
- **No `${{ }}` interpolation added.** The change is trigger config and comments; this workflow still references no event-context expressions anywhere.

## Verification

`bash scripts/ci.sh` — the canonical full gate, not a subset — **all gates passed**: py_compile (320 files) + 87 integration tests + 11 scripts/ + 10 hooks/tests unit suites + shellcheck + phase-doc python + utf8 console guard.

YAML re-parsed after the edit: triggers now `[merge_group, pull_request, push, schedule, workflow_dispatch]`, single job `dependency audit (npm + pip)`, concurrency unchanged.

## Not closing a ticket

Found while measuring MYC-3419's job-floor work. This is a **prerequisite for MYC-3418**, not a completion of either — the branch deliberately omits an issue ID so it does not auto-close a ticket whose Done predicate this does not satisfy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)