### PR TITLE
fix(windows,handoff-guard): finish the remaining install gaps from #375

### DIFF
--- a/footprint-budgets.json
+++ b/footprint-budgets.json
@@ -42,13 +42,14 @@
     "SessionEnd": 3
   },
   "_budget_rationale": {
-    "fanout_per_tool.PreToolUse.Bash": "5 -> 6: activating check-cd-outside-worktree.py, the worktree HEAD-isolation gate that shipped unregistered (present on disk, dormant in behavior). Intentional: it is a pure in-process string match on the payload cwd — no git, no I/O — and returns immediately unless the session is worktree-rooted, so the added cost is one interpreter spawn on Bash calls. Bought against a documented ~30-minute reflog rescue from CONCURRENT-SESSION-HEAD-DRIFT."
+    "fanout_per_tool.PreToolUse.Bash": "5 -> 6: activating check-cd-outside-worktree.py, the worktree HEAD-isolation gate that shipped unregistered (present on disk, dormant in behavior). Intentional: it is a pure in-process string match on the payload cwd — no git, no I/O — and returns immediately unless the session is worktree-rooted, so the added cost is one interpreter spawn on Bash calls. Bought against a documented ~30-minute reflog rescue from CONCURRENT-SESSION-HEAD-DRIFT.",
+    "fanout_per_tool.PreToolUse.Write/Edit/MultiEdit": "9 -> 10: activating validate-handoff-frontmatter.py, which shipped with templates/rules/handoff-files.md documenting it as enforcement but was never registered, so the rule described a guard that did nothing on every install (issue #375, same ARTIFACT-WITHOUT-ACTIVATION class as the Bash entry above). Intentional: the hook gates on file extension before any I/O, so a non-markdown write (the common case) costs one interpreter spawn and a suffix compare; the directory walk that finds the vault root runs ONLY for a markdown file that is already a handoff missing consumes_when, which is the rare denial path."
   },
   "fanout_per_tool": {
     "PreToolUse": {
-      "Write": 9,
-      "Edit": 9,
-      "MultiEdit": 9,
+      "Write": 10,
+      "Edit": 10,
+      "MultiEdit": 10,
       "Bash": 6,
       "Read": 4,
       "Glob": 3,

--- a/hooks.json
+++ b/hooks.json
@@ -157,6 +157,11 @@
           },
           {
             "type": "command",
+            "command": "[PYTHON] ~/.claude/skills/ai-brain-starter/hooks/validate-handoff-frontmatter.py 2>/dev/null || echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"allow\"}}'",
+            "statusMessage": "Checking handoff files declare consumes_when..."
+          },
+          {
+            "type": "command",
             "command": "[PYTHON] ~/.claude/skills/ai-brain-starter/hooks/block-populated-public-skill.py 2>/dev/null || echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"allow\"}}'",
             "statusMessage": "Checking template purity (populated data in a public skill)..."
           },

--- a/hooks/validate-handoff-frontmatter.py
+++ b/hooks/validate-handoff-frontmatter.py
@@ -15,10 +15,23 @@ A file is a handoff if EITHER:
   - frontmatter `type:` is handoff / session-handoff / session-starter /
     prompt
 
-This hook fires on Write and Edit. It scopes to the personal vault
-($HOME/vault/, including its
-.claude/worktrees/ children) so it never fires on unrelated Anthropic
-projects elsewhere on disk.
+This hook fires on Write, Edit and MultiEdit. It scopes to a VAULT so it never
+fires on unrelated projects elsewhere on disk.
+
+Vault detection (issue #375): the old code read
+`os.environ.get("VAULT_ROOT", str(Path.home() / "vault"))`. Nothing sets
+VAULT_ROOT, so it silently defaulted to ~/vault and in_vault() returned False
+for every real file on any vault not literally named "vault" - the guard was
+inert everywhere, with no signal that it was doing nothing.
+
+Now: explicit $VAULT_ROOT wins; otherwise walk up from the target file for the
+nearest ancestor containing a Meta-suffixed folder ("Meta" / "⚙️ Meta"), the
+same signature scripts/_meta_resolver.py keys on. A CLAUDE.md marker is NOT
+usable here: every code repo has one, so it would fire this guard on source
+trees. Detection is deliberately self-contained (no import off scripts/) so a
+hook that gates every Write cannot be broken by an import error.
+
+FAIL OPEN: if no vault can be identified, the write is allowed.
 
 Bypass: HANDOFF_FRONTMATTER_BYPASS=1 in the environment.
 """
@@ -30,7 +43,42 @@ import re
 import sys
 from pathlib import Path
 
-VAULT_ROOT = Path(os.environ.get("VAULT_ROOT", str(Path.home() / "vault")))
+
+def find_vault_root(start: Path) -> Path | None:
+    """Nearest ancestor of `start` that contains a Meta-suffixed folder, or None."""
+    try:
+        here = start.resolve()
+    except (OSError, RuntimeError):
+        return None
+    for cand in (here, *here.parents):
+        try:
+            if any(c.is_dir() and c.name.endswith("Meta") for c in cand.iterdir()):
+                return cand
+        except (OSError, PermissionError):
+            continue
+    return None
+
+
+def vault_root_for(path: Path) -> Path | None:
+    """Vault root governing `path`: auto-detected from the file, else $VAULT_ROOT.
+
+    Detection comes FIRST on purpose. $VAULT_ROOT names ONE vault, but a machine
+    routinely has several (a personal vault plus one per project). If the env var
+    won, every write into any OTHER vault would resolve to a root it does not sit
+    under, in_vault() would be False, and the guard would silently skip exactly
+    the files it exists to check. Per-file detection is correct for all of them;
+    $VAULT_ROOT stays as the fallback for a vault with no Meta-suffixed folder.
+    """
+    found = find_vault_root(path.parent)
+    if found is not None:
+        return found
+    env = (os.environ.get("VAULT_ROOT") or "").strip()
+    if env:
+        try:
+            return Path(env).expanduser().resolve()
+        except (OSError, RuntimeError):
+            return None
+    return None
 
 HANDOFF_FILENAME_RE = re.compile(
     r"(?:^|/)(?:[^/]*[Hh]andoff[^/]*|next-session-[^/]+)\.md$"
@@ -38,16 +86,26 @@ HANDOFF_FILENAME_RE = re.compile(
 
 HANDOFF_TYPES = {"handoff", "session-handoff", "session-starter", "prompt"}
 
+# A handoff is markdown by definition (the lifecycle rule puts them in
+# `⚙️ Meta/Handoffs/*.md`, and HANDOFF_FILENAME_RE already requires .md). Gating
+# on the extension lets the common case (writing code) exit before any I/O.
+MARKDOWN_EXTS = {".md", ".markdown", ".mdx"}
+
 FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n", re.DOTALL)
 TYPE_LINE_RE = re.compile(r"^type:\s*(\S+)\s*$", re.MULTILINE)
 CONSUMES_LINE_RE = re.compile(r"^consumes_when:\s*(.*?)\s*$", re.MULTILINE)
 
 
 def in_vault(path: Path) -> bool:
+    """True only when `path` sits under an identifiable vault root. No vault
+    found -> False, so the caller allows the write (fail open)."""
+    root = vault_root_for(path)
+    if root is None:
+        return False
     try:
-        path.resolve().relative_to(VAULT_ROOT.resolve())
+        path.resolve().relative_to(root)
         return True
-    except ValueError:
+    except (ValueError, OSError, RuntimeError):
         return False
 
 
@@ -88,6 +146,20 @@ def has_valid_consumes_when(content: str) -> bool:
     return bool(value)
 
 
+def _allow() -> int:
+    print(json.dumps({"hookSpecificOutput": {
+        "hookEventName": "PreToolUse", "permissionDecision": "allow"}}))
+    return 0
+
+
+def _deny(reason: str) -> int:
+    print(json.dumps({"hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": reason}}))
+    return 0
+
+
 def simulate_edit(current: str, old_string: str, new_string: str,
                   replace_all: bool) -> str | None:
     if old_string not in current:
@@ -97,52 +169,78 @@ def simulate_edit(current: str, old_string: str, new_string: str,
     return current.replace(old_string, new_string, 1)
 
 
-def main() -> None:
+def main() -> int:
     if os.environ.get("HANDOFF_FRONTMATTER_BYPASS") == "1":
-        sys.exit(0)
+        return _allow()
 
     try:
         payload = json.load(sys.stdin)
     except Exception:
-        sys.exit(0)
+        return _allow()
 
     tool_name = payload.get("tool_name") or ""
-    if tool_name not in {"Write", "Edit"}:
-        sys.exit(0)
+    # MultiEdit is included deliberately: it can produce exactly the same final
+    # content as Edit, so a guard that ignored it was bypassable by switching tool.
+    if tool_name not in {"Write", "Edit", "MultiEdit"}:
+        return _allow()
 
     tool_input = payload.get("tool_input") or {}
     file_path_str = tool_input.get("file_path") or ""
     if not file_path_str:
-        sys.exit(0)
+        return _allow()
 
     file_path = Path(file_path_str)
-    if not in_vault(file_path):
-        sys.exit(0)
+    # CHEAP GATES FIRST. This hook runs on every Write/Edit/MultiEdit, so the
+    # ordering below is deliberate: the only filesystem WALK (in_vault) happens
+    # last, after the string checks have already ruled out the overwhelming
+    # majority of writes. A handoff is markdown by definition, so a non-markdown
+    # path can exit before any I/O at all.
+    if file_path.suffix.lower() not in MARKDOWN_EXTS:
+        return _allow()
 
     if tool_name == "Write":
         proposed = tool_input.get("content") or ""
     else:
-        old_string = tool_input.get("old_string") or ""
-        new_string = tool_input.get("new_string") or ""
-        replace_all = bool(tool_input.get("replace_all"))
-        if not file_path.exists():
-            sys.exit(0)
+        if tool_name == "MultiEdit":
+            edits = tool_input.get("edits") or []
+        else:
+            edits = [{
+                "old_string": tool_input.get("old_string") or "",
+                "new_string": tool_input.get("new_string") or "",
+                "replace_all": bool(tool_input.get("replace_all")),
+            }]
+        if not edits or not file_path.exists():
+            return _allow()
         try:
             current = file_path.read_text(encoding="utf-8")
         except Exception:
-            sys.exit(0)
-        result = simulate_edit(current, old_string, new_string, replace_all)
-        if result is None:
-            sys.exit(0)
-        proposed = result
+            return _allow()
+        # Apply sequentially, exactly as the tool would. Any edit that does not
+        # apply means we cannot model the result -> allow (fail open).
+        for e in edits:
+            result = simulate_edit(current, e.get("old_string") or "",
+                                   e.get("new_string") or "",
+                                   bool(e.get("replace_all")))
+            if result is None:
+                return _allow()
+            current = result
+        proposed = current
 
     if not is_handoff(file_path, proposed):
-        sys.exit(0)
+        return _allow()
 
     if has_valid_consumes_when(proposed):
-        sys.exit(0)
+        return _allow()
 
-    sys.stderr.write(
+    # Only a file that WOULD be denied pays for the vault walk.
+    if not in_vault(file_path):
+        return _allow()
+
+    # DENY on stdout as JSON, exit 0. NOT stderr+exit 2: the canonical wrapper in
+    # hooks.json is `<hook> 2>/dev/null || echo '{...permissionDecision:allow}'`,
+    # so a non-zero exit is swallowed and REWRITTEN into an allow. A guard that
+    # blocked via exit 2 under that wrapper would be wired and still never block.
+    return _deny(
         "HANDOFF FRONTMATTER MISSING `consumes_when:`\n"
         f"  file: {file_path}\n"
         "\n"
@@ -166,8 +264,21 @@ def main() -> None:
         "Full lifecycle rule: ⚙️ Meta/rules/handoff-files.md\n"
         "Bypass (rare): HANDOFF_FRONTMATTER_BYPASS=1\n"
     )
-    sys.exit(2)
 
 
 if __name__ == "__main__":
-    main()
+    # Windows cp1252-console safety (#313): force UTF-8 so the non-ASCII reason
+    # text can't crash the hook on a Windows console.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
+    try:
+        sys.exit(main())
+    except Exception:
+        # FAIL OPEN: a write-time guard must never block a legitimate write on a
+        # bug of its own. Matches hooks/block-secret-in-note.py.
+        print(json.dumps({"hookSpecificOutput": {
+            "hookEventName": "PreToolUse", "permissionDecision": "allow"}}))
+        sys.exit(0)

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -230,6 +230,10 @@ INTEGRATION_TESTS=(
   # matchers whose stored interpreter path drifted duplicated per matcher; proves owning
   # observe-tool-calls + the dedupe pass collapse the drift copy and never touch user hooks.
   test_installer_dedupes_owned_hooks
+  # Handoff consumes_when guard (#375): proves the guard detects a vault by its
+  # Meta folder (not a hardcoded ~/vault), denies via the JSON protocol the
+  # hooks.json wrapper preserves, covers MultiEdit, and fails OPEN off-vault.
+  test_handoff_frontmatter_guard
 )
 # ---- Gate-coverage invariant -------------------------------------------------
 # The list above is an explicit allow-list, and allow-lists rot: a new

--- a/scripts/demote-stale-procedural.py
+++ b/scripts/demote-stale-procedural.py
@@ -411,4 +411,10 @@ def main(argv: list[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/entity-disambiguator.py
+++ b/scripts/entity-disambiguator.py
@@ -419,4 +419,10 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/install-hooks-user-level.py
+++ b/scripts/install-hooks-user-level.py
@@ -103,6 +103,11 @@ ABS_FINGERPRINTS = [
     "ai-brain-starter/hooks/remediate-runaway-procs.py",
     # Write-time secret guard:
     "ai-brain-starter/hooks/block-secret-in-note.py",
+    # Handoff lifecycle guard (issue #375). Shipped since the handoff-files rule
+    # existed but was never registered here, so templates/rules/handoff-files.md
+    # documented an enforcement that did nothing on every install
+    # (ARTIFACT-WITHOUT-ACTIVATION).
+    "ai-brain-starter/hooks/validate-handoff-frontmatter.py",
     # Write-time template-purity guard (MYC-1765, structural isolation plane):
     "ai-brain-starter/hooks/block-populated-public-skill.py",
     # Write-time reusable-workflow permission guard. A callee asking for a scope
@@ -164,6 +169,7 @@ ABS_OWNED_BASENAMES = {
     # dedups against the skill-path copy instead of double-firing.
     "check-cd-outside-worktree.py",
     "block-secret-in-note.py", "context-budget-measure.py",
+    "validate-handoff-frontmatter.py",
     "block-populated-public-skill.py",
     "warn-workflow-call-permission-elevation.py",
     "warn-vault-session-in-worktree.py", "warn-learning-to-tool-private-memory.py",

--- a/scripts/resolver-branch-merge-prompt.py
+++ b/scripts/resolver-branch-merge-prompt.py
@@ -319,4 +319,10 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/resolver-conflict-report.py
+++ b/scripts/resolver-conflict-report.py
@@ -162,4 +162,10 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/rotate_graphify_backups.py
+++ b/scripts/rotate_graphify_backups.py
@@ -114,4 +114,10 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     main()

--- a/scripts/stale-rule-check.py
+++ b/scripts/stale-rule-check.py
@@ -208,4 +208,10 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/sync-vault-scripts.sh
+++ b/scripts/sync-vault-scripts.sh
@@ -86,12 +86,36 @@ CREATED=(); UPDATED=(); BACKED_UP=(); SKIPPED=(); ABSENT=(); ERRORS=()
 
 note() { [ "$QUIET" -eq 1 ] || echo "$1"; }
 
+# --- pick a REAL python interpreter -------------------------------------------
+# Mirrors the probe sync-vault-scripts.ps1 uses (#313). Under git-bash / MSYS on
+# Windows a bare `python3` on PATH is usually the Microsoft Store
+# app-execution-alias shim: it satisfies `command -v`, but prints nothing and
+# pops the Store, so the resolver call came back EMPTY and this script misread
+# it as "no Meta folder" and silently no-opped (issue #375). Trust only a
+# candidate that actually reports major version 3.
+PY_CMD=""
+_probe_python() {
+  [ "$("$@" -c 'import sys; print(sys.version_info[0])' 2>/dev/null \
+        | head -n1 | tr -d '\r')" = "3" ]
+}
+for _cand in python3 python py; do
+  command -v "$_cand" >/dev/null 2>&1 || continue
+  if [ "$_cand" = "py" ]; then
+    # The Windows launcher needs -3 to guarantee a Python 3 interpreter.
+    _probe_python py -3 && { PY_CMD="py -3"; break; }
+  else
+    _probe_python "$_cand" && { PY_CMD="$_cand"; break; }
+  fi
+done
+unset _cand
+
 # --- Resolve the vault root ---------------------------------------------------
 resolve_vault_from_settings() {
   local settings="$HOME/.claude/settings.json"
   [ -f "$settings" ] || return 1
-  command -v python3 >/dev/null 2>&1 || return 1
-  python3 - "$settings" <<'PY' 2>/dev/null
+  [ -n "$PY_CMD" ] || return 1
+  # shellcheck disable=SC2086  # PY_CMD may be "py -3"; word-splitting intended
+  $PY_CMD - "$settings" <<'PY' 2>/dev/null
 import json, re, sys
 try:
     data = json.load(open(sys.argv[1], encoding="utf-8"))
@@ -126,7 +150,8 @@ fi
 # resolution.sh bans re-implementing the glob in shell); it prefers whichever
 # Meta variant holds a known human subfolder. Disambiguate on folders the human
 # meta owns. It lives beside this script in the repo, so $SCRIPT_DIR resolves it.
-META="$(python3 "$SCRIPT_DIR/_meta_resolver.py" "$VAULT" scripts Decisions Sessions 2>/dev/null || true)"
+# shellcheck disable=SC2086  # PY_CMD may be "py -3"; word-splitting intended
+META="$([ -n "$PY_CMD" ] && $PY_CMD "$SCRIPT_DIR/_meta_resolver.py" "$VAULT" scripts Decisions Sessions 2>/dev/null || true)"
 if [ -z "$META" ]; then
   note "sync-vault-scripts: no Meta folder in $VAULT — skipping (non-fatal)."
   exit 0

--- a/templates/rules/handoff-files.md
+++ b/templates/rules/handoff-files.md
@@ -34,7 +34,7 @@ consumes_when: production launch complete (calendar bookings, message relays, sc
 
 If you cannot name a concrete completion signal, the bridged work is not concrete enough to ship, write a clearer plan first.
 
-**Enforcement.** PreToolUse hook `~/.claude/hooks/validate-handoff-frontmatter.py` blocks any Write or Edit that produces a handoff file with missing/empty `consumes_when:`. Bypass: `HANDOFF_FRONTMATTER_BYPASS=1` (rare).
+**Enforcement.** PreToolUse hook `~/.claude/skills/ai-brain-starter/hooks/validate-handoff-frontmatter.py` blocks any Write, Edit or MultiEdit that produces a handoff file with missing/empty `consumes_when:`. Scope: markdown files inside a vault, where a vault is the nearest ancestor folder holding a `Meta` / `⚙️ Meta` subfolder (`$VAULT_ROOT` applies only when that lookup finds nothing). Writes outside a vault, and any internal error, fail OPEN. Bypass: `HANDOFF_FRONTMATTER_BYPASS=1` (rare).
 
 ## Close-time scan (Phase 0c of session-close.md)
 

--- a/tests/integration/test_handoff_frontmatter_guard.sh
+++ b/tests/integration/test_handoff_frontmatter_guard.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Test: hooks/validate-handoff-frontmatter.py — the handoff `consumes_when:` guard.
+#
+# Covers issue #375 bug 3. The guard shipped for months but was never registered,
+# and even when hand-wired it was inert: VAULT_ROOT defaulted to ~/vault, so
+# in_vault() was False for every real vault not literally named "vault".
+#
+# The controls below FAIL against the pre-fix hook:
+#   - vault-autodetected-*  : pre-fix resolved ~/vault, so it never fired
+#   - deny-is-json-*        : pre-fix wrote stderr + exit 2, which hooks.json's
+#                             `|| echo {allow}` wrapper rewrites into an ALLOW
+#   - multiedit-*           : pre-fix ignored MultiEdit entirely
+set -uo pipefail
+
+# HERMETIC: the running account's real $VAULT_ROOT must not leak into the
+# autodetection controls (it points at a DIFFERENT vault and silently answered
+# for every case while this test was being written).
+unset VAULT_ROOT
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOK="$REPO_ROOT/hooks/validate-handoff-frontmatter.py"
+PASS=0; FAIL=0
+ok()  { echo "PASS  $1"; PASS=$((PASS+1)); }
+bad() { echo "FAIL  $1 (expected: $2, got: $3)"; FAIL=$((FAIL+1)); }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# A vault is a dir containing a Meta-suffixed folder. Deliberately NOT named
+# "vault", which is the whole point of the bug.
+VAULT="$TMP/NotCalledVault"
+mkdir -p "$VAULT/⚙️ Meta/Handoffs"
+# A code repo: has CLAUDE.md but NO Meta dir. Must never be treated as a vault.
+REPO="$TMP/some-code-repo"
+mkdir -p "$REPO"; echo "# code" > "$REPO/CLAUDE.md"
+
+# decision(): run the hook and print allow / deny / crash.
+decision() {
+  local out rc
+  out="$(printf '%s' "$1" | python3 "$HOOK" 2>/dev/null)"; rc=$?
+  [ $rc -ne 0 ] && { echo "crash"; return; }
+  printf '%s' "$out" | python3 -c 'import json,sys
+try: print(json.load(sys.stdin)["hookSpecificOutput"]["permissionDecision"])
+except Exception: print("nojson")'
+}
+
+write_payload() {  # $1 path  $2 content
+  python3 -c 'import json,sys; print(json.dumps({"tool_name":"Write","tool_input":{"file_path":sys.argv[1],"content":sys.argv[2]}}))' "$1" "$2"
+}
+
+BAD_HANDOFF='---
+type: handoff
+consumes_when:
+---
+body'
+GOOD_HANDOFF='---
+type: handoff
+consumes_when: PR #402 merged to main
+---
+body'
+
+echo "=== 1. the bug: a real vault NOT named 'vault' is now detected ==="
+r=$(decision "$(write_payload "$VAULT/⚙️ Meta/Handoffs/h.md" "$BAD_HANDOFF")")
+[ "$r" = "deny" ] && ok "vault-autodetected-denies-missing-consumes_when" \
+  || bad "vault-autodetected-denies-missing-consumes_when" deny "$r"
+
+r=$(decision "$(write_payload "$VAULT/⚙️ Meta/Handoffs/h.md" "$GOOD_HANDOFF")")
+[ "$r" = "allow" ] && ok "vault-autodetected-allows-valid-consumes_when" \
+  || bad "vault-autodetected-allows-valid-consumes_when" allow "$r"
+
+echo "=== 2. deny speaks JSON on stdout (exit 0), not stderr+exit 2 ==="
+out="$(write_payload "$VAULT/⚙️ Meta/Handoffs/h.md" "$BAD_HANDOFF" | python3 "$HOOK" 2>/dev/null)"; rc=$?
+[ $rc -eq 0 ] && ok "deny-is-json-exit-0" || bad "deny-is-json-exit-0" 0 "$rc"
+printf '%s' "$out" | grep -q '"permissionDecision": *"deny"' \
+  && ok "deny-is-json-payload" || bad "deny-is-json-payload" "deny json" "$out"
+
+echo "=== 3. scoping: a code repo with CLAUDE.md but no Meta dir is NOT a vault ==="
+r=$(decision "$(write_payload "$REPO/some-handoff.md" "$BAD_HANDOFF")")
+[ "$r" = "allow" ] && ok "code-repo-not-treated-as-vault" \
+  || bad "code-repo-not-treated-as-vault" allow "$r"
+
+echo "=== 4. fail OPEN when no vault can be identified ==="
+r=$(decision "$(write_payload "$TMP/loose-handoff.md" "$BAD_HANDOFF")")
+[ "$r" = "allow" ] && ok "no-vault-fails-open" || bad "no-vault-fails-open" allow "$r"
+
+echo "=== 5. \$VAULT_ROOT is the FALLBACK for a vault with no Meta folder ==="
+FLAT="$TMP/FlatVault"; mkdir -p "$FLAT"
+r=$(VAULT_ROOT="$FLAT" decision "$(write_payload "$FLAT/some-handoff.md" "$BAD_HANDOFF")")
+[ "$r" = "deny" ] && ok "vault-root-fallback-honored" || bad "vault-root-fallback-honored" deny "$r"
+
+# ...and detection WINS over a $VAULT_ROOT naming a different vault, so a
+# multi-vault machine still guards every vault, not just the one in the env.
+OTHER="$TMP/OtherVault"; mkdir -p "$OTHER/⚙️ Meta"
+r=$(VAULT_ROOT="$OTHER" decision "$(write_payload "$VAULT/⚙️ Meta/Handoffs/h.md" "$BAD_HANDOFF")")
+[ "$r" = "deny" ] && ok "detection-beats-mismatched-vault-root" \
+  || bad "detection-beats-mismatched-vault-root" deny "$r"
+
+echo "=== 6. MultiEdit is covered (was a free bypass) ==="
+TARGET="$VAULT/⚙️ Meta/Handoffs/existing.md"
+printf '%s' "$GOOD_HANDOFF" > "$TARGET"
+ME=$(python3 -c 'import json,sys; print(json.dumps({"tool_name":"MultiEdit","tool_input":{"file_path":sys.argv[1],"edits":[{"old_string":"consumes_when: PR #402 merged to main","new_string":"consumes_when:"}]}}))' "$TARGET")
+r=$(decision "$ME")
+[ "$r" = "deny" ] && ok "multiedit-denies-blanking-consumes_when" \
+  || bad "multiedit-denies-blanking-consumes_when" deny "$r"
+
+echo "=== 7. non-handoff files in the vault are untouched ==="
+r=$(decision "$(write_payload "$VAULT/⚙️ Meta/notes.md" '---
+type: decision
+---
+body')")
+[ "$r" = "allow" ] && ok "non-handoff-allowed" || bad "non-handoff-allowed" allow "$r"
+
+echo "=== 8. bypass env ==="
+r=$(HANDOFF_FRONTMATTER_BYPASS=1 decision "$(write_payload "$VAULT/⚙️ Meta/Handoffs/h.md" "$BAD_HANDOFF")")
+[ "$r" = "allow" ] && ok "bypass-env-allows" || bad "bypass-env-allows" allow "$r"
+
+echo
+echo "=== summary: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #375. Follows #402, which fixed the `heal-journal-guard.py` Windows path regex from the same report.

## Status of each item in #375

| # | Item | Status |
|---|---|---|
| 1 | `_meta_resolver.py` cp1252 emoji crash | **Already fixed**, no change needed. `c342be7` (#313, 2026-07-09) added the UTF-8 `reconfigure` to `_cli()`. That commit predates the issue, so the reported clone had it. |
| 2 | `sync-vault-scripts.sh` hits the Store `python3` shim | **Fixed here.** #313 fixed the `.ps1` but not the `.sh`. |
| 3a | `validate-handoff-frontmatter.py` never registered | **Fixed here.** |
| 3b | Vault root defaults to `~/vault` | **Fixed here.** |

## 3a. The guard was never registered, and wiring alone would not have enforced anything

`hooks/validate-handoff-frontmatter.py` shipped next to `templates/rules/handoff-files.md`, which documents it as the enforcement for `consumes_when:`. It appeared in no `hooks.json` entry and no installer list, so the rule described a guard that did nothing on every install. Same ARTIFACT-WITHOUT-ACTIVATION class as `check-cd-outside-worktree.py` before it.

Registering it is necessary but **not sufficient**. The canonical wrapper in `hooks.json` is:

```
<hook> 2>/dev/null || echo '{"hookSpecificOutput":{...,"permissionDecision":"allow"}}'
```

The hook blocked via **stderr + `exit 2`**. A non-zero exit triggers that `||`, which swallows the block and rewrites it into an **allow**. Wired as-was, it would have been registered, visible in `settings.json`, and still incapable of blocking anything.

Converted to the JSON protocol its siblings use (deny on stdout, exit 0), matching `hooks/block-secret-in-note.py`.

## 3b. Vault detection

`VAULT_ROOT` is set by nothing in the installer, so the old default made `in_vault()` false for every vault not literally named `vault`.

Now: the nearest ancestor holding a `Meta`-suffixed folder. Two deliberate choices:

**Detection runs before `$VAULT_ROOT`, not after.** The env var names one vault; a machine routinely has several. If the env won, writes into any *other* vault would resolve to a root they do not sit under and skip the guard silently. `$VAULT_ROOT` remains the fallback for a vault with no Meta folder. This was caught by the test suite: `VAULT_ROOT` was set in the authoring environment and answered for every case until the test was made hermetic.

**`CLAUDE.md` is not the marker**, though the issue suggested it. Every code repo has one, so it would fire this guard on source trees. Verified: `ai-brain-starter` has `CLAUDE.md` and no Meta folder; both real vaults tested have one.

Fails OPEN throughout: no identifiable vault, non-markdown path, unparseable payload, unreadable file, non-applying edit, or any exception all allow the write.

## Also included

- **MultiEdit coverage.** The hook handled only `Write` and `Edit`. MultiEdit can produce identical content, so ignoring it was a free bypass of a guard being switched on for the first time.
- **cp1252 UTF-8 CLI guard** added to six scripts that resolve and print Meta paths but lacked it (`demote-stale-procedural`, `entity-disambiguator`, `resolver-branch-merge-prompt`, `resolver-conflict-report`, `rotate_graphify_backups`, `stale-rule-check`). Same class as #313. `hooks/` needed nothing: the Windows installer wraps every hook in `hook_runner.py`, which already reconfigures.
- **`templates/rules/handoff-files.md`** corrected. It named `~/.claude/hooks/...`, which is not where this is wired, and did not state the scope or the fail-open behavior.

## Footprint budget

`PreToolUse:Write|Edit|MultiEdit` raised 9 to 10, with a rationale recorded in `footprint-budgets.json` next to the existing one.

To keep that honest, the hook's checks are ordered cheapest-first. A handoff is markdown by definition, so a non-markdown write (the common case) exits on a suffix compare with no I/O. The directory walk that locates the vault root runs **only** for a markdown file already determined to be a handoff missing `consumes_when:`, which is the denial path.

## What newly fires

This activates enforcement that has never run for anyone. Inside a vault, a markdown file is treated as a handoff when its frontmatter `type:` is one of `handoff`, `session-handoff`, `session-starter`, `prompt`, or (only when it has no `type:` at all) its filename matches the handoff pattern. `type: prompt` is the broadest of those and is worth knowing about before upgrading. Those definitions are unchanged; they are simply live now.

## Verification

New `tests/integration/test_handoff_frontmatter_guard.sh`, 11 controls, wired into `scripts/ci.sh` (the gate-coverage invariant rejects an unlisted test, so it cannot go dormant).

Negative control, swapping in the hook from `origin/main`:

```
=== summary: 1 passed, 10 failed ===
```

10 of 11 fail pre-fix, mostly as `nojson` because the old hook never spoke the decision protocol. Post-fix: 11/11.

Local gate green: `ci-test` with 320 files `py_compile`, 88 integration tests (87 before this suite), 11 scripts suites, 10 hooks unit suites, shellcheck, phase-doc, utf8 console guard. `footprint-sla-check.py --gate` clean.

Reported by @darrieta01 in #375.
