### PR TITLE
fix(windows): setup registered a backup task that could never run

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -220,7 +220,7 @@ if ($env:EMAIL_GATE_BYPASS -ne "1" -and -not $DryRun -and -not (Test-Path $email
 }
 
 # ─── Pre-flight gate (skip with $env:PREFLIGHT_BYPASS = "1") ──────────────────
-$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$scriptRoot = Split-Path -Parent $PSCommandPath
 $preflightLocal = Join-Path $scriptRoot "scripts\preflight.ps1"
 $preflightInstalled = "$env:USERPROFILE\.claude\skills\ai-brain-starter\scripts\preflight.ps1"
 $preflightToRun = ""

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -184,6 +184,7 @@ INTEGRATION_TESTS=(
   test_vault_safety_guards
   test_vault_backup_conf_bom
   test_backup_staleness_surfaces
+  test_scheduled_task_registration
   test_resource_aware_session_close
   test_cloud_sync_guard
   test_cloud_safe_file_walkers

--- a/scripts/drift-check.ps1
+++ b/scripts/drift-check.ps1
@@ -31,7 +31,7 @@ $OutputEncoding = [System.Text.Encoding]::UTF8
 
 # Self-locate the starter dir from the script's own location
 # scripts\drift-check.ps1 → parent dir is the repo root
-$ScriptDir   = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ScriptDir   = Split-Path -Parent $PSCommandPath
 $StarterDir  = Split-Path -Parent $ScriptDir
 $InstallDir  = "$env:USERPROFILE\.claude\skills"
 $CooldownFile = "$env:USERPROFILE\.claude\.ai-brain-starter-drift-check-last-run"

--- a/scripts/sync-vault-scripts.ps1
+++ b/scripts/sync-vault-scripts.ps1
@@ -29,7 +29,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 $Stamp = Get-Date -Format "yyyy-MM-dd-HHmm"
-$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ScriptDir = Split-Path -Parent $PSCommandPath
 $StarterDir = if ($env:STARTER_DIR) { $env:STARTER_DIR } else { Split-Path -Parent $ScriptDir }
 
 function Note($m) { if (-not $Quiet) { Write-Output $m } }

--- a/scripts/vault-backup.ps1
+++ b/scripts/vault-backup.ps1
@@ -183,17 +183,52 @@ function Cmd-Setup {
   Cmd-Run
 
   if ($Schedule -eq "daily") {
+    $taskName = "ai-brain-starter vault-backup $slug"
     try {
-      $self = $MyInvocation.MyCommand.Path
-      $action  = New-ScheduledTaskAction -Execute "pwsh" -Argument "-NoProfile -File `"$self`" run -Vault `"$v`""
+      # $PSCommandPath, NOT $MyInvocation.MyCommand.Path. We are inside a
+      # function, where the latter describes the FUNCTION's invocation and is
+      # EMPTY - so this registered `-File ""` and the task could never run.
+      $self = $PSCommandPath
+      if (-not $self) { throw "cannot resolve this script's own path" }
+
+      # pwsh is PowerShell 7 and is NOT on a stock Windows install; the task
+      # then dies with 0x80070002 (file not found) on the INTERPRETER.
+      $exe = (Get-Command pwsh -ErrorAction SilentlyContinue).Source
+      if (-not $exe) { $exe = (Get-Command powershell.exe -ErrorAction SilentlyContinue).Source }
+      if (-not $exe) { throw "no PowerShell interpreter found on PATH" }
+
+      $action  = New-ScheduledTaskAction -Execute $exe -Argument "-NoProfile -ExecutionPolicy Bypass -File `"$self`" run -Vault `"$v`""
       $trigger = New-ScheduledTaskTrigger -Daily -At 3am
-      Register-ScheduledTask -TaskName "ai-brain-starter vault-backup $slug" -Action $action -Trigger $trigger -Force | Out-Null
-      Ok "Daily backup scheduled (03:00 local)."
-    } catch { Warn "Could not register a scheduled task; run vault-backup.ps1 run yourself." }
+      # Task Scheduler's DEFAULT settings refuse to start on battery, so on a
+      # laptop the 03:00 run is refused every night (0x800710E0) and the vault
+      # silently goes months without a snapshot. StartWhenAvailable catches up
+      # a window missed while the machine was asleep.
+      $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable
+      Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -Settings $settings -Force | Out-Null
+
+      # Registering is not running. Register-ScheduledTask SUCCEEDS on an action
+      # that can never execute, which is exactly how this shipped broken: setup
+      # printed "Backup is live" over a task that never fired once. Read back
+      # what we actually registered and prove both halves resolve.
+      $reg = (Get-ScheduledTask -TaskName $taskName -ErrorAction Stop).Actions[0]
+      $regFile = [regex]::Match($reg.Arguments, '-File\s+"([^"]+)"').Groups[1].Value
+      if (-not $regFile -or -not (Test-Path -LiteralPath $regFile)) {
+        throw "registered task points at a script path that does not exist: '$regFile'"
+      }
+      if (-not (Get-Command $reg.Execute -ErrorAction SilentlyContinue)) {
+        throw "registered task points at an interpreter that does not resolve: '$($reg.Execute)'"
+      }
+      Ok "Daily backup scheduled (03:00 local), verified runnable."
+    } catch {
+      Warn "Could not register a working scheduled task: $($_.Exception.Message)"
+      Warn "Run it yourself, or re-run setup: $PSCommandPath run -Vault `"$v`""
+    }
   }
   Say ""
   Ok "Backup is live. Now prove it restores (do this once):"
-  Say "    pwsh `"$($MyInvocation.MyCommand.Path)`" verify -Vault `"$v`""
+  $hintExe = (Get-Command pwsh -ErrorAction SilentlyContinue).Source
+  if (-not $hintExe) { $hintExe = "powershell" }
+  Say "    $hintExe `"$PSCommandPath`" verify -Vault `"$v`""
 }
 
 function Cmd-Run {

--- a/tests/integration/test_scheduled_task_registration.sh
+++ b/tests/integration/test_scheduled_task_registration.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Structural regression - the "registered but dead" class.
+#
+# vault-backup.ps1 setup registered a daily task that could never run, on any
+# machine, and then printed "Backup is live." Measured on a real install: 25
+# days with no snapshot. Three independent defects in two lines:
+#
+#   1. `$self = $MyInvocation.MyCommand.Path` INSIDE a function. That variable
+#      describes the FUNCTION's invocation, not the script file, and is EMPTY
+#      there - so the task registered with `-File ""`. `$PSCommandPath` is the
+#      correct spelling and is right at BOTH scopes, which is why this guard
+#      bans the fragile one outright instead of trying to detect scope.
+#   2. `-Execute "pwsh"`. PowerShell 7 is NOT on a stock Windows install, so
+#      the action fails 0x80070002 on the interpreter even given a good path.
+#   3. Default task settings refuse to start on battery, so a laptop's 03:00
+#      run is refused nightly (0x800710E0) and the vault quietly rots.
+#
+# The reason all three survived to a user: `Register-ScheduledTask` SUCCEEDS
+# when handed an action that can never execute. Registration is not execution.
+# So the third check below requires any registrar to read its own work back.
+#
+# Bash only, no network. exit 0 = no registrar can ship dead again.
+set -u
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+fail=0
+
+ps1_files() { git -C "$REPO" ls-files -- '*.ps1' 2>/dev/null; }
+
+# Code only. A guard that cannot tell a banned call from a comment EXPLAINING
+# the ban flags its own documentation - including the comment a few lines up.
+code_hits() { grep -nF -- "$2" "$REPO/$1" 2>/dev/null | grep -vE '^[0-9]+:[[:space:]]*#'; }
+
+# --- 1. $MyInvocation.MyCommand.Path is empty inside a function -------------
+n=0
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  n=$((n + 1))
+  if [ -n "$(code_hits "$f" 'MyInvocation.MyCommand.Path')" ]; then
+    echo "FAIL  \$MyInvocation.MyCommand.Path is EMPTY inside a function:"
+    echo "        $f"
+    echo "        Use \$PSCommandPath - correct at top level AND in a function."
+    fail=1
+  fi
+done < <(ps1_files)
+if [ "$n" -eq 0 ]; then
+  echo "FAIL  found ZERO tracked .ps1 files - this guard is blind."
+  exit 1
+fi
+
+# --- 2. a hardcoded pwsh is a missing interpreter on stock Windows ----------
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  if grep -nE 'New-ScheduledTaskAction[^|]*-Execute[[:space:]]+"?pwsh"?' "$REPO/$f" >/dev/null 2>&1; then
+    echo "FAIL  scheduled task hardcodes 'pwsh', absent on a stock Windows install:"
+    echo "        $f"
+    echo "        Resolve it: pwsh if present, else powershell.exe, else fail loud."
+    fail=1
+  fi
+done < <(ps1_files)
+
+# --- 3. registering is not running: a registrar must verify its own work ----
+regs=0
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  grep -qF 'Register-ScheduledTask' "$REPO/$f" || continue
+  regs=$((regs + 1))
+  if ! grep -qF 'Get-ScheduledTask' "$REPO/$f"; then
+    echo "FAIL  registers a scheduled task but never reads it back:"
+    echo "        $f"
+    echo "        Register-ScheduledTask SUCCEEDS on an action that cannot run."
+    echo "        Read the registration back and prove exe + -File both resolve."
+    fail=1
+  fi
+done < <(ps1_files)
+
+if [ "$fail" -eq 0 ]; then
+  echo "PASS  $n .ps1 file(s): no empty self-path, no hardcoded pwsh, $regs registrar(s) verify their own work"
+  exit 0
+fi
+exit 1


### PR DESCRIPTION
## Severity

**Every Windows user who ran `vault-backup.ps1 setup` has a dead daily backup and was told it was live.** Measured on a real install: 25 days, zero snapshots, while setup printed `Backup is live.` and `/diagnose` reported the vault backed up. The only snapshot on disk was the one setup took by hand.

## Three independent defects, two lines

```powershell
$self = $MyInvocation.MyCommand.Path
$action = New-ScheduledTaskAction -Execute "pwsh" -Argument "-NoProfile -File `"$self`" run ..."
```

**1. `$MyInvocation.MyCommand.Path` inside a function is empty.** There it describes the *function's* invocation, not the script file. The task registered with `-File ""`. Verified rather than asserted:

```
top level      MyInvocation.MyCommand.Path = [...\t.ps1]
in a function  MyInvocation.MyCommand.Path = []
in a function  PSCommandPath               = [...\t.ps1]
```

**2. `pwsh` is not on a stock Windows install.** PowerShell 7 is a separate download; Windows ships `powershell.exe`. Even with a correct path the action dies `0x80070002` on the interpreter.

**3. Default task settings refuse to start on battery.** `DisallowStartIfOnBatteries` is on by default, so a laptop's 03:00 run is refused nightly (`0x800710E0`).

Any **one** of these is total, silent backup loss. Observed order on the reporting machine: clear the battery block → `0x80070002` → find `-File ""` **and** a missing `pwsh`.

## Why all three shipped

`Register-ScheduledTask` **succeeds** when handed an action that can never execute. Registration is not execution, so setup had no way to be wrong out loud.

Setup now reads its own registration back and proves the interpreter and the `-File` path both resolve before claiming success. A failure names which half broke instead of printing reassurance.

## Scope

`$PSCommandPath` is correct at **both** scopes, so the three top-level uses (`bootstrap.ps1`, `drift-check.ps1`, `sync-vault-scripts.ps1`) move to it as well. They work today, but break silently the moment anyone wraps them in a function — and it lets the guard be absolute, with no exemptions to maintain.

## The guard

`tests/integration/test_scheduled_task_registration.sh` locks all three halves: no `$MyInvocation.MyCommand.Path` in any tracked `.ps1`, no hardcoded `pwsh` in a task action, and any file calling `Register-ScheduledTask` must also call `Get-ScheduledTask` to verify its own work.

**It caught my own first pass.** I had grepped `scripts/` and missed `bootstrap.ps1` at the repo root — the same *"a guard's scan scope IS its blind spot"* shape as MYC-603. It also skips comment lines, or it would flag the comment explaining the ban.

Evidence:

```
pre-fix main:  FAIL x3  (empty self-path, hardcoded pwsh, no read-back)
after fix:     PASS  11 .ps1 file(s)
planted 1 bad line in a clean tree:  exactly 1 FAIL, naming scripts/planted.ps1
```

Also confirmed green after these edits: `check-utf8-stdout.py` (159 scripts, incl. the widened predicate from #408) and `check-vault-root-reads.py` (from #407).

The repaired task then ran on the reporting machine with result `0x00000000` and produced a real snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)