### PR TITLE
fix(diagnose): a 25-day-old snapshot is not a healthy backup

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -169,6 +169,7 @@ INTEGRATION_TESTS=(
   test_footprint_sla
   test_vault_safety_guards
   test_vault_backup_conf_bom
+  test_backup_staleness_surfaces
   test_resource_aware_session_close
   test_cloud_sync_guard
   test_cloud_safe_file_walkers

--- a/scripts/diagnose.ps1
+++ b/scripts/diagnose.ps1
@@ -332,7 +332,28 @@ if ($checkBackup) {
     $bverdict = "$(& $py.Source $checkBackup --porcelain $Vault 2>$null)".Trim()
     if ($bverdict -like "BACKED_UP:vault-backup:*") {
       $age = ($bverdict -split ":")[-1]
-      Ok "Off-machine backup present (vault-backup, ~$age days old)"
+      # An archive that EXISTS is not the same as a backup that RUNS. Mirror the
+      # staleness contract of hooks/surface-backup-status.py so the two surfaces
+      # cannot disagree: past the threshold, a snapshot is evidence the schedule
+      # stopped firing, not evidence of a healthy backup.
+      $staleDays = 3.0
+      $envStale = 0.0
+      if ($env:VAULT_BACKUP_STALE_DAYS -and [double]::TryParse(
+            $env:VAULT_BACKUP_STALE_DAYS, [Globalization.NumberStyles]::Float,
+            [Globalization.CultureInfo]::InvariantCulture, [ref]$envStale)) {
+        $staleDays = $envStale
+      }
+      # InvariantCulture on purpose: check-vault-backup.py always emits a '.'
+      # decimal, which a comma-decimal locale (es-ES, de-DE, fr-FR) would fail
+      # to parse, silently collapsing every age to 0 and re-greening the check.
+      $ageNum = 0.0
+      $ageOk = [double]::TryParse($age, [Globalization.NumberStyles]::Float,
+                                  [Globalization.CultureInfo]::InvariantCulture, [ref]$ageNum)
+      if ($ageOk -and $ageNum -gt $staleDays) {
+        Warn "Last vault snapshot is ~$age days old (> ${staleDays}d) - the backup is not running on schedule" "Run it now: pwsh scripts/vault-backup.ps1 run -Vault '$Vault'. Then find out why the schedule stopped: on Windows a task with DisallowStartIfOnBatteries never fires on a laptop running on battery (last result 0x800710E0)."
+      } else {
+        Ok "Off-machine backup present (vault-backup, ~$age days old)"
+      }
     } elseif ($bverdict -eq "BACKED_UP:timemachine") {
       Ok "Off-machine backup present (Time Machine destination configured)"
     } elseif ($bverdict -like "BACKED_UP:cloud:*") {

--- a/scripts/diagnose.sh
+++ b/scripts/diagnose.sh
@@ -345,7 +345,18 @@ if [ -n "$CHECK_BACKUP" ]; then
   bverdict="$(python3 "$CHECK_BACKUP" --porcelain "$VAULT" 2>/dev/null)"
   case "$bverdict" in
     BACKED_UP:vault-backup:*)
-      ok "Off-machine backup present (vault-backup, ~${bverdict##*:} days old)" ;;
+      # An archive that EXISTS is not the same as a backup that RUNS. Mirror the
+      # staleness contract of hooks/surface-backup-status.py so the two surfaces
+      # cannot disagree: past the threshold, a snapshot is evidence the schedule
+      # stopped firing, not evidence of a healthy backup.
+      _bage="${bverdict##*:}"
+      _bstale="${VAULT_BACKUP_STALE_DAYS:-3}"
+      if awk "BEGIN{exit !($_bage > $_bstale)}" 2>/dev/null; then
+        warn "Last vault snapshot is ~${_bage} days old (> ${_bstale}d) — the backup is not running on schedule" \
+          "Run it now: bash scripts/vault-backup.sh run --vault '$VAULT'. Then find out why the schedule stopped firing."
+      else
+        ok "Off-machine backup present (vault-backup, ~${_bage} days old)"
+      fi ;;
     BACKED_UP:timemachine)   ok "Off-machine backup present (Time Machine destination configured)" ;;
     BACKED_UP:cloud:*)       ok "Off-machine copy present (${bverdict#BACKED_UP:cloud:} — a cloud copy; single-file snapshots are safer, see docs/BACKUP.md)" ;;
     BACKED_UP:git-remote)    ok "Off-machine backup present (git HEAD pushed to a remote)" ;;

