### PR TITLE
ci: fail a hook that is wired but structurally cannot block

### DIFF
--- a/scripts/check-hook-block-protocol.py
+++ b/scripts/check-hook-block-protocol.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Structural lint: a blocking hook must not rely on a non-zero exit under the
+allow-fallback wrapper.
+
+THE BUG CLASS THIS EXISTS FOR
+    Most hooks in hooks.json are registered with a fail-open wrapper:
+
+        <interpreter> <hook>.py 2>/dev/null || echo '{... "permissionDecision":"allow"}'
+
+    That `||` exists so a CRASHING hook cannot wedge the tool. But it fires on
+    ANY non-zero exit -- including a deliberate `sys.exit(2)` block. A hook that
+    blocks by exiting 2 under this wrapper is therefore rewritten into an ALLOW:
+    it is present on disk, registered in settings.json, visible in every audit,
+    and structurally incapable of blocking anything.
+
+    Caught live on validate-handoff-frontmatter.py (issue #375): registering it
+    without converting it to the JSON protocol would have shipped a guard that
+    looked correct and enforced nothing.
+
+    This is the WIRED-BUT-NEUTERED sibling of ARTIFACT-WITHOUT-ACTIVATION. The
+    gate-coverage invariant in ci.sh catches a test that never runs; this catches
+    a guard that runs and can never say no.
+
+THE RULE
+    If a hook's registered command carries the allow-fallback wrapper, the hook
+    must signal a block by PRINTING a deny decision (exit 0), never by exiting
+    non-zero. Enforced by inspecting the script the command points at.
+
+Exit 0 clean, 1 on violation, 2 on usage error.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+
+# The wrapper that rewrites a non-zero exit into an allow.
+WRAPPER_RE = re.compile(r"\|\|\s*echo\b[^\n]*permissionDecision")
+# A .py the command invokes, at either the skill path or ~/.claude/hooks/.
+PY_IN_CMD_RE = re.compile(r"(?:~|\$HOME|/)[^\s'\"|&;]*?/([A-Za-z0-9_.-]+\.py)")
+# A deliberate non-zero exit (the blocking mechanism we are banning here).
+NONZERO_EXIT_RE = re.compile(r"^\s*(?:sys\.)?exit\(\s*([1-9]\d*)\s*\)", re.MULTILINE)
+# Speaking the decision protocol at all.
+DENY_RE = re.compile(r'"permissionDecision"\s*:\s*"deny"|permissionDecision.{0,20}deny')
+
+
+def hook_commands(hooks_json: Path):
+    """Yield (event, matcher, command) for every registered hook command."""
+    data = json.loads(hooks_json.read_text(encoding="utf-8"))
+    for event, groups in (data.get("hooks") or {}).items():
+        for group in groups or []:
+            for entry in group.get("hooks", []) or []:
+                cmd = entry.get("command") or ""
+                if cmd:
+                    yield event, group.get("matcher"), cmd
+
+
+def resolve_script(basename: str) -> Path | None:
+    for sub in ("hooks", "scripts"):
+        p = REPO / sub / basename
+        if p.is_file():
+            return p
+    return None
+
+
+def main() -> int:
+    hooks_json = REPO / "hooks.json"
+    if not hooks_json.is_file():
+        print(f"ERROR: no hooks.json at {hooks_json}", file=sys.stderr)
+        return 2
+
+    violations: list[str] = []
+    checked = 0
+    for event, matcher, cmd in hook_commands(hooks_json):
+        if not WRAPPER_RE.search(cmd):
+            continue
+        names = PY_IN_CMD_RE.findall(cmd)
+        if not names:
+            continue
+        # The LAST .py is the hook itself (an earlier one is the Windows runner).
+        script = resolve_script(names[-1])
+        if script is None:
+            continue  # not a script this repo ships; nothing to assert
+        checked += 1
+        src = script.read_text(encoding="utf-8")
+        bad = NONZERO_EXIT_RE.findall(src)
+        if bad:
+            where = f"{event}" + (f" [{matcher}]" if matcher else "")
+            violations.append(
+                f"  {script.relative_to(REPO)}  ({where})\n"
+                f"      exits non-zero ({', '.join(sorted(set(bad)))}) under the allow-fallback\n"
+                f"      wrapper, so the `|| echo ...allow` rewrites that block into an ALLOW.\n"
+                f"      Fix: print a permissionDecision deny on stdout and exit 0\n"
+                f"      (see hooks/block-secret-in-note.py)."
+            )
+
+    if violations:
+        print("::error::hook block-protocol violation - a guard that can never block:")
+        print("\n".join(violations))
+        return 1
+
+    print(f"hook block-protocol: OK ({checked} wrapped hook(s) verified, "
+          "none block via a non-zero exit)")
+    return 0
+
+
+if __name__ == "__main__":
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
+    sys.exit(main())

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -331,6 +331,17 @@ else
   utf8_note="passed"
 fi
 
+# ---- (e2) Hook block-protocol ----------------------------------------------
+# scripts/check-hook-block-protocol.py fails a hook that is registered with the
+# allow-fallback wrapper (`... || echo '{...permissionDecision:allow}'`) but
+# blocks by exiting non-zero. That `||` fires on ANY non-zero exit, so such a
+# hook is rewritten into an ALLOW: present, registered, auditable, and unable to
+# block anything. Caught live on validate-handoff-frontmatter.py (#375) -- the
+# WIRED-BUT-NEUTERED sibling of ARTIFACT-WITHOUT-ACTIVATION. Pure stdlib, so it
+# always runs here.
+echo "==> (e2) hook block-protocol: $PY scripts/check-hook-block-protocol.py"
+"$PY" scripts/check-hook-block-protocol.py
+
 # ---- (f) Python unit tests (scripts/ + hooks/ + tests/) --------------------
 # Every Python unit suite in the repo, run under the SAME interpreter as the rest
 # of the gate. Gate (a) py_compiles them (proves they parse); this proves their
@@ -398,4 +409,4 @@ done
 echo "    OK - ${#PY_DIRECT[@]} hooks/+tests/ direct suite(s) passed; dormancy invariant clean"
 
 echo
-echo "All gates passed: py_compile ($count file(s)) + ${#INTEGRATION_TESTS[@]} integration tests + $unit_count scripts/ + ${#PY_DIRECT[@]} hooks/tests unit suite(s) + shellcheck [$shellcheck_note] + phase-doc python [$phasepy_note] + utf8 console guard [$utf8_note]."
+echo "All gates passed: py_compile ($count file(s)) + ${#INTEGRATION_TESTS[@]} integration tests + $unit_count scripts/ + ${#PY_DIRECT[@]} hooks/tests unit suite(s) + shellcheck [$shellcheck_note] + phase-doc python [$phasepy_note] + utf8 console guard [$utf8_note] + hook block-protocol [passed]."


### PR DESCRIPTION
Follow-up to #404. Turns the subtlest failure found while fixing #375 into an automated gate.

## The bug class

Most hooks are registered with a fail-open wrapper:

```
<interpreter> <hook>.py 2>/dev/null || echo '{..."permissionDecision":"allow"}'
```

That `||` exists so a crashing hook cannot wedge the tool. But it fires on **any** non-zero exit, including a deliberate `sys.exit(2)` block. A hook that blocks by exiting non-zero under that wrapper is rewritten into an **allow**: present on disk, registered in `settings.json`, visible in every audit, and structurally incapable of blocking anything.

This was caught by hand while wiring `validate-handoff-frontmatter.py` in #404. Registering it without also converting it to the JSON decision protocol would have shipped a guard that looked correct in every observable way and enforced nothing. Nothing in CI would have noticed.

It is the WIRED-BUT-NEUTERED sibling of ARTIFACT-WITHOUT-ACTIVATION. `ci.sh` already has a gate-coverage invariant that catches a *test* that never runs; nothing caught a *guard* that can never say no.

## The check

`scripts/check-hook-block-protocol.py` walks `hooks.json`, and for every command carrying the allow-fallback wrapper, resolves the script it points at and asserts it does not exit non-zero. Pure stdlib. Wired into `ci.sh` as gate `(e2)`, so it runs in the pre-push gate as well as CI.

The last `.py` in a command is the hook itself, which keeps the Windows `hook_runner.py` wrapper form from being mistaken for the target.

## Verification

Current `main` is clean:

```
hook block-protocol: OK (11 wrapped hook(s) verified, none block via a non-zero exit)
```

That is also a useful sweep result: no other hook in the repo currently has this defect.

Negative control, restoring the pre-fix `validate-handoff-frontmatter.py`:

```
::error::hook block-protocol violation - a guard that can never block:
  hooks/validate-handoff-frontmatter.py  (PreToolUse [Write|Edit|MultiEdit])
      exits non-zero (2) under the allow-fallback
      wrapper, so the `|| echo ...allow` rewrites that block into an ALLOW.
      Fix: print a permissionDecision deny on stdout and exit 0
      (see hooks/block-secret-in-note.py).
```

Exit 1, naming the file, event, matcher, and the fix.

Local gate green: `ci-test` with 321 files `py_compile`, 88 integration tests, 11 scripts suites, 10 hooks unit suites, shellcheck, phase-doc, utf8 console guard, and the new hook block-protocol gate.

## Scope note

This intentionally checks only hooks carrying the allow-fallback wrapper. A hook registered *without* that wrapper (a bare command) blocks correctly via a non-zero exit, which is a valid pattern and is left alone.
