### PR TITLE
ci: ban naive VAULT_ROOT reads outside a sanctioned resolver (MYC-2505)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -138,6 +138,21 @@ jobs:
       - name: no naive Meta glob (resolve via _meta_resolver)
         run: bash scripts/check-meta-resolution.sh
 
+      # The twin of the check above, for the OTHER globally-exported handle that
+      # silently redirects vault code. VAULT_ROOT names exactly ONE vault, so a
+      # naive read fails two ways and both are silent: UNSET it defaults to
+      # ~/vault, so a guard is inert on every vault not literally named "vault";
+      # SET it overrides the vault the caller actually meant, so a hook checks
+      # the wrong vault and skips the file it exists for. Shipped that way in
+      # hooks/validate-handoff-frontmatter.py and was inert on every install
+      # (#375/#404) - two unrelated users had already hand-patched it identically.
+      # Self-test first (cheap, and proves the guard still bites), then the tree.
+      - name: naive VAULT_ROOT read negative controls (the guard must still bite)
+        run: python3 scripts/check-vault-root-reads.py --self-test
+
+      - name: no naive VAULT_ROOT reads (resolve via _resolve_vault_root)
+        run: python3 scripts/check-vault-root-reads.py
+
       # Phase docs distinguish between two kinds of `scripts/foo.sh` references:
       #
       #   1. Backticked relative paths like `scripts/foo.sh` -> should exist in the repo.

--- a/hooks/scan-prior-sessions-for-secrets.py
+++ b/hooks/scan-prior-sessions-for-secrets.py
@@ -125,6 +125,11 @@ def _stamp() -> None:
 
 def _vault_root() -> Path | None:
     """Resolve VAULT_ROOT or return None (disables auto-scrub safely)."""
+    # vault-root-ok: here VAULT_ROOT is an explicit opt-in SWITCH for auto-scrub,
+    # not vault detection (see "Environment" above). There is no ~/vault default:
+    # unset returns None and the hook drops to warn-only, the safe mode. Detecting
+    # a vault instead would silently ENABLE in-place redaction on a vault the user
+    # never opted in for, so the naive read is the correct behavior here.
     val = os.environ.get(VAULT_ROOT_ENV, "").strip()
     if not val:
         return None

