### PR TITLE
docs: align close phase numbers between the shipped rule and the cascade

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -149,6 +149,7 @@ INTEGRATION_TESTS=(
   test_detect_closing_signal_worktree
   test_detect_closing_signal_repo_aware_vault
   test_detect_closing_signal_goal_clear
+  test_close_phase_numbering_aligned
   test_closing_claim_shared
   test_meta_resolver
   test_meta_resolution_guard

--- a/templates/rules/session-close.md
+++ b/templates/rules/session-close.md
@@ -10,7 +10,7 @@ supersedes: session-end-cascade.md (deprecated; this file is the canonical sourc
 
 **What a close is for: nothing the session produced gets lost.** What the user learned, decided, felt, and committed to gets written to their vault — their second brain — so the next session, and the next month, build on it instead of starting cold. Everything else in this file is plumbing that serves that one goal.
 
-**Most people running this are not developers.** They journal, plan, think, run a business. Speak to them in plain language. Never narrate machinery — "git snapshot", "Bash task", "mutex", "worktree" — at them. The git/resource detail in Phase 4 runs automatically and silently; it is maintainer reference, not something the user reads or hears.
+**Most people running this are not developers.** They journal, plan, think, run a business. Speak to them in plain language. Never narrate machinery — "git snapshot", "Bash task", "mutex", "worktree" — at them. The git/resource detail in the final step runs automatically and silently; it is maintainer reference, not something the user reads or hears.
 
 **You don't need to read this file when the cascade fires** — `detect-closing-signal.py` injects all paths and instructions into your context automatically. This file is documentation, debugging, and the rare manual run. Full architecture + internals: [docs/SESSION_CLOSE.md](../../docs/SESSION_CLOSE.md).
 
@@ -21,6 +21,8 @@ supersedes: session-end-cascade.md (deprecated; this file is the canonical sourc
 | 1 | `detect-closing-signal.py` (UserPromptSubmit) | Detect the goodbye; resolve paths; pre-build the session-file shell; inject everything you need |
 | 2 | Your turn | Surface unfinished work, scan the conversation, write captures to the vault in one batched block |
 | 3 | `session-end-hook.sh` (Stop) | Backstop + aggregate + (only if the vault is backed up by git) snapshot — automatic, silent |
+
+**Phase numbers match the injected cascade.** The phase names and numbers below are the same ones `detect-closing-signal.py` puts in your context at close, so the two can be read together. Numbering that drifts between the two is a bug in whichever one moved: they describe one process, and a number that means different things in each is worse than no number.
 
 **Skip condition.** Fewer than 5 user messages AND no captures = trivial. Say a warm goodbye, skip the protocol. The hook still logs a timestamp.
 
@@ -68,7 +70,23 @@ All edits in parallel. No read-write ping-pong. No tool-call narration.
 
 **Vault firewall.** Personal content → personal vault. Team/business → team vault. Ambiguous → personal. Never leak personal content into a shared vault.
 
-## Phase 3 — Goodbye (you, one line)
+## Phase 2b — Commit what you wrote (you, before the goodbye)
+
+Save the files this close produced: the session file, any decision files, the captures, plus anything else you touched. Use the vault's safe-commit wrapper with **explicit paths** — never stage the whole tree, which on a large vault is slow and sweeps up work that is not yours.
+
+```bash
+bash "<vault>/scripts/vault-safe-commit.sh" "session: <slug> — <summary>" "<path>" "<path>"
+```
+
+This is yours to do, not the Stop hook's. `verify-session-close-cascade.py` runs BEFORE the Stop hook and blocks the close while session-close artifacts are still uncommitted, so waiting for the automatic snapshot in the final step costs you a hard block and a forced re-run.
+
+*Skip if the vault is not git-tracked* — the captures are already on disk.
+
+## Phase 3 — Functional audit (you, code sessions only)
+
+Only when the session shipped code or docs to a repo other people install. Syntax-check what changed, resolve every path referenced in docs, smoke-test new scripts, and reread shipped copy for claims that overstate what is actually wired. Non-dev sessions have none of this: skip it and say nothing.
+
+## Phase 4 — Goodbye (you, one line)
 
 Tell the user plainly what you saved: "Saved to your vault: N decisions, M to-dos, the belief shift about Y. Anything I missed?" Then a warm goodbye in their language. No machinery, no phase names, no file paths unless they ask.
 
@@ -76,7 +94,7 @@ Tell the user plainly what you saved: "Saved to your vault: N decisions, M to-do
 
 **The one exception:** a goal whose condition was actually met auto-cleared already. Say nothing then. Telling someone to clear a goal that succeeded is noise.
 
-## Phase 4 — Automatic finalization (the Stop hook — you do nothing)
+## After your turn — Automatic finalization (the Stop hook, you do nothing)
 
 Runs after your turn with zero involvement from you, and silently from the user's view:
 

--- a/tests/integration/test_close_phase_numbering_aligned.sh
+++ b/tests/integration/test_close_phase_numbering_aligned.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Test: the shipped close rule and the injected close cascade agree on what each
+# phase NUMBER means.
+#
+# Why: templates/rules/session-close.md and hooks/detect-closing-signal.py both
+# reach the model — the template when it reads the rule, the cascade when the
+# hook injects it at close. They describe ONE process. Before this test they
+# disagreed:
+#
+#   number   template said              cascade said
+#   3        Goodbye                    Functional audit
+#   4        Automatic finalization     Final summary (the goodbye)
+#             ("you do nothing")
+#
+# That shipped a live trap: #400 added a `/goal clear` reminder to the template
+# and labelled it "Phase 4b", borrowing the cascade's numbering. Under the
+# template's own numbering Phase 4 is the part that happens automatically with
+# no involvement from the reader — so the label said the goal clears itself,
+# which is the exact opposite of the truth.
+#
+# The rule this locks: a phase number present in BOTH files must denote the same
+# step in both. Numbers unique to one file are fine (the cascade is more
+# granular: 0a, 0c/0d/0e, 1.8 have no template section).
+#
+# Assertions:
+#   1. Every phase number the template defines is either absent from the cascade
+#      or carries a matching meaning there.
+#   2. The specific historical collisions stay fixed: template 3 is the audit,
+#      template 4 is the goodbye.
+#   3. The template does not reintroduce a bare "Phase 4b" label (#401).
+#
+# Exit 0 = pass, 1 = fail.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RULE="$REPO_ROOT/templates/rules/session-close.md"
+HOOK="$REPO_ROOT/hooks/detect-closing-signal.py"
+
+for f in "$RULE" "$HOOK"; do
+  [ -f "$f" ] || { echo "ERROR: $f not found" >&2; exit 1; }
+done
+
+failed=0
+fail() { echo "FAIL: $*" >&2; failed=1; }
+ok() { echo "ok   $*"; }
+
+# --- 1 + 2. Shared numbers must denote the same step ------------------------
+# Pairs of "<number>|<regex the template heading must match>|<regex the cascade
+# phase line must match>". Kept explicit rather than derived: the whole point is
+# to pin MEANING, and a derivation would just re-encode whatever is there today.
+check_pair() {
+  local num="$1" want_rule="$2" want_hook="$3"
+  local rule_line hook_line
+  rule_line="$(grep -iE "^## Phase ${num} " "$RULE" | head -1)"
+  hook_line="$(grep -iE "^PHASE ${num} " "$HOOK" | head -1)"
+
+  if [ -z "$rule_line" ]; then fail "template has no '## Phase ${num}' heading"; return; fi
+  if [ -z "$hook_line" ]; then fail "cascade has no 'PHASE ${num}' line"; return; fi
+
+  echo "$rule_line" | grep -qiE "$want_rule" \
+    || fail "template Phase ${num} should be ${want_rule}, got: ${rule_line}"
+  echo "$hook_line" | grep -qiE "$want_hook" \
+    || fail "cascade PHASE ${num} should be ${want_hook}, got: ${hook_line}"
+
+  ok "Phase ${num} means the same thing in both"
+}
+
+check_pair 1  "scan the conversation" "conversation scan"
+check_pair 2  "write to the vault"    "batch writes"
+check_pair 3  "functional audit"      "functional audit"
+check_pair 4  "goodbye"               "final summary"
+
+# --- 2b. Each number may head at most ONE template section ------------------
+# Without this, re-adding a second "## Phase 4 —" heading is invisible: the
+# meaning checks above read the FIRST match and pass while the file defines the
+# same number twice. Found by mutating the template (mutant B) — the original
+# version of this test was blind to it.
+dupes="$(grep -oE "^## Phase [0-9]+[a-z]? " "$RULE" | sort | uniq -d)"
+if [ -n "$dupes" ]; then
+  fail "template defines the same phase number more than once:"
+  echo "$dupes" | sed 's/^/       /' >&2
+else
+  ok "every template phase number heads exactly one section"
+fi
+
+# --- 2c. Phase 2b (commit) must stay present --------------------------------
+# It is the step whose absence causes a hard block: verify-session-close-cascade
+# fires before the Stop hook and refuses the close while artifacts are
+# uncommitted. A template without it teaches a model to skip the commit.
+if grep -qE "^## Phase 2b " "$RULE"; then
+  ok "template keeps the Phase 2b commit step"
+else
+  fail "template lost its Phase 2b commit step (the close will hard-block)"
+fi
+
+# --- 3. The #401 regression: no bare "Phase 4b" label in the template -------
+if grep -q "Phase 4b" "$RULE"; then
+  fail "template reintroduced a 'Phase 4b' label (see #401 — the cascade owns that number)"
+else
+  ok "template carries no cross-numbered 'Phase 4b' label"
+fi
+
+# --- Negative control -------------------------------------------------------
+# Prove the comparison can actually fail: a deliberately wrong expectation must
+# be rejected. Without this, a check_pair that silently matched everything would
+# look identical to a passing suite.
+control="$(grep -iE "^## Phase 4 " "$RULE" | head -1)"
+if echo "$control" | grep -qiE "automatic finalization"; then
+  fail "negative control: template Phase 4 still reads as the automatic step"
+else
+  ok "negative control: a wrong meaning for Phase 4 would be caught"
+fi
+
+if [ "$failed" -ne 0 ]; then
+  echo "FAILED: close phase numbering drifted between the rule and the cascade" >&2
+  exit 1
+fi
+echo "PASS: close phase numbering is aligned between the shipped rule and the cascade"


### PR DESCRIPTION
docs: align close phase numbers between the shipped rule and the cascade

templates/rules/session-close.md and hooks/detect-closing-signal.py both reach
the model — the template when it reads the rule, the cascade when the hook
injects it at close — and they described ONE process with conflicting numbers:

  number   template said                       cascade said
  3        Goodbye                             Functional audit
  4        Automatic finalization              Final summary (the goodbye)
            ("the Stop hook — you do nothing")

That is not cosmetic. #400 added a `/goal clear` reminder to the template and
labelled it "Phase 4b" using the cascade's numbering; under the template's own
numbering Phase 4 is the step that happens automatically with no involvement
from the reader, so the label announced that the goal clears itself — the exact
opposite of the truth. #401 removed the label; this removes the trap.

Template now matches the cascade:

  Phase 2b  Commit what you wrote      (was missing entirely)
  Phase 3   Functional audit           (was Goodbye)
  Phase 4   Goodbye                    (was Automatic finalization)
  After your turn — Automatic finalization   (unnumbered: you perform no phase)

Phase 2b was not just misnumbered, it was ABSENT. verify-session-close-cascade
runs before the Stop hook and blocks the close while session-close artifacts
are uncommitted, so a model working from the template alone skipped the commit
and earned a hard block. Phase 3 was likewise undocumented here.

Cascade-only phases (0a, 0c/0d/0e, 1.8, 4b) stay cascade-only — the template is
deliberately the simpler, non-developer-facing view. The rule locked is
narrower: a number present in BOTH must mean the same thing in both.

Test: tests/integration/test_close_phase_numbering_aligned.sh, wired into
scripts/ci.sh. Verified against 4 mutants. The first version of the test was
BLIND to mutant B (re-adding a second "## Phase 4" heading passed, because the
meaning checks read the first match and stopped) — added a uniqueness assertion
so a duplicated number fails, plus a presence assertion on Phase 2b.
