### PR TITLE
fix(ci): pin the cloud-safe walker ratchet to content, not the checkout

### DIFF
--- a/scripts/check-cloud-safe-file-walkers.py
+++ b/scripts/check-cloud-safe-file-walkers.py
@@ -588,11 +588,24 @@ def evaluate(source: str, filename: str = "<memory>") -> dict:
     return {"ok": not findings, "parse_error": None, "findings": findings}
 
 
+def normalize(source: str) -> str:
+    """CRLF/CR -> LF.
+
+    The ratchet hash MUST be identical on every checkout or the pin is useless.
+    This repo has no .gitattributes, so a Windows clone with core.autocrlf=true
+    has CRLF on disk while the Linux CI runner has LF.  A raw-decode hash pinned
+    on one platform is 100% stale on the other: every reviewed row reds the gate
+    with no real violation behind it, which trains maintainers to ignore it.
+    Normalizing makes the pin describe the CONTENT, not the checkout.
+    """
+    return source.replace("\r\n", "\n").replace("\r", "\n")
+
+
 def check_file(path: Path) -> tuple[int, dict]:
     result = safe_read_text(path, timeout=5.0, max_bytes=1_000_000)
     if not result.ok:
         return 2, {"ok": False, "read_error": result.status, "findings": []}
-    source = result.text or ""
+    source = normalize(result.text or "")
     verdict = evaluate(source, str(path))
     verdict["sha256"] = hashlib.sha256(source.encode("utf-8")).hexdigest()
     if verdict.get("parse_error"):
@@ -678,7 +691,7 @@ def check_all(root: Path, baseline_path: Path) -> int:
         return 1
     print(
         f"CLEAN fleet: {len(relative_files)} Python files; "
-        f"{len(current_unsafe)} byte-pinned legacy exception(s)"
+        f"{len(current_unsafe)} content-pinned legacy exception(s)"
     )
     return 0
 

--- a/tests/integration/test_cloud_safe_file_walkers.sh
+++ b/tests/integration/test_cloud_safe_file_walkers.sh
@@ -49,7 +49,7 @@ else
 fi
 
 # The repo-wide gate must catch a brand-new unsafe file, allow only the exact
-# reviewed legacy bytes, then bite again when that legacy file changes.
+# reviewed legacy content, then bite again when that legacy file changes.
 git -C "$TMP" init -q
 : > "$TMP/baseline.txt"
 if python3 "$GUARD" --all --root "$TMP" --baseline "$TMP/baseline.txt" >/dev/null 2>&1; then
@@ -61,15 +61,64 @@ python3 - "$TMP/unsafe.py" "$TMP/baseline.txt" <<'PY'
 import hashlib, sys
 from pathlib import Path
 source = Path(sys.argv[1])
-Path(sys.argv[2]).write_text(f"{hashlib.sha256(source.read_bytes()).hexdigest()} unsafe.py\n")
+# Mirror the guard's own pin: newline-normalized content, not raw bytes. The
+# heredoc above happens to write LF, so this row would match either way today --
+# normalizing keeps the fixture honest instead of accidentally correct.
+content = source.read_bytes().replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+Path(sys.argv[2]).write_text(f"{hashlib.sha256(content).hexdigest()} unsafe.py\n")
 PY
-run "fleet ratchet: exact reviewed legacy bytes pass" \
+run "fleet ratchet: exact reviewed legacy content passes" \
   python3 "$GUARD" --all --root "$TMP" --baseline "$TMP/baseline.txt"
 printf '\n# changed after review\n' >> "$TMP/unsafe.py"
 if python3 "$GUARD" --all --root "$TMP" --baseline "$TMP/baseline.txt" >/dev/null 2>&1; then
   bad "fleet ratchet: edited legacy walker trips"
 else
   ok "fleet ratchet: edited legacy walker trips"
+fi
+
+# ---- the pin must describe CONTENT, not the checkout ------------------------
+# This repo has no .gitattributes, so a Windows clone with core.autocrlf=true has
+# CRLF on disk while the Linux CI runner has LF. A raw-decode hash pinned on one
+# platform is 100% stale on the other -- the whole baseline reds the local gate
+# with no real violation behind it, which silently trains Windows maintainers to
+# ignore that gate. (Not hypothetical: before the fix, all 41 reviewed rows in
+# scripts/cloud-safe-walker-baseline.txt reported STALE on a Windows checkout
+# while CI on ubuntu stayed green.) The pin is over newline-
+# normalized source; same body as LF and as CRLF must hash identically.
+if python3 - "$GUARD" <<'PY'
+import importlib.util, shutil, sys, tempfile
+from pathlib import Path
+spec = importlib.util.spec_from_file_location("walkers", sys.argv[1])
+walkers = importlib.util.module_from_spec(spec)
+# Register before exec: the guard defines @dataclass at module scope, and
+# dataclasses resolves the owning module out of sys.modules while decorating.
+sys.modules[spec.name] = walkers
+spec.loader.exec_module(walkers)
+body = (
+    b"import os\n"
+    b"def scan(root):\n"
+    b"    for base, dirs, files in os.walk(root):\n"
+    b"        open(files[0]).read()\n"
+)
+tmp = Path(tempfile.mkdtemp())
+try:
+    out = {}
+    for name, data in (("lf", body), ("crlf", body.replace(b"\n", b"\r\n"))):
+        path = tmp / f"{name}.py"
+        path.write_bytes(data)
+        rc, verdict = walkers.check_file(path)
+        out[name] = (verdict["sha256"], rc, len(verdict["findings"]))
+    assert out["lf"][0] == out["crlf"][0], f"hash differs across line endings: {out}"
+    # A matching hash on two clean files would pass vacuously; pin a real finding.
+    assert out["lf"][1] == out["crlf"][1] == 1, f"verdict differs: {out}"
+    assert out["lf"][2] == out["crlf"][2] == 1, f"finding count differs: {out}"
+finally:
+    shutil.rmtree(tmp, ignore_errors=True)
+PY
+then
+  ok "baseline hash is line-ending independent (CRLF checkout == LF checkout)"
+else
+  bad "baseline hash changes with line endings - the ratchet would red on the other platform"
 fi
 
 cat > "$TMP/metadata.py" <<'PY'


