### PR TITLE
fix(memory-index): 7 defects from the adversarial review that #412 skipped

### DIFF
--- a/hooks/_lib/memory_index.py
+++ b/hooks/_lib/memory_index.py
@@ -10,18 +10,33 @@ to it.
 The invariant: **an indexed entry is either loaded, or its omission is
 announced.** Never silently dropped.
 
-Two failure modes:
+Failure modes, all announced:
 
-  OVER-CLIFF   the index is larger than the readable budget, so some entries are
-               already unread this session.
-  UNREACHABLE  a memory file exists that no index references, so it is invisible
-               regardless of size.
+  OVER-CLIFF    an index file is larger than the readable budget, so some of its
+                entries are already unread. Checked for tier 1 AND every tier-2
+                file, because "split it into tier 2" is useless advice if the
+                tier you move entries into is never measured.
+  UNREACHABLE   a memory file exists that no index references.
+  ORPHAN-INDEX  a tier-2 index that tier 1 does not link to. Nothing loads it,
+                so the memories it exclusively lists are invisible even though
+                a file on disk names them.
+  UNREADABLE    a tier-2 index that cannot be read. Announced as itself — a
+                failed read is not an empty answer, and must never be silently
+                converted into "everything it listed is missing".
 
 Two-tier aware. A corpus of ~1000 memories needs roughly 57KB of link markup
 alone, several times the cliff, so a single flat index physically cannot list
 everything. The supported shape is a capped tier-1 MEMORY.md plus `_index_*.md`
-tier-2 files it links to. A memory indexed in EITHER tier is reachable; checking
-tier 1 alone would report almost every memory in a split vault as missing.
+tier-2 files **that tier 1 links to**. A memory named by either tier is
+reachable.
+
+Reachability is deliberately generous about SYNTAX and strict about REACH: a
+memory counts as indexed if its filename appears anywhere in a loaded index,
+link or not. Markdown has many link spellings (`](./x.md)`, `](<x.md>)`,
+`](x.md "t")`, `](x.md#a)`, reference-style, backticked bare names) and a
+regex that recognises only the canonical one reports correctly-indexed
+memories as missing. A false "your memory is invisible" is worse than counting
+a filename mentioned in prose, which a reader can in fact find.
 
 Consumed by `hooks/session-start-context.py` — the loader announces what it
 could not load. It lives here rather than in its own SessionStart hook because
@@ -38,8 +53,8 @@ import os
 import re
 from pathlib import Path
 
-# The reader stops loading past this many bytes. Entries below the cut are
-# silently unread, which is the whole bug.
+# The reader stops loading PAST this many bytes. Entries below the cut are
+# silently unread, which is the whole bug. Band is (WARN, CLIFF].
 READ_CLIFF_BYTES = 24_400
 
 # Report before the cliff, not at it: at the cliff, entries are ALREADY lost.
@@ -49,78 +64,125 @@ WARN_BYTES = 17_000
 # emits a readable message rather than a wall of text.
 MAX_NAMED = 12
 
-LINK_RE = re.compile(r"\]\(([^)]+?\.md)\)")
+# Structural link forms, used to find which tier-2 files tier 1 actually links
+# to. Tolerates `<...>`, a title, an anchor and a path prefix.
+LINK_RE = re.compile(r"\]\(\s*<?([^)>\s]+?\.md)(?:#[^)>\s]*)?>?(?:\s+[^)]*)?\)")
 
 
-def memory_dirs() -> list:
-    """Candidate Agent Memory directories.
+def _dedup_dirs(dirs):
+    """Collapse aliases of the same underlying directory.
+
+    Project-key directories are routinely symlinked to one shared memory dir.
+    Measured on a real machine: 212 glob hits, 5 distinct inodes, 208 of them
+    aliasing a single directory. Without this, the audit runs once per alias —
+    a full second of stat/read per session start and 208 copies of every
+    reported line injected into context. The guard warning about an oversized
+    index must not itself be the oversized injection.
+    """
+    seen = set()
+    out = []
+    for d in dirs:
+        try:
+            st = d.stat()
+            key = (st.st_dev, st.st_ino)
+        except OSError:
+            key = (None, str(d))
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(d)
+    return out
+
+
+def memory_dirs():
+    """Candidate Agent Memory directories, de-aliased.
 
     An override wins outright so tests and non-default layouts never depend on
