### PR TITLE
fix(hooks): the 12 SEV-A vault-root reads resolve per target, not from $VAULT_ROOT (MYC-3529)

### DIFF
--- a/hooks/_lib/vault_root.py
+++ b/hooks/_lib/vault_root.py
@@ -29,17 +29,38 @@ Meta folder) and uses that when found. The VAULT_ROOT env var / cwd fallback
 is now exactly that — a fallback for when no such repo is found (untracked
 locations, or a session already rooted in the default vault itself, which
 never needs the walk-up to win since it's reached via the fallback anyway).
+
+TWO RESOLVERS, TWO SURFACES (MYC-3529)
+    resolve_vault_root(cwd, env)  — SESSION-scoped. "Which vault does THIS
+        session's close cascade write to?" Keyed on a CLAUDE.md that declares
+        its own Session End/Close cascade, because that is the thing being
+        asked about. Always returns a Path (cwd is the floor).
+
+    vault_root_for(target)        — PER-TARGET. "Which vault governs THIS
+        file / directory?" Keyed on a Meta-suffixed folder, the same signature
+        scripts/_meta_resolver.py uses, because a hook fires on paths in ANY
+        vault and most of them never declare a close cascade. Returns None
+        when no vault can be identified, so a caller SKIPS rather than
+        guessing at `~/vault` — the #375/#404 defect shape.
+
+    The distinction is the whole point of MYC-2505's severity tagging: a
+    SCRIPT serves one vault, a SESSION has one vault, but a HOOK fires on
+    files in any vault and must resolve per target or it silently answers for
+    the wrong one. `$VAULT_ROOT` is the FALLBACK in both, never the primary.
 """
 
 from __future__ import annotations
 
+import os
 import re
 from pathlib import Path
 
 __all__ = [
     "collapse_worktree",
+    "find_meta_vault_root",
     "find_repo_vault_root",
     "resolve_vault_root",
+    "vault_root_for",
 ]
 
 # Matches "## Session End", "## Session end", "# Session Close", etc. Deliberately
@@ -140,6 +161,82 @@ def find_repo_vault_root(start: Path) -> Path | None:
         if parent == current:  # reached filesystem root
             break
         current = parent
+    return None
+
+
+def find_meta_vault_root(start: Path) -> Path | None:
+    """Nearest ancestor of `start` (inclusive) holding a Meta-suffixed folder.
+
+    This is the PER-TARGET vault signature, and it is deliberately weaker than
+    _declares_own_session_close_cascade: a hook fires on files in any vault,
+    and most vaults never declare a close cascade, so keying per-file detection
+    on that heading would leave the hook inert on exactly the vaults it exists
+    to cover. A Meta-suffixed folder is the same signature
+    scripts/_meta_resolver.py and hooks/validate-handoff-frontmatter.py already
+    key on, so all three agree on what "a vault" means.
+
+    `start` may be a FILE: iterdir() on a non-directory raises OSError, which
+    is caught, so the walk simply continues at the parent. That makes one
+    function correct for both a target file and a target directory (a cwd),
+    which is what the hook surface actually needs.
+
+    Bounded by _MAX_WALKUP_LEVELS and stopped at the filesystem root, for the
+    same reason find_repo_vault_root is: a hook has a sub-500ms budget and must
+    not turn into an unbounded stat loop on an odd filesystem. Deliberately NOT
+    stopped at $HOME — a vault can live outside the home directory (an external
+    drive, D:\\ on Windows), and unlike the session-close walk there is no
+    default-vault fallback that would otherwise reach it.
+    """
+    try:
+        current = start.resolve()
+    except (OSError, RuntimeError):
+        return None
+    for _ in range(_MAX_WALKUP_LEVELS):
+        try:
+            if any(c.is_dir() and c.name.endswith("Meta") for c in current.iterdir()):
+                return current
+        except (OSError, ValueError):
+            pass
+        parent = current.parent
+        if parent == current:  # reached filesystem root
+            break
+        current = parent
+    return None
+
+
+def vault_root_for(target: Path) -> Path | None:
+    """Vault root governing `target`: detected FROM the target, else $VAULT_ROOT.
+
+    The per-target resolver for the hook surface, extracted from
+    hooks/validate-handoff-frontmatter.py (the #375/#404 fix) so the other
+    hooks in that class share one implementation instead of twelve.
+
+    Detection comes FIRST on purpose. $VAULT_ROOT names ONE vault, but a
+    machine routinely has several (a personal vault plus one per project) and
+    the variable is routinely exported machine-wide. If the env var won, a hook
+    firing on a path in any OTHER vault would resolve to a root that path does
+    not sit under, its containment check would return False, and it would
+    silently SKIP the very file it exists to check — failing open with no
+    signal. Per-target detection is correct for all of them.
+
+    Worktree paths collapse first: `<vault>/.claude/worktrees/<slug>/...` is
+    governed by `<vault>`, not by the throwaway checkout, which carries a full
+    copy of the tree (Meta folder included) and would otherwise win the walk-up.
+
+    Returns None when no vault can be identified at all. Callers must treat
+    that as "no vault here, do nothing" — NOT as a reason to fall back to
+    `Path.home() / "vault"`, which is the exact default that made this whole
+    class of guard inert on every vault not literally named "vault".
+    """
+    found = find_meta_vault_root(collapse_worktree(target))
+    if found is not None:
+        return found
+    env = (os.environ.get("VAULT_ROOT") or "").strip()
+    if env:
+        try:
+            return collapse_worktree(Path(env).expanduser()).resolve()
+        except (OSError, RuntimeError):
+            return None
     return None
 
 

--- a/hooks/auto-capture-public-ships.py
+++ b/hooks/auto-capture-public-ships.py
@@ -22,8 +22,14 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
-VAULT = Path(os.environ.get("VAULT_ROOT", str(Path.home() / "vault")))
-PENDING_DIR = VAULT / "🍄 the user's consulting brand" / "📋 Pending Signals"
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    from _lib.vault_root import vault_root_for  # noqa: E402
+except Exception:  # fail-open: a SessionEnd capture must never break the close
+    def vault_root_for(target: Path):  # type: ignore
+        return None
+
+PENDING_SUBPATH = ("🍄 the user's consulting brand", "📋 Pending Signals")
 DEV = Path.home() / "dev"
 TZ = ZoneInfo("America/user-local-tz")
 
@@ -84,11 +90,31 @@ def existing_repos(file: Path) -> set[str]:
     return {r for r in PUBLIC_REPOS if f"`{r}`" in text}
 
 
-def append_bullets(bullets: list[str]) -> None:
+def pending_dir() -> Path | None:
+    """Where today's Pending Signals file lives, in the vault owning this cwd.
+
+    MYC-3529 — resolved per invocation, not from a naive
+    `os.environ.get("VAULT_ROOT", str(Path.home() / "vault"))` at import. This
+    hook WRITES, and append_bullets() calls mkdir(parents=True), so the naive
+    default did not merely read the wrong place: UNSET, on every vault not
+    literally named "vault", it CREATED `~/vault/🍄 .../📋 Pending Signals/` and
+    filed the day's ships into a phantom vault the user never opens. The signals
+    were not lost loudly, they were lost quietly, which is worse.
+
+    None = no vault identifiable from the cwd and no $VAULT_ROOT fallback. The
+    caller must skip; there is no correct place to invent.
+    """
+    vault = vault_root_for(Path.cwd())
+    if vault is None:
+        return None
+    return vault.joinpath(*PENDING_SUBPATH)
+
+
+def append_bullets(pending: Path, bullets: list[str]) -> None:
     if not bullets:
         return
-    PENDING_DIR.mkdir(parents=True, exist_ok=True)
-    file = PENDING_DIR / f"{target_date()}.md"
+    pending.mkdir(parents=True, exist_ok=True)
+    file = pending / f"{target_date()}.md"
     if not file.exists():
         file.write_text(
             f"---\ntype: pending-signals\nworkspace: mycelium\ncreated: {target_date()}\n---\n\n"
@@ -102,7 +128,14 @@ def main() -> int:
         print(json.dumps({"continue": True, "suppressOutput": True}))
         return 0
 
-    file = PENDING_DIR / f"{target_date()}.md"
+    pending = pending_dir()
+    if pending is None:
+        # No vault to file into. Say so instead of inventing ~/vault.
+        print(json.dumps({"continue": True, "suppressOutput": True,
+                          "captured": 0, "skipped": "no vault resolved"}))
+        return 0
+
+    file = pending / f"{target_date()}.md"
     seen = existing_repos(file)
     since = window_start()
     captured_at = datetime.now(TZ).strftime("%H:%M")
@@ -123,7 +156,7 @@ def main() -> int:
             f"— source: `~/dev/{name}` git log · captured: {captured_at} (auto)"
         )
 
-    append_bullets(bullets)
+    append_bullets(pending, bullets)
     print(json.dumps({"continue": True, "suppressOutput": True, "captured": len(bullets)}))
     return 0
 

--- a/hooks/block-raw-vault-git.py
+++ b/hooks/block-raw-vault-git.py
@@ -39,8 +39,43 @@ import os
 from pathlib import Path
 import json, sys, re, os, subprocess
 
-VAULT = os.environ.get("VAULT_ROOT", str(Path.home() / "vault"))
-VAULT_GIT_DIR = os.path.realpath(os.path.join(VAULT, ".git"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    from _lib.vault_root import vault_root_for  # noqa: E402
+except Exception:  # fail-open: never block a git op on an import error
+    def vault_root_for(target: Path):  # type: ignore
+        return None
+
+
+def _vault_git_dir_for(target: str) -> str | None:
+    """realpath of the `.git` of the vault governing `target`, or None.
+
+    MYC-3529 — resolved PER TARGET. The module used to bind
+        VAULT = os.environ.get("VAULT_ROOT", str(Path.home() / "vault"))
+        VAULT_GIT_DIR = os.path.realpath(os.path.join(VAULT, ".git"))
+    once, at import. That is the #375/#404 shape and it fails silently OPEN in
+    both directions: UNSET, VAULT_GIT_DIR was `~/vault/.git`, which exists on
+    almost no install, so `_targets_vault_repo` returned False for every op and
+    this guard allowed raw `git add`/`commit` in the vault it was written to
+    protect. SET, it named exactly ONE vault, so the same raw ops against a
+    SECOND vault — with the same 60K-file index.lock contention — passed
+    straight through.
+
+    A hook fires on ops against ANY vault, so the vault has to be derived from
+    the path the op actually targets (its effective cwd, or an explicit
+    --git-dir). vault_root_for detects it from that path and falls back to
+    $VAULT_ROOT only when detection finds nothing, which is what keeps the
+    previous behavior intact for a vault with no Meta-suffixed folder.
+
+    None = no vault governs this path; the caller must fail open (allow).
+    """
+    try:
+        root = vault_root_for(Path(target) if target else Path.cwd())
+    except (OSError, RuntimeError, ValueError):
+        return None
+    if root is None:
+        return None
+    return os.path.realpath(os.path.join(str(root), ".git"))
 
 
 def _effective_cwd(command: str, initial: str) -> str:
@@ -120,8 +155,11 @@ def _targets_vault_repo(cwd: str) -> bool:
         return False
     if out.returncode != 0 or not out.stdout.strip():
         return False
+    vault_git_dir = _vault_git_dir_for(cwd)
+    if vault_git_dir is None:
+        return False
     common_dir = os.path.realpath(os.path.join(cwd, out.stdout.strip()))
-    return common_dir == VAULT_GIT_DIR
+    return common_dir == vault_git_dir
 
 
 def _git_dir_arg(opts_blob: str):
@@ -155,7 +193,10 @@ def _git_dir_is_vault(git_dir: str) -> bool:
             cands.append(os.path.join(git_dir, out.stdout.strip()))
     except Exception:
         pass
-    return any(os.path.realpath(c) == VAULT_GIT_DIR for c in cands)
+    vault_git_dir = _vault_git_dir_for(git_dir)
+    if vault_git_dir is None:
+        return False
+    return any(os.path.realpath(c) == vault_git_dir for c in cands)
 
 
 def _targets_vault(opts_blob: str, base_cwd: str) -> bool:

--- a/hooks/block-raw-vault-git.py
+++ b/hooks/block-raw-vault-git.py
@@ -35,6 +35,14 @@ Allows explicit escapes:
     vault-safe-commit.sh ...   (the sanctioned wrapper)
     GIT_VAULT_BYPASS=1 git ... (emergency escape hatch for the user)
 """
+# MYC-3529: REQUIRED, not cosmetic. This module annotates with PEP-604
+# `X | None`, which is evaluated at def-time and is a TypeError on Python
+# 3.9 -- the floor version scripts/ci.sh's gate actually runs. py_compile
+# does NOT catch it (the annotation compiles fine and only blows up when
+# the def executes), so the import crash is invisible to the lint gates and
+# shows up only as a hook that silently does nothing.
+from __future__ import annotations
+
 import os
 from pathlib import Path
 import json, sys, re, os, subprocess

--- a/hooks/block-vault-git-fullwalk.py
+++ b/hooks/block-vault-git-fullwalk.py
@@ -31,8 +31,44 @@ import os
 from pathlib import Path
 import json, sys, re, os, subprocess
 
-VAULT = os.environ.get("VAULT_ROOT", str(Path.home() / "vault"))
-VAULT_GIT_DIR = os.path.realpath(os.path.join(VAULT, ".git"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    from _lib.vault_root import vault_root_for  # noqa: E402
+except Exception:  # fail-open: never block a git op on an import error
+    def vault_root_for(target: Path):  # type: ignore
+        return None
+
+
+def _vault_git_dir_for(target: str) -> str | None:
+    """realpath of the `.git` of the vault governing `target`, or None.
+
+    MYC-3529 — resolved PER TARGET. The module used to bind
+        VAULT = os.environ.get("VAULT_ROOT", str(Path.home() / "vault"))
+        VAULT_GIT_DIR = os.path.realpath(os.path.join(VAULT, ".git"))
+    once, at import. That is the #375/#404 shape and it fails silently OPEN in
+    both directions: UNSET, the comparison target was `~/vault/.git`, which
+    exists on almost no install, so `_targets_vault_repo` returned False for
+    every op and `git add -A` walked the 60K-file vault unimpeded — the exact
+    10-minute index.lock stall this hook exists to prevent, with no signal that
+    the guard had done nothing. SET, it named exactly ONE vault, so the same
+    full-tree stage against a SECOND vault passed straight through.
+
+    A hook fires on ops against ANY vault, so the vault has to be derived from
+    the path the op actually targets (its effective cwd, or an explicit
+    --git-dir). vault_root_for detects it from that path and falls back to
+    $VAULT_ROOT only when detection finds nothing, which is what keeps the
+    previous behavior intact for a vault with no Meta-suffixed folder.
+
+    None = no vault governs this path; the caller must fail open (allow), which
+    is what keeps `git add -A` in a standard-sized ~/dev/* repo instant.
+    """
+    try:
+        root = vault_root_for(Path(target) if target else Path.cwd())
+    except (OSError, RuntimeError, ValueError):
+        return None
+    if root is None:
+        return None
+    return os.path.realpath(os.path.join(str(root), ".git"))
 
 
 def _effective_cwd(command: str, initial: str) -> str:
@@ -112,8 +148,11 @@ def _targets_vault_repo(cwd: str) -> bool:
         return False
     if out.returncode != 0 or not out.stdout.strip():
         return False
+    vault_git_dir = _vault_git_dir_for(cwd)
+    if vault_git_dir is None:
+        return False
     common_dir = os.path.realpath(os.path.join(cwd, out.stdout.strip()))
-    return common_dir == VAULT_GIT_DIR
+    return common_dir == vault_git_dir
 
 
 def _git_dir_arg(opts_blob: str):
@@ -147,7 +186,10 @@ def _git_dir_is_vault(git_dir: str) -> bool:
             cands.append(os.path.join(git_dir, out.stdout.strip()))
     except Exception:
         pass
-    return any(os.path.realpath(c) == VAULT_GIT_DIR for c in cands)
+    vault_git_dir = _vault_git_dir_for(git_dir)
+    if vault_git_dir is None:
+        return False
+    return any(os.path.realpath(c) == vault_git_dir for c in cands)
 
 
 def _targets_vault(opts_blob: str, base_cwd: str) -> bool:

--- a/hooks/block-vault-git-fullwalk.py
+++ b/hooks/block-vault-git-fullwalk.py
@@ -27,6 +27,14 @@ retarget the op; `-c <name>=<value>`, `--work-tree` and `--namespace` are
 consumed too. `git -C "<vault>" add -A`, `git --git-dir="<vault>/.git" add -A`,
 and `git -c core.hooksPath=/dev/null add -A` are all detected.
 """
+# MYC-3529: REQUIRED, not cosmetic. This module annotates with PEP-604
+# `X | None`, which is evaluated at def-time and is a TypeError on Python
+# 3.9 -- the floor version scripts/ci.sh's gate actually runs. py_compile
+# does NOT catch it (the annotation compiles fine and only blows up when
+# the def executes), so the import crash is invisible to the lint gates and
+# shows up only as a hook that silently does nothing.
+from __future__ import annotations
+
 import os
 from pathlib import Path
 import json, sys, re, os, subprocess

--- a/hooks/block-worktree-shared-edit.py
+++ b/hooks/block-worktree-shared-edit.py
@@ -43,12 +43,53 @@ from pathlib import Path
 import re
 import sys
 
-VAULT_ROOT = os.environ.get("VAULT_ROOT", str(Path.home() / "vault"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    from _lib.vault_root import vault_root_for  # noqa: E402
+except Exception:  # fail-open: a write guard must never block on its own bug
+    def vault_root_for(target: Path):  # type: ignore
+        return None
 
-# Match worktree paths: <vault>/.claude/worktrees/<slug>/<rest>
+# Match worktree paths: <vault>/.claude/worktrees/<slug>/<rest>.
+#
+# MYC-3529 — the vault segment is CAPTURED from the target path, not baked in
+# from `os.environ.get("VAULT_ROOT", str(Path.home() / "vault"))`. Baking it in
+# is the #375/#404 defect and it bit hardest here: this is a PreToolUse guard on
+# Write/Edit/MultiEdit, so an unmatched path is an ALLOWED write. UNSET, the
+# pattern anchored on `~/vault/.claude/worktrees/`, matched nothing on any vault
+# not named "vault", and the guard allowed every stranding edit it exists to
+# block — silently OPEN, on every install. SET, it protected exactly one vault
+# and let worktree edits in every other vault strand on the throwaway branch.
+#
+# is_vault_root() below re-imposes the scoping the baked-in prefix used to
+# provide: a `.claude/worktrees/` path under a plain code repo is NOT a vault
+# worktree, and must stay allowed (SHARED_PATTERNS includes bare `CLAUDE.md`
+# and `.mcp.json`, which every code repo has).
 WORKTREE_RE = re.compile(
-    r"^" + re.escape(VAULT_ROOT) + r"/\.claude/worktrees/([^/]+)/(.+)$"
+    r"^(?P<vault>.+)/\.claude/worktrees/(?P<slug>[^/]+)/(?P<rel>.+)$"
 )
+
+
+def is_vault_root(candidate: str) -> bool:
+    """True iff `candidate` is a real vault root (per-target detection).
+
+    vault_root_for walks up from the candidate for a Meta-suffixed folder and
+    falls back to $VAULT_ROOT. The candidate qualifies when detection lands on
+    the candidate ITSELF — a match higher up would mean the worktree belongs to
+    some ancestor vault, not to this path, and the rel-path patterns below are
+    written relative to the vault root.
+    """
+    try:
+        here = Path(candidate).resolve()
+    except (OSError, RuntimeError):
+        return False
+    root = vault_root_for(here)
+    if root is None:
+        return False
+    try:
+        return root.resolve() == here
+    except (OSError, RuntimeError):
+        return False
 
 # Files where worktree-path edits silently diverge from master.
 # Editing these MUST happen at main vault path so vault-safe-commit picks them up.
@@ -107,11 +148,20 @@ def main() -> int:
     if not file_path:
         return 0
 
-    m = WORKTREE_RE.match(file_path)
+    # Normalize separators so a Windows path (backslashes) matches the same
+    # worktree shape as a POSIX one — #375 was reported from a Windows install.
+    m = WORKTREE_RE.match(file_path.replace("\\", "/"))
     if not m:
         return 0
 
-    slug, rel = m.groups()
+    vault_root, slug, rel = m.group("vault"), m.group("slug"), m.group("rel")
+
+    # Scope: only vault worktrees. A `.claude/worktrees/` checkout of a plain
+    # code repo is out of scope and must stay allowed.
+    if not is_vault_root(vault_root):
+        return 0
+
+    VAULT_ROOT = vault_root  # the messages below quote the resolved main vault
 
     for pat in SESSION_ARTIFACT_PATTERNS:
         if pat.match(rel):

--- a/hooks/build-runbook-check.py
+++ b/hooks/build-runbook-check.py
@@ -27,7 +27,14 @@ import re
 import sys
 from pathlib import Path
 
-VAULT_ROOT = Path(os.environ.get("VAULT_ROOT", str(Path.home() / "vault")))
+# NO VAULT_ROOT here on purpose (MYC-3529). This hook never touches the vault:
+# it matches BUILD_STANDARDS / MCP_RUNBOOK as bare FILENAME substrings against
+# `file_path` arguments recorded in the session transcript under
+# ~/.claude/projects, so it already works for a Read of either runbook in ANY
+# vault. The module used to bind `VAULT_ROOT` from the env var with a ~/vault
+# default and then never reference it — a dead read that made the file look
+# vault-rooted to every reader and to the MYC-2505 survey, which is why it was
+# tagged SEV-A. Deleting it is the whole fix; nothing here needs a vault root.
 BUILD_STANDARDS = "Build Standards.md"
 MCP_RUNBOOK = "MCP Build Runbook.md"
 TRANSCRIPT_DIR = Path.home() / ".claude" / "projects"

--- a/hooks/create-dev-repo-checkpoint.py
+++ b/hooks/create-dev-repo-checkpoint.py
@@ -28,11 +28,17 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    from _lib.vault_root import vault_root_for  # noqa: E402
+except Exception:  # fail-open: never break the Stop chain on an import error
+    def vault_root_for(target: Path):  # type: ignore
+        return None
+
 BYPASS_ENV = "DEV_CHECKPOINT_BYPASS"
 PREFIX = "claude-checkpoint"
 MAX_CHECKPOINTS = 20
 DEV_ROOT = Path.home() / "dev"
-VAULT_ROOT = Path(os.environ.get("VAULT_ROOT", str(Path.home() / "vault")))
 
 
 def run_git(repo: Path, args: list[str], timeout: int = 10) -> subprocess.CompletedProcess:
@@ -130,12 +136,24 @@ def main() -> int:
     except (OSError, RuntimeError):
         return 0
 
-    # Defense-in-depth: NEVER fire on vault paths (handled by auto-snapshot.sh)
-    try:
-        cwd.relative_to(VAULT_ROOT.resolve())
-        return 0  # cwd is under vault, skip
-    except ValueError:
-        pass  # Not under vault, continue
+    # Defense-in-depth: NEVER fire on vault paths (handled by auto-snapshot.sh).
+    #
+    # MYC-3529 — resolved PER CWD, not from $VAULT_ROOT. This gate is what keeps
+    # `git add -A` (below, in checkpoint()) away from a 60K-file vault, and
+    # block-raw-vault-git.py bans exactly that op there. The old code compared
+    # against a single env-named vault with a ~/vault default, so a SECOND vault
+    # sailed through: a vault checked out under ~/dev (e.g. ~/dev/mycelium-vault,
+    # which this repo's own hooks document as a real vault-namespace repo) passes
+    # the ~/vault test AND the DEV_ROOT test below, and gets the full-tree stage
+    # the vault guards exist to prevent. vault_root_for detects the vault from
+    # the cwd itself, so any vault is excluded regardless of what the env says.
+    vault = vault_root_for(cwd)
+    if vault is not None:
+        try:
+            cwd.relative_to(vault)
+            return 0  # cwd is under A vault, skip
+        except ValueError:
+            pass  # Not under that vault, continue
 
     # Only fire under ~/dev/<repo>
     try:

--- a/hooks/surface-stale-automation-failures.py
+++ b/hooks/surface-stale-automation-failures.py
@@ -30,52 +30,79 @@ import time
 from pathlib import Path
 
 HOME = Path.home()
-VAULT = Path(os.environ.get("VAULT_ROOT", str(Path.home() / "vault")))
 
-# Known runner logs to scan.
-# Each entry: (label, log path, fail-pattern, threshold, hint).
-RUNNERS = [
-    (
-        "auto-snapshot",
-        VAULT / "⚙️ Meta" / ".auto-snapshot.log",
-        re.compile(r"FAIL|errored"),
-        3,
-        "hourly vault commit; mirror-drift between CLAUDE.md and AGENTS.md "
-        "is the common blocker",
-    ),
-    (
-        "hookify-auto-commit",
-        HOME / ".claude" / "hooks" / "hookify-auto-commit.log",
-        re.compile(r"failed|error", re.IGNORECASE),
-        5,
-        "on-edit auto-commit of .claude/hookify.*.local.md files",
-    ),
-    (
-        "vault-safe-commit",
-        VAULT / "⚙️ Meta" / ".vault-snapshot.log",
-        re.compile(r"FAIL"),
-        3,
-        "the wrapper Claude uses for explicit vault commits",
-    ),
-    (
-        "scrub-session-jsonl",
-        HOME / ".claude" / "hooks" / "scrub-log.jsonl",
-        re.compile(r'"error"'),
-        3,
-        "SessionEnd secret-pattern redaction over the closing session's JSONL",
-    ),
-    # team-broadcast-daily moved to team_broadcast_findings() below: a daily
-    # job needs last-run-outcome detection, not a 3-in-72h count (2026-05-22).
-    (
-        "substack-cookie-refresh",
-        HOME / ".claude" / "substack-mcp" / "refresh.log",
-        re.compile(r"ERROR"),
-        3,
-        "12-hourly Substack session-cookie refresh; a logged-out browser or "
-        "a flaky cookie-store backend (the comet keychain-decryption class) "
-        "shows here. Fix: switch the pub's `browser` field in config.json",
-    ),
-]
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    from _lib.vault_root import vault_root_for  # noqa: E402
+except Exception:  # fail-open: a SessionStart nudge must never break startup
+    def vault_root_for(target: Path):  # type: ignore
+        return None
+
+
+def runners(vault: Path | None) -> list[tuple]:
+    """Known runner logs to scan: (label, log path, fail-pattern, threshold, hint).
+
+    MYC-3529 — the vault-rooted entries take the vault resolved for THIS
+    session's cwd, not a module-level
+    `os.environ.get("VAULT_ROOT", str(Path.home() / "vault"))`. Both branches of
+    that read were wrong for the job. UNSET, the two vault logs resolved under
+    `~/vault/⚙️ Meta/`, which does not exist on any vault not literally named
+    "vault", so `fail_count_in_window` short-circuited on `log_path.exists()`
+    and returned 0 — this hook reported "nothing wrong" while auto-snapshot
+    failed hourly, which is precisely the 2026-05-14 191-file strand it was
+    written to make impossible. SET, it watched ONE vault's runners and stayed
+    blind to a second vault's.
+
+    `vault is None` (no vault detectable, no $VAULT_ROOT) drops the vault-rooted
+    entries entirely; the ~/.claude-rooted runners are machine-global and are
+    always scanned.
+    """
+    machine_global = [
+        (
+            "hookify-auto-commit",
+            HOME / ".claude" / "hooks" / "hookify-auto-commit.log",
+            re.compile(r"failed|error", re.IGNORECASE),
+            5,
+            "on-edit auto-commit of .claude/hookify.*.local.md files",
+        ),
+        (
+            "scrub-session-jsonl",
+            HOME / ".claude" / "hooks" / "scrub-log.jsonl",
+            re.compile(r'"error"'),
+            3,
+            "SessionEnd secret-pattern redaction over the closing session's JSONL",
+        ),
+        # team-broadcast-daily moved to team_broadcast_findings() below: a daily
+        # job needs last-run-outcome detection, not a 3-in-72h count (2026-05-22).
+        (
+            "substack-cookie-refresh",
+            HOME / ".claude" / "substack-mcp" / "refresh.log",
+            re.compile(r"ERROR"),
+            3,
+            "12-hourly Substack session-cookie refresh; a logged-out browser or "
+            "a flaky cookie-store backend (the comet keychain-decryption class) "
+            "shows here. Fix: switch the pub's `browser` field in config.json",
+        ),
+    ]
+    if vault is None:
+        return machine_global
+    return [
+        (
+            "auto-snapshot",
+            vault / "⚙️ Meta" / ".auto-snapshot.log",
+            re.compile(r"FAIL|errored"),
+            3,
+            "hourly vault commit; mirror-drift between CLAUDE.md and AGENTS.md "
+            "is the common blocker",
+        ),
+        (
+            "vault-safe-commit",
+            vault / "⚙️ Meta" / ".vault-snapshot.log",
+            re.compile(r"FAIL"),
+            3,
+            "the wrapper Claude uses for explicit vault commits",
+        ),
+    ] + machine_global
 
 WINDOW_SECONDS = 72 * 3600  # 72-hour rolling window
 # Optional leading bracket: auto-snapshot.log uses "[2026-...]", refresh.log
@@ -171,15 +198,19 @@ def launchd_failures() -> list[str]:
     return out
 
 
-def receipts_reconcile_findings() -> list[str]:
+def receipts_reconcile_findings(vault: Path | None) -> list[str]:
     """Surface receipts-reconcile data findings the launchd pass can't see.
 
     daily_reconcile.py exits 0 on data findings (only operational errors exit
     non-zero), so a stale pipeline heartbeat or bad receipt row slips past the
     launchctl-status pass. Read the newest note: flag hard_violations > 0, or
     flag the note being > 48h stale (the reconcile job itself stopped).
+
+    `vault is None` → nothing to read; the notes live inside a vault.
     """
-    notes_dir = VAULT / "⚙️ Meta" / "Receipts Reconcile"
+    if vault is None:
+        return []
+    notes_dir = vault / "⚙️ Meta" / "Receipts Reconcile"
     if not notes_dir.exists():
         return []
     notes = sorted(notes_dir.glob("*.md"), reverse=True)
@@ -287,13 +318,23 @@ def main() -> int:
         return 0
 
     # SessionStart payload arrives on stdin (JSON). Drain so we don't block.
+    # `cwd` on it is how we know WHICH vault's runners to scan.
+    raw = ""
     try:
-        sys.stdin.read()
+        raw = sys.stdin.read()
     except Exception:
         pass
+    cwd = ""
+    try:
+        payload = json.loads(raw) if raw.strip() else {}
+        if isinstance(payload, dict):
+            cwd = payload.get("cwd") or ""
+    except Exception:
+        pass
+    vault = vault_root_for(Path(cwd) if cwd else Path.cwd())
 
     findings: list[str] = []
-    for label, log_path, pattern, threshold, hint in RUNNERS:
+    for label, log_path, pattern, threshold, hint in runners(vault):
         try:
             n = fail_count_in_window(log_path, pattern, WINDOW_SECONDS)
         except Exception:
@@ -314,7 +355,7 @@ def main() -> int:
     # receipts-reconcile exits 0 on data findings, so its stale-pipeline
     # signal won't show in the launchd pass — read the note directly.
     try:
-        findings.extend(receipts_reconcile_findings())
+        findings.extend(receipts_reconcile_findings(vault))
     except Exception:
         pass
 

--- a/hooks/vault-command-nudges.py
+++ b/hooks/vault-command-nudges.py
@@ -31,6 +31,14 @@ Two scoping models, tagged per rule:
 
 Escape hatch: prefix the command with VAULT_VALIDATOR_BYPASS=1.
 """
+# MYC-3529: REQUIRED, not cosmetic. This module annotates with PEP-604
+# `X | None`, which is evaluated at def-time and is a TypeError on Python
+# 3.9 -- the floor version scripts/ci.sh's gate actually runs. py_compile
+# does NOT catch it (the annotation compiles fine and only blows up when
+# the def executes), so the import crash is invisible to the lint gates and
+# shows up only as a hook that silently does nothing.
+from __future__ import annotations
+
 import os
 from pathlib import Path
 import json, sys, re, os, subprocess

--- a/hooks/vault-command-nudges.py
+++ b/hooks/vault-command-nudges.py
@@ -35,8 +35,94 @@ import os
 from pathlib import Path
 import json, sys, re, os, subprocess
 
-VAULT = os.environ.get("VAULT_ROOT", str(Path.home() / "vault"))
-VAULT_GIT_DIR = os.path.realpath(os.path.join(VAULT, ".git"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    from _lib.vault_root import vault_root_for  # noqa: E402
+except Exception:  # fail-open: never block a command on an import error
+    def vault_root_for(target: Path):  # type: ignore
+        return None
+
+# MYC-3529 — every vault root used below is resolved PER TARGET. The module
+# used to bind
+#     VAULT = os.environ.get("VAULT_ROOT", str(Path.home() / "vault"))
+#     VAULT_GIT_DIR = os.path.realpath(os.path.join(VAULT, ".git"))
+# once, at import. That is the #375/#404 shape, and BOTH scoping models here
+# inherited it. UNSET, every rule compared against `~/vault`, which exists on
+# almost no install: `git push`/`git status` in the vault were never blocked,
+# and `rm -rf` against a top-level vault folder was never blocked either — a
+# destructive-command guard that was inert and silent about it. SET, all five
+# rules protected exactly ONE vault while every other vault on the machine was
+# unguarded.
+
+# Cap on how many absolute path tokens a single command may be probed for.
+# Namespace scoping has to consider paths NAMED in the command (`cd /tmp &&
+# rm -rf "<abs vault path>"`), and each probe is a bounded filesystem walk-up.
+# Real commands name a handful of paths; the cap keeps a pathological one-liner
+# from turning a PreToolUse hook into a stat storm.
+_MAX_PATH_TOKENS = 12
+_ABS_PATH_TOKEN_RE = re.compile(
+    r'"([^"]{2,})"' r"|'([^']{2,})'" r'|((?:~|/|[A-Za-z]:[\\/])[^\s;|&]+)'
+)
+
+
+def _vault_git_dir_for(target: str) -> str | None:
+    """realpath of the `.git` of the vault governing `target`, or None.
+
+    None = no vault governs this path; the caller must fail open (allow), which
+    is what keeps every ~/dev/* repo and non-vault repo passing straight
+    through.
+    """
+    try:
+        root = vault_root_for(Path(target) if target else Path.cwd())
+    except (OSError, RuntimeError, ValueError):
+        return None
+    if root is None:
+        return None
+    return os.path.realpath(os.path.join(str(root), ".git"))
+
+
+def _in_vault_namespace(command: str, cwd: str) -> bool:
+    """True iff this command touches SOME vault's path namespace.
+
+    Namespace-scoped rules (rm -rf / grep / find) are about the filesystem
+    tree, not git identity, so the question is "is a vault path involved" —
+    for ANY vault, not just the one $VAULT_ROOT happens to name. Two signals,
+    matching the pre-MYC-3529 intent:
+      - the effective cwd sits inside a vault, or
+      - the command NAMES a path that sits inside a vault (so
+        `cd /tmp && rm -rf "<abs vault path>"` is still caught).
+    """
+    if cwd:
+        root = vault_root_for(Path(cwd))
+        if root is not None and _is_under(cwd, root):
+            return True
+
+    seen: set[str] = set()
+    for m in _ABS_PATH_TOKEN_RE.finditer(command):
+        raw = next((g for g in m.groups() if g is not None), None)
+        if raw is None:
+            continue
+        token = os.path.expanduser(raw.strip())
+        if not os.path.isabs(token) or token in seen:
+            continue
+        seen.add(token)
+        if len(seen) > _MAX_PATH_TOKENS:
+            break
+        root = vault_root_for(Path(token))
+        if root is not None and _is_under(token, root):
+            return True
+    return False
+
+
+def _is_under(path: str, root: Path) -> bool:
+    """True iff `path` is `root` or sits beneath it. Lexical, no existence
+    requirement — `rm -rf <vault>/x` must be caught before x exists."""
+    try:
+        a = os.path.normcase(os.path.abspath(str(path)))
+        b = os.path.normcase(os.path.abspath(str(root)))
+    except (OSError, ValueError):
+        return False
+    return a == b or a.startswith(b.rstrip(os.sep) + os.sep)
 
 
 def _effective_cwd(command: str, initial: str) -> str:
@@ -116,8 +202,11 @@ def _targets_vault_repo(cwd: str) -> bool:
         return False
     if out.returncode != 0 or not out.stdout.strip():
         return False
+    vault_git_dir = _vault_git_dir_for(cwd)
+    if vault_git_dir is None:
+        return False
     common_dir = os.path.realpath(os.path.join(cwd, out.stdout.strip()))
-    return common_dir == VAULT_GIT_DIR
+    return common_dir == vault_git_dir
 
 
 def _git_dir_arg(opts_blob: str):
@@ -151,7 +240,10 @@ def _git_dir_is_vault(git_dir: str) -> bool:
             cands.append(os.path.join(git_dir, out.stdout.strip()))
     except Exception:
         pass
-    return any(os.path.realpath(c) == VAULT_GIT_DIR for c in cands)
+    vault_git_dir = _vault_git_dir_for(git_dir)
+    if vault_git_dir is None:
+        return False
+    return any(os.path.realpath(c) == vault_git_dir for c in cands)
 
 
 def _targets_vault(opts_blob: str, base_cwd: str) -> bool:
@@ -235,10 +327,17 @@ def main():
     cwd = os.environ.get("CLAUDE_CWD", data.get("cwd", ""))
     cwd = _effective_cwd(command, cwd)
 
-    # Namespace-scoped rules fire when the command touches the vault path
-    # namespace: cwd under the vault, or the literal vault path in the
-    # command (so `cd /tmp && rm -rf <abs vault path>` is still caught).
-    in_vault_namespace = (bool(cwd) and cwd.startswith(VAULT)) or (VAULT in command)
+    # Namespace-scoped rules fire when the command touches SOME vault's path
+    # namespace: cwd under a vault, or a vault path named in the command (so
+    # `cd /tmp && rm -rf <abs vault path>` is still caught). Computed lazily
+    # and once — every probe is a filesystem walk-up, and the overwhelming
+    # majority of Bash calls never match a namespace-scoped rule at all.
+    namespace_cache: list[bool] = []
+
+    def in_vault_namespace() -> bool:
+        if not namespace_cache:
+            namespace_cache.append(_in_vault_namespace(command, cwd))
+        return namespace_cache[0]
 
     # Repo-scoped rules consult `git rev-parse` -- run it lazily, and
     # cache by the captured git-options blob.
@@ -261,7 +360,7 @@ def main():
                 for m in matches
             )
         else:
-            fired = in_vault_namespace
+            fired = in_vault_namespace()
         if fired:
             hits.append((severity, message))
 

--- a/hooks/vault-context.py
+++ b/hooks/vault-context.py
@@ -17,6 +17,14 @@ Now: resolve per invocation from the session's cwd (vault_root_for — detection
 from the target first, $VAULT_ROOT as fallback). No vault identified → inject
 nothing, which is the honest answer.
 """
+# MYC-3529: REQUIRED, not cosmetic. This module annotates with PEP-604
+# `X | None`, which is evaluated at def-time and is a TypeError on Python
+# 3.9 -- the floor version scripts/ci.sh's gate actually runs. py_compile
+# does NOT catch it (the annotation compiles fine and only blows up when
+# the def executes), so the import crash is invisible to the lint gates and
+# shows up only as a hook that silently does nothing.
+from __future__ import annotations
+
 import json
 import os
 from pathlib import Path

--- a/hooks/vault-context.py
+++ b/hooks/vault-context.py
@@ -2,6 +2,20 @@
 """
 UserPromptSubmit hook: detect strategic topics, read key vault files, inject as additionalContext.
 Fires before Claude responds — no instructions needed, context is just there.
+
+Vault resolution (MYC-3529, same defect as #375/#404): this hook used to bind
+`VAULT = os.environ.get("VAULT_ROOT", str(Path.home() / "vault"))` at import.
+Both branches were wrong. UNSET, it read `~/vault/⚙️ Meta/Current Priorities.md`,
+which does not exist on any vault not literally named "vault" — every read
+returned None, `parts` stayed length 1, and the hook exited 0 injecting nothing,
+silently, forever. SET, it named ONE vault, so a session working in a SECOND
+vault got the FIRST vault's priorities injected as if they were its own — worse
+than nothing, because the model cannot tell injected context is from the wrong
+place.
+
+Now: resolve per invocation from the session's cwd (vault_root_for — detection
+from the target first, $VAULT_ROOT as fallback). No vault identified → inject
+nothing, which is the honest answer.
 """
 import json
 import os
@@ -9,7 +23,13 @@ from pathlib import Path
 import re
 import sys
 
-VAULT = os.environ.get("VAULT_ROOT", str(Path.home() / "vault"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    from _lib.vault_root import vault_root_for  # noqa: E402
+except Exception:  # fail-open: a context-injector must never break a prompt
+    def vault_root_for(target: Path):  # type: ignore
+        return None
+
 MAX_CHARS = 4000  # per file truncation limit
 
 # Always load these for strategic questions
@@ -60,8 +80,8 @@ STRATEGIC_SIGNALS = [
 ]
 
 
-def read_file(rel_path: str) -> str | None:
-    full = os.path.join(VAULT, rel_path)
+def read_file(vault: Path, rel_path: str) -> str | None:
+    full = os.path.join(str(vault), rel_path)
     try:
         with open(full, "r", encoding="utf-8") as f:
             content = f.read()
@@ -84,6 +104,14 @@ def main():
     if not any(re.search(sig, p) for sig in STRATEGIC_SIGNALS):
         sys.exit(0)
 
+    # Resolve the vault from THIS session's cwd before doing any I/O. None means
+    # no vault is identifiable here (a plain code repo, no $VAULT_ROOT set) —
+    # inject nothing rather than guessing at ~/vault and reading a phantom tree.
+    cwd = payload.get("cwd") or os.environ.get("CLAUDE_CWD") or ""
+    vault = vault_root_for(Path(cwd) if cwd else Path.cwd())
+    if vault is None:
+        sys.exit(0)
+
     files_to_load = list(CORE_FILES)
     for signals, extra_files in TOPIC_MAP:
         if any(re.search(sig, p) for sig in signals):
@@ -97,9 +125,9 @@ def main():
             seen.add(f)
             unique_files.append(f)
 
-    parts = ["[vault-context] Vault files auto-loaded for this query:\n"]
+    parts = [f"[vault-context] Vault files auto-loaded for this query (vault: {vault}):\n"]
     for rel_path in unique_files:
-        content = read_file(rel_path)
+        content = read_file(vault, rel_path)
         if content:
             parts.append(f"\n=== {rel_path} ===\n{content}")
 

--- a/hooks/verify-discoverability-on-close.py
+++ b/hooks/verify-discoverability-on-close.py
@@ -85,18 +85,23 @@ DEV_ROOT = Path.home() / "dev"
 # payload. main() calls _resolve_vault_context(cwd) right after confirming
 # there's a closing claim worth acting on, rebinding these to the SAME
 # repo-aware vault detect-closing-signal.py resolved for this session.
-VAULT_ROOT = Path(os.environ.get("VAULT_ROOT", str(Path.home() / "vault")))
-MEMORY_ROOT = VAULT_ROOT / "⚙️ Meta" / "Agent Memory"
-# Test seam: DISCOVERABILITY_VERIFIER_PATH overrides the verifier the hook
-# shells out to, so tests can inject a deterministic stub verifier and stay
-# independent of the live (concurrent-session) Agent Memory state. Unset in
-# production → the canonical vault verifier is used (no behavior change).
-VERIFIER = Path(
-    os.environ.get(
-        "DISCOVERABILITY_VERIFIER_PATH",
-        str(VAULT_ROOT / "⚙️ Meta" / "scripts" / "discoverability-verifier.py"),
-    )
-)
+#
+# MYC-3529: these used to be seeded from a naive
+# `os.environ.get("VAULT_ROOT", str(Path.home() / "vault"))`. The seed was
+# always overwritten before use, but it is the exact #375/#404 shape and it
+# made the module's import-time answer wrong for every vault not literally
+# named "vault" — including for anything that imports this module without
+# calling main(). They are now seeded through the SAME sanctioned resolver
+# the rebind uses, so the import-time answer and the per-invocation answer
+# can never disagree by construction.
+#
+# Test seam, preserved: DISCOVERABILITY_VERIFIER_PATH overrides the verifier
+# the hook shells out to, so tests can inject a deterministic stub verifier and
+# stay independent of the live (concurrent-session) Agent Memory state. Unset
+# in production → the canonical vault verifier is used (no behavior change).
+VAULT_ROOT: Path
+MEMORY_ROOT: Path
+VERIFIER: Path
 
 
 def _resolve_vault_context(cwd: str) -> None:
@@ -115,6 +120,12 @@ def _resolve_vault_context(cwd: str) -> None:
             str(VAULT_ROOT / "⚙️ Meta" / "scripts" / "discoverability-verifier.py"),
         )
     )
+
+
+# Seed the module globals declared above. Going through _resolve_vault_context
+# rather than repeating the expression is the point: one resolution path, so an
+# import-time read can never drift from the per-invocation rebind.
+_resolve_vault_context("")
 
 # Tool calls that author/modify a file by an explicit file_path argument.
 # These are the primary "this session wrote X" signal.

--- a/hooks/verify-session-close-cascade.py
+++ b/hooks/verify-session-close-cascade.py
@@ -114,16 +114,24 @@ def _find_meta_dir(vault_root: Path) -> Path:
     return vault_root / "Meta"
 
 
-# Import-time placeholders (env-var-only, home-relative default) so the
-# module stays importable without a hook payload. main() calls
-# _resolve_vault_context(cwd) immediately after reading cwd from stdin,
-# before any gate function runs, rebinding these to the SAME repo-aware
-# vault detect-closing-signal.py resolved for this session.
-VAULT_ROOT = Path(os.environ.get("VAULT_ROOT", str(Path.home() / "vault")))
-META_DIR = _find_meta_dir(VAULT_ROOT)
-META_NAME = META_DIR.name
-SESSIONS_DIR = META_DIR / "Sessions"
-RUNNER_SCRIPT = META_DIR / "scripts" / "session-close-runner.sh"
+# Import-time placeholders so the module stays importable without a hook
+# payload. main() calls _resolve_vault_context(cwd) immediately after reading
+# cwd from stdin, before any gate function runs, rebinding these to the SAME
+# repo-aware vault detect-closing-signal.py resolved for this session.
+#
+# MYC-3529: these used to be seeded from a naive
+# `os.environ.get("VAULT_ROOT", str(Path.home() / "vault"))`. The seed was
+# always overwritten before use, but it is the exact #375/#404 shape and it
+# made the module's import-time answer wrong for every vault not literally
+# named "vault" — including for anything that imports this module without
+# calling main(). They are now seeded through the SAME sanctioned resolver
+# the rebind uses, so the import-time answer and the per-invocation answer
+# can never disagree by construction.
+VAULT_ROOT: Path
+META_DIR: Path
+META_NAME: str
+SESSIONS_DIR: Path
+RUNNER_SCRIPT: Path
 
 
 def _resolve_vault_context(cwd: str) -> None:
@@ -134,11 +142,18 @@ def _resolve_vault_context(cwd: str) -> None:
     with — no signature changes needed downstream.
     """
     global VAULT_ROOT, META_DIR, META_NAME, SESSIONS_DIR, RUNNER_SCRIPT
-    VAULT_ROOT = resolve_vault_root(Path(cwd), os.environ.get("VAULT_ROOT"))
+    VAULT_ROOT = resolve_vault_root(Path(cwd) if cwd else Path.cwd(), os.environ.get("VAULT_ROOT"))
     META_DIR = _find_meta_dir(VAULT_ROOT)
     META_NAME = META_DIR.name
     SESSIONS_DIR = META_DIR / "Sessions"
     RUNNER_SCRIPT = META_DIR / "scripts" / "session-close-runner.sh"
+
+
+# Seed the module globals declared above. Going through _resolve_vault_context
+# rather than repeating the expression is the point: one resolution path, so an
+# import-time read can never drift from the per-invocation rebind.
+_resolve_vault_context("")
+
 # Default is the exact path session-close-runner.sh writes; the env override is
 # for hermetic tests (and any setup where both sides agree to relocate it).
 # The literal /tmp (NOT tempfile.gettempdir()) is deliberate on POSIX: the bash

--- a/hooks/verify-session-close-cascade.py
+++ b/hooks/verify-session-close-cascade.py
@@ -56,6 +56,14 @@ Bypass / overrides:
                                installed (warn, never block).
 """
 
+# MYC-3529: REQUIRED, not cosmetic. This module annotates with PEP-604
+# `X | None`, which is evaluated at def-time and is a TypeError on Python
+# 3.9 -- the floor version scripts/ci.sh's gate actually runs. py_compile
+# does NOT catch it (the annotation compiles fine and only blows up when
+# the def executes), so the import crash is invisible to the lint gates and
+# shows up only as a hook that silently does nothing.
+from __future__ import annotations
+
 import json
 import os
 import re

--- a/hooks/worktree-archive-autoprep.py
+++ b/hooks/worktree-archive-autoprep.py
@@ -43,11 +43,36 @@ import subprocess
 import sys
 from pathlib import Path
 
-# Where the prep script lives. Must be the MAIN vault path (the
-# worktree filesystem won't have it under the same path because the
-# worktree is a sparse checkout of the same git repo).
-MAIN_VAULT = Path(os.environ.get("VAULT_ROOT", str(Path.home() / "vault")))
-PREP_SCRIPT = MAIN_VAULT / "⚙️ Meta/scripts/worktree-archive-prep.py"
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    from _lib.vault_root import vault_root_for  # noqa: E402
+except Exception:  # fail-open: a Stop hook must never break the turn
+    def vault_root_for(target: Path):  # type: ignore
+        return None
+
+# MYC-3529 — the MAIN vault is derived from the WORKTREE WE ARE IN, not from
+# $VAULT_ROOT. This hook only ever runs inside `<vault>/.claude/worktrees/<slug>/`,
+# so the cwd already names the vault unambiguously; vault_root_for collapses the
+# worktree segment and confirms the result is really a vault. The old code bound
+# `MAIN_VAULT = os.environ.get("VAULT_ROOT", str(Path.home() / "vault"))` at
+# import: UNSET it looked for the prep script under ~/vault, found nothing, and
+# returned 0 silently on every install whose vault is not named "vault" — the
+# false-alarm archive warning this hook exists to kill fired anyway, with no
+# signal that the fix was inert. SET, a worktree of a SECOND vault ran the FIRST
+# vault's prep script against it (or, more often, silently skipped).
+
+
+def _prep_script_for(cwd: Path) -> Path | None:
+    """The main vault's worktree-archive-prep.py for the vault owning `cwd`.
+
+    Must resolve to the MAIN vault path: the worktree checkout won't have the
+    script at the same path, because the worktree is a sparse checkout of the
+    same git repo.
+    """
+    vault = vault_root_for(cwd)
+    if vault is None:
+        return None
+    return vault / "⚙️ Meta/scripts/worktree-archive-prep.py"
 
 
 def main() -> int:
@@ -55,13 +80,19 @@ def main() -> int:
         return 0
 
     cwd = Path.cwd().resolve()
-    cwd_str = str(cwd)
+    cwd_str = str(cwd).replace("\\", "/")
 
     # Only run when actually inside a worktree.
     if "/.claude/worktrees/" not in cwd_str:
         return 0
 
-    if not PREP_SCRIPT.exists():
+    prep_script = _prep_script_for(cwd)
+    if prep_script is None:
+        # No vault owns this worktree (and no $VAULT_ROOT fallback) — nothing
+        # to run. Silent no-op, same as a missing prep script.
+        return 0
+
+    if not prep_script.exists():
         # Prep script missing — silent no-op. Don't break Stop hook
         # chain on a transient state.
         return 0
@@ -73,7 +104,7 @@ def main() -> int:
     # uv-nudge shim installed 2026-05-09) don't silently 1-out the call.
     try:
         result = subprocess.run(
-            [sys.executable, str(PREP_SCRIPT)],
+            [sys.executable, str(prep_script)],
             cwd=cwd,
             capture_output=True,
             text=True,

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -259,6 +259,13 @@ INTEGRATION_TESTS=(
   # blind (fleet scan still matches, sanctioned resolver names still exist,
   # pinned rows are still real violations, guard still wired into both gates).
   test_vault_root_read_guard
+  # SEV-A remediation (MYC-3529): the guard above froze 12 naive VAULT_ROOT reads
+  # in hooks/; this proves they are FIXED. Every assertion points $VAULT_ROOT at a
+  # decoy vault and acts on a different one, because that is the assertion the
+  # whole class was missing -- #404's bug survived a full suite precisely because
+  # every test ran against the vault the env var already named, which makes
+  # "resolve from the env" and "resolve from the target" indistinguishable.
+  test_hook_vault_root_per_target
 )
 # ---- Gate-coverage invariant -------------------------------------------------
 # The list above is an explicit allow-list, and allow-lists rot: a new

--- a/scripts/cloud-safe-walker-baseline.txt
+++ b/scripts/cloud-safe-walker-baseline.txt
@@ -1,5 +1,5 @@
 # SHA-256-pinned legacy recursive content walkers. Edited/new files must adopt safe_read.
-628b715ae85d0f2fdbd043a166f6ed60e1c964a85c9dd6f4265f20e1b17b11aa hooks/build-runbook-check.py
+b552b16724232b207192f04461c11804ba77007d77f2d264390e42050fbdc798 hooks/build-runbook-check.py
 2cde67ec1bd8c7c340da4b906b3acf67b4e8ebff9294ddaa1231e9d64da20474 hooks/scan-prior-sessions-for-secrets.py
 834faaab5745decd0b36e1df0a245289e632cef8260258ab2a2cd35ce73ffa76 hooks/test_live_session_reap.py
 0e5e50ea4361108fbcf77fed5ebcf8ab037275a1d0f385931a80a77eb786ad75 hooks/test_relocation_orphan_reclaim.py

--- a/scripts/vault-root-read-baseline.txt
+++ b/scripts/vault-root-read-baseline.txt
@@ -28,13 +28,9 @@
 # SET failure mode (a globally-exported VAULT_ROOT names ONE vault and silently
 # wins over the one the caller meant).
 #
-#   SEV-A-home-vault   default is `Path.home() / "vault"`. Inert on every vault
-#                      not literally named "vault" - the guard/hook does nothing
-#                      and says nothing. This is the exact shape of #375/#404.
-#                      All 12 are in hooks/, the higher-severity surface: a hook
-#                      fires on files in ANY vault, so a wrong root makes it fail
-#                      silently OPEN. Fix per-file (see vault_root_for in
-#                      hooks/validate-handoff-frontmatter.py), not per-process.
+#   SEV-A-home-vault   CLEARED by MYC-3529 - see below. Default was
+#                      `Path.home() / "vault"`: inert on every vault not
+#                      literally named "vault", the exact shape of #375/#404.
 #   SEV-B-cwd          default is the process cwd. Right often enough to look
 #                      fine, wrong whenever the tool is run from anywhere else.
 #   SEV-C-script-loc   default derives from __file__. This is the RIGHT default
@@ -47,19 +43,22 @@
 #                      with the None/"". Needs reading case by case.
 #
 
-# ---- SEV-A-home-vault  (12 file(s), 12 read(s)) ----
-77d67b3c9295d7dd2b3c34868679cf86b2e1e62eaad17b5ee4adf20245731dd6 SEV-A-home-vault hooks/auto-capture-public-ships.py
-8f0b58bc3dd57112be05fbf554216c2680dde61fbdf9470e60007fd1d8b4b45f SEV-A-home-vault hooks/block-raw-vault-git.py
-3bec2b51063086d5db9b20dc9f136a08401a780d0efcf97fde2d90ef3981d3cf SEV-A-home-vault hooks/block-vault-git-fullwalk.py
-85a233806b9756b451f3a0b81b8c75eae33afe687d08dfa0f1271a53f9203d5c SEV-A-home-vault hooks/block-worktree-shared-edit.py
-628b715ae85d0f2fdbd043a166f6ed60e1c964a85c9dd6f4265f20e1b17b11aa SEV-A-home-vault hooks/build-runbook-check.py
-dce3ed5df366f6a56d5cd20338302a94932932b87e2f40d867ef772b7ef38266 SEV-A-home-vault hooks/create-dev-repo-checkpoint.py
-d23de68310d25dd3bf5f5508e1a84b89b7d156ea2daeedbd3ee321c872b07149 SEV-A-home-vault hooks/surface-stale-automation-failures.py
-d90976775414288e229f198825f2ab6b904d23c6163b185fa106eb9dff6af2ca SEV-A-home-vault hooks/vault-command-nudges.py
-792c1593b8b22f6dea63a5d7d657a5d0b1ec6f9270531b9357bb2201c15a4e7f SEV-A-home-vault hooks/vault-context.py
-306fd985cd1e1f43314209ad8b9d3f0f9a33613474d91bcdc843bb37409ed1eb SEV-A-home-vault hooks/verify-discoverability-on-close.py
-c2b8ab2406e954ee6688c6b9450d998ff17b18ec1a66f8259ff8eea055df0e10 SEV-A-home-vault hooks/verify-session-close-cascade.py
-3cfa5a97dc3604c9ae6c8ff715e7bd6590176496674a3d2e823400035de56e86 SEV-A-home-vault hooks/worktree-archive-autoprep.py
+# ---- SEV-A-home-vault  (0 file(s), 0 read(s)) -- CLEARED by MYC-3529 --------
+# All 12 rows deleted, not re-pinned. Every one is now resolved per target
+# through hooks/_lib/vault_root.py: vault_root_for() for the per-target surface
+# (detection from the file/dir being acted on FIRST, $VAULT_ROOT as fallback,
+# None when no vault can be identified) and resolve_vault_root(cwd, env) for
+# the two session-close verifiers. hooks/build-runbook-check.py had no fix to
+# make: its VAULT_ROOT binding was dead code and was deleted.
+#
+# No exemptions were issued for this tier. Every one of the 12 was a real
+# silent-open defect.
+#
+# Class invariant guarding the tier: tests/integration/test_hook_vault_root_per_target.sh
+# — each converted hook is exercised against a vault that is NOT $VAULT_ROOT,
+# with $VAULT_ROOT pointed at a decoy. That is the assertion the class was
+# missing; #404's bug survived because the suite only ever ran on the
+# env-named vault.
 
 # ---- SEV-B-cwd  (16 file(s), 16 read(s)) ----
 dd3795425a250401136ea1739bbc0090324a54ca2ac737fcb7ed36f7268d66a3 SEV-B-cwd scripts/check-claude-md-drift.py

--- a/tests/integration/test_hook_vault_root_per_target.sh
+++ b/tests/integration/test_hook_vault_root_per_target.sh
@@ -1,0 +1,569 @@
+#!/usr/bin/env bash
+# Test: every hook remediated by MYC-3529 resolves its vault PER TARGET, and
+# therefore fires on a vault that is NOT the one $VAULT_ROOT names.
+#
+# THE ASSERTION THIS CLASS WAS MISSING
+#   MYC-2505 (#407) surveyed the fleet and found 52 naive `VAULT_ROOT` reads.
+#   Twelve of them were tagged SEV-A: all in hooks/, all shaped
+#       VAULT = os.environ.get("VAULT_ROOT", str(Path.home() / "vault"))
+#   which fails silently in both directions. UNSET it resolves to ~/vault, so
+#   the hook is inert on every vault not literally named "vault". SET it names
+#   exactly ONE vault, so a target in any OTHER vault resolves against the wrong
+#   root, the containment check returns False, and the hook SKIPS the thing it
+#   exists to check -- failing OPEN, with no output at all.
+#
+#   #404 fixed this once, in hooks/validate-handoff-frontmatter.py. The bug had
+#   survived that long precisely because the suite was not hermetic: every test
+#   ran against the vault $VAULT_ROOT already named, so "resolve from the env
+#   var" and "resolve from the target" were indistinguishable. A test written
+#   that way re-creates the blind spot no matter how many cases it has.
+#
+#   So EVERY assertion below points $VAULT_ROOT at a DECOY vault and then acts
+#   on a DIFFERENT one. A hook that still reads the env var naively cannot pass:
+#   it will either do nothing (silent open) or answer for the decoy.
+#
+# STRUCTURE
+#   $TMP/decoy-vault    a real, populated vault. $VAULT_ROOT points here in
+#                       every assertion, and no assertion wants its content.
+#   $TMP/other-vault    the vault each hook must actually resolve to.
+#   $TMP/coderepo       NOT a vault (no Meta-suffixed folder) -- the negative
+#                       control that keeps the fixes from over-firing.
+#   $TMP/home           HOME/USERPROFILE override, so the ~/dev-scoped and
+#                       ~/.claude-scoped hooks are hermetic too.
+#
+# Bash + python3 only, no network. exit 0 = every remediated hook is per-target.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOKS="$REPO_ROOT/hooks"
+GUARD="$REPO_ROOT/scripts/check-vault-root-reads.py"
+BASELINE="$REPO_ROOT/scripts/vault-root-read-baseline.txt"
+
+# The MYC-3529 population, verbatim from the SEV-A tier of PR #407's survey.
+# Named explicitly so this guard cannot silently narrow: if a file is renamed or
+# deleted the existence check below fails LOUD rather than skipping it.
+SEV_A=(
+  auto-capture-public-ships.py
+  block-raw-vault-git.py
+  block-vault-git-fullwalk.py
+  block-worktree-shared-edit.py
+  build-runbook-check.py
+  create-dev-repo-checkpoint.py
+  surface-stale-automation-failures.py
+  vault-command-nudges.py
+  vault-context.py
+  verify-discoverability-on-close.py
+  verify-session-close-cascade.py
+  worktree-archive-autoprep.py
+)
+
+FAILURES=0
+pass() { echo "PASS: $1"; }
+fail() {
+  echo "FAIL: $1" >&2
+  FAILURES=$((FAILURES + 1))
+}
+show_streams() {
+  echo "  --- stdout ---" >&2; sed 's/^/  /' "$OUT" >&2
+  echo "  --- stderr ---" >&2; sed 's/^/  /' "$ERR" >&2
+}
+
+# The tmpdir comes from python's tempfile, NOT `mktemp -d`, and is normalized to
+# forward slashes. Under Git Bash on Windows `mktemp -d` hands back an MSYS path
+# ("/tmp/tmp.XXXX") that native python cannot resolve -- it silently reinterprets
+# it relative to the current drive. Every assertion here compares a path the
+# SHELL produced against a path PYTHON resolved, so the two must agree on what a
+# path is or the suite tests nothing. python's tempfile answers in the same
+# namespace the hooks run in, on both platforms.
+TMP="$(python3 -c 'import tempfile; print(tempfile.mkdtemp(prefix="abs-vault-root-").replace(chr(92), "/"))')"
+if [ -z "$TMP" ] || [ ! -d "$TMP" ]; then
+  echo "FAIL: could not create a tmpdir python and the shell both agree on" >&2
+  exit 1
+fi
+trap 'rm -rf "$TMP"' EXIT
+OUT="$TMP/out.txt"
+ERR="$TMP/err.txt"
+DECOY="$TMP/decoy-vault"
+OTHER="$TMP/other-vault"
+CODEREPO="$TMP/coderepo"
+FAKEHOME="$TMP/home"
+
+# Every hook's own bypass switch is cleared, and CLAUDE_CWD with it: several of
+# these hooks prefer $CLAUDE_CWD over the payload's cwd, and the ambient value
+# (set by the harness that may be running this suite) would silently retarget
+# every assertion at the real machine.
+CLEAN_ENV=(
+  -u CLAUDE_CWD
+  -u AUTO_CAPTURE_SHIPS_BYPASS
+  -u BUILD_RUNBOOK_BYPASS
+  -u DEV_CHECKPOINT_BYPASS
+  -u DISCOVERABILITY_VERIFIER_BYPASS
+  -u DISCOVERABILITY_VERIFIER_PATH
+  -u SURFACE_STALE_AUTOMATION_BYPASS
+  -u VERIFY_CASCADE_BYPASS
+  -u VERIFY_CASCADE_SOFT
+  -u WORKTREE_AUTOPREP_BYPASS
+  -u WORKTREE_VAULT_EDIT_BYPASS
+)
+
+run_hook() {  # <hook-file> <stdin-json> [extra env args...] -> sets RC
+  local hook="$1" payload="$2"; shift 2
+  printf '%s' "$payload" | env "${CLEAN_ENV[@]}" "$@" python3 "$hook" >"$OUT" 2>"$ERR"
+  RC=$?
+}
+
+payload_bash() {  # <command> <cwd>
+  python3 -c 'import json,sys; print(json.dumps({"tool_name":"Bash","tool_input":{"command":sys.argv[1]},"cwd":sys.argv[2]}))' "$1" "$2"
+}
+payload_write() {  # <file_path> <cwd>
+  python3 -c 'import json,sys; print(json.dumps({"tool_name":"Write","tool_input":{"file_path":sys.argv[1],"content":"x"},"cwd":sys.argv[2]}))' "$1" "$2"
+}
+
+git_repo() {  # <dir> -- init + identity + one commit so rev-parse/stash work
+  git -C "$1" init -q
+  git -C "$1" config user.email t@t
+  git -C "$1" config user.name t
+  echo seed > "$1/seed.txt"
+  git -C "$1" add seed.txt >/dev/null 2>&1
+  git -C "$1" -c commit.gpgsign=false commit -qm init >/dev/null 2>&1
+}
+
+# --------------------------------------------------------------------------
+# fixture
+# --------------------------------------------------------------------------
+# Built in python, not bash: the vault subpaths this repo actually uses carry
+# emoji ("⚙️ Meta", "🍄 .../📋 Pending Signals") and the shell's locale handling
+# of those is not something a portability gate should depend on.
+python3 - "$TMP" <<'PY'
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+tmp = Path(sys.argv[1])
+decoy, other, coderepo, home = (
+    tmp / "decoy-vault", tmp / "other-vault", tmp / "coderepo", tmp / "home")
+
+# PRECONDITION. Detection walks UP from the target for a Meta-suffixed folder,
+# so a stray "*Meta" directory in an ancestor of the tmpdir would make the
+# not-a-vault negative controls resolve to it and quietly stop testing anything.
+# Assert the fixture's ancestry is clean instead of assuming it.
+for anc in [tmp, *tmp.parents]:
+    try:
+        hit = next((c.name for c in anc.iterdir()
+                    if c.is_dir() and c.name.endswith("Meta")), None)
+    except OSError:
+        continue
+    if hit:
+        print(f"FIXTURE-UNUSABLE {anc}/{hit}", flush=True)
+        sys.exit(3)
+
+for v in (decoy, other):
+    (v / "⚙️ Meta").mkdir(parents=True, exist_ok=True)
+    (v / "⚙️ Meta" / "scripts").mkdir(exist_ok=True)
+coderepo.mkdir(parents=True, exist_ok=True)
+(coderepo / ".claude" / "worktrees" / "slug1").mkdir(parents=True, exist_ok=True)
+(coderepo / "CLAUDE.md").write_text("# a plain code repo\n", encoding="utf-8")
+(home / ".claude").mkdir(parents=True, exist_ok=True)
+(home / "dev").mkdir(exist_ok=True)
+
+# vault-context.py CORE_FILES, distinguishable per vault.
+for v, tag in ((decoy, "DECOY"), (other, "OTHER")):
+    (v / "⚙️ Meta" / "Current Priorities.md").write_text(
+        f"SENTINEL-PRIORITIES-{tag}\n", encoding="utf-8")
+    (v / "⚙️ Meta" / "Open Loops.md").write_text(
+        f"SENTINEL-LOOPS-{tag}\n", encoding="utf-8")
+
+# worktree-archive-autoprep.py prep script, distinguishable per vault, so a
+# wrong resolution is DETECTED rather than merely absent.
+for v, tag in ((decoy, "DECOY"), (other, "OTHER")):
+    (v / "⚙️ Meta" / "scripts" / "worktree-archive-prep.py").write_text(
+        f"print('SENTINEL-PREP-RAN-IN-{tag}')\n", encoding="utf-8")
+(other / ".claude" / "worktrees" / "slug1").mkdir(parents=True, exist_ok=True)
+
+# surface-stale-automation-failures.py: three distinct failure-minutes inside
+# the 72h window, in the OTHER vault ONLY. The decoy deliberately has no log,
+# so a decoy-resolved scan finds nothing and the assertion is unambiguous.
+now = datetime.now()
+lines = [f"[{(now - timedelta(minutes=5 * i)).strftime('%Y-%m-%dT%H:%M:%S')}] FAIL snapshot errored\n"
+         for i in range(1, 5)]
+(other / "⚙️ Meta" / ".auto-snapshot.log").write_text("".join(lines), encoding="utf-8")
+
+# The two session-close verifiers resolve through resolve_vault_root(), which
+# keys on a CLAUDE.md declaring its OWN Session End/Close cascade.
+(other / "CLAUDE.md").write_text(
+    "# other vault\n\n## Session End -- capture cascade\n", encoding="utf-8")
+
+print("FIXTURE-OK", flush=True)
+PY
+if [ $? -ne 0 ]; then
+  echo "FAIL: fixture could not be built hermetically (see FIXTURE-UNUSABLE above)." >&2
+  echo "      An ancestor of the tmpdir holds a Meta-suffixed folder, so the" >&2
+  echo "      not-a-vault controls would resolve to it and assert nothing." >&2
+  exit 1
+fi
+
+git_repo "$OTHER"
+git_repo "$CODEREPO"
+
+# --------------------------------------------------------------------------
+# 0. structural: the tier is remediated, and this guard is not blind
+# --------------------------------------------------------------------------
+missing=()
+for f in "${SEV_A[@]}"; do
+  [ -f "$HOOKS/$f" ] || missing+=("$f")
+done
+if [ "${#missing[@]}" -gt 0 ]; then
+  echo "FAIL  SEV-A hook(s) not found: ${missing[*]}" >&2
+  echo "      Renamed or removed? Update this guard to track them, or it is blind." >&2
+  exit 1
+fi
+pass "all ${#SEV_A[@]} SEV-A hooks present (guard is not blind)"
+
+# Comment lines are excluded deliberately: the baseline's SEV-A section header
+# now NAMES these files while explaining that their rows were deleted, and a
+# plain substring match would read that prose as a live pin. A row is
+# `<sha256> <TAG> <path>`; only those count.
+pinned=()
+for f in "${SEV_A[@]}"; do
+  if grep -qE "^[0-9a-f]{64}[[:space:]]+[^[:space:]]+[[:space:]]+hooks/$f\$" "$BASELINE"; then
+    pinned+=("$f")
+  fi
+done
+if [ "${#pinned[@]}" -gt 0 ]; then
+  fail "SEV-A row(s) still pinned in the ratchet: ${pinned[*]} -- a remediated file must be UNPINNED, never re-pinned"
+else
+  pass "all ${#SEV_A[@]} SEV-A rows are gone from vault-root-read-baseline.txt"
+fi
+
+sev_a_paths=()
+for f in "${SEV_A[@]}"; do sev_a_paths+=("$HOOKS/$f"); done
+if python3 "$GUARD" --check "${sev_a_paths[@]}" >"$OUT" 2>"$ERR"; then
+  pass "no unsanctioned VAULT_ROOT read remains in any of the 12"
+else
+  fail "check-vault-root-reads --check still reports a violation in the SEV-A tier"
+  show_streams
+fi
+
+# Every remediated hook must still REACH a sanctioned resolver. Without this a
+# future edit could delete the resolver call, satisfy the lint by deleting the
+# read too, and quietly restore a hardcoded root. build-runbook-check.py is the
+# one exception: its VAULT_ROOT binding was dead code and needs no resolver.
+resolved=0
+for f in "${SEV_A[@]}"; do
+  [ "$f" = "build-runbook-check.py" ] && continue
+  if grep -qE 'vault_root_for|resolve_vault_root' "$HOOKS/$f"; then
+    resolved=$((resolved + 1))
+  else
+    fail "$f no longer references a sanctioned resolver"
+  fi
+done
+if [ "$resolved" -eq $(( ${#SEV_A[@]} - 1 )) ]; then
+  pass "all $resolved vault-consuming SEV-A hooks route through a sanctioned resolver"
+fi
+
+if grep -qE '^[^#]*VAULT_ROOT' "$HOOKS/build-runbook-check.py"; then
+  fail "build-runbook-check.py still binds VAULT_ROOT (the read was dead code; it should be gone)"
+else
+  pass "build-runbook-check.py carries no VAULT_ROOT binding at all"
+fi
+
+# --------------------------------------------------------------------------
+# 1. vault-context.py -- injects the OTHER vault's priorities, not the decoy's
+# --------------------------------------------------------------------------
+p=$(python3 -c 'import json,sys; print(json.dumps({"prompt":"what is the plan","cwd":sys.argv[1]}))' "$OTHER")
+run_hook "$HOOKS/vault-context.py" "$p" "VAULT_ROOT=$DECOY"
+if grep -q "SENTINEL-PRIORITIES-OTHER" "$OUT" && ! grep -q "SENTINEL-PRIORITIES-DECOY" "$OUT"; then
+  pass "vault-context injects the cwd's vault, not \$VAULT_ROOT's (rc=$RC)"
+else
+  fail "vault-context did not inject the OTHER vault (rc=$RC)"
+  show_streams
+fi
+
+run_hook "$HOOKS/vault-context.py" \
+  "$(python3 -c 'import json,sys; print(json.dumps({"prompt":"what is the plan","cwd":sys.argv[1]}))' "$CODEREPO")" \
+  -u VAULT_ROOT
+if [ ! -s "$OUT" ]; then
+  pass "vault-context injects nothing when no vault is resolvable (no phantom ~/vault)"
+else
+  fail "vault-context injected context with no vault resolvable"
+  show_streams
+fi
+
+# --------------------------------------------------------------------------
+# 2. block-worktree-shared-edit.py -- blocks a worktree write in ANY vault
+# --------------------------------------------------------------------------
+run_hook "$HOOKS/block-worktree-shared-edit.py" \
+  "$(payload_write "$OTHER/.claude/worktrees/slug1/⚙️ Meta/rules/foo.md" "$OTHER")" \
+  "VAULT_ROOT=$DECOY"
+if [ "$RC" -eq 2 ] && grep -q "BLOCKED" "$ERR"; then
+  pass "block-worktree-shared-edit blocks a shared-canonical write in a non-\$VAULT_ROOT vault (rc=$RC)"
+else
+  fail "block-worktree-shared-edit failed OPEN on the OTHER vault's worktree (rc=$RC)"
+  show_streams
+fi
+
+run_hook "$HOOKS/block-worktree-shared-edit.py" \
+  "$(payload_write "$CODEREPO/.claude/worktrees/slug1/CLAUDE.md" "$CODEREPO")" \
+  "VAULT_ROOT=$DECOY"
+if [ "$RC" -eq 0 ]; then
+  pass "block-worktree-shared-edit stays out of a plain code repo's worktree (rc=$RC)"
+else
+  fail "block-worktree-shared-edit over-fired on a non-vault worktree (rc=$RC)"
+  show_streams
+fi
+
+# --------------------------------------------------------------------------
+# 3. block-raw-vault-git.py -- mutating git op in ANY vault
+# --------------------------------------------------------------------------
+run_hook "$HOOKS/block-raw-vault-git.py" \
+  "$(payload_bash 'git add "note.md"' "$OTHER")" "VAULT_ROOT=$DECOY"
+if [ "$RC" -eq 2 ]; then
+  pass "block-raw-vault-git blocks a raw git add in a non-\$VAULT_ROOT vault (rc=$RC)"
+else
+  fail "block-raw-vault-git failed OPEN on the OTHER vault (rc=$RC)"
+  show_streams
+fi
+
+run_hook "$HOOKS/block-raw-vault-git.py" \
+  "$(payload_bash "git -C \"$OTHER\" commit -m x" "$CODEREPO")" "VAULT_ROOT=$DECOY"
+if [ "$RC" -eq 2 ]; then
+  pass "block-raw-vault-git follows -C into a non-\$VAULT_ROOT vault from a non-vault cwd (rc=$RC)"
+else
+  fail "block-raw-vault-git missed a -C retarget into the OTHER vault (rc=$RC)"
+  show_streams
+fi
+
+run_hook "$HOOKS/block-raw-vault-git.py" \
+  "$(payload_bash 'git add "note.md"' "$CODEREPO")" "VAULT_ROOT=$DECOY"
+if [ "$RC" -eq 0 ]; then
+  pass "block-raw-vault-git lets a plain code repo through (rc=$RC)"
+else
+  fail "block-raw-vault-git over-fired on a non-vault repo (rc=$RC)"
+  show_streams
+fi
+
+# --------------------------------------------------------------------------
+# 4. block-vault-git-fullwalk.py -- full-tree stage in ANY vault
+# --------------------------------------------------------------------------
+run_hook "$HOOKS/block-vault-git-fullwalk.py" \
+  "$(payload_bash 'git add -A' "$OTHER")" "VAULT_ROOT=$DECOY"
+if [ "$RC" -eq 2 ]; then
+  pass "block-vault-git-fullwalk blocks git add -A in a non-\$VAULT_ROOT vault (rc=$RC)"
+else
+  fail "block-vault-git-fullwalk failed OPEN on the OTHER vault (rc=$RC)"
+  show_streams
+fi
+
+run_hook "$HOOKS/block-vault-git-fullwalk.py" \
+  "$(payload_bash 'git add -A' "$CODEREPO")" "VAULT_ROOT=$DECOY"
+if [ "$RC" -eq 0 ]; then
+  pass "block-vault-git-fullwalk leaves a standard-sized repo's git add -A alone (rc=$RC)"
+else
+  fail "block-vault-git-fullwalk over-fired on a non-vault repo (rc=$RC)"
+  show_streams
+fi
+
+# --------------------------------------------------------------------------
+# 5. vault-command-nudges.py -- both scoping models, on ANY vault
+# --------------------------------------------------------------------------
+run_hook "$HOOKS/vault-command-nudges.py" \
+  "$(payload_bash 'git push' "$OTHER")" "VAULT_ROOT=$DECOY"
+if [ "$RC" -eq 2 ] && grep -q "BLOCKED" "$ERR"; then
+  pass "vault-command-nudges (repo-scoped) blocks git push in a non-\$VAULT_ROOT vault (rc=$RC)"
+else
+  fail "vault-command-nudges repo-scoped rule failed OPEN on the OTHER vault (rc=$RC)"
+  show_streams
+fi
+
+run_hook "$HOOKS/vault-command-nudges.py" \
+  "$(payload_bash "grep foo \"$OTHER/note.md\"" "$CODEREPO")" "VAULT_ROOT=$DECOY"
+if [ "$RC" -eq 2 ] && grep -q "NUDGE" "$ERR"; then
+  pass "vault-command-nudges (namespace-scoped) catches a path in a non-\$VAULT_ROOT vault (rc=$RC)"
+else
+  fail "vault-command-nudges namespace rule missed a path inside the OTHER vault (rc=$RC)"
+  show_streams
+fi
+
+run_hook "$HOOKS/vault-command-nudges.py" \
+  "$(payload_bash 'grep foo note.md' "$CODEREPO")" "VAULT_ROOT=$DECOY"
+if [ "$RC" -eq 0 ]; then
+  pass "vault-command-nudges stays quiet outside every vault namespace (rc=$RC)"
+else
+  fail "vault-command-nudges over-fired outside any vault (rc=$RC)"
+  show_streams
+fi
+
+# --------------------------------------------------------------------------
+# 6. create-dev-repo-checkpoint.py -- excludes a vault that is NOT $VAULT_ROOT
+#    This one has teeth: checkpoint() runs `git add -A`, the exact full-tree
+#    stage block-vault-git-fullwalk.py exists to keep out of a vault. Before
+#    MYC-3529 the exclusion compared against a single env-named vault, so a
+#    vault checked out under ~/dev sailed through both gates.
+# --------------------------------------------------------------------------
+python3 - "$FAKEHOME" <<'PY'
+from pathlib import Path
+home = Path(__import__("sys").argv[1])
+(home / "dev" / "vault-under-dev" / "⚙️ Meta").mkdir(parents=True, exist_ok=True)
+(home / "dev" / "plain-repo").mkdir(parents=True, exist_ok=True)
+PY
+git_repo "$FAKEHOME/dev/vault-under-dev"
+git_repo "$FAKEHOME/dev/plain-repo"
+echo dirty >> "$FAKEHOME/dev/vault-under-dev/seed.txt"
+echo dirty >> "$FAKEHOME/dev/plain-repo/seed.txt"
+
+run_hook "$HOOKS/create-dev-repo-checkpoint.py" \
+  "$(python3 -c 'import json,sys; print(json.dumps({"cwd":sys.argv[1]}))' "$FAKEHOME/dev/vault-under-dev")" \
+  "VAULT_ROOT=$DECOY" "HOME=$FAKEHOME" "USERPROFILE=$FAKEHOME"
+if git -C "$FAKEHOME/dev/vault-under-dev" stash list | grep -q claude-checkpoint; then
+  fail "create-dev-repo-checkpoint stashed (git add -A) inside a vault that is not \$VAULT_ROOT"
+  show_streams
+else
+  pass "create-dev-repo-checkpoint excludes a non-\$VAULT_ROOT vault under ~/dev (rc=$RC)"
+fi
+
+run_hook "$HOOKS/create-dev-repo-checkpoint.py" \
+  "$(python3 -c 'import json,sys; print(json.dumps({"cwd":sys.argv[1]}))' "$FAKEHOME/dev/plain-repo")" \
+  "VAULT_ROOT=$DECOY" "HOME=$FAKEHOME" "USERPROFILE=$FAKEHOME"
+if git -C "$FAKEHOME/dev/plain-repo" stash list | grep -q claude-checkpoint; then
+  pass "create-dev-repo-checkpoint still checkpoints a real ~/dev code repo (control: the exclusion above is not vacuous)"
+else
+  fail "create-dev-repo-checkpoint did not checkpoint a plain ~/dev repo -- the vault-exclusion assertion above proves nothing"
+  show_streams
+fi
+
+# --------------------------------------------------------------------------
+# 7. worktree-archive-autoprep.py -- runs the OTHER vault's prep script
+# --------------------------------------------------------------------------
+(
+  cd "$OTHER/.claude/worktrees/slug1" || exit 1
+  printf '{}' | env "${CLEAN_ENV[@]}" "VAULT_ROOT=$DECOY" \
+    python3 "$HOOKS/worktree-archive-autoprep.py"
+) >"$OUT" 2>"$ERR"
+RC=$?
+if grep -q "SENTINEL-PREP-RAN-IN-OTHER" "$ERR" && ! grep -q "SENTINEL-PREP-RAN-IN-DECOY" "$ERR"; then
+  pass "worktree-archive-autoprep runs the owning vault's prep script, not \$VAULT_ROOT's (rc=$RC)"
+else
+  fail "worktree-archive-autoprep did not reach the OTHER vault's prep script (rc=$RC)"
+  show_streams
+fi
+
+# --------------------------------------------------------------------------
+# 8. surface-stale-automation-failures.py -- reads the OTHER vault's runner log
+# --------------------------------------------------------------------------
+run_hook "$HOOKS/surface-stale-automation-failures.py" \
+  "$(python3 -c 'import json,sys; print(json.dumps({"cwd":sys.argv[1]}))' "$OTHER")" \
+  "VAULT_ROOT=$DECOY" "HOME=$FAKEHOME" "USERPROFILE=$FAKEHOME"
+if grep -q "auto-snapshot" "$OUT"; then
+  pass "surface-stale-automation-failures surfaces a non-\$VAULT_ROOT vault's silent failures (rc=$RC)"
+else
+  fail "surface-stale-automation-failures reported nothing while the OTHER vault was failing hourly (rc=$RC)"
+  show_streams
+fi
+
+run_hook "$HOOKS/surface-stale-automation-failures.py" \
+  "$(python3 -c 'import json,sys; print(json.dumps({"cwd":sys.argv[1]}))' "$DECOY")" \
+  "VAULT_ROOT=$DECOY" "HOME=$FAKEHOME" "USERPROFILE=$FAKEHOME"
+if grep -q "auto-snapshot" "$OUT"; then
+  fail "surface-stale-automation-failures reported the OTHER vault's failures for a session in the decoy vault"
+  show_streams
+else
+  pass "surface-stale-automation-failures does not leak one vault's failures into another's session (rc=$RC)"
+fi
+
+# --------------------------------------------------------------------------
+# 9 + 10. the two session-close verifiers -- import-time root is repo-aware
+#    Their per-invocation rebind was already repo-aware (MYC-1270 / 2026-06-30);
+#    what MYC-3529 removes is the naive env read that SEEDED the module globals,
+#    which answered for ~/vault on any import that did not run main().
+# --------------------------------------------------------------------------
+import_root() {  # <hook-file> <cwd> -> prints the module's resolved VAULT_ROOT
+  ( cd "$2" || exit 1
+    env "${CLEAN_ENV[@]}" "VAULT_ROOT=$DECOY" python3 - "$1" <<'PY'
+import importlib.util, sys
+from pathlib import Path
+spec = importlib.util.spec_from_file_location("hook_under_test", sys.argv[1])
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+print(str(Path(mod.VAULT_ROOT).resolve()).replace(chr(92), "/"))
+PY
+  )
+}
+
+for hook in verify-session-close-cascade.py verify-discoverability-on-close.py; do
+  got="$(import_root "$HOOKS/$hook" "$OTHER" 2>"$ERR")"
+  want="$(python3 -c 'import sys;from pathlib import Path;print(str(Path(sys.argv[1]).resolve()).replace(chr(92),"/"))' "$OTHER")"
+  if [ "$got" = "$want" ]; then
+    pass "$hook seeds VAULT_ROOT from the session's repo-vault, not \$VAULT_ROOT"
+  else
+    fail "$hook resolved '$got' at import; expected the repo-vault '$want'"
+    sed 's/^/  /' "$ERR" >&2
+  fi
+done
+
+# --------------------------------------------------------------------------
+# 11. auto-capture-public-ships.py -- files ships into the OTHER vault
+#
+#     NOTE, and it is not this ticket's to fix: this hook cannot be run
+#     end-to-end on any machine. Line 34 is
+#         TZ = ZoneInfo("America/user-local-tz")
+#     an unsubstituted template placeholder that is not an IANA zone, so the
+#     module raises ZoneInfoNotFoundError at IMPORT, before main() is reached.
+#     That is a separate, pre-existing defect (nothing in the repo substitutes
+#     it). The vault-root fix is still assertable: stub zoneinfo, import, and
+#     ask pending_dir() where the day's ships would be filed.
+# --------------------------------------------------------------------------
+got="$( cd "$OTHER" || exit 1
+  env "${CLEAN_ENV[@]}" "VAULT_ROOT=$DECOY" python3 - "$HOOKS/auto-capture-public-ships.py" <<'PY' 2>&1
+import importlib.util, sys, types
+fake = types.ModuleType("zoneinfo")
+class ZoneInfo:  # placeholder-tolerant stand-in; see the note above
+    def __init__(self, key): self.key = key
+fake.ZoneInfo = ZoneInfo
+sys.modules["zoneinfo"] = fake
+spec = importlib.util.spec_from_file_location("hook_under_test", sys.argv[1])
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+print(str(mod.pending_dir()).replace(chr(92), "/"))
+PY
+)"
+case "$got" in
+  "$OTHER"*)
+    pass "auto-capture-public-ships files ships into the cwd's vault, not \$VAULT_ROOT's" ;;
+  *)
+    fail "auto-capture-public-ships resolved '$got'; expected a path under '$OTHER'" ;;
+esac
+
+# --------------------------------------------------------------------------
+# 12. build-runbook-check.py -- behaviour is identical with and without
+#     $VAULT_ROOT, which is the point: it never needed a vault at all.
+# --------------------------------------------------------------------------
+agent_payload=$(python3 -c 'import json; print(json.dumps({"tool_name":"Agent","tool_input":{"description":"build the MCP connector","prompt":"ship it"}}))')
+run_hook "$HOOKS/build-runbook-check.py" "$agent_payload" "VAULT_ROOT=$DECOY" "HOME=$FAKEHOME" "USERPROFILE=$FAKEHOME"
+with_env="$(cat "$ERR")"
+run_hook "$HOOKS/build-runbook-check.py" "$agent_payload" -u VAULT_ROOT "HOME=$FAKEHOME" "USERPROFILE=$FAKEHOME"
+without_env="$(cat "$ERR")"
+if [ -n "$with_env" ] && [ "$with_env" = "$without_env" ]; then
+  pass "build-runbook-check warns identically with and without \$VAULT_ROOT (vault-independent by construction)"
+else
+  fail "build-runbook-check behaviour still depends on \$VAULT_ROOT (or it stopped warning at all)"
+  echo "  --- with \$VAULT_ROOT ---" >&2; printf '%s\n' "$with_env" | sed 's/^/  /' >&2
+  echo "  --- without ---" >&2; printf '%s\n' "$without_env" | sed 's/^/  /' >&2
+fi
+
+# --------------------------------------------------------------------------
+# 13. the fleet ratchet still holds after the 12 rows were deleted
+# --------------------------------------------------------------------------
+if python3 "$GUARD" --all >"$OUT" 2>"$ERR"; then
+  pass "check-vault-root-reads --all passes with the SEV-A tier unpinned"
+else
+  fail "check-vault-root-reads --all fails after unpinning the SEV-A tier"
+  show_streams
+fi
+
+echo
+if [ "$FAILURES" -eq 0 ]; then
+  echo "All assertions passed. Every MYC-3529 hook resolves its vault per target."
+  exit 0
+fi
+echo "$FAILURES assertion(s) FAILED -- a remediated hook is still answering for \$VAULT_ROOT." >&2
+exit 1

--- a/tests/integration/test_hook_vault_root_per_target.sh
+++ b/tests/integration/test_hook_vault_root_per_target.sh
@@ -267,6 +267,54 @@ else
   pass "build-runbook-check.py carries no VAULT_ROOT binding at all"
 fi
 
+# PYTHON FLOOR. scripts/ci.sh's gate runs on Python 3.9, but a contributor's
+# laptop is usually 3.12+. A PEP-604 `X | None` annotation is evaluated at
+# def-time and raises TypeError on 3.9 unless the module carries
+# `from __future__ import annotations` -- so the hook crashes at IMPORT and,
+# under the hooks.json wrapper, silently does nothing. Exactly the failure mode
+# this whole ticket is about, arriving by a different road.
+#
+# py_compile does NOT catch it: the annotation compiles fine and only blows up
+# when the def executes. The behavioural assertions below DO catch it, but only
+# when they run on 3.9 -- which means a dev on 3.12 sees green locally and red
+# in CI. This check catches it on every interpreter. (Caught live: this suite
+# reddened CI on 3.9 for four of these hooks, two of which were already broken
+# on origin/main and had simply never been imported by a test.)
+floor_bad="$(python3 - "$HOOKS" "${SEV_A[@]}" <<'PY'
+import ast, sys
+from pathlib import Path
+hooks = Path(sys.argv[1])
+bad = []
+for name in sys.argv[2:]:
+    tree = ast.parse((hooks / name).read_text(encoding="utf-8"))
+    future = any(
+        isinstance(n, ast.ImportFrom) and n.module == "__future__"
+        and any(a.name == "annotations" for a in n.names)
+        for n in tree.body
+    )
+    if future:
+        continue
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        args = node.args
+        anns = [a.annotation for a in args.args + args.kwonlyargs + args.posonlyargs
+                if a.annotation]
+        if node.returns:
+            anns.append(node.returns)
+        if any(isinstance(s, ast.BinOp) and isinstance(s.op, ast.BitOr)
+               for a in anns for s in ast.walk(a)):
+            bad.append(f"{name}:{node.name}")
+            break
+print(" ".join(bad))
+PY
+)"
+if [ -n "$floor_bad" ]; then
+  fail "PEP-604 annotation without \`from __future__ import annotations\` -- TypeError at import on Python 3.9, the version scripts/ci.sh runs: $floor_bad"
+else
+  pass "no SEV-A hook uses a PEP-604 annotation that would crash the import on Python 3.9"
+fi
+
 # --------------------------------------------------------------------------
 # 1. vault-context.py -- injects the OTHER vault's priorities, not the decoy's
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Closes MYC-3529.

## What this is

MYC-2505 (#407) shipped `scripts/check-vault-root-reads.py` and **byte-pinned** the 52 naive `VAULT_ROOT` reads it found. That froze the status quo; it did not fix it. This clears the worst tier: the **12 SEV-A reads, all in `hooks/`**, all shaped

```python
VAULT = os.environ.get("VAULT_ROOT", str(Path.home() / "vault"))
```

A hook fires on targets in **any** vault, so that read fails silently in both directions. **Unset** it resolves to `~/vault`, so the hook is inert on every vault not literally named `vault`. **Set** it names ONE vault, so a target in any other vault resolves against the wrong root and is skipped. Both are silent, and on a PreToolUse guard "skipped" means **allowed** — it fails **open**. This is the defect the external 30X Windows install reported in #375 and PR #404 fixed once, in `validate-handoff-frontmatter.py`.

## Per-file disposition

No exemptions were issued. All 12 were real defects.

| # | File | Surface | Disposition | Why |
|---|---|---|---|---|
| 1 | `hooks/auto-capture-public-ships.py` | SessionEnd | **fixed** → `vault_root_for(cwd)` | It **writes**, via `mkdir(parents=True)`. Unset, it *created* `~/vault/🍄 .../📋 Pending Signals/` and filed the day's ships into a phantom vault. Now returns `None` → skip, rather than inventing a destination. |
| 2 | `hooks/block-raw-vault-git.py` | PreToolUse Bash | **fixed** → per-target `_vault_git_dir_for()` | Compared `git rev-parse --git-common-dir` against a single import-time `~/vault/.git`. Raw `git add`/`commit` against any other vault passed straight through, with the same index.lock contention. Now resolved from the op's effective cwd / `--git-dir`, so `-C` retargeting is followed. |
| 3 | `hooks/block-vault-git-fullwalk.py` | PreToolUse Bash | **fixed** → per-target `_vault_git_dir_for()` | Same shape. `git add -A` walked a second vault's 60K-file tree unimpeded. |
| 4 | `hooks/block-worktree-shared-edit.py` | PreToolUse Write/Edit | **fixed** → vault captured from the target path | The worktree regex was `re.escape(VAULT_ROOT) + r"/\.claude/worktrees/..."`. Anchored on `~/vault`, it matched nothing and **allowed every stranding edit it exists to block**. The vault segment is now captured and validated via `vault_root_for`; a code repo's `.claude/worktrees/` stays out of scope. Also normalizes `\` so Windows paths match (#375 was a Windows report). |
| 5 | `hooks/build-runbook-check.py` | PreToolUse Agent | **fixed by deletion — dead code** | `VAULT_ROOT` was assigned and **never referenced**. The hook matches runbook *filenames* against transcript paths and never needed a vault. The binding is the whole reason it was tagged SEV-A. |
| 6 | `hooks/create-dev-repo-checkpoint.py` | Stop | **fixed** → `vault_root_for(cwd)` | Highest real-world severity here. Its "never fire on vault paths" gate protects `checkpoint()`'s `git add -A`. Comparing against one env-named vault meant a vault checked out under `~/dev` (this repo's own hooks document `~/dev/mycelium-vault` as exactly that) passed both the vault gate *and* the `DEV_ROOT` gate and got the full-tree stage the vault guards exist to prevent. |
| 7 | `hooks/surface-stale-automation-failures.py` | SessionStart | **fixed** → `vault_root_for(payload cwd)` | The two vault-rooted runner logs resolved under `~/vault/⚙️ Meta/`, so `fail_count_in_window` short-circuited on `exists()` and returned 0. The hook reported "nothing wrong" while auto-snapshot failed hourly — precisely the 2026-05-14 191-file strand it was written to make impossible. |
| 8 | `hooks/vault-command-nudges.py` | PreToolUse Bash | **fixed** → per-target, both scoping models | Repo-scoped rules (`git push`/`git status`) now resolve from the op's target; namespace-scoped rules (`rm -rf`/`grep`/`find`) now probe the cwd's vault **and** vault paths named in the command, so `cd /tmp && rm -rf "<other vault>"` is caught. The namespace probe is lazy and capped at 12 path tokens. |
| 9 | `hooks/vault-context.py` | UserPromptSubmit | **fixed** → `vault_root_for(payload cwd)` | The sampled instance from the ticket. Unset: every read returned `None`, so it exited 0 injecting nothing, silently, forever. Set: a session in a second vault got the **first** vault's priorities injected as if they were its own — worse than nothing, because the model cannot tell. |
| 10 | `hooks/verify-discoverability-on-close.py` | Stop | **fixed** → seeded through `_resolve_vault_context()` | The per-invocation rebind was already repo-aware; the naive read only **seeded** the module globals. Now seeded through the same sanctioned `resolve_vault_root()` call the rebind uses, so import-time and per-invocation answers cannot drift. |
| 11 | `hooks/verify-session-close-cascade.py` | Stop | **fixed** → seeded through `_resolve_vault_context()` | Same. |
| 12 | `hooks/worktree-archive-autoprep.py` | Stop | **fixed** → `vault_root_for(cwd)` | Only ever runs inside `<vault>/.claude/worktrees/<slug>/`, so the cwd already names the vault. Unset, it looked for the prep script under `~/vault`, found nothing, and returned 0 — the false-alarm archive warning fired anyway, with no signal the fix was inert. |

## A ticket claim that did not hold

The ticket says `hooks/_lib/vault_root.py` "already exposes `vault_root_for`". **It does not.** The only copy lived inside `hooks/validate-handoff-frontmatter.py`, which is not importable (hyphens in the filename). This PR lifts it into `_lib/vault_root.py` so the class shares one implementation instead of twelve, with the two resolvers now documented side by side:

- `resolve_vault_root(cwd, env)` — **session**-scoped, keyed on a CLAUDE.md declaring its own Session End/Close cascade. Always returns a Path.
- `vault_root_for(target)` — **per-target**, keyed on the nearest Meta-suffixed ancestor (worktree-collapsed), `$VAULT_ROOT` as fallback, `None` when no vault exists. `None` means *skip*, never *guess `~/vault`*.

`validate-handoff-frontmatter.py` is deliberately **not** touched: it is already correct, and a sibling PR is pinning hook contents.

## Baseline

All 12 rows **deleted**, never re-pinned. The section header now records that the tier is cleared.

```
before:  49 byte-pinned legacy file(s), 51 pinned read(s)
after:   37 byte-pinned legacy file(s), 39 pinned read(s)
```

Verified self-enforcing — re-adding one stale row reds the build:

```
$ python scripts/check-vault-root-reads.py --all --baseline <copy + 1 stale row>
::error::naive VAULT_ROOT read(s) - resolve through a sanctioned resolver:
  STALE BASELINE hooks/vault-context.py: file changed, became clean, or was removed.
EXIT=1
```

### A second ratchet, caught by CI

`hooks/build-runbook-check.py` is also pinned by `scripts/cloud-safe-walker-baseline.txt`. Deleting its dead `VAULT_ROOT` binding changed its bytes, so that row went stale and reded the `ci gate` job on the first push.

The row is **refreshed, not removed, and deliberately not "fixed"**: the walker itself is untouched here. The file still reaches `open(read)` through a recursive `rglob` over `~/.claude/projects` without the shared `safe_read` primitive, exactly as the reviewed row records. Adopting `safe_read` there carries a real behaviour question — `safe_read_text` caps `max_bytes`, and a session transcript can exceed any cap, which would flip this advisory hook from "found the runbook read" to "warn" on large transcripts. That deserves its own review.

Precedent for refreshing rather than removing: e7ffc5c (MYC-3520, #408) did exactly this for `scripts/check-utf8-stdout.py`. The guard's own failure text sanctions it: *"adopt safe_read or refresh/remove this reviewed row"*.

The new hash is computed by importing the guard and calling its own `check_file()`, so the row cannot drift from what the guard computes — and that routes through its `normalize()` (CRLF/CR → LF), so the pin describes the **content**, not this Windows checkout (#411's rule).

Both baselines were then swept for any other row naming one of this PR's 13 changed hooks. That was the only one.

### The suite caught a second bug class — including two pre-existing ones

`scripts/ci.sh`'s gate job pins **python-version 3.9** (the floor). A PEP-604 `X | None` annotation is evaluated at def-time and is a `TypeError` on 3.9 unless the module carries `from __future__ import annotations`. The def never completes, the **module never imports**, and under the `hooks.json` wrapper (`<hook> 2>/dev/null || echo '{...allow}'`) that is indistinguishable from a hook that ran and found nothing. A crash-to-silence — the same failure shape as this whole ticket, arriving by a different road.

`py_compile` does not catch it: the annotation compiles fine and only blows up when the def executes. Gate (a) compiles all 324 files on 3.9 and passes.

Three were **my** regression (the new `_vault_git_dir_for` helper). **Two were pre-existing on `origin/main`**:

- **`hooks/vault-context.py`** — `def read_file(...) -> str | None` at module level. This hook is **wired in `hooks.json`**, so on any 3.9 install it has been crashing at import and injecting nothing, silently, for as long as that annotation has been there. It was already in the SEV-A tier for reading `~/vault`; it turns out it could not run at all on the floor version.
- **`hooks/verify-session-close-cascade.py`** — same shape, but inside the `except Exception:` fallback stub for the `_lib` import, so it only bites when that import fails. Latent; fixed while in the file.

Fixed in all five, and the suite now carries a structural assertion for the class: no SEV-A hook may use a PEP-604 annotation without the future import. The behavioural assertions already catch this — but only when they run on 3.9, which means green on a 3.12 laptop and red in CI, which is exactly what happened. The structural check catches it on every interpreter, and is verified load-bearing (removing the future import from `vault-context.py` reddens it by name).

## Hermetic-test evidence

`tests/integration/test_hook_vault_root_per_target.sh` (new, wired into `INTEGRATION_TESTS` per the gate-coverage invariant).

**Every assertion points `$VAULT_ROOT` at a decoy vault and then acts on a different one.** That is the assertion the whole class was missing: #404's bug survived a full suite because every test ran against the vault the env var already named, which makes "resolve from the env" and "resolve from the target" indistinguishable.

The suite is load-bearing. Run unchanged against the **pre-fix** tree, **25 of 27 assertions fail** — and note that nearly every failure is `rc=0`, i.e. silently open:

```
FAIL: vault-context did not inject the OTHER vault (rc=0)
FAIL: block-worktree-shared-edit failed OPEN on the OTHER vault's worktree (rc=0)
FAIL: block-raw-vault-git failed OPEN on the OTHER vault (rc=0)
FAIL: block-raw-vault-git missed a -C retarget into the OTHER vault (rc=0)
FAIL: block-vault-git-fullwalk failed OPEN on the OTHER vault (rc=0)
FAIL: vault-command-nudges repo-scoped rule failed OPEN on the OTHER vault (rc=0)
FAIL: vault-command-nudges namespace rule missed a path inside the OTHER vault (rc=0)
FAIL: create-dev-repo-checkpoint stashed (git add -A) inside a vault that is not $VAULT_ROOT
FAIL: worktree-archive-autoprep did not reach the OTHER vault's prep script (rc=0)
FAIL: surface-stale-automation-failures reported nothing while the OTHER vault was failing hourly (rc=0)
FAIL: verify-session-close-cascade.py resolved '.../decoy-vault' at import; expected '.../other-vault'
FAIL: verify-discoverability-on-close.py resolved '.../decoy-vault' at import; expected '.../other-vault'
25 assertion(s) FAILED
```

Post-fix, all 27 pass:

```
PASS: vault-context injects the cwd's vault, not $VAULT_ROOT's (rc=0)
PASS: block-worktree-shared-edit blocks a shared-canonical write in a non-$VAULT_ROOT vault (rc=2)
PASS: block-raw-vault-git blocks a raw git add in a non-$VAULT_ROOT vault (rc=2)
PASS: block-raw-vault-git follows -C into a non-$VAULT_ROOT vault from a non-vault cwd (rc=2)
PASS: block-vault-git-fullwalk blocks git add -A in a non-$VAULT_ROOT vault (rc=2)
PASS: vault-command-nudges (repo-scoped) blocks git push in a non-$VAULT_ROOT vault (rc=2)
PASS: vault-command-nudges (namespace-scoped) catches a path in a non-$VAULT_ROOT vault (rc=2)
PASS: create-dev-repo-checkpoint excludes a non-$VAULT_ROOT vault under ~/dev (rc=0)
PASS: create-dev-repo-checkpoint still checkpoints a real ~/dev code repo (control: the exclusion above is not vacuous)
PASS: worktree-archive-autoprep runs the owning vault's prep script, not $VAULT_ROOT's (rc=0)
PASS: surface-stale-automation-failures surfaces a non-$VAULT_ROOT vault's silent failures (rc=0)
PASS: surface-stale-automation-failures does not leak one vault's failures into another's session (rc=0)
PASS: verify-session-close-cascade.py seeds VAULT_ROOT from the session's repo-vault, not $VAULT_ROOT
PASS: verify-discoverability-on-close.py seeds VAULT_ROOT from the session's repo-vault, not $VAULT_ROOT
PASS: auto-capture-public-ships files ships into the cwd's vault, not $VAULT_ROOT's
PASS: build-runbook-check warns identically with and without $VAULT_ROOT (vault-independent by construction)

All assertions passed. Every MYC-3529 hook resolves its vault per target.
```

Design notes on the suite, following `test_vault_backup_conf_bom.sh`:

- **Fails loud on zero matches.** The 12 filenames are named explicitly; a rename fails the existence check rather than silently narrowing coverage. It also asserts no SEV-A row remains in the baseline, that the guard reports clean, and that all 11 vault-consuming hooks still *reach* a sanctioned resolver — so a future edit cannot satisfy the lint by deleting the resolver along with the read.
- **Negative controls throughout**, so the fixes cannot over-fire: a plain code repo's `.claude/worktrees/`, `git add -A` in a standard-sized repo, `grep` outside any vault namespace, and a "still checkpoints a real `~/dev` repo" control that keeps the `create-dev-repo-checkpoint` exclusion assertion from being vacuous.
- **Fixture precondition.** Detection walks *up* for a Meta-suffixed folder, so a stray `*Meta` directory above the tmpdir would make the not-a-vault controls resolve to it and quietly stop testing anything. The fixture asserts its own ancestry is clean and aborts loudly otherwise.
- The tmpdir comes from python's `tempfile`, not `mktemp -d`: under Git Bash on Windows the latter returns an MSYS path native python silently reinterprets, and every assertion compares a shell-produced path against a python-resolved one.

## Gates

**All 12 CI checks green** on `origin/main` @ f8e716d, including `ci gate (py_compile + unit + integration tests)` — 324 files compiled, **93 integration tests**, 11 `scripts/` + 11 `hooks/tests` unit suites, on Python 3.9:

```
--- test_hook_vault_root_per_target
PASS: all 12 SEV-A hooks present (guard is not blind)
PASS: all 12 SEV-A rows are gone from vault-root-read-baseline.txt
All assertions passed. Every MYC-3529 hook resolves its vault per target.

All gates passed: py_compile (324 file(s)) + 93 integration tests + 11 scripts/
+ 11 hooks/tests unit suite(s) + ... + hook block-protocol [passed]
+ vault-root reads [passed].
```

Locally (Python 3.12, Windows):

```
py_compile ........................... 324 files, 0 failed
check-vault-root-reads --all ......... OK (37 pinned files, 39 pinned reads)
check-vault-root-reads --self-test ... 22/22 passed
check-hook-block-protocol ............ OK (11 wrapped hooks)
check-utf8-stdout .................... exit 0
shellcheck -S warning (new test) ..... clean
test_hook_vault_root_per_target ...... PASS (new)
test_vault_root_read_guard ........... PASS
test_verify_cascade_repo_aware_vault . PASS
test_verify_cascade_failsafe ......... PASS
test_discoverability_partition ....... PASS
test_handoff_frontmatter_guard ....... PASS
test_closing_claim_shared ............ PASS
test_meta_resolution_guard ........... PASS
test_aggregator_vault_root_guard ..... PASS
test_worktree_on_vault_guard ......... PASS
test_worktree_session_close .......... PASS
test_detect_closing_signal_goal_clear     PASS
test_detect_closing_signal_strict_guards  PASS
test_stranded_session_artifacts_watchdog  PASS
test_utf8_console_guard .............. PASS
```

## Honest gaps

- **Local verification on Windows/Python 3.12 was not sufficient, and CI caught two real defect classes I could not see** (the stale walker-baseline row and the Python-3.9 annotation crash). Both are now fixed and both are covered going forward. Treat Linux CI as the authority for this repo.
- **The full local integration sweep could not be run green on Windows.** Nine suites in the plausible-impact set fail on this box; **all nine fail identically on a pristine `origin/main` tree** extracted with `git archive` (`test_detect_closing_signal_worktree`, `test_detect_closing_signal_repo_aware_vault`, `test_meta_resolver`, `test_session_coordination_guards`, `test_offmain_strand_guard`, `test_sessionstart_boundedness`, `test_sessionstart_hook_snapshot_guard`, `test_resource_aware_session_close`, `test_cloud_safe_file_walkers`). They are pre-existing Windows/POSIX artifacts (MSYS `/tmp` paths, `launchctl`, GNU/BSD `stat`), not regressions. Linux CI is the authority.
- **`hooks/auto-capture-public-ships.py` cannot run end-to-end on any machine, for an unrelated reason.** Line 34 is `TZ = ZoneInfo("America/user-local-tz")` — an unsubstituted template placeholder that is not an IANA zone, so the module raises `ZoneInfoNotFoundError` at **import**, before `main()`. Nothing in the repo substitutes it. Out of scope here; its vault-root fix is asserted at unit level (stub `zoneinfo`, import, ask `pending_dir()` where ships would be filed), and the test says so in a comment. Worth its own ticket.
- **`hooks/vault-command-nudges.py` has a second latent bug I did not touch**: the `rm -rf` rule's regex begins `r'...rm\s+(?:-[A-Za-z]*[rRf][A-Za-z]*\s+)+"?(?:$HOME/vault|...)'`. In a Python regex `$` is an anchor, so `$HOME/vault` can never match a real path. Only the emoji-folder alternatives work. Separate defect, separate fix.
- **Scope note:** `hooks/_lib/vault_root.py` is a 13th file. It was unavoidable — the ticket assumed `vault_root_for` already lived there and it did not.

## Merge-order note (sibling PR)

MYC-3530 extends `check-utf8-stdout.py` to scan `hooks/` and will add a hash baseline pinning hook files. **This PR changes the content of 13 files under `hooks/`**, so its baseline rows for these will need refreshing whichever way the merge lands:

```
hooks/_lib/vault_root.py                     hooks/surface-stale-automation-failures.py
hooks/auto-capture-public-ships.py           hooks/vault-command-nudges.py
hooks/block-raw-vault-git.py                 hooks/vault-context.py
hooks/block-vault-git-fullwalk.py            hooks/verify-discoverability-on-close.py
hooks/block-worktree-shared-edit.py          hooks/verify-session-close-cascade.py
hooks/build-runbook-check.py                 hooks/worktree-archive-autoprep.py
hooks/create-dev-repo-checkpoint.py
```

Plus, outside `hooks/`: `scripts/vault-root-read-baseline.txt`, `scripts/cloud-safe-walker-baseline.txt` (one row refreshed), `scripts/ci.sh` (one entry appended to `INTEGRATION_TESTS`), and the new `tests/integration/test_hook_vault_root_per_target.sh`. `scripts/ci.sh` is the only file both PRs touch; the two edits are in different sections.

⚠️ **If MYC-3530 lands first**, note that editing any hook invalidates rows in *both* existing hash ratchets plus whatever new one it adds. `scripts/cloud-safe-walker-baseline.txt` is the easy one to miss — it is not vault-root-related, and its wrapper test (`test_cloud_safe_file_walkers.sh`) does not run green on Windows, so the signal only appears on Linux CI.

Nothing here touches `check-utf8-stdout.py`, its baseline, or `validate-handoff-frontmatter.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