--- a/tests/integration/test_backup_staleness_surfaces.sh
+++ b/tests/integration/test_backup_staleness_surfaces.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Structural regression — the sibling-miss class, recurring.
+#
+# check-vault-backup.py emits BACKED_UP:vault-backup:<age_days>. The age is the
+# whole point of the token: an archive that EXISTS is not the same as a backup
+# that RUNS. hooks/surface-backup-status.py honours that — it compares the age
+# against VAULT_BACKUP_STALE_DAYS (default 3) and nags past the threshold.
+#
+# Both /diagnose surfaces (scripts/diagnose.ps1, scripts/diagnose.sh) parsed the
+# same token, INTERPOLATED the age into their message, and then reported OK
+# unconditionally. A vault whose scheduled backup had not fired in 25 days
+# printed "OK  Off-machine backup present (vault-backup, ~25.2 days old)" — the
+# number was right there in the green line. Observed on Windows, where a task
+# created with DisallowStartIfOnBatteries never fires on a laptop on battery
+# (last result 0x800710E0), so the schedule dies silently and /diagnose blesses
+# it. That is strictly worse than no check: it converts a dead backup into a
+# reassurance, and it disagreed with the SessionStart hook on the same machine.
+#
+# This is the same shape as the #301 BOM miss that test_vault_backup_conf_bom.sh
+# backfills: one consumer of a shared backup signal was fixed, its siblings were
+# not. So lock the CLASS invariant instead of the instance — every consumer of
+# the age token must threshold it, so a fourth surface cannot re-green a dead
+# backup. Fails loud if zero consumers are found (the token was renamed and this
+# guard is now blind).
+#
+# Bash only, no network. exit 0 = every consumer thresholds the age.
+set -u
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# Consumers only. Excluded on purpose:
+#   check-vault-backup.py  — the PRODUCER; it computes the age, it does not judge it.
+#   test-*                 — harnesses that fabricate the token as fixture input.
+age_consumers() {
+  grep -rl 'BACKED_UP:vault-backup' "$REPO/hooks" "$REPO/scripts" 2>/dev/null \
+    | grep -v '/check-vault-backup\.py$' \
+    | grep -v '/test-'
+}
+
+total=0
+bad=0
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  total=$((total + 1))
+  # A real threshold means naming the shared budget. Printing the age is not
+  # thresholding it — that was precisely the bug.
+  if ! grep -q 'VAULT_BACKUP_STALE_DAYS\|STALE_DAYS' "$f"; then
+    echo "FAIL  backup-age consumer never thresholds the age it prints:"
+    echo "        ${f#"$REPO"/}"
+    bad=$((bad + 1))
+  fi
+done < <(age_consumers)
+
+if [ "$total" -eq 0 ]; then
+  echo "FAIL  found ZERO BACKED_UP:vault-backup consumers — the token likely"
+  echo "      renamed. Update this guard to track it, or it is blind."
+  exit 1
+fi
+
+if [ "$bad" -eq 0 ]; then
+  echo "PASS  all $total backup-age consumer(s) threshold the age (stale != healthy)"
+  exit 0
+fi
+echo
+echo "FAIL  $bad of $total consumer(s) would report a long-dead backup as healthy."
+echo "      Fix: compare the age against VAULT_BACKUP_STALE_DAYS (default 3)"
+echo "      before reporting OK, as hooks/surface-backup-status.py does."
+exit 1


### PR DESCRIPTION
## The bug

`check-vault-backup.py` emits `BACKED_UP:vault-backup:<age_days>`. The age is the whole point of the token: **an archive that EXISTS is not the same as a backup that RUNS.**

`hooks/surface-backup-status.py` honours that — it compares against `VAULT_BACKUP_STALE_DAYS` (default `3`) and nags past the threshold.

Both `/diagnose` surfaces (`diagnose.ps1`, `diagnose.sh`) parsed the same token, **interpolated the age into their message, then reported `OK` unconditionally.** Found on a Windows vault whose scheduled backup had not fired in 25 days:

```
12. Off-machine backup
  OK    Off-machine backup present (vault-backup, ~25.2 days old)
```

The number is right there in the green line. 8x past the repo's own definition of stale.

Root cause on that machine: the backup task was registered with `DisallowStartIfOnBatteries`, so it never fires on a laptop running on battery (last result `0x800710E0`, "operator or administrator refused the request"). The schedule dies silently and `/diagnose` blesses it.

This is strictly worse than having no check — it converts a dead backup into a reassurance, and it **contradicted the SessionStart hook on the same machine.**

## The fix

Both surfaces now honour the same threshold and `VAULT_BACKUP_STALE_DAYS` override the hook already uses, so the three cannot disagree.

The PowerShell side parses with `InvariantCulture` deliberately: the producer always emits a `.` decimal, which a comma-decimal locale (es-ES, de-DE, fr-FR) would fail to parse — collapsing every age to `0` and re-greening the check on exactly the machines this repo has been hardening. Found on an es-ES machine.

After, same vault:

```
12. Off-machine backup
  WARN  Last vault snapshot is ~25.2 days old (> 3d) - the backup is not running on schedule
        -> Run it now: pwsh scripts/vault-backup.ps1 run -Vault '...'. Then find out why
           the schedule stopped: on Windows a task with DisallowStartIfOnBatteries never
           fires on a laptop running on battery (last result 0x800710E0).
```

## The test

Same shape as the #301 BOM miss that `test_vault_backup_conf_bom.sh` backfills — one consumer of a shared backup signal fixed, siblings missed. So this guards the **class**, not the instance: every consumer of the age token must threshold it, and it fails loud if zero consumers are found (token renamed → guard blind). Producer and test harnesses excluded by design.

Verified in both directions:

- **pre-fix tree rebuilt from `origin/main`** → FAIL, naming both `diagnose.ps1` and `diagnose.sh`
- **with the fix** → `PASS  all 3 backup-age consumer(s) threshold the age`

Not a tautological test.

Also checked: `.ps1` keeps its UTF-8 BOM, no em dashes, parses clean (check 8's own rules); `diagnose.sh` passes `bash -n`; blob committed LF; empty/garbage ages degrade to the previous behaviour rather than crashing or false-alarming; `test_vault_backup_conf_bom.sh` still green.

Second commit wires the test into `INTEGRATION_TESTS` — `ci.sh` L248 fails the build for any unlisted `tests/integration/test_*.sh` (the dormant-test class #294 closes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)