### PR DESCRIPTION
## The defect

`scripts/check-cloud-safe-file-walkers.py` hashed the raw decoded source:

```python
verdict["sha256"] = hashlib.sha256(source.encode("utf-8")).hexdigest()
```

`source` came from `safe_read_text()` — a raw decode with no newline normalization. The repo has no `.gitattributes`, so a Windows clone with `core.autocrlf=true` has CRLF on disk while the Linux CI runner has LF. Identical content, two different digests.

So the baseline described **the checkout**, not the file.

## Why it mattered

On a Windows checkout, all 41 rows in `scripts/cloud-safe-walker-baseline.txt` reported `STALE`:

```
STALE BASELINE skills/graphify/scripts/graphify_prep.py: file changed, became clean, or was removed; ...
(x41)
```

`tests/integration/test_cloud_safe_file_walkers.sh` runs `--all`, so `bash scripts/ci.sh` — and the `~/.local/bin/ci-test` pre-push gate behind it — could never pass on Windows.

CI on ubuntu stayed green the whole time, because the committed rows are correct for LF. That made this a local-gate-only failure, which is the worst kind: it silently trains Windows maintainers to ignore a gate that is still load-bearing on CI.

## The fix

Normalize newlines before hashing, so the pin describes CONTENT rather than the checkout — the same approach already taken by `scripts/check-vault-root-reads.py` in #407:

```python
def normalize(source: str) -> str:
    return source.replace("\r\n", "\n").replace("\r", "\n")
```

The normalized source feeds both the digest and the AST scan, so the two can never disagree about what was inspected.

Output wording moves from `byte-pinned` to `content-pinned` to match what the pin now actually is.

## The baseline needed no row changes

Confirmed explicitly, as requested. The LF-normalized digest equals the currently committed value for **41/41 rows**, so `scripts/cloud-safe-walker-baseline.txt` is untouched by this PR:

```
rows: 41
LF-normalized match: 41/41  mismatch=0 missing=0
```

`git diff --stat scripts/cloud-safe-walker-baseline.txt` is empty. No row was rewritten, so nothing needed investigating.

## Verification

Same commit, same baseline, on both line-ending regimes:

| checkout | before | after |
|---|---|---|
| Windows, `core.autocrlf=true` (CRLF on disk) | 41/41 rows `STALE`, exit 1 | `CLEAN fleet: 321 Python files; 41 content-pinned legacy exception(s)`, exit 0 |
| simulated Linux CI (`core.autocrlf=false`, LF on disk) | green | green — unchanged |

The LF run was a real local clone checked out with `core.autocrlf=false`, verified to have 0 CRLF on disk before running.

## Regression coverage

Added to `tests/integration/test_cloud_safe_file_walkers.sh`, modelled on the `line-ending independent` test in #407's `test_vault_root_read_guard.sh`. It writes one body as LF and again as CRLF into a temp dir and asserts identical digests:

```
PASS  baseline hash is line-ending independent (CRLF checkout == LF checkout)
```

It also asserts both files produce identical **non-zero** verdicts, so a pair of clean files can't satisfy it vacuously.

Confirmed load-bearing — reverting just the `normalize()` call reds it along with the existing fleet test:

```
FAIL  whole Python fleet matches the reviewed hash ratchet
FAIL  baseline hash changes with line endings - the ratchet would red on the other platform
```

The in-test baseline writer now normalizes too. The heredoc emits LF so that row matched either way, but it was only accidentally correct.

No new test file, so the `INTEGRATION_TESTS` gate list in `scripts/ci.sh` is unchanged.

## `.gitattributes` — deliberately not in this PR

Recommended as a **separate** change. `* text=auto eol=lf` would be reasonable defense in depth (the repo is 100% text — 321 `.py`, 280 `.md`, 168 `.sh`, 30 `.json`, 11 `.ps1`, no tracked binaries), but it does not belong here:

- **It rewrites working trees on next checkout.** 849 of 853 tracked files are currently CRLF in a Windows working tree. Adding it renormalizes essentially the entire repo for every Windows maintainer, entangling ~849 files of churn with a 2-file bugfix and making a bisect painful.
- **It deserves its own commit with an explicit `git add --renormalize .`**, so the rewrite is reviewable in one place instead of happening silently in people's checkouts.
- **It is not needed for correctness here.** `.gitattributes` only helps if every clone honors it and renormalization actually ran; the `normalize()` fix holds regardless of checkout config, which is why it is the right primary fix.

Worth noting for whoever picks it up: the 11 `.ps1` files are the ones to eyeball, given this repo's existing PowerShell BOM sensitivities.

## Pre-existing, unrelated

`hooks/test_safe_read.py` and `hooks/test_worktree_cloud_safe_recovery.py` have 4 failing Windows-environment assertions (`clean regular text is returned`, `regular unique bytes are surfaced from the bounded read`, `recovery copy preserves private source mode`, `local blob hash recognizes content already in Git`). Verified identical at clean `HEAD` with these changes stashed — untouched by this PR, and out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
