### PR TITLE
fix: vault frontmatter lint denies every Write on Windows

### DIFF
--- a/hooks/lint-vault-frontmatter.py
+++ b/hooks/lint-vault-frontmatter.py
@@ -212,7 +212,15 @@ def main() -> int:
     # Write projected content to a temp file and call validator
     import subprocess
     import tempfile
-    with tempfile.NamedTemporaryFile(suffix=".md", mode="w", delete=False, encoding="utf-8") as tf:
+    # newline="" is REQUIRED, not cosmetic. Without it, Python text mode on
+    # Windows rewrites every "\n" to "\r\n" as it writes. The validator then
+    # reads this file through safe_read_text, which decodes BYTES directly
+    # (no universal-newline translation), so it sees the injected "\r\n" and
+    # its LF-only frontmatter regex fails — denying every Write/Edit of a
+    # vault .md file on Windows regardless of content. Preserve bytes exactly.
+    with tempfile.NamedTemporaryFile(
+        suffix=".md", mode="w", delete=False, encoding="utf-8", newline=""
+    ) as tf:
         # Adjust path so detect_type in validator finds the right schema
         tf.write(projected)
         tmp_path = tf.name

--- a/scripts/vault-root-read-baseline.txt
+++ b/scripts/vault-root-read-baseline.txt
@@ -77,7 +77,6 @@ a826003cdacfbeefdfe8019947632e71fb369ae9a5905d7dcce5a947b94b60ee SEV-B-cwd scrip
 30efd1751a2a773b931fb67a12214db06bc8b9820fe49f48028236b42450659d SEV-B-cwd scripts/stale-rule-check.py
 c27dc2a06172b75ca4ed910c9da19b8e45761fd44908161a1fb42afdfd65fcd7 SEV-B-cwd scripts/undo-last-close.py
 8a1bf7b92664f946386b6af0e61b03042422f132d8f0f79b830aecd314385b17 SEV-B-cwd scripts/vault-hygiene.py
-e2db75570334b975049b27838715b8d7c201a996c26cb1287eb9e6f9b11fb0ad SEV-B-cwd scripts/vault-schema-validator.py
 
 # ---- SEV-C-script-loc  (6 file(s), 6 read(s)) ----
 f874491253a72291559c34c46187adf5b74c2ea305ef8ae59343debc784410ee SEV-C-script-loc scripts/compress-vault-doc.py

--- a/scripts/vault-schema-validator.py
+++ b/scripts/vault-schema-validator.py
@@ -359,6 +359,12 @@ def run_self_test() -> int:
 
 def main() -> int:
     ap = argparse.ArgumentParser()
+    # vault-root-ok: CLI default for an explicit --vault-root flag on a standalone
+    # validator that checks ANY vault by path. This script ships in the skill dir and
+    # is never itself inside a vault, so a location-derived _resolve_vault_root() would
+    # resolve to the skill rather than to the vault under test. In --file mode (how
+    # lint-vault-frontmatter.py invokes it) the value is computed but never read: the
+    # --file branch resolves the target path directly. Caller always wins.
     ap.add_argument("--vault-root", default=os.environ.get("VAULT_ROOT", os.getcwd()))
     ap.add_argument("--type", choices=["decision", "session", "journal", "all"], default="all")
     ap.add_argument("--file", help="validate one specific file")

--- a/scripts/vault-schema-validator.py
+++ b/scripts/vault-schema-validator.py
@@ -101,7 +101,12 @@ def extract_frontmatter(text: str) -> tuple[str | None, str | None]:
     """Return (frontmatter_text, error_message_or_None)."""
     if not text.startswith("---"):
         return (None, None)  # no frontmatter, that's fine for many files
-    m = re.match(r"^---\n(.*?)\n---\s*", text, re.DOTALL)
+    # \r?\n throughout: this text arrives from safe_read_text, which decodes
+    # bytes directly with no universal-newline translation. A vault authored or
+    # touched on Windows genuinely contains CRLF on disk (the session-close
+    # cascade's own pre-built session shell is one), so an LF-only pattern
+    # reports perfectly valid frontmatter as unterminated.
+    m = re.match(r"^---\r?\n(.*?)\r?\n---\s*", text, re.DOTALL)
     if not m:
         return (None, "frontmatter delimiter '---' not properly closed")
     return (m.group(1), None)


### PR DESCRIPTION
On Windows the frontmatter linter rejected **every** `Write`/`Edit`/`MultiEdit` to a vault `.md` file with frontmatter — 100% of the time, regardless of whether the content was valid. The file being written was fine; the check corrupted it in transit and then failed its own check.

## Chain

1. `hooks/lint-vault-frontmatter.py` wrote the projected content to a temp file with `mode="w"` and no `newline=""`, so Python text mode rewrote every `\n` as `\r\n` on Windows.
2. `scripts/vault-schema-validator.py` reads that file via `safe_read_text`, which decodes **bytes** directly — no universal-newline translation — so it saw the injected `\r\n`.
3. Its frontmatter regex was LF-only, so it reported valid frontmatter as `delimiter '---' not properly closed` and the hook denied the write.

## Fix

Two independent changes, both wanted:

- `newline=""` on the temp write, so the linter stops mutating content it is only supposed to inspect.
- `\r?\n` in the validator regex, because a vault authored or touched on Windows genuinely contains CRLF on disk — the session-close cascade's own pre-built session shell is one — so the validator must accept it whether or not the linter is in the path.

Either change alone fixes the Write path; the regex change is additionally required for CRLF files already on disk.

## Verification

Reproduced the denial against the real validator, then confirmed all three cases pass: LF via the fixed path, LF via the old path, and a genuine CRLF file on disk.

- `vault-schema-validator.py --self-test` — 11/11
- `tests/integration/test_handoff_frontmatter_guard.sh` — 11/11

Found while running the session-close cascade on Windows, where it blocked the cascade from writing its own session file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)