### PR TITLE
feat(memory-index): announce what the index could not load (MYC-1763)

### DIFF
--- a/hooks/_lib/memory_index.py
+++ b/hooks/_lib/memory_index.py
@@ -1,0 +1,155 @@
+"""Detect when the Agent Memory index cannot be fully loaded.
+
+The memory index (MEMORY.md) is read into session context. Past a byte cliff the
+reader silently stops, so entries below the cut are never seen — no error, no
+warning, just a brain that quietly forgot part of itself. Write-time tooling
+warns when the index GROWS; a session that only READS it gets a truncated list
+and no signal at all. An index is proven by what LOADS, not by what was written
+to it.
+
+The invariant: **an indexed entry is either loaded, or its omission is
+announced.** Never silently dropped.
+
+Two failure modes:
+
+  OVER-CLIFF   the index is larger than the readable budget, so some entries are
+               already unread this session.
+  UNREACHABLE  a memory file exists that no index references, so it is invisible
+               regardless of size.
+
+Two-tier aware. A corpus of ~1000 memories needs roughly 57KB of link markup
+alone, several times the cliff, so a single flat index physically cannot list
+everything. The supported shape is a capped tier-1 MEMORY.md plus `_index_*.md`
+tier-2 files it links to. A memory indexed in EITHER tier is reachable; checking
+tier 1 alone would report almost every memory in a split vault as missing.
+
+Consumed by `hooks/session-start-context.py` — the loader announces what it
+could not load. It lives here rather than in its own SessionStart hook because
+that event is at its cold-start fan-out budget, and a housekeeping check does
+not earn a new subprocess on every session for the life of the install.
+
+Read-only: never edits an index or a memory file.
+Bypass: MEMORY_INDEX_TRUNCATION_BYPASS=1
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+# The reader stops loading past this many bytes. Entries below the cut are
+# silently unread, which is the whole bug.
+READ_CLIFF_BYTES = 24_400
+
+# Report before the cliff, not at it: at the cliff, entries are ALREADY lost.
+WARN_BYTES = 17_000
+
+# Cap the names listed so a vault with hundreds of unreachable memories still
+# emits a readable message rather than a wall of text.
+MAX_NAMED = 12
+
+LINK_RE = re.compile(r"\]\(([^)]+?\.md)\)")
+
+
+def memory_dirs() -> list:
+    """Candidate Agent Memory directories.
+
+    An override wins outright so tests and non-default layouts never depend on
+    guessing. A symlinked directory resolves fine because glob follows it.
+    """
+    override = os.environ.get("AGENT_MEMORY_DIR")
+    if override:
+        return [Path(override)]
+    return [
+        d for d in (Path.home() / ".claude" / "projects").glob("*/memory")
+        if d.is_dir()
+    ]
+
+
+def _topic_files(mdir: Path) -> list:
+    return sorted(
+        p for p in mdir.glob("*.md")
+        if p.name != "MEMORY.md" and not p.name.startswith("_index_")
+    )
+
+
+def _reachable(mdir: Path, tier1_text: str):
+    """Names reachable from tier 1 plus every tier-2 file, and the tier-2 count."""
+    names = set(LINK_RE.findall(tier1_text))
+    tier2 = sorted(p for p in mdir.glob("_index_*.md") if p.is_file())
+    for sub in tier2:
+        try:
+            names |= set(LINK_RE.findall(sub.read_text(encoding="utf-8", errors="replace")))
+        except OSError:
+            continue
+    return names, len(tier2)
+
+
+def audit(mdir: Path) -> list:
+    """Problems for one memory dir. Empty list = healthy."""
+    tier1 = mdir / "MEMORY.md"
+    if not tier1.exists():
+        return []
+    try:
+        size = tier1.stat().st_size
+        text = tier1.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+
+    problems = []
+    if size > READ_CLIFF_BYTES:
+        problems.append(
+            "MEMORY.md is {:,} bytes, past the {:,}-byte read cliff by {:,}. "
+            "Entries past the cut are NOT being loaded — silently missing, not "
+            "merely at risk.".format(size, READ_CLIFF_BYTES, size - READ_CLIFF_BYTES)
+        )
+    elif size > WARN_BYTES:
+        problems.append(
+            "MEMORY.md is {:,} bytes, over the {:,}-byte budget (cliff {:,}). "
+            "Still fully loaded, but the next few additions start dropping "
+            "entries.".format(size, WARN_BYTES, READ_CLIFF_BYTES)
+        )
+
+    reachable, tier2_count = _reachable(mdir, text)
+    unreachable = [p.name for p in _topic_files(mdir) if p.name not in reachable]
+    if unreachable:
+        shown = ", ".join(unreachable[:MAX_NAMED])
+        more = (" and {} more".format(len(unreachable) - MAX_NAMED)
+                if len(unreachable) > MAX_NAMED else "")
+        tier_note = (
+            " (checked MEMORY.md plus {} tier-2 index file(s))".format(tier2_count)
+            if tier2_count
+            else " (no tier-2 `_index_*.md` files present; a large corpus needs them)"
+        )
+        problems.append(
+            "{} memory file(s) are referenced by NO index{} — invisible to this "
+            "and every future session: {}{}.".format(
+                len(unreachable), tier_note, shown, more)
+        )
+    return problems
+
+
+def report() -> str:
+    """Human-readable announcement, or '' when everything loads."""
+    if os.environ.get("MEMORY_INDEX_TRUNCATION_BYPASS") == "1":
+        return ""
+    lines = []
+    for mdir in memory_dirs():
+        try:
+            problems = audit(mdir)
+        except Exception:
+            continue  # one bad dir must not suppress the others
+        label = mdir.parent.name or str(mdir)
+        for p in problems:
+            lines.append("  [{}] {}".format(label, p))
+    if not lines:
+        return ""
+    return (
+        "**[memory-index]** The memory index cannot be fully loaded. An indexed "
+        "entry is either loaded or its omission is announced — this is the "
+        "announcement.\n\n" + "\n".join(lines) + "\n\n"
+        "Trim the always-loaded index, or split it into a capped MEMORY.md plus "
+        "`_index_*.md` tier-2 files it links to, so nothing is dropped in silence. "
+        "Bypass: MEMORY_INDEX_TRUNCATION_BYPASS=1"
+    )

--- a/hooks/session-start-context.py
+++ b/hooks/session-start-context.py
@@ -53,11 +53,42 @@ CONTEXT = (
 )
 
 
+def _memory_index_warning() -> str:
+    """Announce it when the memory index cannot be fully loaded.
+
+    The loader is the honest place for this. Past a byte cliff the reader
+    silently stops and entries below the cut are never seen; write-time tooling
+    warns when the index grows, but a session that only READS it gets a
+    truncated list and no signal. An index is proven by what LOADS, so the thing
+    doing the loading announces what it could not load.
+
+    Folded in here rather than shipped as its own SessionStart hook: that event
+    is at its cold-start fan-out budget, and a housekeeping check does not earn
+    a new subprocess on every session for the life of the install.
+
+    Fail-open and cheap: any error yields no warning rather than a broken start.
+    """
+    try:
+        import os
+        sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "_lib"))
+        import memory_index
+        return memory_index.report()
+    except Exception:
+        return ""
+
+
 def main() -> int:
+    context = CONTEXT
+    try:
+        warning = _memory_index_warning()
+    except Exception:
+        warning = ""
+    if warning:
+        context = context + "\n\n" + warning
     payload = {
         "hookSpecificOutput": {
             "hookEventName": "SessionStart",
-            "additionalContext": CONTEXT,
+            "additionalContext": context,
         }
     }
     sys.stdout.write(json.dumps(payload))

--- a/hooks/test_memory_index.py
+++ b/hooks/test_memory_index.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Tests for hooks/_lib/memory_index.py and the loader that consumes it.
+
+A guard earns trust only by FAILING on the thing it catches, so every positive
+control is paired with a negative one: a healthy index must stay silent, or the
+guard is noise that trains the reader to ignore it.
+
+Stdlib only. Run: python3 hooks/test_memory_index.py
+Exit 0 = all pass.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HOOKS = Path(__file__).resolve().parent
+sys.path.insert(0, str(HOOKS / "_lib"))
+import memory_index  # noqa: E402
+
+LOADER = HOOKS / "session-start-context.py"
+
+PASS = 0
+FAIL = 0
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    global PASS, FAIL
+    if cond:
+        PASS += 1
+        print("  PASS  " + name)
+    else:
+        FAIL += 1
+        print("  FAIL  " + name + (("\n        " + detail) if detail else ""))
+
+
+def memo(d: Path, name: str) -> None:
+    (d / name).write_text(
+        "---\nname: {}\n---\n\nbody\n".format(name[:-3]), encoding="utf-8")
+
+
+def report_for(d: Path, env_extra=None) -> str:
+    old = os.environ.get("AGENT_MEMORY_DIR")
+    old_bypass = os.environ.get("MEMORY_INDEX_TRUNCATION_BYPASS")
+    os.environ["AGENT_MEMORY_DIR"] = str(d)
+    if env_extra:
+        os.environ.update(env_extra)
+    try:
+        return memory_index.report()
+    finally:
+        if old is None:
+            os.environ.pop("AGENT_MEMORY_DIR", None)
+        else:
+            os.environ["AGENT_MEMORY_DIR"] = old
+        if old_bypass is None:
+            os.environ.pop("MEMORY_INDEX_TRUNCATION_BYPASS", None)
+        else:
+            os.environ["MEMORY_INDEX_TRUNCATION_BYPASS"] = old_bypass
+
+
+def main() -> int:
+    print("memory_index")
+
+    # 1. NEGATIVE CONTROL: a healthy flat index says nothing.
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td)
+        memo(d, "alpha.md")
+        memo(d, "beta.md")
+        (d / "MEMORY.md").write_text(
+            "# Index\n\n- [Alpha](alpha.md) - hook\n- [Beta](beta.md) - hook\n",
+            encoding="utf-8")
+        r = report_for(d)
+        check("healthy flat index is silent", r == "", r[:200])
+
+    # 2. POSITIVE: an unindexed memo is reported, BY NAME.
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td)
+        memo(d, "alpha.md")
+        memo(d, "ghost.md")
+        (d / "MEMORY.md").write_text("# Index\n\n- [Alpha](alpha.md) - hook\n",
+                                     encoding="utf-8")
+        r = report_for(d)
+        check("unreachable memo is reported", r != "")
+        check("unreachable memo is named", "ghost.md" in r, r[:200])
+
+    # 3. TWO-TIER: a memo indexed only in tier 2 is NOT reported. This is the
+    #    regression that makes a split vault unusable if it is missed.
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td)
+        memo(d, "alpha.md")
+        memo(d, "deep.md")
+        (d / "MEMORY.md").write_text(
+            "# Index\n\n- [Alpha](alpha.md) - h\n- [More](_index_misc.md) - tier 2\n",
+            encoding="utf-8")
+        (d / "_index_misc.md").write_text("# Misc\n\n- [Deep](deep.md) - h\n",
+                                          encoding="utf-8")
+        r = report_for(d)
+        check("tier-2-only memo is NOT reported", r == "", r[:300])
+
+    # 4. TWO-TIER negative control: an orphan is still caught when tier 2 exists.
+    #    Guards against "accept everything once any _index_ file is present".
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td)
+        memo(d, "deep.md")
+        memo(d, "ghost.md")
+        (d / "MEMORY.md").write_text("# Index\n\n- [More](_index_misc.md) - tier 2\n",
+                                     encoding="utf-8")
+        (d / "_index_misc.md").write_text("# Misc\n\n- [Deep](deep.md) - h\n",
+                                          encoding="utf-8")
+        r = report_for(d)
+        check("orphan still caught alongside tier 2",
+              "ghost.md" in r and "deep.md" not in r, r[:300])
+
+    # 5. OVER-CLIFF: says entries are already gone, not merely at risk.
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td)
+        memo(d, "alpha.md")
+        pad = "\n".join("- [Pad{}](alpha.md) - {}".format(i, "p" * 60)
+                        for i in range(600))
+        (d / "MEMORY.md").write_text("# Index\n\n- [Alpha](alpha.md) - h\n" + pad,
+                                     encoding="utf-8")
+        r = report_for(d)
+        check("over-cliff is reported", r != "")
+        check("over-cliff says NOT being loaded", "NOT being loaded" in r, r[:300])
+
+    # 6. WARN band: over budget, under cliff -> warns without claiming loss.
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td)
+        memo(d, "alpha.md")
+        pad = "\n".join("- [Pad{}](alpha.md) - {}".format(i, "p" * 60)
+                        for i in range(250))
+        (d / "MEMORY.md").write_text("# Index\n\n- [Alpha](alpha.md) - h\n" + pad,
+                                     encoding="utf-8")
+        size = (d / "MEMORY.md").stat().st_size
+        r = report_for(d)
+        in_band = memory_index.WARN_BYTES < size <= memory_index.READ_CLIFF_BYTES
+        check("warn band is over budget but under cliff", in_band, "size={}".format(size))
+        check("warn band does not claim entries are lost",
+              r != "" and "NOT being loaded" not in r, r[:200])
+
+    # 7. BYPASS silences it.
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td)
+        memo(d, "ghost.md")
+        (d / "MEMORY.md").write_text("# Index\n", encoding="utf-8")
+        r = report_for(d, {"MEMORY_INDEX_TRUNCATION_BYPASS": "1"})
+        check("bypass silences the guard", r == "", r[:200])
+
+    # 8. No MEMORY.md -> silent; not our gap to report.
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td)
+        memo(d, "alpha.md")
+        check("missing MEMORY.md is silent", report_for(d) == "")
+
+    # 9. Nonexistent dir -> silent, never raises.
+    check("nonexistent dir is silent",
+          report_for(Path("/nonexistent/agent/memory")) == "")
+
+    # 10. END-TO-END through the REAL loader: the warning reaches the payload
+    #     the harness actually reads, on stdout. A guard that computed the right
+    #     answer but never reached a reader would be green and mute.
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td)
+        memo(d, "ghost.md")
+        (d / "MEMORY.md").write_text("# Index\n", encoding="utf-8")
+        env = dict(os.environ, AGENT_MEMORY_DIR=str(d))
+        proc = subprocess.run([sys.executable, str(LOADER)], input="{}",
+                              capture_output=True, text=True, env=env)
+        ok = proc.returncode == 0
+        ctx = ""
+        try:
+            ctx = json.loads(proc.stdout)["hookSpecificOutput"]["additionalContext"]
+        except Exception:
+            pass
+        check("loader exits 0", ok, proc.stderr[:200])
+        check("loader payload carries the warning", "ghost.md" in ctx, ctx[-200:])
+        check("loader still carries its own context",
+              "SESSION START" in ctx or "SESSION CLOSE" in ctx, ctx[:200])
+
+    # 11. END-TO-END negative control: healthy dir -> loader emits context only.
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td)
+        memo(d, "alpha.md")
+        (d / "MEMORY.md").write_text("# Index\n\n- [Alpha](alpha.md) - h\n",
+                                     encoding="utf-8")
+        env = dict(os.environ, AGENT_MEMORY_DIR=str(d))
+        proc = subprocess.run([sys.executable, str(LOADER)], input="{}",
+                              capture_output=True, text=True, env=env)
+        ctx = json.loads(proc.stdout)["hookSpecificOutput"]["additionalContext"]
+        check("healthy dir adds nothing to the loader payload",
+              "memory-index" not in ctx, ctx[-200:])
+
+    print("\n{} passed, {} failed".format(PASS, FAIL))
+    return 1 if FAIL else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -122,6 +122,7 @@ echo "    OK - $count file(s) compiled clean"
 # tests/integration/ also holds .sh/.py files that are NOT part of this gate, so
 # it must be an explicit allow-list, never a glob over the directory.
 INTEGRATION_TESTS=(
+  test_session_start_announces_memory_index
   test_worktree_session_close
   test_bootstrap_dry_run
   test_dry_run_purity
@@ -373,6 +374,7 @@ echo "    OK - $unit_count scripts/ unit suite(s) passed"
 # fails the gate LOUD (the false-green class MYC-2922 closed for scripts/, MYC-2959
 # for hooks/+tests/). PY_DIRECT then runs the non-wrapped suites exactly once.
 PY_DIRECT=(
+  hooks/test_memory_index.py
   tests/test_instinct.py
   hooks/test_live_session_reap.py
   hooks/test_relocation_orphan_reclaim.py

--- a/tests/integration/test_session_start_announces_memory_index.sh
+++ b/tests/integration/test_session_start_announces_memory_index.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Fresh-install activation proof for the memory-index announcement.
+#
+# The bug this closes is ARTIFACT-WITHOUT-ACTIVATION: logic can sit in the repo
+# fully tested and green while nothing installed ever runs it, so every install
+# gets the code and none gets the behavior. File presence is NOT the assertion.
+# The assertion is that the command the INSTALLER wires into settings.json, run
+# verbatim, actually announces an unreachable memory.
+#
+# Asserts, against a sandboxed HOME:
+#   0. NEGATIVE CONTROL: pre-install settings.json has no session-start loader.
+#   1. The loader is registered on SessionStart by the real installer.
+#   2. The registered command names a script that exists.
+#   3. END-TO-END: that command, run verbatim against a memory dir with an
+#      unreachable memo, announces it.                      <- activation works
+#   4. END-TO-END negative control: healthy dir -> no announcement.
+#   5. The announcement rides the SAME payload as the session context, so it
+#      costs no extra SessionStart cold start (that event is at fan-out budget).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# A REAL interpreter, resolved absolutely. Bare `python3` may be a refuse-shim
+# that exit-1s on every invocation, failing this test for an unrelated reason.
+PY=""
+for c in /opt/homebrew/bin/python3 /usr/bin/python3 /usr/local/bin/python3; do
+  [ -x "$c" ] && "$c" -c 'import sys' >/dev/null 2>&1 && { PY="$c"; break; }
+done
+if [ -z "$PY" ]; then
+  PY="$(command -v python3 || true)"
+  [ -n "$PY" ] && ! "$PY" -c 'import sys' >/dev/null 2>&1 && PY=""
+fi
+[ -z "$PY" ] && { echo "SKIP: no usable python3"; exit 0; }
+
+INSTALLER="$REPO_ROOT/scripts/install-hooks-user-level.py"
+LOADER_NAME="session-start-context.py"
+LOADER="$REPO_ROOT/hooks/$LOADER_NAME"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+SETTINGS="$TMP/.claude/settings.json"
+mkdir -p "$TMP/.claude"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# --- 0. negative control -------------------------------------------------------
+printf '{"hooks":{}}' > "$SETTINGS"
+grep -q "$LOADER_NAME" "$SETTINGS" && fail "negative control broken: loader present pre-install"
+echo "PASS  0. pre-install settings.json has no session-start loader"
+
+env -u CLAUDECODE HOME="$TMP" "$PY" "$INSTALLER" \
+  --hooks-source "$REPO_ROOT/hooks.json" --settings "$SETTINGS" --quiet
+
+# --- 1. registered on SessionStart --------------------------------------------
+EVENTS="$("$PY" - "$SETTINGS" "$LOADER_NAME" <<'PYEOF'
+import json, sys
+settings, needle = sys.argv[1], sys.argv[2]
+for event, blocks in json.load(open(settings)).get("hooks", {}).items():
+    for blk in blocks:
+        for e in blk.get("hooks", []):
+            if needle in e.get("command", ""):
+                print(event)
+PYEOF
+)"
+echo "$EVENTS" | grep -qx "SessionStart" \
+  || fail "loader not registered on SessionStart (found: ${EVENTS:-none})"
+echo "PASS  1. loader registered on SessionStart"
+
+# --- 2. the registered command names a real script ----------------------------
+[ -f "$LOADER" ] || fail "registered loader missing from the repo: $LOADER"
+echo "PASS  2. registered command names an existing script"
+
+# --- 3. END-TO-END: announces an unreachable memo -----------------------------
+MEM="$TMP/memory"; mkdir -p "$MEM"
+printf -- '---\nname: ghost\n---\n\nbody\n' > "$MEM/ghost.md"
+printf -- '# Index\n\n' > "$MEM/MEMORY.md"
+OUT="$(AGENT_MEMORY_DIR="$MEM" "$PY" "$LOADER" <<< '{}')"
+printf '%s' "$OUT" | grep -q "ghost.md" \
+  || fail "loader did not announce the unreachable memo. stdout: ${OUT:0:300}"
+printf '%s' "$OUT" | grep -q "memory-index" \
+  || fail "announcement missing its [memory-index] tag"
+echo "PASS  3. end-to-end: unreachable memo is announced"
+
+# --- 4. END-TO-END negative control -------------------------------------------
+MEM2="$TMP/memory-ok"; mkdir -p "$MEM2"
+printf -- '---\nname: alpha\n---\n\nbody\n' > "$MEM2/alpha.md"
+printf -- '# Index\n\n- [Alpha](alpha.md) - hook\n' > "$MEM2/MEMORY.md"
+OUT2="$(AGENT_MEMORY_DIR="$MEM2" "$PY" "$LOADER" <<< '{}')"
+printf '%s' "$OUT2" | grep -q "memory-index" \
+  && fail "false positive: healthy memory dir produced an announcement"
+echo "PASS  4. end-to-end negative control: healthy dir is silent"
+
+# --- 5. no extra SessionStart cold start --------------------------------------
+COUNT="$("$PY" - "$REPO_ROOT/hooks.json" <<'PYEOF'
+import json, sys
+d = json.load(open(sys.argv[1]))
+c = d.get("hooks", d)
+print(sum(1 for b in c.get("SessionStart", []) for e in b.get("hooks", [])
+          if "memory-index" in e.get("command", "")
+          or "memory_index" in e.get("command", "")))
+PYEOF
+)"
+[ "$COUNT" = "0" ] || fail "memory-index got its own SessionStart hook (count=$COUNT); it must ride the loader"
+echo "PASS  5. announcement adds no SessionStart cold start"
+
+echo "OK  all 6 assertions passed"


### PR DESCRIPTION
Closes MYC-1763.

## The bug

The memory index is read into session context. Past a byte cliff the reader silently stops, so entries below the cut are never seen — no error, no warning, just a brain that quietly forgot part of itself. Write-time tooling warns when the index **grows**; a session that only **reads** it got no signal at all.

An index is proven by what LOADS, not by what was written to it.

**The invariant now enforced: an indexed entry is either loaded, or its omission is announced.**

## What lands

`hooks/_lib/memory_index.py` detects two failure modes, announced at session start through the existing loader:

| Mode | Meaning |
|---|---|
| **OVER-CLIFF** | index past the readable budget — entries are **already** unread, and the message says so rather than calling it a future risk |
| **UNREACHABLE** | a memory file no index references — invisible regardless of size |

**Two-tier aware by construction.** A corpus of ~1000 memories needs roughly 57KB of link markup, several times the cliff, so a flat index physically cannot list everything. The supported shape is a capped tier-1 `MEMORY.md` plus `_index_*.md` tier-2 files it links to; a memory indexed in **either** tier is reachable. Checking tier 1 alone would report almost every memory in a split vault as missing.

## Why it rides the loader instead of its own hook

The first draft was a standalone SessionStart hook. `footprint-sla-check.py` blocked it at **19/18** cold starts and was right to: a housekeeping check does not earn a new subprocess on every session for the life of the install. Folding it into `session-start-context.py` is also the more honest design — the loader announces what it could not load — and it is this ticket's own first listed option. Fan-out stays **18/18**, and assertion 5 of the smoke test pins it there so a future change cannot quietly reintroduce the cost.

## Verification

- **`hooks/test_memory_index.py`** — 16 assertions. Every positive control is paired with a negative one: healthy index silent, tier-2 memo silent, orphan still caught *alongside* tier 2 (guards against "accept everything once any `_index_` file exists"), warn band does not claim entries are lost.
- **`tests/integration/test_session_start_announces_memory_index.sh`** — proves **activation**, not presence. The real installer wires it into a sandboxed `HOME`, and the wired command run verbatim announces an unreachable memo; plus a healthy-dir negative control and the no-extra-cold-start assertion.
- Both suites are wired into `scripts/ci.sh` (`PY_DIRECT` + `INTEGRATION_TESTS`). An unwired suite fails the gate as dormant — which is how the first draft got caught.
- Full canonical gate green via `ci-test`: 323 files compiled, 90 integration tests, 11 script suites, 11 hook suites, shellcheck, UTF-8 console guard, hook block-protocol.

## Safety

Read-only — never edits an index or a memory file. Fail-open — any error yields no warning rather than a broken session start. Non-blocking — it reports, it does not deny; a SessionStart guard that blocked would lock a user out of their own brain over housekeeping. Bypass: `MEMORY_INDEX_TRUNCATION_BYPASS=1`.

## Note for review

An earlier revision of this branch reformatted `hooks.json` via `json.dumps`, which ASCII-escaped `⚙️ Meta/` into `⚙️ Meta/` — JSON-equivalent, but that file's own `_paths_note` warns the bash scripts match the literal folder name. `hooks.json` is now byte-identical to `origin/main` and this PR does not touch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