--- a/scripts/check-vault-root-reads.py
+++ b/scripts/check-vault-root-reads.py
@@ -1,0 +1,678 @@
+#!/usr/bin/env python3
+"""check-vault-root-reads.py - ban naive VAULT_ROOT env reads in vault code.
+
+THE BUG CLASS THIS EXISTS FOR
+    `VAULT_ROOT` is routinely exported machine-wide (a shell profile, or Claude
+    Code's settings.json `env` block, so every hook subprocess always sees it).
+    It names exactly ONE vault. Any code that reads it naively therefore has two
+    distinct failure modes, and BOTH are silent:
+
+      1. UNSET  -> the near-universal default `str(Path.home() / "vault")` is
+         wrong for every vault not literally named "vault". A guard written this
+         way is inert on essentially every install, and says nothing while it is.
+      2. SET    -> the env var wins over the vault the caller actually means. A
+         file written into vault B resolves against vault A, the containment
+         check returns False, and the guard skips the very file it exists for.
+
+    Caught live on hooks/validate-handoff-frontmatter.py (#375/#404), which read
+    the env var with a ~/vault default and was inert everywhere. Two unrelated
+    users had already hand-patched it identically, each hardcoding their own
+    absolute vault path -- when two people patch a defect the same way, the
+    upstream default is the bug.
+
+    MYC-2439 fixed 3 scripts; MYC-2504 fixes 5 more. Both are INSTANCE
+    remediation. This is the class-level watchdog: the third layer of
+    immediate remediation -> per-script hardening -> class-level guard, and the
+    twin of scripts/check-meta-resolution.sh (the naive `*Meta` glob ban).
+
+THE RULE
+    A read of the VAULT_ROOT environment variable
+        os.environ.get("VAULT_ROOT", ...) / os.getenv("VAULT_ROOT")
+        os.environ["VAULT_ROOT"]
+    is a VIOLATION unless one of the following is true:
+
+      (1) it is lexically inside a sanctioned resolver definition (SANCTIONED
+          below) -- the one place allowed to decide what the env var means;
+      (2) it is an ARGUMENT to a sanctioned resolver call, e.g.
+              resolve_vault_root(cwd, os.environ.get("VAULT_ROOT"))
+          which is the hooks/_lib/vault_root.py contract: the env var is the
+          FALLBACK, behind detection, never the primary signal;
+      (3) it carries an explicit `# vault-root-ok: <reason>` exemption comment
+          on the read's own line, the line above, or any line of a multi-line
+          call. An empty reason is itself a violation -- an exemption with no
+          argument is a rubber stamp.
+
+    The sanctioned patterns differ by surface, and the difference matters:
+      - A SCRIPT serves one vault, so `_resolve_vault_root()` prefers the
+        script's own location and ignores a mismatched env var (aggregate-*.py).
+      - A HOOK fires on files in ANY vault, so it must resolve PER FILE, from
+        the target path, with the env var only as fallback
+        (validate-handoff-frontmatter.py's vault_root_for). A hook is the
+        higher-severity surface: a wrong root makes it fail silently OPEN.
+
+WHY AST AND NOT GREP
+    The twin is a regex over shell. This one is over Python, and Python lets the
+    banned pattern appear legitimately as DATA -- in this module's own docstring,
+    in a test fixture stored as a source string, in a comment explaining the bug.
+    Parsing means a string is a string: only an executable read is ever flagged,
+    so the guard needs no self-exclusion list and cannot be defeated by moving a
+    fixture around. Real .py fixtures under tests/ are additionally out of the
+    fleet scope (scripts/ + hooks/), so both fixture styles are safe.
+
+THE LEGACY POPULATION
+    This lint landed on a tree with a large pre-existing population (see
+    scripts/vault-root-read-baseline.txt). Those rows are pinned by SHA-256, the
+    same ratchet scripts/check-cloud-safe-file-walkers.py uses: a pinned file
+    passes only while it is byte-identical, so ANY edit forces remediation, and
+    a NEW file is never pinned and fails immediately. The baseline is the
+    remediation backlog, tagged by severity -- not a set of silent pardons.
+
+Modes:
+    --all           fleet scan (scripts/ + hooks/) against the ratchet [default]
+    --check PATH..  audit named files/dirs, no baseline (fixtures, tests)
+    --report        enumerate every violation by tag, never fail
+    --self-test     load-bearing positive/negative controls
+
+Exit: 0 clean, 1 violation, 2 usage/IO error.
+
+ASCII-only output on purpose -- see scripts/check-utf8-stdout.py.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import hashlib
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "hooks"))
+
+from _lib.safe_read import safe_read_text  # noqa: E402
+
+# The fleet this guard owns. scripts/ (vault-side CLIs) + hooks/ (the
+# higher-severity surface: a hook fires on files in ANY vault). Git pathspec
+# wildcards cross directory separators, so nested files are included.
+FLEET_PATHSPECS = ("scripts/*.py", "hooks/*.py")
+
+DEFAULT_BASELINE = REPO / "scripts" / "vault-root-read-baseline.txt"
+
+# Functions allowed to read the env var, and calls allowed to receive it.
+#
+#   _resolve_vault_root  scripts/aggregate-{decisions,sessions}.py,
+#                        scripts/decision-outcome-check.py -- prefers the
+#                        script's own vault, ignores a mismatched env var
+#                        unless VAULT_ROOT_FORCE=1.
+#   resolve_vault_root   hooks/_lib/vault_root.py -- cwd-derived detection
+#                        first, env var as fallback. Both the definition and a
+#                        call site passing the env var IN are sanctioned.
+#   vault_root_for       the per-file hook resolver
+#                        (hooks/validate-handoff-frontmatter.py): detection
+#                        from the TARGET FILE first, env var as fallback.
+SANCTIONED = frozenset({
+    "_resolve_vault_root",
+    "resolve_vault_root",
+    "vault_root_for",
+    "_vault_root_for",
+})
+
+ENV_VAR = "VAULT_ROOT"
+
+# `# vault-root-ok: <reason>`. The reason is mandatory: an exemption that does
+# not say why is a rubber stamp, and is reported as its own violation kind.
+EXEMPT_RE = re.compile(r"#\s*vault-root-ok\s*:\s*(?P<reason>.*)$")
+MIN_REASON_CHARS = 3
+
+# Baseline row: <sha256> <TAG> <path>. TAG is documented in the baseline header.
+_SHA_LEN = 64
+
+
+class Violation:
+    __slots__ = ("path", "line", "kind", "snippet")
+
+    def __init__(self, path: str, line: int, kind: str, snippet: str) -> None:
+        self.path = path
+        self.line = line
+        self.kind = kind
+        self.snippet = snippet
+
+    def render(self) -> str:
+        return f"  {self.path}:{self.line}: {self.kind}\n      {self.snippet}"
+
+
+def _is_os_environ(node: ast.AST) -> bool:
+    """True for `os.environ` or a bare `environ` (from os import environ)."""
+    if isinstance(node, ast.Attribute) and node.attr == "environ":
+        return isinstance(node.value, ast.Name) and node.value.id == "os"
+    return isinstance(node, ast.Name) and node.id == "environ"
+
+
+def _module_str_constants(tree: ast.Module) -> dict:
+    """Module-level `NAME = "literal"` bindings.
+
+    Needed because the env var name is not always written inline. Real example:
+    hooks/scan-prior-sessions-for-secrets.py binds `VAULT_ROOT_ENV = "VAULT_ROOT"`
+    and reads `os.environ.get(VAULT_ROOT_ENV, "")`. A literal-only rule misses it,
+    which would leave the guard with a one-line bypass -- exactly the false green
+    this repo treats as worse than no guard at all.
+    """
+    consts: dict = {}
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant):
+            if isinstance(node.value.value, str):
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        consts[target.id] = node.value.value
+    return consts
+
+
+def _const_str(node: ast.AST | None, consts: dict | None = None) -> str | None:
+    """The string value of `node`: a literal, or a module-level string constant."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if consts and isinstance(node, ast.Name):
+        return consts.get(node.id)
+    return None
+
+
+def _reads_vault_root(node: ast.AST, consts: dict | None = None) -> bool:
+    """True iff `node` is an executable read of the VAULT_ROOT env var.
+
+    Name-equality (after resolving module-level string constants) means
+    VAULT_ROOT_FORCE -- a different, benign knob -- is never matched, and a
+    genuinely dynamic key is never guessed at.
+    """
+    if isinstance(node, ast.Call):
+        func = node.func
+        # os.environ.get("VAULT_ROOT", ...) / environ.get(...)
+        if isinstance(func, ast.Attribute) and func.attr == "get" and _is_os_environ(func.value):
+            return bool(node.args) and _const_str(node.args[0], consts) == ENV_VAR
+        # os.getenv("VAULT_ROOT", ...) / getenv(...)
+        is_getenv = (
+            (isinstance(func, ast.Attribute) and func.attr == "getenv"
+             and isinstance(func.value, ast.Name) and func.value.id == "os")
+            or (isinstance(func, ast.Name) and func.id == "getenv")
+        )
+        if is_getenv:
+            return bool(node.args) and _const_str(node.args[0], consts) == ENV_VAR
+        return False
+    # os.environ["VAULT_ROOT"] -- LOAD only. A STORE (os.environ["VAULT_ROOT"] = x)
+    # SETS the variable for a child process; it is not a naive read of it.
+    if isinstance(node, ast.Subscript) and isinstance(node.ctx, ast.Load):
+        if _is_os_environ(node.value):
+            return _const_str(node.slice, consts) == ENV_VAR
+    return False
+
+
+def _sanctioned_call(node: ast.AST) -> bool:
+    """True iff `node` is a call to a sanctioned resolver (env var as fallback)."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+    return name in SANCTIONED
+
+
+def _exemption(lines: list[str], start: int, end: int) -> tuple[bool, bool]:
+    """Look for the exemption marker on the read, or in the comment block above it.
+
+    The window is the read's own lines PLUS the contiguous run of comment-only
+    lines immediately above it. A real justification rarely fits on one line, and
+    requiring the marker to be the LAST line before the code would force every
+    reason to be written upside down. A blank line or any code ends the block, so
+    the marker still has to sit with the read it exempts.
+
+    Returns (found, reason_ok). `found` without `reason_ok` is a bare marker --
+    reported as its own violation kind, because an exemption that does not say
+    why is a rubber stamp.
+    """
+    hi = min(len(lines), max(end, start))
+    lo = start
+    idx = start - 1
+    while idx >= 1 and lines[idx - 1].lstrip().startswith("#"):
+        lo = idx
+        idx -= 1
+    found = False
+    for i in range(lo, hi + 1):
+        m = EXEMPT_RE.search(lines[i - 1])
+        if m:
+            found = True
+            if len(m.group("reason").strip()) >= MIN_REASON_CHARS:
+                return True, True
+    return found, False
+
+
+def scan_source(source: str, rel: str) -> list[Violation]:
+    """Every unsanctioned VAULT_ROOT read in `source`. Raises SyntaxError on bad input."""
+    tree = ast.parse(source)
+    lines = source.splitlines()
+    consts = _module_str_constants(tree)
+    found: list[Violation] = []
+
+    def walk(node: ast.AST, in_resolver: bool, in_sanctioned_call: bool) -> None:
+        child_resolver = in_resolver
+        child_call = in_sanctioned_call
+
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.name in SANCTIONED:
+                child_resolver = True
+        elif _sanctioned_call(node):
+            child_call = True
+
+        if _reads_vault_root(node, consts):
+            if not (in_resolver or in_sanctioned_call):
+                start = node.lineno
+                end = getattr(node, "end_lineno", None) or start
+                has_marker, reason_ok = _exemption(lines, start, end)
+                if not (has_marker and reason_ok):
+                    kind = (
+                        "vault-root-ok marker with no reason"
+                        if has_marker else
+                        "naive VAULT_ROOT read outside a sanctioned resolver"
+                    )
+                    snippet = lines[start - 1].strip() if start <= len(lines) else "?"
+                    found.append(Violation(rel, start, kind, snippet))
+            # A read is a leaf for this purpose; its own args cannot contain another.
+            return
+
+        for child in ast.iter_child_nodes(node):
+            walk(child, child_resolver, child_call)
+
+    walk(tree, False, False)
+    found.sort(key=lambda v: v.line)
+    return found
+
+
+def normalize(source: str) -> str:
+    """CRLF/CR -> LF.
+
+    The baseline hash MUST be identical on every checkout or the ratchet is
+    useless. This repo has no .gitattributes, so a Windows clone with
+    core.autocrlf=true has CRLF on disk while the Linux CI runner has LF -- a
+    raw-bytes hash pinned on one platform is 100% stale on the other, which
+    reds the build for everyone with no real violation behind it. (Verified
+    live: scripts/cloud-safe-walker-baseline.txt, which hashes unnormalized,
+    reports every row stale on a Windows checkout today.) Normalizing makes
+    the pin describe the CONTENT, not the checkout.
+    """
+    return source.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def scan_file(path: Path, rel: str) -> tuple[list[Violation], str]:
+    """(violations, sha256-of-normalized-source) for one file.
+
+    Reads through the shared bounded primitive (hooks/_lib/safe_read.py): this
+    lint walks a whole tree, and an install living on a cloud-synced folder can
+    hand back a placeholder file whose read blocks indefinitely. Raises OSError
+    on an unreadable file so the caller can report it rather than skip silently.
+    """
+    result = safe_read_text(path, timeout=5.0, max_bytes=4_000_000)
+    if not result.ok:
+        raise OSError(f"unreadable ({result.status}{': ' + result.detail if result.detail else ''})")
+    source = normalize(result.text or "")
+    digest = hashlib.sha256(source.encode("utf-8")).hexdigest()
+    return scan_source(source, rel), digest
+
+
+# --------------------------------------------------------------------------
+# baseline ratchet
+# --------------------------------------------------------------------------
+
+def load_baseline(path: Path) -> dict:
+    """path -> (sha256, tag). Raises ValueError on a malformed row."""
+    entries = {}
+    if not path.is_file():
+        raise ValueError(f"baseline not found: {path}")
+    result = safe_read_text(path, timeout=5.0, max_bytes=1_000_000)
+    if not result.ok:
+        raise ValueError(f"baseline {path} is {result.status}")
+    for line_no, raw in enumerate((result.text or "").splitlines(), start=1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split(None, 2)
+        if len(parts) != 3 or len(parts[0]) != _SHA_LEN:
+            raise ValueError(f"invalid baseline row {path}:{line_no}: {raw!r}")
+        entries[parts[2]] = (parts[0], parts[1])
+    return entries
+
+
+def fleet_files(root: Path) -> list[str]:
+    # --others --exclude-standard so a brand-new, not-yet-committed script is in
+    # scope too: the local pre-push gate must catch it before it is ever pushed,
+    # not one commit later.
+    proc = subprocess.run(
+        ["git", "-C", str(root), "ls-files", "-z", "--cached", "--others",
+         "--exclude-standard", "--"] + list(FLEET_PATHSPECS),
+        capture_output=True, timeout=30,
+    )
+    if proc.returncode != 0:
+        raise OSError("git ls-files failed for the vault-root fleet")
+    return sorted(os.fsdecode(item) for item in proc.stdout.split(b"\x00") if item)
+
+
+def check_all(root: Path, baseline_path: Path, report_only: bool = False) -> int:
+    try:
+        baseline = {} if report_only else load_baseline(baseline_path)
+        relative = fleet_files(root)
+    except (ValueError, OSError, subprocess.TimeoutExpired) as exc:
+        print(f"ERROR vault-root fleet: {exc}", file=sys.stderr)
+        return 2
+
+    current: dict = {}
+    unpinned: list[Violation] = []
+    errors = 0
+
+    for rel in relative:
+        try:
+            violations, digest = scan_file(root / rel, rel)
+        except (OSError, SyntaxError, UnicodeDecodeError) as exc:
+            errors += 1
+            print(f"ERROR {rel}: {exc}", file=sys.stderr)
+            continue
+        if not violations:
+            continue
+        current[rel] = (digest, violations)
+        if report_only:
+            continue
+        pinned = baseline.get(rel)
+        if pinned and pinned[0] == digest:
+            continue
+        unpinned.extend(violations)
+
+    if report_only:
+        total = sum(len(v) for _, v in current.values())
+        print(f"vault-root read report: {len(current)} file(s), {total} unsanctioned read(s)")
+        for rel in sorted(current):
+            digest, violations = current[rel]
+            print(f"  {rel}  [{digest[:12]}]")
+            for v in violations:
+                print(f"      L{v.line}: {v.snippet}")
+        return 0
+
+    if errors:
+        return 2
+
+    # A row is live only while its file still violates at exactly the pinned
+    # bytes. Anything else in the baseline is stale. `current` also holds files
+    # that are NOT pinned at all, so the membership test is required.
+    still_pinned = {r for r in current if r in baseline and baseline[r][0] == current[r][0]}
+    stale = sorted(set(baseline) - still_pinned)
+
+    if unpinned or stale:
+        print("::error::naive VAULT_ROOT read(s) - resolve through a sanctioned resolver:")
+        for v in unpinned:
+            print(v.render())
+        for rel in stale:
+            print(
+                f"  STALE BASELINE {rel}: file changed, became clean, or was removed.\n"
+                f"      Adopt the resolver (or `# vault-root-ok: <reason>`), then delete\n"
+                f"      this row -- do NOT re-pin an edited file to keep it exempt."
+            )
+        print()
+        print("  Fix, by surface:")
+        print("    script (serves ONE vault):  _resolve_vault_root() -- prefer the")
+        print("        script's own location; honor the env var only when it agrees")
+        print("        (see scripts/aggregate-sessions.py).")
+        print("    hook (fires on ANY vault):  resolve per TARGET FILE first, env var")
+        print("        as fallback (see hooks/validate-handoff-frontmatter.py's")
+        print("        vault_root_for). A hook with the wrong root fails silently OPEN.")
+        print("    session-close cascade:  resolve_vault_root(cwd, os.environ.get(...))")
+        print("        from hooks/_lib/vault_root.py.")
+        print("    genuinely correct as-is:  add `# vault-root-ok: <reason>` on the line")
+        print("        above. The reason is mandatory.")
+        return 1
+
+    pinned_reads = sum(len(v) for _, v in current.values())
+    print(
+        f"vault-root reads: OK ({len(relative)} file(s) scanned; "
+        f"{len(current)} byte-pinned legacy file(s), {pinned_reads} pinned read(s))"
+    )
+    return 0
+
+
+def check_paths(paths: list[Path]) -> int:
+    """Audit explicit files/dirs with no baseline. Used by the negative controls."""
+    targets: list[Path] = []
+    for p in paths:
+        if p.is_dir():
+            targets.extend(sorted(p.rglob("*.py")))
+        else:
+            targets.append(p)
+    if not targets:
+        print("ERROR: no .py files to check", file=sys.stderr)
+        return 2
+    failures: list[Violation] = []
+    for t in targets:
+        try:
+            violations, _ = scan_file(t, str(t))
+        except (OSError, SyntaxError, UnicodeDecodeError) as exc:
+            print(f"ERROR {t}: {exc}", file=sys.stderr)
+            return 2
+        failures.extend(violations)
+    if failures:
+        print("::error::naive VAULT_ROOT read(s):")
+        for v in failures:
+            print(v.render())
+        return 1
+    print(f"vault-root reads: OK ({len(targets)} file(s) scanned)")
+    return 0
+
+
+# --------------------------------------------------------------------------
+# self-test
+# --------------------------------------------------------------------------
+
+_CASES = (
+    # (name, source, expect_violation)
+    (
+        "naive get with ~/vault default is caught",
+        "import os\n"
+        "from pathlib import Path\n"
+        "VAULT = Path(os.environ.get('VAULT_ROOT', str(Path.home() / 'vault')))\n",
+        True,
+    ),
+    (
+        "naive getenv is caught",
+        "import os\n"
+        "V = os.getenv('VAULT_ROOT')\n",
+        True,
+    ),
+    (
+        "subscript read is caught",
+        "import os\n"
+        "V = os.environ['VAULT_ROOT']\n",
+        True,
+    ),
+    (
+        "bare environ.get after `from os import environ` is caught",
+        "from os import environ\n"
+        "V = environ.get('VAULT_ROOT', '')\n",
+        True,
+    ),
+    (
+        "read inside _resolve_vault_root is sanctioned",
+        "import os\n"
+        "def _resolve_vault_root():\n"
+        "    return os.environ.get('VAULT_ROOT')\n",
+        False,
+    ),
+    (
+        "read inside the per-file hook resolver is sanctioned",
+        "import os\n"
+        "def vault_root_for(path):\n"
+        "    return os.environ.get('VAULT_ROOT') or detect(path)\n",
+        False,
+    ),
+    (
+        "env var passed INTO resolve_vault_root is sanctioned",
+        "import os\n"
+        "from _lib.vault_root import resolve_vault_root\n"
+        "root = resolve_vault_root(cwd, os.environ.get('VAULT_ROOT'))\n",
+        False,
+    ),
+    (
+        "exemption comment with a reason passes",
+        "import os\n"
+        "# vault-root-ok: installer flag default; user passes --vault-path explicitly\n"
+        "V = os.environ.get('VAULT_ROOT')\n",
+        False,
+    ),
+    (
+        "exemption comment on the same line passes",
+        "import os\n"
+        "V = os.environ.get('VAULT_ROOT')  # vault-root-ok: opt-in cross-vault scrub\n",
+        False,
+    ),
+    (
+        "exemption comment with NO reason is itself a violation",
+        "import os\n"
+        "# vault-root-ok:\n"
+        "V = os.environ.get('VAULT_ROOT')\n",
+        True,
+    ),
+    (
+        "read indirected through a module-level constant is caught",
+        "import os\n"
+        "VAULT_ROOT_ENV = 'VAULT_ROOT'\n"
+        "def _vault_root():\n"
+        "    return os.environ.get(VAULT_ROOT_ENV, '')\n",
+        True,
+    ),
+    (
+        "a module constant naming a DIFFERENT var is not flagged",
+        "import os\n"
+        "OTHER_ENV = 'SNAPSHOTS_DIR'\n"
+        "v = os.environ.get(OTHER_ENV, '')\n",
+        False,
+    ),
+    (
+        "VAULT_ROOT_FORCE is a different knob and is never flagged",
+        "import os\n"
+        "if os.environ.get('VAULT_ROOT_FORCE'):\n"
+        "    pass\n",
+        False,
+    ),
+    (
+        "WRITING the env var for a child process is not a read",
+        "import os\n"
+        "os.environ['VAULT_ROOT'] = str(vault)\n",
+        False,
+    ),
+    (
+        "a non-os mapping named env is not the environment",
+        "env = {}\n"
+        "env['VAULT_ROOT'] = vault_root\n",
+        False,
+    ),
+    (
+        "the pattern quoted as DATA in a fixture string is not executable",
+        "FIXTURE = '''\n"
+        "import os\n"
+        "VAULT = os.environ.get(\"VAULT_ROOT\", \"~/vault\")\n"
+        "'''\n",
+        False,
+    ),
+    (
+        "the pattern named in a docstring is not executable",
+        '"""The old code read os.environ.get("VAULT_ROOT", str(Path.home() / "vault"))."""\n',
+        False,
+    ),
+    (
+        "a naive read in a nested helper inside a resolver is still sanctioned",
+        "import os\n"
+        "def _resolve_vault_root():\n"
+        "    def inner():\n"
+        "        return os.environ.get('VAULT_ROOT')\n"
+        "    return inner()\n",
+        False,
+    ),
+    (
+        "a naive read in a function merely NEAR a resolver is caught",
+        "import os\n"
+        "def _resolve_vault_root():\n"
+        "    return None\n"
+        "def other():\n"
+        "    return os.environ.get('VAULT_ROOT', '~/vault')\n",
+        True,
+    ),
+    (
+        "marker at the TOP of a multi-line comment block still exempts the read",
+        "import os\n"
+        "# vault-root-ok: the installer runs before any vault is resolvable from\n"
+        "# anything else; --vault-path is the explicit override and the default\n"
+        "# is None, so unset skips substitution rather than guessing a vault.\n"
+        "ap.add_argument('--vault-path', default=os.environ.get('VAULT_ROOT'))\n",
+        False,
+    ),
+    (
+        "a comment block separated from the read by a blank line does NOT exempt it",
+        "import os\n"
+        "# vault-root-ok: this reason belongs to something else entirely\n"
+        "\n"
+        "V = os.environ.get('VAULT_ROOT', '~/vault')\n",
+        True,
+    ),
+    (
+        "multi-line call with the marker above passes",
+        "import os\n"
+        "# vault-root-ok: argparse default; --vault-root overrides it\n"
+        "V = os.environ.get(\n"
+        "    'VAULT_ROOT',\n"
+        "    '',\n"
+        ")\n",
+        False,
+    ),
+)
+
+
+def self_test() -> int:
+    failures = 0
+    for name, source, expect in _CASES:
+        try:
+            got = bool(scan_source(source, "<self-test>"))
+        except SyntaxError as exc:
+            print(f"  FAIL {name}: fixture does not parse: {exc}")
+            failures += 1
+            continue
+        if got != expect:
+            verb = "expected a violation, got none" if expect else "expected clean, got a violation"
+            print(f"  FAIL {name}: {verb}")
+            failures += 1
+        else:
+            print(f"  ok   {name}")
+    total = len(_CASES)
+    if failures:
+        print(f"check-vault-root-reads self-test: {failures} of {total} FAILED")
+        return 1
+    print(f"check-vault-root-reads self-test: {total}/{total} passed")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--all", action="store_true", help="fleet scan against the ratchet (default)")
+    ap.add_argument("--check", nargs="+", type=Path, help="audit these files/dirs, no baseline")
+    ap.add_argument("--report", action="store_true", help="enumerate violations, never fail")
+    ap.add_argument("--self-test", action="store_true", help="run the pos/neg controls")
+    ap.add_argument("--root", type=Path, default=REPO)
+    ap.add_argument("--baseline", type=Path, default=DEFAULT_BASELINE)
+    args = ap.parse_args(argv)
+
+    if args.self_test:
+        return self_test()
+    if args.check:
+        return check_paths([p for p in args.check])
+    return check_all(args.root.resolve(), args.baseline.resolve(), report_only=args.report)
+
+
+if __name__ == "__main__":
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
+    sys.exit(main())

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -446,4 +446,4 @@ done
 echo "    OK - ${#PY_DIRECT[@]} hooks/+tests/ direct suite(s) passed; dormancy invariant clean"
 
 echo
-echo "All gates passed: py_compile ($count file(s)) + ${#INTEGRATION_TESTS[@]} integration tests + $unit_count scripts/ + ${#PY_DIRECT[@]} hooks/tests unit suite(s) + shellcheck [$shellcheck_note] + phase-doc python [$phasepy_note] + utf8 console guard [$utf8_note] + hook block-protocol [passed]."
+echo "All gates passed: py_compile ($count file(s)) + ${#INTEGRATION_TESTS[@]} integration tests + $unit_count scripts/ + ${#PY_DIRECT[@]} hooks/tests unit suite(s) + shellcheck [$shellcheck_note] + phase-doc python [$phasepy_note] + utf8 console guard [$utf8_note] + hook block-protocol [passed] + vault-root reads [passed]."

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -36,6 +36,13 @@
 #                           reads the empty output as failure (ai-brain-starter#313).
 #                           A dedicated lint.yml 'utf8-console-guard' job is
 #                           authoritative in CI; here it runs locally (pure stdlib).
+#   (e2) Hook block-protocol - scripts/check-hook-block-protocol.py fails a hook
+#                           registered with the allow-fallback wrapper
+#                           (`... || echo '{...permissionDecision:allow}'`) that
+#                           blocks by exiting non-zero: the `||` fires on ANY
+#                           non-zero exit, so the block is rewritten into an
+#                           ALLOW and the guard is structurally unable to say no
+#                           (#405). Pure stdlib.
 #   (e3) VAULT_ROOT reads - scripts/check-vault-root-reads.py fails code that
 #                           reads the VAULT_ROOT env var outside a sanctioned
 #                           resolver. A globally-exported VAULT_ROOT names ONE

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -36,6 +36,13 @@
 #                           reads the empty output as failure (ai-brain-starter#313).
 #                           A dedicated lint.yml 'utf8-console-guard' job is
 #                           authoritative in CI; here it runs locally (pure stdlib).
+#   (e3) VAULT_ROOT reads - scripts/check-vault-root-reads.py fails code that
+#                           reads the VAULT_ROOT env var outside a sanctioned
+#                           resolver. A globally-exported VAULT_ROOT names ONE
+#                           vault: unset, the usual ~/vault default makes a guard
+#                           inert on every vault not named "vault"; set, it
+#                           overrides the vault the caller meant. Same
+#                           SILENT-NO-OP family as (e)/(e2); pure stdlib.
 #   (f) Python unit tests - the scripts/test_*.py stdlib suites (the claude-router
 #                           structured-envelope gate, the graph-liveness
 #                           STAMP-GREEN-WHILE-GONE guard). Gate (a) py_compiles them,
@@ -235,6 +242,14 @@ INTEGRATION_TESTS=(
   # Meta folder (not a hardcoded ~/vault), denies via the JSON protocol the
   # hooks.json wrapper preserves, covers MultiEdit, and fails OPEN off-vault.
   test_handoff_frontmatter_guard
+  # Naive VAULT_ROOT read ban (MYC-2505): negative controls for the (e3) gate.
+  # Proves the guard trips on all four read forms (including one indirected
+  # through a module constant), that an exemption with no reason is itself a
+  # violation, that the hash ratchet bites on an EDITED pinned file and on a row
+  # left behind after its file went clean -- and that the guard has not gone
+  # blind (fleet scan still matches, sanctioned resolver names still exist,
+  # pinned rows are still real violations, guard still wired into both gates).
+  test_vault_root_read_guard
 )
 # ---- Gate-coverage invariant -------------------------------------------------
 # The list above is an explicit allow-list, and allow-lists rot: a new
@@ -342,6 +357,20 @@ fi
 # always runs here.
 echo "==> (e2) hook block-protocol: $PY scripts/check-hook-block-protocol.py"
 "$PY" scripts/check-hook-block-protocol.py
+
+# ---- (e3) Naive VAULT_ROOT reads -------------------------------------------
+# scripts/check-vault-root-reads.py fails code that reads the VAULT_ROOT env var
+# outside a sanctioned resolver. A globally-exported VAULT_ROOT names ONE vault,
+# so a naive read fails two ways and both are silent: UNSET it defaults to
+# ~/vault (inert on every vault not literally named "vault"), SET it overrides
+# the vault the caller actually meant. hooks/validate-handoff-frontmatter.py
+# shipped that way and was inert on every install (#375/#404) -- the same
+# SILENT-NO-OP family as (e) and (e2). Twin of the naive *Meta glob ban
+# (scripts/check-meta-resolution.sh, a lint.yml step). The pre-existing
+# population is byte-pinned in scripts/vault-root-read-baseline.txt, so a NEW or
+# EDITED file fails while the backlog burns down. Pure stdlib, always runs here.
+echo "==> (e3) vault-root reads: $PY scripts/check-vault-root-reads.py"
+"$PY" scripts/check-vault-root-reads.py
 
 # ---- (f) Python unit tests (scripts/ + hooks/ + tests/) --------------------
 # Every Python unit suite in the repo, run under the SAME interpreter as the rest

--- a/scripts/cloud-safe-walker-baseline.txt
+++ b/scripts/cloud-safe-walker-baseline.txt
@@ -1,6 +1,6 @@
 # SHA-256-pinned legacy recursive content walkers. Edited/new files must adopt safe_read.
 628b715ae85d0f2fdbd043a166f6ed60e1c964a85c9dd6f4265f20e1b17b11aa hooks/build-runbook-check.py
-2a59bc023f2d34e3ed36d60829a53d8addc062756b448ee31329784515e8c90b hooks/scan-prior-sessions-for-secrets.py
+2cde67ec1bd8c7c340da4b906b3acf67b4e8ebff9294ddaa1231e9d64da20474 hooks/scan-prior-sessions-for-secrets.py
 834faaab5745decd0b36e1df0a245289e632cef8260258ab2a2cd35ce73ffa76 hooks/test_live_session_reap.py
 0e5e50ea4361108fbcf77fed5ebcf8ab037275a1d0f385931a80a77eb786ad75 hooks/test_relocation_orphan_reclaim.py
 217d45222b41718f24d160434c1cc25dfe023cd8460790e3841b290ad2bb4009 scripts/auto-crm-from-mentions.py

--- a/scripts/install-hooks-user-level.py
+++ b/scripts/install-hooks-user-level.py
@@ -1014,6 +1014,11 @@ def main() -> int:
     ap.add_argument("--dry-run", action="store_true")
     ap.add_argument("--uninstall", action="store_true")
     ap.add_argument("--hooks-source", help="path to hooks.json (default: auto-detect)")
+    # vault-root-ok: the installer runs BEFORE the vault it targets is resolvable
+    # from anything else -- it does not live in a vault (no script-location signal)
+    # and has no target file (no per-file signal). --vault-path is the explicit
+    # override, and the default is None, not ~/vault: unset simply skips the
+    # [VAULT_PATH] substitution rather than pointing it at a wrong vault.
     ap.add_argument("--vault-path", default=os.environ.get("VAULT_ROOT"),
                     help="vault path for [VAULT_PATH] substitution (optional)")
     ap.add_argument("--settings", default=str(Path.home() / ".claude" / "settings.json"),

--- a/scripts/vault-root-read-baseline.txt
+++ b/scripts/vault-root-read-baseline.txt
@@ -1,0 +1,108 @@
+# vault-root-read-baseline.txt - the legacy population under
+# scripts/check-vault-root-reads.py, pinned by SHA-256.
+#
+# THIS FILE IS A BACKLOG, NOT A SET OF PARDONS.
+#
+# Every row is a file that reads the VAULT_ROOT env var outside a sanctioned
+# resolver. They predate the guard (MYC-2505 shipped the guard; MYC-2439 fixed
+# 3 instances, MYC-2504 fixes 5 more, and this is what is left after those).
+# Pinning them lets the CLASS-level guard land without a 50-file rewrite, while
+# still failing the build for anything new.
+#
+# THE RATCHET (same mechanism as scripts/cloud-safe-walker-baseline.txt)
+#   - A pinned file passes ONLY while it is byte-identical to its row. Edit it
+#     at all and the row goes STALE and the build fails, so the next person to
+#     touch any of these files has to fix the read.
+#   - A file NOT in this list has no grace period: it fails on the first read.
+#   - Rows only ever get DELETED. Do not re-pin an edited file to keep it quiet
+#     -- that converts the backlog into a permanent exemption, which is exactly
+#     the failure mode this file exists to avoid. If a read is genuinely correct,
+#     it gets `# vault-root-ok: <reason>` in the source (where a reviewer sees
+#     it) and its row is deleted from here.
+#
+# ROW FORMAT
+#   <sha256>  <tag>  <path>
+#
+# TAGS - mechanically derived from the DEFAULT expression, worst first. The tag
+# says what happens when the env var is UNSET; every row additionally has the
+# SET failure mode (a globally-exported VAULT_ROOT names ONE vault and silently
+# wins over the one the caller meant).
+#
+#   SEV-A-home-vault   default is `Path.home() / "vault"`. Inert on every vault
+#                      not literally named "vault" - the guard/hook does nothing
+#                      and says nothing. This is the exact shape of #375/#404.
+#                      All 12 are in hooks/, the higher-severity surface: a hook
+#                      fires on files in ANY vault, so a wrong root makes it fail
+#                      silently OPEN. Fix per-file (see vault_root_for in
+#                      hooks/validate-handoff-frontmatter.py), not per-process.
+#   SEV-B-cwd          default is the process cwd. Right often enough to look
+#                      fine, wrong whenever the tool is run from anywhere else.
+#   SEV-C-script-loc   default derives from __file__. This is the RIGHT default
+#                      for a script serving one vault; what is missing is the
+#                      env-var-disagrees guard that _resolve_vault_root() adds
+#                      (scripts/aggregate-sessions.py is the model).
+#   SEV-D-cli-default  the read is an argparse `default=` with an explicit CLI
+#                      override, so a caller can always correct it.
+#   SEV-E-no-default   no default; the failure moves to whatever the caller does
+#                      with the None/"". Needs reading case by case.
+#
+
+# ---- SEV-A-home-vault  (12 file(s), 12 read(s)) ----
+77d67b3c9295d7dd2b3c34868679cf86b2e1e62eaad17b5ee4adf20245731dd6 SEV-A-home-vault hooks/auto-capture-public-ships.py
+8f0b58bc3dd57112be05fbf554216c2680dde61fbdf9470e60007fd1d8b4b45f SEV-A-home-vault hooks/block-raw-vault-git.py
+3bec2b51063086d5db9b20dc9f136a08401a780d0efcf97fde2d90ef3981d3cf SEV-A-home-vault hooks/block-vault-git-fullwalk.py
+85a233806b9756b451f3a0b81b8c75eae33afe687d08dfa0f1271a53f9203d5c SEV-A-home-vault hooks/block-worktree-shared-edit.py
+628b715ae85d0f2fdbd043a166f6ed60e1c964a85c9dd6f4265f20e1b17b11aa SEV-A-home-vault hooks/build-runbook-check.py
+dce3ed5df366f6a56d5cd20338302a94932932b87e2f40d867ef772b7ef38266 SEV-A-home-vault hooks/create-dev-repo-checkpoint.py
+d23de68310d25dd3bf5f5508e1a84b89b7d156ea2daeedbd3ee321c872b07149 SEV-A-home-vault hooks/surface-stale-automation-failures.py
+d90976775414288e229f198825f2ab6b904d23c6163b185fa106eb9dff6af2ca SEV-A-home-vault hooks/vault-command-nudges.py
+792c1593b8b22f6dea63a5d7d657a5d0b1ec6f9270531b9357bb2201c15a4e7f SEV-A-home-vault hooks/vault-context.py
+306fd985cd1e1f43314209ad8b9d3f0f9a33613474d91bcdc843bb37409ed1eb SEV-A-home-vault hooks/verify-discoverability-on-close.py
+c2b8ab2406e954ee6688c6b9450d998ff17b18ec1a66f8259ff8eea055df0e10 SEV-A-home-vault hooks/verify-session-close-cascade.py
+3cfa5a97dc3604c9ae6c8ff715e7bd6590176496674a3d2e823400035de56e86 SEV-A-home-vault hooks/worktree-archive-autoprep.py
+
+# ---- SEV-B-cwd  (16 file(s), 16 read(s)) ----
+dd3795425a250401136ea1739bbc0090324a54ca2ac737fcb7ed36f7268d66a3 SEV-B-cwd scripts/check-claude-md-drift.py
+dfd1dee24edf0b7a56cc5241504e9190ac1625f24df2fc3b1a223baa9802f581 SEV-B-cwd scripts/check-rule-conflicts.py
+ecf437791a2199e922f3b4ea83fd5541e1f9b2852b6323243791ba827770a243 SEV-B-cwd scripts/crm-collision-check.py
+113b61af71c96cce33c625f6865f16050662270b509619ef3d032a5452aaab2a SEV-B-cwd scripts/decision-retrospective.py
+926b37dcb6f6b689dab5c69b74f169a74e911887f20e7ed6aeb3c1b51e507b58 SEV-B-cwd scripts/drift-detection.py
+1c7184abe8bea026809915956b43a5b945e44680a9248a8c83887a66f8d19bf0 SEV-B-cwd scripts/entity-disambiguator.py
+b461174f186d1a5bee479caf657c50c002324a09336324aa1bfef88090bfc8f1 SEV-B-cwd scripts/mcp-config-check.py
+601e5c47d84531274d14e3d0211c411fe4d37d1293879aa9c3c3fa163dd62883 SEV-B-cwd scripts/passive-capture.py
+3c41956000c24ca559be548481031b53a6fc269ef980af1bfedcd3c0bab133f0 SEV-B-cwd scripts/proposed-update-drafter.py
+2bf61214c177290c2408dd5b404d35bce060d22dbd9c06b10792ab4d286df3b9 SEV-B-cwd scripts/resolver-branch-merge-prompt.py
+8484cdc3aaea0a7882dd1f1c1c8d8a0b46c9977995a3c09563ebf74611fb8dd9 SEV-B-cwd scripts/resolver-build.py
+a826003cdacfbeefdfe8019947632e71fb369ae9a5905d7dcce5a947b94b60ee SEV-B-cwd scripts/resolver-conflict-report.py
+30efd1751a2a773b931fb67a12214db06bc8b9820fe49f48028236b42450659d SEV-B-cwd scripts/stale-rule-check.py
+c27dc2a06172b75ca4ed910c9da19b8e45761fd44908161a1fb42afdfd65fcd7 SEV-B-cwd scripts/undo-last-close.py
+8a1bf7b92664f946386b6af0e61b03042422f132d8f0f79b830aecd314385b17 SEV-B-cwd scripts/vault-hygiene.py
+e2db75570334b975049b27838715b8d7c201a996c26cb1287eb9e6f9b11fb0ad SEV-B-cwd scripts/vault-schema-validator.py
+
+# ---- SEV-C-script-loc  (6 file(s), 6 read(s)) ----
+f874491253a72291559c34c46187adf5b74c2ea305ef8ae59343debc784410ee SEV-C-script-loc scripts/compress-vault-doc.py
+c608cc6897ce3366e45301acd6c6bfe46eac6c4bfa2a1d066b1fa931eef97e6e SEV-C-script-loc scripts/context-audit.py
+d89c7a148f7598591627863187f12938ce56ff5c41c5db6805559f3b1f29d499 SEV-C-script-loc scripts/monthly-baseline.py
+fd7dcaf462d1fe6a8a3d350573c2b63c896ca4089a02b7888048b70e9807b459 SEV-C-script-loc scripts/rotate-meta-archives.py
+3c1a5e886fc162733d9f2c3a7575b17e4dd7a3591c45aefaf03882179d97ee09 SEV-C-script-loc scripts/token-usage-report.py
+6f3b4bf43bfe2f4edd00db13a4892399cded87e0b3cf02fb84f5f7f925d2ae50 SEV-C-script-loc scripts/worktree-archive-prep.py
+
+# ---- SEV-D-cli-default  (1 file(s), 1 read(s)) ----
+36aafbca40f8381430c029bb0a53794a679a102007dfe0b06a174d4d72955576 SEV-D-cli-default scripts/whatsapp/rename-contacts.py
+
+# ---- SEV-E-no-default  (15 file(s), 17 read(s)) ----
+85006d7e25f42ba787b2ce616bd1c71590c3990f89f3153a6f958156c93029ed SEV-E-no-default hooks/coach-auto-prescribe-on-journal.py
+33804a89b8c6ac80575f93ea2a5e0f9f6e47aeb3bb6e8dab0413729fd3fc8c94 SEV-E-no-default hooks/inject-love-language-context.py
+439b81f59712732d566301a7a1fe2b7f4f61c8f49a48c56a2b45f69a331c3087 SEV-E-no-default hooks/inject-meeting-workflow-on-trigger.py
+fe6732085fc9a60ca52539a9d4ca30307b5d37d214a00eec58c86353d69cb56f SEV-E-no-default hooks/worktree-footprint-signal.py
+d11e46cfd26ba07935e39f6bd73c36095e242d4a2a5a6856d12a07f7b929195b SEV-E-no-default scripts/backfill-journal-body-context.py
+66295b6759ce0653131ffa32fcbdb4e2c467fb833fe9770f1d72948ece7df513 SEV-E-no-default scripts/extractors/_base.py
+9ceedddb923461f4c803b48b1d8349c9e54f9f6ff73e40969aeb3332206c8824 SEV-E-no-default scripts/granola_core.py
+63fb9c590ff9d6f690249a4238094e595229adda50a5cfc8d55e87c1115b7a9d SEV-E-no-default scripts/graph-to-neo4j.py
+c41c1955f5ecc763a067cff06cd3c6cbe0a8aa47ad20625dd8eb7e779f8fd20d SEV-E-no-default scripts/hallucination-sample-audit.py
+24f7876383293d84f9524173e1e1b795b90eb4f18cee25dc64f5adaa57f59783 SEV-E-no-default scripts/hallucination-watch.py
+6670bcec0a1d80f8ea0d75ae7a8aae27993c4c5790e2e53f5029f9d2b1be7dea SEV-E-no-default scripts/heal-journal-guard.py
+6082be21cce7a61305998c0b07dd6c1148aebe660dcf364d8998d317b7cdcc57 SEV-E-no-default scripts/insight-fact-check.py
+a5aed49db53aae2474b33dd27da96d15a3fb4d13676974aa3d43e6c7d1d900c9 SEV-E-no-default scripts/rotate-last-session.py
+094e856feb69cd63ac7602b4d763d2067201d9b88c79aa7edc6f50fca9f7038a SEV-E-no-default scripts/security-snapshot.py
+af967eddf3c660a13fddafcbb9e5e4d1a9128fff605e3bbf4da1766b55cbf5ab SEV-E-no-default scripts/skill-usage-report.py

--- a/tests/integration/test_vault_root_read_guard.sh
+++ b/tests/integration/test_vault_root_read_guard.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# Negative-control suite for scripts/check-vault-root-reads.py - the class-level
+# ban on naive VAULT_ROOT env reads (MYC-2505).
+#
+# WHY THIS EXISTS
+#   A globally-exported VAULT_ROOT names exactly ONE vault. Code that reads it
+#   naively fails two ways, both silently: UNSET it defaults to ~/vault (inert on
+#   every vault not literally named "vault"), and SET it overrides the vault the
+#   caller actually meant. hooks/validate-handoff-frontmatter.py shipped that way
+#   and was inert on every install (#375/#404).
+#
+#   The guard is the third layer of immediate remediation -> per-script hardening
+#   -> class-level watchdog, and the twin of scripts/check-meta-resolution.sh.
+#   A guard that is only ever seen PASS is worthless, so every claim it makes has
+#   a control here that proves it still bites.
+#
+# THIS SUITE ALSO FAILS LOUD WHEN THE GUARD GOES BLIND, not just when it is
+# wrong: a sanctioned resolver that no longer exists, a fleet scan that matches
+# zero files, a baseline row for a file that is already clean, and the guard
+# being unwired from CI are each their own assertion. Silence is the only banned
+# state (mirrors tests/integration/test_vault_backup_conf_bom.sh).
+#
+# Bash + stdlib Python only, no network.
+set -u
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+GUARD="$ROOT/scripts/check-vault-root-reads.py"
+BASELINE="$ROOT/scripts/vault-root-read-baseline.txt"
+FAIL=0
+
+ok()  { echo "PASS  $1"; }
+bad() { echo "FAIL  $1"; FAIL=$((FAIL + 1)); }
+run() { local label="$1"; shift; if "$@" >/dev/null 2>&1; then ok "$label"; else bad "$label"; fi; }
+# trips <label> <cmd...> - the command MUST fail (that is the assertion).
+trips() {
+  local label="$1"; shift
+  if "$@" >/dev/null 2>&1; then bad "$label"; else ok "$label"; fi
+}
+
+if [ ! -f "$GUARD" ]; then
+  echo "FAIL  guard missing: $GUARD"
+  exit 1
+fi
+
+# ---- the guard's own built-in controls ------------------------------------
+run "guard built-in positive/negative controls" python3 "$GUARD" --self-test
+
+# ---- the live tree ---------------------------------------------------------
+run "real scripts/ + hooks/ fleet matches the reviewed hash ratchet" \
+  python3 "$GUARD" --all
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# ---- positive control: the bug class must trip -----------------------------
+cat > "$TMP/naive.py" <<'PY'
+import os
+from pathlib import Path
+VAULT = Path(os.environ.get("VAULT_ROOT", str(Path.home() / "vault")))
+PY
+trips "negative control: naive ~/vault-defaulting read trips the guard" \
+  python3 "$GUARD" --check "$TMP/naive.py"
+
+cat > "$TMP/naive_getenv.py" <<'PY'
+import os
+VAULT = os.getenv("VAULT_ROOT")
+PY
+trips "negative control: os.getenv form trips the guard" \
+  python3 "$GUARD" --check "$TMP/naive_getenv.py"
+
+cat > "$TMP/naive_subscript.py" <<'PY'
+import os
+VAULT = os.environ["VAULT_ROOT"]
+PY
+trips "negative control: os.environ[...] form trips the guard" \
+  python3 "$GUARD" --check "$TMP/naive_subscript.py"
+
+# Indirection through a module constant is a real shape in this repo
+# (hooks/scan-prior-sessions-for-secrets.py). A literal-only rule would have a
+# one-line bypass, which is worse than no guard.
+cat > "$TMP/naive_indirect.py" <<'PY'
+import os
+VAULT_ROOT_ENV = "VAULT_ROOT"
+def _root():
+    return os.environ.get(VAULT_ROOT_ENV, "")
+PY
+trips "negative control: read indirected through a module constant trips" \
+  python3 "$GUARD" --check "$TMP/naive_indirect.py"
+
+# An exemption that does not say WHY is a rubber stamp, not an exemption.
+cat > "$TMP/bare_marker.py" <<'PY'
+import os
+# vault-root-ok:
+VAULT = os.environ.get("VAULT_ROOT", "")
+PY
+trips "negative control: vault-root-ok with no reason is itself a violation" \
+  python3 "$GUARD" --check "$TMP/bare_marker.py"
+
+# ---- clean controls: the sanctioned paths must pass ------------------------
+cat > "$TMP/resolver.py" <<'PY'
+import os
+from pathlib import Path
+def _resolve_vault_root():
+    auto = Path(__file__).resolve().parents[2]
+    env = os.environ.get("VAULT_ROOT")
+    return Path(env) if env and Path(env) == auto else auto
+VAULT_ROOT = _resolve_vault_root()
+PY
+run "clean control: read inside _resolve_vault_root passes" \
+  python3 "$GUARD" --check "$TMP/resolver.py"
+
+cat > "$TMP/perfile.py" <<'PY'
+import os
+from pathlib import Path
+def vault_root_for(path):
+    found = detect_from(path)
+    if found is not None:
+        return found
+    env = (os.environ.get("VAULT_ROOT") or "").strip()
+    return Path(env) if env else None
+PY
+run "clean control: per-file hook resolver (detection first) passes" \
+  python3 "$GUARD" --check "$TMP/perfile.py"
+
+cat > "$TMP/fallback.py" <<'PY'
+import os
+from _lib.vault_root import resolve_vault_root
+root = resolve_vault_root(cwd, os.environ.get("VAULT_ROOT"))
+PY
+run "clean control: env var passed INTO resolve_vault_root passes" \
+  python3 "$GUARD" --check "$TMP/fallback.py"
+
+cat > "$TMP/exempt.py" <<'PY'
+import os
+# vault-root-ok: opt-in switch, not vault detection; unset disables the feature
+VAULT = os.environ.get("VAULT_ROOT", "")
+PY
+run "clean control: vault-root-ok WITH a reason passes" \
+  python3 "$GUARD" --check "$TMP/exempt.py"
+
+# The pattern appearing as DATA must never trip: a docstring describing the bug,
+# or a test fixture stored as a source string. This is why the guard parses
+# instead of grepping - and it is what lets the guard scan its own tree without
+# an exclusion list that could silently grow.
+cat > "$TMP/as_data.py" <<'PY'
+"""The old code read os.environ.get("VAULT_ROOT", str(Path.home() / "vault"))."""
+FIXTURE = '''
+import os
+VAULT = os.environ.get("VAULT_ROOT", "~/vault")
+'''
+PY
+run "clean control: the pattern quoted as data (docstring/fixture) never trips" \
+  python3 "$GUARD" --check "$TMP/as_data.py"
+
+# ---- the ratchet: new fails, exact reviewed bytes pass, edited fails again --
+mkdir -p "$TMP/repo/hooks"
+git -C "$TMP/repo" init -q
+cp "$TMP/naive.py" "$TMP/repo/hooks/legacy.py"
+: > "$TMP/repo/baseline.txt"
+# A NAMED error, not a traceback. Caught live while writing this suite: an
+# unpinned new file raised KeyError out of the stale-row computation, which
+# still exits non-zero -- so a bare "did it fail?" assertion went green on a
+# crash. "Fails CI with a named error" is the actual requirement, so assert the
+# message, and assert the crash signature is absent.
+new_out="$(python3 "$GUARD" --all --root "$TMP/repo" --baseline "$TMP/repo/baseline.txt" 2>&1)"
+new_rc=$?
+if [ "$new_rc" -ne 0 ] \
+   && printf '%s' "$new_out" | grep -q 'naive VAULT_ROOT read' \
+   && ! printf '%s' "$new_out" | grep -q 'Traceback'; then
+  ok "fleet ratchet: an unpinned new naive read trips with a NAMED error"
+else
+  bad "fleet ratchet: unpinned new read must fail with a named error, not a crash (rc=$new_rc)"
+fi
+
+python3 - "$TMP/repo/hooks/legacy.py" "$TMP/repo/baseline.txt" <<'PY'
+import hashlib, sys
+from pathlib import Path
+src = Path(sys.argv[1])
+Path(sys.argv[2]).write_text(
+    f"{hashlib.sha256(src.read_bytes()).hexdigest()} SEV-A-home-vault hooks/legacy.py\n"
+)
+PY
+run "fleet ratchet: exact reviewed legacy bytes pass" \
+  python3 "$GUARD" --all --root "$TMP/repo" --baseline "$TMP/repo/baseline.txt"
+
+printf '\n# edited after review\n' >> "$TMP/repo/hooks/legacy.py"
+trips "fleet ratchet: EDITING a pinned legacy file trips it again" \
+  python3 "$GUARD" --all --root "$TMP/repo" --baseline "$TMP/repo/baseline.txt"
+
+# A row whose file became clean must also fail: the backlog has to shrink by
+# DELETING the row, not by leaving a dead one behind that hides a re-added read.
+cat > "$TMP/repo/hooks/legacy.py" <<'PY'
+import os
+def _resolve_vault_root():
+    return os.environ.get("VAULT_ROOT")
+PY
+trips "fleet ratchet: a baseline row for a now-clean file is STALE and trips" \
+  python3 "$GUARD" --all --root "$TMP/repo" --baseline "$TMP/repo/baseline.txt"
+
+# ---- the pin must describe CONTENT, not the checkout ------------------------
+# This repo has no .gitattributes, so a Windows clone with core.autocrlf=true has
+# CRLF on disk while the Linux CI runner has LF. A raw-bytes hash pinned on one
+# platform is 100% stale on the other -- the whole baseline reds the build with
+# no real violation behind it. (Not hypothetical: the unnormalized
+# scripts/cloud-safe-walker-baseline.txt reports every row stale on a Windows
+# checkout today.) The pin is over newline-normalized source; this proves it.
+if python3 - "$GUARD" <<'PY'
+import importlib.util, sys, tempfile
+from pathlib import Path
+spec = importlib.util.spec_from_file_location("cvr", sys.argv[1])
+cvr = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cvr)
+body = b'import os\nfrom pathlib import Path\nV = os.environ.get("VAULT_ROOT", "x")\n'
+tmp = Path(tempfile.mkdtemp())
+out = {}
+for name, data in (("lf", body), ("crlf", body.replace(b"\n", b"\r\n"))):
+    p = tmp / f"{name}.py"
+    p.write_bytes(data)
+    violations, digest = cvr.scan_file(p, name)
+    out[name] = (digest, len(violations))
+assert out["lf"][0] == out["crlf"][0], f"hash differs across line endings: {out}"
+assert out["lf"][1] == out["crlf"][1] == 1, f"violation count differs: {out}"
+PY
+then
+  ok "baseline hash is line-ending independent (CRLF checkout == LF checkout)"
+else
+  bad "baseline hash changes with line endings - the ratchet would red on the other platform"
+fi
+
+# ---- blindness checks: the guard must not silently stop covering anything ---
+
+# 1. The real fleet scan must actually match files. A pathspec typo or a repo
+#    reshuffle would make this pass vacuously forever.
+scanned="$(python3 "$GUARD" --all 2>/dev/null | sed -n 's/.*OK (\([0-9]*\) file(s) scanned.*/\1/p')"
+if [ -n "$scanned" ] && [ "$scanned" -gt 50 ] 2>/dev/null; then
+  ok "fleet scan is live ($scanned scripts/ + hooks/ files in scope)"
+else
+  bad "fleet scan matched ${scanned:-0} files - the pathspec went blind, or the gate is red"
+fi
+
+# 2. Every sanctioned resolver name must still be a real def in the tree. A name
+#    kept after its function was renamed is a permanent hole nobody can see.
+missing_resolver=""
+for fn in _resolve_vault_root resolve_vault_root vault_root_for; do
+  if ! grep -rqE "^[[:space:]]*def[[:space:]]+$fn\b" "$ROOT/scripts" "$ROOT/hooks" 2>/dev/null; then
+    missing_resolver="$missing_resolver $fn"
+  fi
+done
+if [ -z "$missing_resolver" ]; then
+  ok "every sanctioned resolver name still exists as a def"
+else
+  bad "sanctioned name(s) with no def -- stale exemption:$missing_resolver"
+fi
+
+# 3. The baseline rows must still be REAL violations. If they were already clean
+#    the ratchet would be pinning nothing and the backlog count would be a lie.
+pinned_file="$(awk '$1 ~ /^[0-9a-f]{64}$/ {print $3; exit}' "$BASELINE" 2>/dev/null)"
+if [ -z "$pinned_file" ]; then
+  ok "baseline is empty - the backlog is cleared (nothing left to pin)"
+elif [ ! -f "$ROOT/$pinned_file" ]; then
+  bad "baseline names a missing file: $pinned_file"
+else
+  trips "baseline rows are real violations (spot-check: $pinned_file)" \
+    python3 "$GUARD" --check "$ROOT/$pinned_file"
+fi
+
+# 4. Wired, not merely present. The dormant-guard class this repo keeps hitting
+#    is a check that exists, passes locally, and runs in no CI job.
+if grep -q "check-vault-root-reads.py" "$ROOT/scripts/ci.sh"; then
+  ok "guard is wired into scripts/ci.sh"
+else
+  bad "guard is NOT wired into scripts/ci.sh - it would never run pre-push"
+fi
+if grep -q "check-vault-root-reads.py" "$ROOT/.github/workflows/lint.yml"; then
+  ok "guard is wired into .github/workflows/lint.yml"
+else
+  bad "guard is NOT wired into .github/workflows/lint.yml - it would never run in CI"
+fi
+
+if [ "$FAIL" -ne 0 ]; then
+  echo "FAILED: $FAIL"
+  exit 1
+fi
+echo "ALL TESTS PASSED"


### PR DESCRIPTION
Closes MYC-2505.

## Why this is a lint and not another fix

MYC-2439 fixed 3 scripts. MYC-2504 fixes 5 more. Both are *instance* remediation. The root cause is that a globally-exported `VAULT_ROOT` names exactly **one** vault, so any naive read silently redirects — and it fails two ways, both silent:

1. **Unset** — the near-universal `Path.home() / "vault"` default is wrong for every vault not literally named `vault`. A guard written this way is inert on essentially every install, and says nothing while it is.
2. **Set** — the env var wins over the vault the caller actually meant. A file written into vault B resolves against vault A, the containment check returns False, and the guard skips the very file it exists for.

`hooks/validate-handoff-frontmatter.py` shipped exactly that way and was inert everywhere (#375/#404). Two unrelated users had already hand-patched it identically, each hardcoding their own absolute vault path. When two people patch a defect the same way, the upstream default is the bug.

This is the third layer — immediate remediation, then per-script hardening, then a **class-level guard** — and the twin of `scripts/check-meta-resolution.sh` (the naive `*Meta` glob ban).

## The rule

A read of `VAULT_ROOT` (`os.environ.get`, `os.getenv`, `os.environ[...]`) is a violation unless:

1. it is inside a **sanctioned resolver definition** (`_resolve_vault_root`, `resolve_vault_root`, `vault_root_for`), or
2. it is an **argument to** one — the `hooks/_lib/vault_root.py` contract, where the env var is the fallback *behind* detection, or
3. it carries `# vault-root-ok: <reason>`. **An empty reason is itself a violation** — an exemption that does not say why is a rubber stamp.

The sanctioned pattern differs by surface, and the difference is the whole point: a **script** serves one vault, so `_resolve_vault_root()` prefers the script's own location. A **hook** fires on files in *any* vault, so it must resolve **per target file**, with the env var only as fallback — a hook is the higher-severity surface, because a wrong root makes it fail silently **open**.

### It parses instead of grepping

The twin is a regex over shell; this one is over Python, where the banned pattern legitimately appears as **data** — in a docstring describing the bug, in a fixture stored as a source string. Parsing means a string is a string, so the guard needs no self-exclusion list and cannot be defeated by moving a fixture. Real `.py` fixtures under `tests/` are additionally outside the fleet scope (`scripts/` + `hooks/`). Both fixture styles have controls.

It also resolves module-level string constants. That caught a read a literal-only rule misses — `hooks/scan-prior-sessions-for-secrets.py` reads via `VAULT_ROOT_ENV = "VAULT_ROOT"` — so the guard does not ship with a one-line bypass.

## Violator survey (the full population)

**52 unsanctioned reads across 51 files** — substantially more than the ticket implies.

**Fixed in this PR: 0.** The ticket is explicit that instance remediation belongs to MYC-2439/MYC-2504; rewriting 51 files here would collide with that work.

**Exempted in source: 2, both genuinely correct.**

| File | Line | Why it is correct as-is |
|---|---|---|
| `hooks/scan-prior-sessions-for-secrets.py` | 128 | `VAULT_ROOT` is an explicit **opt-in switch** for auto-scrub, not vault detection (its own "Environment" block says "**Required for auto-scrub**"). No `~/vault` default: unset returns `None` and the hook drops to warn-only, the safe mode. *Detecting* a vault would silently **enable** in-place redaction on a vault the user never opted into. |
| `scripts/install-hooks-user-level.py` | 1017 | The installer runs before its target vault is resolvable from anything else — it does not live in a vault (no script-location signal) and has no target file (no per-file signal). `--vault-path` is the explicit override, and the default is `None`, not `~/vault`: unset simply skips `[VAULT_PATH]` substitution rather than pointing at a wrong vault. |

**Byte-pinned in `scripts/vault-root-read-baseline.txt`: 50 files / 52 reads**, severity-tagged, as the remediation backlog. Same hash-ratchet mechanism as `scripts/cloud-safe-walker-baseline.txt`. This is **not** a set of silent pardons: a pinned file passes only while byte-identical, so **any** edit forces remediation, and a **new** file is never pinned and fails on its first read. Tags are derived mechanically from the default expression, not eyeballed:

| Tag | Files | What happens when unset |
|---|---:|---|
| `SEV-A-home-vault` | 12 | Defaults to `~/vault` — inert on every vault not named `vault`. **All 12 are in `hooks/`**, the fail-silently-open surface. This is the exact shape of #375/#404. |
| `SEV-B-cwd` | 16 | Defaults to process cwd — right often enough to look fine. |
| `SEV-C-script-loc` | 6 | Defaults from `__file__` (the *right* default); what is missing is the env-var-disagrees guard `_resolve_vault_root()` adds. |
| `SEV-D-cli-default` | 1 | argparse `default=` with an explicit CLI override. |
| `SEV-E-no-default` | 15 | No default; failure moves to the caller. |

The baseline header states the rule that keeps it a backlog: **rows only ever get deleted.** Re-pinning an edited file to keep it quiet converts the backlog into a permanent exemption, and there is a test asserting that a row left behind after its file went clean is STALE and fails.

## Negative-control evidence

Non-tautology — identical fixture, rule reverted:

```
=== [1] WITH the lint: fixture must go RED ===
::error::naive VAULT_ROOT read(s):
  naive.py:3: naive VAULT_ROOT read outside a sanctioned resolver
      VAULT = Path(os.environ.get("VAULT_ROOT", str(Path.home() / "vault")))
rc=1

=== [2] Lint REVERTED (rule disabled, everything else identical) ===
vault-root reads: OK (1 file(s) scanned)
rc=0
```

The ticket's done criterion — a brand-new hook fails with a **named** error:

```
::error::naive VAULT_ROOT read(s) - resolve through a sanctioned resolver:
  hooks/zz-brand-new-hook.py:3: naive VAULT_ROOT read outside a sanctioned resolver
      VAULT = Path(os.environ.get("VAULT_ROOT", str(Path.home() / "vault")))

  Fix, by surface:
    script (serves ONE vault):  _resolve_vault_root() -- prefer the script's own location ...
    hook (fires on ANY vault):  resolve per TARGET FILE first, env var as fallback ...
    genuinely correct as-is:  add `# vault-root-ok: <reason>` on the line above.
rc=1
```

An **edited** pinned file fails too:

```
  hooks/vault-context.py:12: naive VAULT_ROOT read outside a sanctioned resolver
  STALE BASELINE hooks/vault-context.py: file changed, became clean, or was removed.
      Adopt the resolver (or `# vault-root-ok: <reason>`), then delete
      this row -- do NOT re-pin an edited file to keep it exempt.
```

Full suite — 22 assertions, all green:

```
PASS  guard built-in positive/negative controls
PASS  real scripts/ + hooks/ fleet matches the reviewed hash ratchet
PASS  negative control: naive ~/vault-defaulting read trips the guard
PASS  negative control: os.getenv form trips the guard
PASS  negative control: os.environ[...] form trips the guard
PASS  negative control: read indirected through a module constant trips
PASS  negative control: vault-root-ok with no reason is itself a violation
PASS  clean control: read inside _resolve_vault_root passes
PASS  clean control: per-file hook resolver (detection first) passes
PASS  clean control: env var passed INTO resolve_vault_root passes
PASS  clean control: vault-root-ok WITH a reason passes
PASS  clean control: the pattern quoted as data (docstring/fixture) never trips
PASS  fleet ratchet: an unpinned new naive read trips with a NAMED error
PASS  fleet ratchet: exact reviewed legacy bytes pass
PASS  fleet ratchet: EDITING a pinned legacy file trips it again
PASS  fleet ratchet: a baseline row for a now-clean file is STALE and trips
PASS  baseline hash is line-ending independent (CRLF checkout == LF checkout)
PASS  fleet scan is live (270 scripts/ + hooks/ files in scope)
PASS  every sanctioned resolver name still exists as a def
PASS  baseline rows are real violations (spot-check: hooks/auto-capture-public-ships.py)
PASS  guard is wired into scripts/ci.sh
PASS  guard is wired into .github/workflows/lint.yml
ALL TESTS PASSED
```

Mirroring `test_vault_backup_conf_bom.sh`, the last five **fail loud when the guard goes blind** rather than only when it is wrong: a fleet scan matching nothing, a sanctioned resolver name whose `def` no longer exists (a permanent hole nobody can see), a baseline row that is no longer a real violation, and the guard being unwired from either gate.

## Two bugs found while building this

**1. A test that was green on a crash.** An unpinned new file raised `KeyError` out of the stale-row computation. That still exits non-zero, so a bare "did it fail?" assertion passed — on a traceback. Fixed, and the test now asserts the named error *and* the absence of `Traceback`. "Fails CI with a named error" is the requirement; "fails" is not.

**2. The baseline pin was platform-dependent.** This repo has no `.gitattributes`, so a Windows clone (`core.autocrlf=true`) has CRLF on disk while the Linux runner has LF. A raw-bytes pin generated on one platform is **100% stale** on the other — the entire baseline would red the build with no violation behind it. The first cut of this baseline hashed `hooks/vault-context.py` to `a41dacba` (CRLF) where the runner sees `792c1593` (LF). The pin is now over newline-normalized source, with a test locking it.

Verified by cloning this branch with `core.autocrlf=false` — an exact LF simulation of the runner:

```
hooks/vault-context.py CR= 0 LF= 120
=== (e3) gate on the LF tree (this is what CI will run) ===
vault-root reads: OK (270 file(s) scanned; 50 byte-pinned legacy file(s), 52 pinned read(s))  rc=0
=== cloud-safe ratchet on the LF tree ===
CLEAN fleet: 322 Python files; 41 byte-pinned legacy exception(s)
ALL TESTS PASSED
```

> Pre-existing, not addressed here: `scripts/cloud-safe-walker-baseline.txt` hashes **unnormalized**, and reports *every* row stale on a Windows checkout today. Its rows are correct for the Linux runner, so CI is unaffected, but the local pre-push gate cannot pass on Windows. Worth its own ticket.

## Wiring

- **`scripts/ci.sh` gate `(e3)`**, immediately after `(e2)` hook block-protocol from #405 — same SILENT-NO-OP family, and #405 confirmed `(e2)` is the right neighborhood. Documented in the header block alongside `(a)`-`(f)`.
- **`.github/workflows/lint.yml`**, two steps beside the Meta-glob twin: `--self-test` first (cheap, and proves the guard still bites before it is believed), then the tree scan. Matches how `ci-cost-audit` and `check-hook-emission-channel` are wired.
- **`INTEGRATION_TESTS`** gains `test_vault_root_read_guard` (gate-coverage invariant verified: 90 test files, 90 listed, none missing).
- **Ships as substrate** the same way the twin does — the repo *is* the installed skill, so `scripts/` and the workflow travel with every client install.

`scripts/cloud-safe-walker-baseline.txt` has one row refreshed: the exemption comment changed the bytes of a file pinned there. Its walker behavior is unchanged and it stays pinned.

## Local gate status, honestly

Green: `py_compile` (322 files), the gate-coverage invariant, `(e)` UTF-8 console guard, `(e2)` block-protocol, `(e3)` the new gate, the new suite, the cloud-safe ratchet on an LF tree, `bash -n`, YAML parse, ASCII purity, open-core boundary.

`bash scripts/ci.sh` does **not** complete on the Windows dev box — it stops at gate (b) on `test_bootstrap_dry_run`, and `scripts/test_auto_gc_default_on.py`, `scripts/test_high_rise_pin.py`, `hooks/test_live_session_reap.py` also fail there. **All four fail identically on pristine `c39ca7e` with this branch stashed** — pre-existing environment limits, not this change. CI on ubuntu is authoritative for those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