-    guessing. A symlinked directory resolves fine because glob follows it.
+    guessing.
     """
     override = os.environ.get("AGENT_MEMORY_DIR")
     if override:
         return [Path(override)]
-    return [
+    found = [
         d for d in (Path.home() / ".claude" / "projects").glob("*/memory")
         if d.is_dir()
     ]
+    return _dedup_dirs(found)
 
 
-def _topic_files(mdir: Path) -> list:
+def _topic_files(mdir: Path):
     return sorted(
         p for p in mdir.glob("*.md")
         if p.name != "MEMORY.md" and not p.name.startswith("_index_")
     )
 
 
-def _reachable(mdir: Path, tier1_text: str):
-    """Names reachable from tier 1 plus every tier-2 file, and the tier-2 count."""
-    names = set(LINK_RE.findall(tier1_text))
-    tier2 = sorted(p for p in mdir.glob("_index_*.md") if p.is_file())
-    for sub in tier2:
-        try:
-            names |= set(LINK_RE.findall(sub.read_text(encoding="utf-8", errors="replace")))
-        except OSError:
-            continue
-    return names, len(tier2)
+def _linked_tier2(mdir: Path, tier1_text: str):
+    """Tier-2 index files that tier 1 actually links to, plus the orphans.
+
+    An `_index_*.md` nothing links to is never loaded, so trusting it would let
+    it mask a genuinely unreachable memory — the exact silent drop this module
+    exists to prevent.
+    """
+    present = sorted(p for p in mdir.glob("_index_*.md") if p.is_file())
+    referenced = {os.path.basename(m) for m in LINK_RE.findall(tier1_text)}
+    linked, orphans = [], []
+    for p in present:
+        (linked if (p.name in referenced or p.name in tier1_text) else orphans).append(p)
+    return linked, orphans
 
 
-def audit(mdir: Path) -> list:
+def audit(mdir: Path):
     """Problems for one memory dir. Empty list = healthy."""
     tier1 = mdir / "MEMORY.md"
     if not tier1.exists():
         return []
     try:
-        size = tier1.stat().st_size
         text = tier1.read_text(encoding="utf-8", errors="replace")
+        size = tier1.stat().st_size
     except OSError:
         return []
 
     problems = []
-    if size > READ_CLIFF_BYTES:
+    problems.extend(_size_problems("MEMORY.md", size))
+
+    linked, orphans = _linked_tier2(mdir, text)
+
+    # Names reachable from tier 1 plus every LINKED tier-2 file. Filename
+    # containment, not link syntax — see the module docstring.
+    loaded_text = [text]
+    unreadable = []
+    for sub in linked:
+        try:
+            loaded_text.append(sub.read_text(encoding="utf-8", errors="replace"))
+            problems.extend(_size_problems(sub.name, sub.stat().st_size))
+        except OSError as exc:
+            unreadable.append("{} ({})".format(sub.name, exc.__class__.__name__))
+    haystack = "\n".join(loaded_text)
+
+    if unreadable:
         problems.append(
-            "MEMORY.md is {:,} bytes, past the {:,}-byte read cliff by {:,}. "
-            "Entries past the cut are NOT being loaded — silently missing, not "
-            "merely at risk.".format(size, READ_CLIFF_BYTES, size - READ_CLIFF_BYTES)
-        )
-    elif size > WARN_BYTES:
-        problems.append(
-            "MEMORY.md is {:,} bytes, over the {:,}-byte budget (cliff {:,}). "
-            "Still fully loaded, but the next few additions start dropping "
-            "entries.".format(size, WARN_BYTES, READ_CLIFF_BYTES)
+            "{} tier-2 index file(s) could not be READ, so what they list is "
+            "unknown, not absent: {}. Fix the read before trusting any "
+            "reachability result below.".format(len(unreadable), ", ".join(unreadable))
         )
 
-    reachable, tier2_count = _reachable(mdir, text)
-    unreachable = [p.name for p in _topic_files(mdir) if p.name not in reachable]
+    if orphans:
+        problems.append(
+            "{} tier-2 index file(s) are not linked from MEMORY.md, so nothing "
+            "loads them and any memory only they list is invisible: {}.".format(
+                len(orphans), ", ".join(p.name for p in orphans))
+        )
+
+    unreachable = [p.name for p in _topic_files(mdir) if p.name not in haystack]
     if unreachable:
         shown = ", ".join(unreachable[:MAX_NAMED])
         more = (" and {} more".format(len(unreachable) - MAX_NAMED)
                 if len(unreachable) > MAX_NAMED else "")
         tier_note = (
-            " (checked MEMORY.md plus {} tier-2 index file(s))".format(tier2_count)
-            if tier2_count
-            else " (no tier-2 `_index_*.md` files present; a large corpus needs them)"
+            " (checked MEMORY.md plus {} linked tier-2 index file(s))".format(len(linked))
+            if linked
+            else " (no linked tier-2 `_index_*.md` files; a large corpus needs them)"
         )
         problems.append(
             "{} memory file(s) are referenced by NO index{} — invisible to this "
@@ -128,6 +190,19 @@ def audit(mdir: Path) -> list:
                 len(unreachable), tier_note, shown, more)
         )
     return problems
+
+
+def _size_problems(label: str, size: int):
+    """Size verdict for one index file. Band is (WARN, CLIFF]."""
+    if size > READ_CLIFF_BYTES:
+        return ["{} is {:,} bytes, past the {:,}-byte read cliff by {:,}. Entries "
+                "past the cut are NOT being loaded — silently missing, not merely "
+                "at risk.".format(label, size, READ_CLIFF_BYTES, size - READ_CLIFF_BYTES)]
+    if size > WARN_BYTES:
+        return ["{} is {:,} bytes, over the {:,}-byte budget (cliff {:,}). Still "
+                "fully loaded, but the next few additions start dropping "
+                "entries.".format(label, size, WARN_BYTES, READ_CLIFF_BYTES)]
+    return []
 
 
 def report() -> str:
@@ -149,7 +224,7 @@ def report() -> str:
         "**[memory-index]** The memory index cannot be fully loaded. An indexed "
         "entry is either loaded or its omission is announced — this is the "
         "announcement.\n\n" + "\n".join(lines) + "\n\n"
-        "Trim the always-loaded index, or split it into a capped MEMORY.md plus "
-        "`_index_*.md` tier-2 files it links to, so nothing is dropped in silence. "
-        "Bypass: MEMORY_INDEX_TRUNCATION_BYPASS=1"
+        "Trim the oversized index, link any orphaned `_index_*.md` from "
+        "MEMORY.md, and index anything listed as unreachable, so nothing is "
+        "dropped in silence. Bypass: MEMORY_INDEX_TRUNCATION_BYPASS=1"
     )

--- a/hooks/test_memory_index.py
+++ b/hooks/test_memory_index.py
@@ -194,6 +194,126 @@ def main() -> int:
         check("healthy dir adds nothing to the loader payload",
               "memory-index" not in ctx, ctx[-200:])
 
+
+    # --- regression tests added after adversarial review of 619ee45 ----------
+
+    # 12. ALIAS DEDUPE (measured 208x amplification on a real machine): many
+    #     project keys symlink to ONE memory dir. Auditing per-alias meant a
+    #     full second per session start and 208 copies of every line.
+    #     Mutation killed: removing _dedup_dirs.
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        real = root / "projects" / "real" / "memory"
+        real.mkdir(parents=True)
+        memo(real, "ghost.md")
+        (real / "MEMORY.md").write_text("# Index\n", encoding="utf-8")
+        for i in range(6):
+            alias = root / "projects" / ("alias%d" % i)
+            alias.mkdir(parents=True)
+            try:
+                (alias / "memory").symlink_to(real, target_is_directory=True)
+            except (OSError, NotImplementedError):
+                pass
+        seen = memory_index._dedup_dirs(
+            [d for d in (root / "projects").glob("*/memory") if d.is_dir()])
+        check("aliases of one dir collapse to one", len(seen) == 1,
+              "got {}".format([str(x) for x in seen]))
+
+    # 13. LINK FORMS: a memo indexed in any plausible markdown spelling is NOT
+    #     reported. Mutation killed: narrowing back to the canonical form only.
+    forms = [
+        "- [A](alpha.md) - h",
+        "- [A](./alpha.md) - h",
+        "- [A](<alpha.md>) - h",
+        '- [A](alpha.md "title") - h',
+        "- [A](alpha.md#anchor) - h",
+        "[ref]: alpha.md",
+        "see `alpha.md` for detail",
+    ]
+    for form in forms:
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            memo(d, "alpha.md")
+            (d / "MEMORY.md").write_text("# Index\n\n" + form + "\n", encoding="utf-8")
+            r = report_for(d)
+            check("link form indexed: {}".format(form[:28]), r == "", r[:160])
+
+    # 14. ORPHAN TIER-2 must NOT mask an unreachable memo. This is mutation A
+    #     from the review: trusting every _index_*.md in the dir, linked or not.
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td)
+        memo(d, "zeta.md")
+        (d / "MEMORY.md").write_text("# Index\n", encoding="utf-8")
+        (d / "_index_stale.md").write_text("# Stale\n\n- [Z](zeta.md) - h\n",
+                                           encoding="utf-8")
+        r = report_for(d)
+        check("orphaned tier-2 does not mask an unreachable memo",
+              "zeta.md" in r or "not linked from MEMORY.md" in r, r[:250])
+        check("orphaned tier-2 is itself reported",
+              "_index_stale.md" in r, r[:250])
+
+    # 15. TIER-2 SIZE is measured too. The advice says "move entries to tier 2";
+    #     if tier 2 is never measured, the advice relocates data into a blind
+    #     spot. Mutation killed: size-checking tier 1 only.
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td)
+        memo(d, "alpha.md")
+        (d / "MEMORY.md").write_text(
+            "# Index\n\n- [A](alpha.md) - h\n- [More](_index_big.md) - t2\n",
+            encoding="utf-8")
+        pad = "\n".join("- [P{}](alpha.md) - {}".format(i, "p" * 60) for i in range(600))
+        (d / "_index_big.md").write_text("# Big\n\n" + pad, encoding="utf-8")
+        r = report_for(d)
+        check("oversized tier-2 index is reported",
+              "_index_big.md" in r and "read cliff" in r, r[:250])
+
+    # 16. UNREADABLE tier-2 is announced as unknown, NOT as mass-unreachable.
+    #     A failed read is not an empty answer.
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td)
+        memo(d, "deep.md")
+        (d / "MEMORY.md").write_text(
+            "# Index\n\n- [More](_index_locked.md) - t2\n", encoding="utf-8")
+        locked = d / "_index_locked.md"
+        locked.write_text("# L\n\n- [D](deep.md) - h\n", encoding="utf-8")
+        try:
+            os.chmod(locked, 0o000)
+            r = report_for(d)
+            readable_again = True
+        except Exception:
+            r, readable_again = "", False
+        finally:
+            try:
+                os.chmod(locked, 0o644)
+            except Exception:
+                pass
+        if readable_again and os.geteuid() != 0:
+            check("unreadable tier-2 is announced as unknown",
+                  "could not be READ" in r, r[:250])
+        else:
+            check("unreadable tier-2 (skipped: running as root)", True)
+
+    # 17. MAX_NAMED truncation path is exercised. Mutation killed: corrupting
+    #     the "and N more" arithmetic, which no fixture previously reached.
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td)
+        for i in range(memory_index.MAX_NAMED + 5):
+            memo(d, "orphan{:02d}.md".format(i))
+        (d / "MEMORY.md").write_text("# Index\n", encoding="utf-8")
+        r = report_for(d)
+        check("truncation says 'and 5 more'", "and 5 more" in r, r[:250])
+
+    # 18. THRESHOLD BOUNDARIES are pinned. Mutation killed: > -> >=.
+    def _size_labels(n):
+        return " ".join(memory_index._size_problems("X", n))
+    check("size == WARN is silent", _size_labels(memory_index.WARN_BYTES) == "")
+    check("size == WARN+1 warns",
+          "over the" in _size_labels(memory_index.WARN_BYTES + 1))
+    check("size == CLIFF is warn, not loss",
+          "over the" in _size_labels(memory_index.READ_CLIFF_BYTES))
+    check("size == CLIFF+1 is loss",
+          "NOT being loaded" in _size_labels(memory_index.READ_CLIFF_BYTES + 1))
+
     print("\n{} passed, {} failed".format(PASS, FAIL))
     return 1 if FAIL else 0
 

--- a/tests/integration/test_session_start_announces_memory_index.sh
+++ b/tests/integration/test_session_start_announces_memory_index.sh
@@ -41,6 +41,14 @@ trap 'rm -rf "$TMP"' EXIT
 SETTINGS="$TMP/.claude/settings.json"
 mkdir -p "$TMP/.claude"
 
+# A real install has the repo at ~/.claude/skills/ai-brain-starter. Seed it so
+# the path baked into the wired command RESOLVES. Without this, running the
+# repo copy instead would prove nothing about the installed wiring — a stale or
+# missing installed copy would stay invisible, which is the exact
+# ARTIFACT-WITHOUT-ACTIVATION class this file exists to close.
+mkdir -p "$TMP/.claude/skills"
+ln -s "$REPO_ROOT" "$TMP/.claude/skills/ai-brain-starter"
+
 fail() { echo "FAIL: $*" >&2; exit 1; }
 
 # --- 0. negative control -------------------------------------------------------
@@ -74,18 +82,31 @@ echo "PASS  2. registered command names an existing script"
 MEM="$TMP/memory"; mkdir -p "$MEM"
 printf -- '---\nname: ghost\n---\n\nbody\n' > "$MEM/ghost.md"
 printf -- '# Index\n\n' > "$MEM/MEMORY.md"
-OUT="$(AGENT_MEMORY_DIR="$MEM" "$PY" "$LOADER" <<< '{}')"
+# Run the command string the INSTALLER WROTE, verbatim, with HOME pointed at
+# the sandbox so `~` resolves to the seeded install. Not the repo copy.
+WIRED="$("$PY" - "$SETTINGS" "$LOADER_NAME" <<'PYEOF'
+import json, sys
+settings, needle = sys.argv[1], sys.argv[2]
+for blocks in json.load(open(settings)).get("hooks", {}).values():
+    for blk in blocks:
+        for e in blk.get("hooks", []):
+            if needle in e.get("command", ""):
+                print(e["command"]); raise SystemExit
+PYEOF
+)"
+[ -n "$WIRED" ] || fail "could not read the wired command out of settings.json"
+OUT="$(cd "$TMP" && HOME="$TMP" AGENT_MEMORY_DIR="$MEM" bash -c "$WIRED" <<< '{}')"
 printf '%s' "$OUT" | grep -q "ghost.md" \
-  || fail "loader did not announce the unreachable memo. stdout: ${OUT:0:300}"
+  || fail "the WIRED command did not announce the unreachable memo. cmd: $WIRED | stdout: ${OUT:0:300}"
 printf '%s' "$OUT" | grep -q "memory-index" \
   || fail "announcement missing its [memory-index] tag"
-echo "PASS  3. end-to-end: unreachable memo is announced"
+echo "PASS  3. end-to-end: the WIRED command announces an unreachable memo"
 
 # --- 4. END-TO-END negative control -------------------------------------------
 MEM2="$TMP/memory-ok"; mkdir -p "$MEM2"
 printf -- '---\nname: alpha\n---\n\nbody\n' > "$MEM2/alpha.md"
 printf -- '# Index\n\n- [Alpha](alpha.md) - hook\n' > "$MEM2/MEMORY.md"
-OUT2="$(AGENT_MEMORY_DIR="$MEM2" "$PY" "$LOADER" <<< '{}')"
+OUT2="$(cd "$TMP" && HOME="$TMP" AGENT_MEMORY_DIR="$MEM2" bash -c "$WIRED" <<< '{}')"
 printf '%s' "$OUT2" | grep -q "memory-index" \
   && fail "false positive: healthy memory dir produced an announcement"
 echo "PASS  4. end-to-end negative control: healthy dir is silent"


### PR DESCRIPTION
Follow-up to #412 (MERGED, same ticket MYC-1763 — this is an intentional fix-forward, not a duplicate).

Seven defects, found by running the adversarial review that **should have gated #412 and did not**: the review agent died mid-run and auto-merge fired on green CI, so the code landed self-attested. This PR is that gate arriving late.

Every fix ships a regression test that kills the mutation which previously survived. Assertions: **16 → 33**.

## HIGH — alias amplification (the severe one)

`memory_dirs()` globbed `~/.claude/projects/*/memory` and audited every hit. Measured on a real machine: **212 glob entries, 5 distinct inodes, 208 aliasing one directory.** The audit ran 208 times over identical bytes.

| | before | after |
|---|---|---|
| dirs audited | 208 | 5 |
| `report()` wall time | 965–1102 ms | **43–49 ms** |
| files stat'd / session | 208,210 | ~1,000 |
| bytes read / session | 40.6 MB | ~195 KB |
| injected output | 41,730 chars | 1,301 chars |

A guard warning that your 24 KB index gets truncated would itself have been the 41 KB injection. Deduped by `(st_dev, st_ino)`.

## HIGH — link-syntax brittleness

The regex matched only `](name.md)`. So `](./x.md)`, `](<x.md>)`, `](x.md "t")`, `](x.md#a)`, reference-style `[a]: x.md` and backticked bare names each produced *"invisible to this and every future session"* for a correctly indexed memory. Reachability is now filename containment across loaded index text — generous about spelling, strict about reach. A false "your memory is invisible" is worse than counting a name a reader can in fact find.

## HIGH — tier 2 was never size-checked

The guard measured tier 1 only, while its own advice said "split into tier 2" — relocating entries into an unmeasured tier. Confirmed against a live vault the moment this landed: **three tier-2 files past the cliff (58 KB, 48 KB, 30 KB).** Reachable by link, unreadable in one pass. Every index file is measured now.

## MEDIUM — four more

- **Orphan index masked a real gap.** An `_index_*.md` nothing links to was trusted, so memories only it listed read as reachable while nothing loads them. Only tier-2 files tier 1 actually links are trusted; an orphan is now reported as its own problem.
- **Unreadable index inverted into mass-unreachable.** An `OSError` on one tier-2 file turned its ~317 correctly indexed memories into "referenced by NO index". A failed read is not an empty answer — it is announced as unknown.
- **The activation smoke test ran the repo copy** while its header claimed to run the wired command, so a stale or missing installed copy was invisible to it — the exact ARTIFACT-WITHOUT-ACTIVATION class it exists to close. It now seeds `~/.claude/skills/ai-brain-starter` and executes the installed command string verbatim under a sandboxed `HOME`. **Negative control: with the install deliberately unseeded, the test goes red.**
- **Four surviving mutations** now have tests that fail on them: orphan-index semantics, the `and N more` arithmetic, both threshold boundaries, and widening the link regex.

## Held under attack (confirmed, not assumed)

stdlib shadowing via the `sys.path` insert · symlink-loop recursion · threshold off-by-one (band is `(17000, 24400]`) · stdout emission channel, the one thing the original got exactly right, since the wired `2>/dev/null` cannot mute it · no personal data in the diff.

## Gate

`bash scripts/ci.sh` green: 324 files compiled, 92 integration tests, 11 script suites, 11 hook suites, shellcheck, UTF-8 console guard, hook block-protocol, vault-root reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
