### PR TITLE
fix(hooks): the rm -rf vault guard never blocked the vault root

### DIFF
--- a/hooks/vault-command-nudges.py
+++ b/hooks/vault-command-nudges.py
@@ -582,4 +582,16 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313, MYC-3520). This hook's block messages
+    # quote the RESOLVED target back to the user, and a vault's top-level folders
+    # are emoji-prefixed ("⚙️ Meta"), so the crashing value arrives from the
+    # filesystem even on a machine whose command was pure ASCII. Without this,
+    # printing the reason raises UnicodeEncodeError and the block is reported as
+    # a hook error instead of a reason — on the one code path that only ever runs
+    # when live work is about to be deleted.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     main()

--- a/hooks/vault-command-nudges.py
+++ b/hooks/vault-command-nudges.py
@@ -7,10 +7,10 @@ Adapted from anthropics/claude-code examples/hooks/bash_command_validator_exampl
 Enforces CLAUDE.md rules that were codified but not hook-blocked:
 - Blocks `git push` against the personal vault repo (no remote configured)
 - Blocks unscoped `git status` against the vault repo (60K-file walk)
-- Blocks `rm -rf` against the vault root or top-level emoji folders
+- Blocks `rm -rf` against a vault root or any of its top-level folders
 - Nudges `grep` -> Grep tool / rg, `find -name` -> Glob tool
 
-Two scoping models, tagged per rule:
+Three scoping models, tagged per rule:
 
 - repo-scoped (git push / git status): fire ONLY when the git op targets
   the personal vault repo itself, or a worktree of it. Repo identity is
@@ -23,11 +23,14 @@ Two scoping models, tagged per rule:
   `--namespace`) are matched WITH their separate-argument value, so a
   subcommand cannot hide behind the value or a quoted value's space.
 
-- namespace-scoped (rm -rf / grep / find): fire whenever the command
-  touches the vault path namespace (cwd under it, or the literal path in
-  the command). `rm -rf` through the 🍄 symlink still destroys real data,
-  and the grep/find slow-walk concern is about the filesystem tree, not
-  git, so these keep the path-prefix gate.
+- namespace-scoped (grep / find): fire whenever the command touches the
+  vault path namespace (cwd under it, or the literal path in the
+  command). The grep/find slow-walk concern is about the filesystem tree,
+  not git, so these keep the path-prefix gate.
+
+- target-scoped (rm -rf): parse the rm's OPERANDS, resolve each one
+  against the effective cwd, and fire only when a resolved target IS a
+  vault root or a direct child of one. See _rm_verdicts.
 
 Escape hatch: prefix the command with VAULT_VALIDATOR_BYPASS=1.
 """
@@ -143,6 +146,164 @@ def _effective_cwd(command: str, initial: str) -> str:
             new_path = os.path.expanduser(next(g for g in m.groups() if g is not None))
             cwd = new_path if os.path.isabs(new_path) else os.path.normpath(os.path.join(cwd, new_path))
     return cwd
+
+
+# ---------------------------------------------------------------------------
+# rm -rf targeting (target-scoped)
+#
+# The rule this replaces pattern-matched FOLDER NAMES immediately after the
+# flags:
+#     ...rm\s+(?:-[A-Za-z]*[rRf][A-Za-z]*\s+)+"?(?:$HOME/vault|⚙️ Meta|...)
+# Two independent defects, and the rule advertised in the docstring above was
+# never actually enforced:
+#
+#   1. `$HOME/vault` is a SHELL string sitting in a PYTHON regex. `$` is an
+#      end-of-line anchor, so that branch parses as "end of line, then the
+#      literal text HOME/vault" and cannot match any input, ever. The vault
+#      ROOT — the most destructive target of all — was never blocked.
+#   2. The four emoji branches are literal names anchored right after the
+#      flags, so they only fire on a bare relative `rm -rf "⚙️ Meta"`. An
+#      absolute `rm -rf "/Users/x/Brain/⚙️ Meta"` — the same deletion, spelled
+#      the way an agent actually spells it — sailed straight through.
+#
+# Both are fixed by asking the filesystem instead of the string: parse the
+# rm's operands, resolve each against the effective cwd, and compare the
+# RESULT to the vault that governs it. Names stop mattering, so a vault whose
+# folders are not the four hardcoded ones is covered too, and depth stops
+# mattering, so every spelling of the same target behaves identically.
+_RM_FLAG = r'(?:--[A-Za-z][A-Za-z-]*|--|-[A-Za-z]+)'
+_RM_RE = re.compile(
+    r'(?:^|&&|\|\|?|;(?!;))\s*rm\s+'      # `rm` at a command boundary
+    r'((?:' + _RM_FLAG + r'\s+)*)'        # 1: leading flag blob
+    r'([^;&|\n]*)'                        # 2: operands, to the end of the chunk
+)
+
+# One shell word: double-quoted, single-quoted, or bare. The bare arm accepts
+# a backslash-escaped space (`⚙️\ Meta`) as part of the word, because that is
+# the idiomatic unquoted spelling of these folder names. Every OTHER backslash
+# stays literal, so a Windows `C:\Users\x\Brain` is not mangled into an escape
+# sequence.
+_RM_TOKEN_RE = re.compile(
+    r'"([^"]*)"'
+    r"|'([^']*)'"
+    r'|((?:\\ |[^\s])+)'
+)
+
+
+def _is_destructive_rm(flag_blob: str, operand_text: str) -> bool:
+    """True iff these rm flags can destroy a directory tree.
+
+    Keeps the predecessor's `[rRf]` reach (recursive OR force) rather than
+    narrowing to `-r`: a guard on the vault root should not be the place we
+    get clever about which flag combination happens to succeed. Flags are
+    read from BOTH sides of the operands, so `rm dir -rf` counts.
+    """
+    for blob in (flag_blob, operand_text):
+        for tok in re.findall(_RM_FLAG, blob):
+            if tok.startswith("--"):
+                if tok in ("--recursive", "--force"):
+                    return True
+            elif any(c in tok for c in "rRf"):
+                return True
+    return False
+
+
+def _rm_operands(operand_text: str, flag_blob: str):
+    """Shell words in an rm's operand text that are TARGETS, not flags."""
+    targets = []
+    for m in _RM_TOKEN_RE.finditer(operand_text):
+        dq, sq, bare = m.groups()
+        if dq is not None:
+            word = dq
+        elif sq is not None:
+            word = sq
+        else:
+            word = bare.replace("\\ ", " ")
+        if not word or (word.startswith("-") and dq is None and sq is None):
+            continue  # a flag, not a target
+        targets.append(word)
+    return targets
+
+
+def _resolve_operand(word: str, cwd: str) -> str:
+    """An rm operand as an absolute path, WITHOUT resolving symlinks.
+
+    Lexical on purpose, matching _is_under: `<vault>/🍄 brand` is a symlink to
+    a separate repo, and `rm -rf` through it still destroys the vault's own
+    top-level entry. Resolving it first would retarget the check at the
+    symlink's destination and lose exactly that case.
+    """
+    path = os.path.expanduser(word.strip())
+    # Trailing separators are cosmetic (`rm -rf "⚙️ Meta/"`); dirname would
+    # otherwise hand back the folder itself instead of its parent.
+    stripped = path.rstrip("/\\")
+    if stripped and not re.fullmatch(r'[A-Za-z]:', stripped):
+        path = stripped
+    if not os.path.isabs(path):
+        path = os.path.join(cwd or os.getcwd(), path)
+    return os.path.normpath(os.path.abspath(path))
+
+
+def _same_dir(a: str, b) -> bool:
+    """True iff two path spellings denote the same directory.
+
+    Compared lexically AND through realpath: `vault_root_for` hands back a
+    RESOLVED root, while the operand above is deliberately unresolved, so a
+    tmpdir that is itself a symlink (`/var` -> `/private/var` on macOS) would
+    make an otherwise-correct match fail on spelling alone.
+    """
+    try:
+        pairs = (
+            (os.path.abspath(str(a)), os.path.abspath(str(b))),
+            (os.path.realpath(str(a)), os.path.realpath(str(b))),
+        )
+    except (OSError, ValueError):
+        return False
+    return any(os.path.normcase(x) == os.path.normcase(y) for x, y in pairs)
+
+
+def _rm_target_verdict(target: str):
+    """'root' | 'top-level' | None for one resolved rm target.
+
+    The vault is resolved PER TARGET (MYC-3529), so this covers every vault on
+    the machine, not the one $VAULT_ROOT happens to name.
+
+    The parent is probed SEPARATELY rather than by walking up from the target,
+    because vault_root_for() resolves symlinks: asking about `<vault>/🍄 brand`
+    directly answers for the repo that symlink points AT. Asking about its
+    parent answers about the vault whose top-level entry is being deleted.
+
+    Depth beyond a direct child is deliberately NOT blocked — `<vault>/⚙️
+    Meta/rules/foo.md` is the "explicit file paths" the message recommends.
+    """
+    root = vault_root_for(Path(target))
+    if root is not None and _same_dir(target, root):
+        return "root"
+    parent = os.path.dirname(target)
+    if parent and parent != target:
+        proot = vault_root_for(Path(parent))
+        if proot is not None and _same_dir(parent, proot):
+            return "top-level"
+    return None
+
+
+def _rm_verdicts(command: str, cwd: str):
+    """Every (target, verdict) in `command` that a destructive rm would hit."""
+    found = []
+    probed = 0
+    for m in _RM_RE.finditer(command):
+        flag_blob, operand_text = m.group(1) or "", m.group(2) or ""
+        if not _is_destructive_rm(flag_blob, operand_text):
+            continue
+        for word in _rm_operands(operand_text, flag_blob):
+            probed += 1
+            if probed > _MAX_PATH_TOKENS:  # same stat-storm bound as above
+                return found
+            target = _resolve_operand(word, cwd)
+            verdict = _rm_target_verdict(target)
+            if verdict is not None:
+                found.append((target, verdict))
+    return found
 
 
 # A git option's value argument:
@@ -269,12 +430,17 @@ def _targets_vault(opts_blob: str, base_cwd: str) -> bool:
     return _targets_vault_repo(eff_cwd)
 
 
-# (regex, severity, message, repo_scoped).
+# (regex, severity, message, scope).
 #   severity 'block' -> exit 2 ; 'nudge' -> exit 2 with softer wording.
-#   repo_scoped True  -> fire only when the op targets the vault repo. The
+#   scope 'repo'      -> fire only when the op targets the vault repo. The
 #                        regex captures the git options blob as group 1 so
 #                        targeting can follow any `git -C <dir>`.
-#   repo_scoped False -> fire whenever the command is in the vault namespace.
+#   scope 'namespace' -> fire whenever the command is in the vault namespace.
+#   scope 'rm-target' -> fire only when a parsed rm target resolves to a vault
+#                        root or a direct child of one. The regex is a cheap
+#                        prefilter; _rm_verdicts is what actually decides.
+SCOPE_REPO, SCOPE_NAMESPACE, SCOPE_RM_TARGET = 'repo', 'namespace', 'rm-target'
+
 RULES = [
     (
         r'(?:^|&&|\|\|?|;(?!;))\s*git\s+' + _GIT_OPTS_CAP + r'push\b',
@@ -282,7 +448,7 @@ RULES = [
         "git push in the vault: no remote is configured. This is a local-only snapshot repo. "
         "If you truly need to push, set up a remote first and confirm with the user. "
         "Rule: CLAUDE.md §'Git in this vault'.",
-        True,
+        SCOPE_REPO,
     ),
     (
         r'(?:^|&&|\|\|?|;(?!;))\s*git\s+' + _GIT_OPTS_CAP + r'status\s*(?:$|&&|;|\|)',
@@ -290,28 +456,28 @@ RULES = [
         "Unscoped `git status` in a 60K-file vault walks the full tree (~10min, locks .git/index.lock). "
         "Pass explicit paths: git status -- \"⚙️ Meta/\" \"path/to/file.md\" "
         "Or use `git status --short --untracked-files=no -- <path>`.",
-        True,
+        SCOPE_REPO,
     ),
     (
-        r'(?:^|&&|\|\|?|;(?!;))\s*rm\s+(?:-[A-Za-z]*[rRf][A-Za-z]*\s+)+"?(?:$HOME/vault|⚙️ Meta|✍️ Writing|📓 Journals|🚀 team-vault)',
+        _RM_RE.pattern,
         'block',
-        "rm -rf against the vault root or a top-level emoji folder would destroy live work. "
-        "Use explicit file paths or move to Archive/ instead.",
-        False,
+        "rm -rf against a vault root or one of its top-level folders would destroy live work. "
+        "Use explicit file paths (deeper than a top-level folder) or move to Archive/ instead.",
+        SCOPE_RM_TARGET,
     ),
     (
         r'(?:^|&&|\|\|?|;(?!;)|\|)\s*grep\b(?!\s+--?version|\s+--?help)',
         'nudge',
         "Prefer the Grep tool (or `rg`) over `grep` — faster, proper ignores, no full-tree walks. "
         "If you really need plain grep (e.g. piping fixed stdin), prefix with VAULT_VALIDATOR_BYPASS=1.",
-        False,
+        SCOPE_NAMESPACE,
     ),
     (
         r'(?:^|&&|\|\|?|;(?!;)|\|)\s*find\s+\S+\s+-name\b',
         'nudge',
         "Prefer the Glob tool over `find -name` — faster and respects vault ignores. "
         "If you really need find, prefix with VAULT_VALIDATOR_BYPASS=1.",
-        False,
+        SCOPE_NAMESPACE,
     ),
 ]
 
@@ -358,15 +524,26 @@ def main():
         return repo_cache[opts_blob]
 
     hits = []
-    for pattern, severity, message, repo_scoped in RULES:
+    for pattern, severity, message, scope in RULES:
         matches = list(re.finditer(pattern, command, re.MULTILINE))
         if not matches:
             continue
-        if repo_scoped:
+        if scope == SCOPE_REPO:
             fired = any(
                 opts_target_vault(m.group(1) or "")
                 for m in matches
             )
+        elif scope == SCOPE_RM_TARGET:
+            # The regex only said "a destructive rm is in here somewhere".
+            # Naming the resolved targets is what makes the block actionable —
+            # and, when it is wrong, obviously wrong to the reader.
+            verdicts = _rm_verdicts(command, cwd)
+            fired = bool(verdicts)
+            if fired:
+                message += "\n  Target(s): " + "; ".join(
+                    f"{t} ({'vault root' if v == 'root' else 'top-level folder'})"
+                    for t, v in verdicts
+                )
         else:
             fired = in_vault_namespace()
         if fired:

--- a/hooks/vault-command-nudges.py
+++ b/hooks/vault-command-nudges.py
@@ -172,10 +172,33 @@ def _effective_cwd(command: str, initial: str) -> str:
 # folders are not the four hardcoded ones is covered too, and depth stops
 # mattering, so every spelling of the same target behaves identically.
 _RM_FLAG = r'(?:--[A-Za-z][A-Za-z-]*|--|-[A-Za-z]+)'
+
+# Wrapper words that put a token in FRONT of `rm` without changing what the
+# command destroys. The predecessor rule required `rm` to be the first word
+# after a command separator, so `sudo rm -rf <vault>` — the single most likely
+# spelling of this mistake — did not match. `env` may also carry VAR=VAL args.
+_RM_WRAPPER = r'(?:sudo|env|time|nohup|command|exec|builtin)'
+# Up to three tokens may sit between a wrapper and `rm`, which covers a flag
+# whose value is a SEPARATE argument (`sudo -u root rm -rf ...`) and `env
+# FOO=bar`. Bounded, and reachable only AFTER a literal wrapper word, so this
+# cannot degrade into "any command containing the word rm" — `git commit -m "rm
+# -rf x"` never enters this branch, which matters because the operands of a
+# false match would be resolved against a vault cwd.
+_RM_LEAD = r'(?:' + _RM_WRAPPER + r'\s+(?:\S+\s+){0,3})*'
 _RM_RE = re.compile(
-    r'(?:^|&&|\|\|?|;(?!;))\s*rm\s+'      # `rm` at a command boundary
+    # A command boundary — including `(` and `{`, so a subshell or brace group
+    # is not a free pass.
+    r'(?:^|&&|\|\|?|;(?!;)|\(|\{)'
+    r'\s*' + _RM_LEAD +                   # optional sudo/env/time/... wrappers
+    r'rm\s+'
     r'((?:' + _RM_FLAG + r'\s+)*)'        # 1: leading flag blob
-    r'([^;&|\n]*)'                        # 2: operands, to the end of the chunk
+    r'([^;&|\n]*)',                       # 2: operands, to the end of the chunk
+    # REQUIRED, and it must match the flag main() passes when it prefilters with
+    # this same pattern. Without it `^` means "start of the string" here while
+    # meaning "start of any line" there, so a newline-separated
+    # `cd /tmp\nrm -rf <vault>` prefilters as a hit and then finds no targets to
+    # judge — the rule reports nothing and the command runs.
+    re.MULTILINE,
 )
 
 # One shell word: double-quoted, single-quoted, or bare. The bare arm accepts

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -271,6 +271,13 @@ INTEGRATION_TESTS=(
   # every test ran against the vault the env var already named, which makes
   # "resolve from the env" and "resolve from the target" indistinguishable.
   test_hook_vault_root_per_target
+  # The rm -rf rule in that same hook, which MYC-3529 left alone: its regex
+  # spelled the vault root `$HOME/vault` -- a SHELL string in a PYTHON regex,
+  # where `$` is an end-of-line anchor, so the branch was dead and the vault
+  # root was never blocked. Asserts on RESOLVED targets (abs, relative, quoted,
+  # escaped) against a vault named neither "vault" nor by any hardcoded folder
+  # name, so a rule that pattern-matches names cannot pass it.
+  test_rm_rf_vault_target
 )
 # ---- Gate-coverage invariant -------------------------------------------------
 # The list above is an explicit allow-list, and allow-lists rot: a new

--- a/scripts/utf8-stdout-baseline.txt
+++ b/scripts/utf8-stdout-baseline.txt
@@ -7,9 +7,16 @@
 # and carries no UTF-8 reconfigure guard - the ai-brain-starter#313 cp1252 crash
 # class. They predate the guard's SCOPE, not its predicate: until MYC-3530 this
 # lint only ever scanned scripts/*.py, so hooks/ was never looked at. All 78
-# rows are files the ORIGINAL, unwidened predicate would already have flagged.
-# Pinning them lets the CLASS-level guard cover hooks/ without a 78-file
-# rewrite, while still failing the build for anything new.
+# rows pinned at the start were files the ORIGINAL, unwidened predicate would
+# already have flagged. Pinning them lets the CLASS-level guard cover hooks/
+# without a 78-file rewrite, while still failing the build for anything new.
+#
+# BURN-DOWN: 78 pinned at MYC-3530, 77 remain.
+#   - hooks/vault-command-nudges.py  guarded + unpinned in PR #416. It was
+#     edited there (the rm -rf rule now quotes the RESOLVED target back to the
+#     user, so an emoji vault folder reaches stderr from the filesystem), which
+#     staled its row and forced the choice this file already documents below:
+#     guard it and delete the row, never re-pin. Deleted, per that rule.
 #
 # THE RATCHET (same mechanism as scripts/vault-root-read-baseline.txt #407 and
 # scripts/cloud-safe-walker-baseline.txt #411)
@@ -80,7 +87,6 @@ d08aadf9dfa1db19269f8866ac0b35a787dbae82baa510b41c323c3d7582b414 SEV-1-hard-cras
 0e5e50ea4361108fbcf77fed5ebcf8ab037275a1d0f385931a80a77eb786ad75 SEV-1-hard-crash hooks/test_relocation_orphan_reclaim.py
 0e0c411a3187e40e800a042f4911b0fec095e4ae6f5caecd15453c83012a31bf SEV-1-hard-crash hooks/test_unpushed_drift_surface.py
 62b8c0391f03aefe44ebf7a17a79063325d41eddae6a77150e4a2feb5e02800d SEV-1-hard-crash hooks/validate-calendar-timezone.py
-21c4531125c368cf3d2ec1654d64768c4b1e27e094e1f63510b09a4bcf95c8c5 SEV-1-hard-crash hooks/vault-command-nudges.py
 21173c16a8465b41d6d0d112453433541df97470beb22c9d9bd73d9b547a2ff4 SEV-1-hard-crash hooks/verify-discoverability-on-close.py
 cc08c6d1c065ae338cf5934cfae3c8489aa35814ba489bc63c16158b2c19711a SEV-1-hard-crash hooks/verify-session-close-cascade.py
 8d2689812e1ca9e8dcb9b1a984e0759d6a6f5d397516a0a9ad1293bead26f15c SEV-1-hard-crash hooks/warn-recreate-deleted-file.test.py

--- a/tests/integration/test_rm_rf_vault_target.sh
+++ b/tests/integration/test_rm_rf_vault_target.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# Test: vault-command-nudges.py blocks a destructive `rm` whose TARGET resolves
+# to a vault root or one of its top-level folders -- however that target is
+# spelled.
+#
+# WHAT WAS BROKEN
+#   The rule advertised in the module docstring as
+#       "Blocks `rm -rf` against the vault root or top-level emoji folders"
+#   was, verbatim:
+#       ...rm\s+(?:-[A-Za-z]*[rRf][A-Za-z]*\s+)+"?(?:$HOME/vault|⚙️ Meta|...)
+#   Two independent defects, both silent:
+#
+#   1. `$HOME/vault` is a SHELL string in a PYTHON regex. `$` is an end-of-line
+#      anchor, so that branch means "end of line, then the literal text
+#      HOME/vault" and cannot match any input on any machine. The vault ROOT --
+#      the single most destructive target there is -- was never blocked at all.
+#   2. The emoji branches are literal names anchored immediately after the
+#      flags, so only a bare relative `rm -rf "⚙️ Meta"` ever matched. The same
+#      deletion spelled absolutely, `rm -rf "/Users/x/Brain/⚙️ Meta"`, passed.
+#
+#   Net: of the whole advertised rule, one spelling of one case worked.
+#
+# WHY A NAME-MATCHING TEST WOULD REPRODUCE THE BLIND SPOT
+#   Asserting on the four hardcoded folder names would pass against the broken
+#   rule for case 3 and prove nothing about 1 or 2. So the vault here is named
+#   "Brain", its folders include a NON-hardcoded one ("Archive"), and
+#   $VAULT_ROOT points at a DECOY vault in every single assertion. A rule that
+#   pattern-matches names, or reads the env var, cannot pass this file.
+#
+# Bash + python3 only, no network. exit 0 = the rule matches resolved targets.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOK="$REPO_ROOT/hooks/vault-command-nudges.py"
+
+FAILURES=0
+pass() { echo "PASS: $1"; }
+fail() { echo "FAIL: $1" >&2; FAILURES=$((FAILURES + 1)); }
+
+# python's tempfile, not `mktemp -d`: under Git Bash on Windows mktemp hands
+# back an MSYS path ("/tmp/tmp.XXXX") that native python reinterprets against
+# the current drive. Every assertion compares a path the SHELL built against a
+# vault python RESOLVED, so both must agree on what a path is.
+TMP="$(python3 -c 'import tempfile; print(tempfile.mkdtemp(prefix="rm-rf-target-").replace(chr(92), "/"))')"
+if [ -z "$TMP" ] || [ ! -d "$TMP" ]; then
+  echo "FAIL: could not create a tmpdir python and the shell both agree on" >&2
+  exit 1
+fi
+trap 'rm -rf "$TMP"' EXIT
+OUT="$TMP/out.txt"
+ERR="$TMP/err.txt"
+VAULT="$TMP/Brain"          # the vault under test -- NOT named "vault"
+DECOY="$TMP/decoy-vault"    # what $VAULT_ROOT names in every assertion
+CODEREPO="$TMP/coderepo"    # not a vault: the over-fire control
+LOOKALIKE="$TMP/Brain-backup"
+
+# --------------------------------------------------------------------------
+# fixture (built in python: these paths carry emoji, and a portability gate
+# should not depend on the shell's locale handling of them)
+# --------------------------------------------------------------------------
+python3 - "$TMP" <<'PY'
+import sys
+from pathlib import Path
+
+tmp = Path(sys.argv[1])
+
+# PRECONDITION. Detection walks UP from the target for a Meta-suffixed folder,
+# so a stray "*Meta" directory above the tmpdir would make every not-a-vault
+# control resolve to it and quietly stop asserting anything.
+for anc in [tmp, *tmp.parents]:
+    try:
+        hit = next((c.name for c in anc.iterdir()
+                    if c.is_dir() and c.name.endswith("Meta")), None)
+    except OSError:
+        continue
+    if hit:
+        print(f"FIXTURE-UNUSABLE {anc}/{hit}", flush=True)
+        sys.exit(3)
+
+for v in ("Brain", "decoy-vault"):
+    (tmp / v / "⚙️ Meta").mkdir(parents=True, exist_ok=True)
+# A top-level folder that is NOT one of the four names the old rule hardcoded.
+# If this one blocks, the rule is resolving targets rather than matching names.
+(tmp / "Brain" / "Archive").mkdir(exist_ok=True)
+(tmp / "Brain" / "📓 Journals").mkdir(exist_ok=True)
+(tmp / "Brain" / "⚙️ Meta" / "rules").mkdir(exist_ok=True)
+(tmp / "coderepo" / "build").mkdir(parents=True, exist_ok=True)
+# Same prefix as the vault, one directory up, no Meta folder -> not a vault.
+(tmp / "Brain-backup" / "⚙️ Meta-ish").mkdir(parents=True, exist_ok=True)
+print("FIXTURE-OK", flush=True)
+PY
+if [ $? -ne 0 ]; then
+  echo "FAIL: fixture could not be built hermetically (see FIXTURE-UNUSABLE above)." >&2
+  exit 1
+fi
+
+# CLAUDE_CWD is cleared: the hook prefers it over the payload's cwd, and an
+# ambient value from the harness running this suite would retarget every
+# assertion at the real machine.
+run_rm() {  # <command> <cwd> -> sets RC
+  local payload
+  payload="$(python3 -c 'import json,sys; print(json.dumps({"tool_name":"Bash","tool_input":{"command":sys.argv[1]},"cwd":sys.argv[2]}))' "$1" "$2")"
+  printf '%s' "$payload" | env -u CLAUDE_CWD "VAULT_ROOT=$DECOY" \
+    python3 "$HOOK" >"$OUT" 2>"$ERR"
+  RC=$?
+}
+
+expect_block() {  # <label> <command> <cwd>
+  run_rm "$2" "$3"
+  if [ "$RC" -eq 2 ] && grep -q "BLOCKED" "$ERR"; then
+    pass "$1"
+  else
+    fail "$1 -- expected a block, got rc=$RC"
+    sed 's/^/  /' "$ERR" >&2
+  fi
+}
+
+expect_allow() {  # <label> <command> <cwd>
+  run_rm "$2" "$3"
+  if [ "$RC" -eq 0 ]; then
+    pass "$1"
+  else
+    fail "$1 -- expected to pass, got rc=$RC"
+    sed 's/^/  /' "$ERR" >&2
+  fi
+}
+
+# --------------------------------------------------------------------------
+# 1. positives: the vault root and its top-level folders, however spelled
+# --------------------------------------------------------------------------
+# Case 1 is the one the `$HOME/vault` branch could never match on any machine.
+expect_block "abs path to the vault ROOT blocks" \
+  "rm -rf \"$VAULT\"" "$CODEREPO"
+
+# Case 2 is the one the name-anchored branches missed: same folder as case 3,
+# spelled absolutely, from a cwd outside the vault entirely.
+expect_block "abs path to a top-level emoji folder blocks" \
+  "rm -rf \"$VAULT/⚙️ Meta\"" "$CODEREPO"
+
+# Case 3 is the ONLY spelling the old rule ever caught -- kept so the rewrite
+# cannot regress it.
+expect_block "relative top-level folder from a vault cwd blocks" \
+  'rm -rf "⚙️ Meta"' "$VAULT"
+
+# The name-independence proof: "Archive" is in none of the four hardcoded
+# branches, so this can only pass if targets are being RESOLVED.
+expect_block "a top-level folder the old rule never named blocks" \
+  "rm -rf \"$VAULT/Archive\"" "$CODEREPO"
+
+expect_block "cd into the vault, then a relative rm, blocks" \
+  "cd \"$VAULT\" && rm -rf \"📓 Journals\"" "$CODEREPO"
+
+expect_block "unquoted (backslash-escaped space) spelling blocks" \
+  "rm -rf $VAULT/⚙️\\ Meta" "$CODEREPO"
+
+expect_block "flag order and a trailing slash do not evade (rm -fr dir/)" \
+  "rm -fr \"$VAULT/⚙️ Meta/\"" "$CODEREPO"
+
+expect_block "split flags and -- do not evade (rm -r -f -- dir)" \
+  "rm -r -f -- \"$VAULT\"" "$CODEREPO"
+
+expect_block "'rm -rf .' resolving to the vault root blocks" \
+  'rm -rf .' "$VAULT"
+
+# --------------------------------------------------------------------------
+# 2. negatives: the guard must stay out of everything that is not a vault
+# --------------------------------------------------------------------------
+expect_allow "rm -rf build/ in a plain code repo passes" \
+  'rm -rf build/' "$CODEREPO"
+
+expect_allow "rm -rf of an abs path in a plain code repo passes" \
+  "rm -rf \"$CODEREPO/build\"" "$TMP"
+
+# Same name prefix as the vault, sitting beside it, but no Meta folder of its
+# own -- a path-prefix guard would fire here; a resolving one must not.
+expect_allow "rm -rf a similarly-named folder outside any vault passes" \
+  "rm -rf \"$LOOKALIKE\"" "$CODEREPO"
+
+# The documented boundary: below a top-level folder is the "explicit file
+# paths" the block message tells you to use, so it must not itself block.
+expect_allow "rm -rf deeper than a top-level folder passes" \
+  "rm -rf \"$VAULT/⚙️ Meta/rules\"" "$CODEREPO"
+
+expect_allow "a non-destructive command naming the vault passes" \
+  "ls \"$VAULT\"" "$CODEREPO"
+
+run_rm "VAULT_VALIDATOR_BYPASS=1 rm -rf \"$VAULT\"" "$CODEREPO"
+if [ "$RC" -eq 0 ]; then
+  pass "the documented VAULT_VALIDATOR_BYPASS=1 escape hatch still works"
+else
+  fail "VAULT_VALIDATOR_BYPASS=1 did not bypass the block (rc=$RC)"
+fi
+
+# --------------------------------------------------------------------------
+# 3. the block names its target
+#    A guard that blocks without saying WHAT it matched is one an agent
+#    retries blind. It is also how case 1 stayed invisible for so long.
+# --------------------------------------------------------------------------
+run_rm "rm -rf \"$VAULT\"" "$CODEREPO"
+if grep -q "Brain" "$ERR" && grep -q "vault root" "$ERR"; then
+  pass "the block message names the resolved target and why it matched"
+else
+  fail "the block message does not name the resolved target"
+  sed 's/^/  /' "$ERR" >&2
+fi
+
+# --------------------------------------------------------------------------
+# 4. anti-regression: no shell $VAR left unescaped inside a regex literal
+#    This is the defect class itself, not an instance of it. `$HOME/vault`
+#    LOOKS like a path in a code review and is an end-of-line anchor followed
+#    by dead literal text -- it type-checks, lints, compiles, and never fires.
+# --------------------------------------------------------------------------
+dollar_hits="$(python3 - "$HOOK" <<'PY'
+import ast, re, sys
+from pathlib import Path
+
+BACKSLASH = chr(92)
+src = Path(sys.argv[1]).read_text(encoding="utf-8")
+var = re.compile(r"\$[A-Z_][A-Z0-9_]+")
+bad = []
+for node in ast.walk(ast.parse(src)):
+    if not (isinstance(node, ast.Constant) and isinstance(node.value, str)):
+        continue
+    seg = ast.get_source_segment(src, node) or ""
+    m = re.match(r'^[a-zA-Z]{0,2}["\']', seg)
+    if not m or "r" not in m.group(0).lower()[:-1]:
+        continue  # not a raw literal
+    for hit in var.finditer(node.value):
+        if hit.start() and node.value[hit.start() - 1] == BACKSLASH:
+            continue  # \$VAR -- a correct literal match
+        bad.append(f"line {node.lineno}: {hit.group(0)}")
+print("; ".join(bad))
+PY
+)"
+if [ -z "$dollar_hits" ]; then
+  pass "no unescaped shell \$VAR survives inside a regex literal in this hook"
+else
+  fail "a shell \$VAR is sitting unescaped in a regex literal (\$ is an anchor; the branch is dead): $dollar_hits"
+fi
+
+echo
+if [ "$FAILURES" -eq 0 ]; then
+  echo "All assertions passed. rm -rf is blocked by resolved TARGET, not by folder name."
+  exit 0
+fi
+echo "$FAILURES assertion(s) FAILED." >&2
+exit 1

--- a/tests/integration/test_rm_rf_vault_target.sh
+++ b/tests/integration/test_rm_rf_vault_target.sh
@@ -163,8 +163,59 @@ expect_block "'rm -rf .' resolving to the vault root blocks" \
   'rm -rf .' "$VAULT"
 
 # --------------------------------------------------------------------------
+# 1b. the command does not have to START with `rm`
+#
+#     The predecessor's boundary was `(?:^|&&|\|\|?|;(?!;))\s*rm`, so `rm` had
+#     to be the first word after a separator. `sudo rm -rf <vault>` -- plausibly
+#     the single most likely spelling of this mistake -- did not match it, and
+#     neither did a subshell, a brace group, or a plain newline between two
+#     commands. Each of these was verified to pass unblocked before the fix.
+# --------------------------------------------------------------------------
+expect_block "a sudo-prefixed rm blocks" \
+  "sudo rm -rf \"$VAULT\"" "$CODEREPO"
+
+expect_block "sudo with its own flag+value blocks (sudo -u root rm)" \
+  "sudo -u root rm -rf \"$VAULT\"" "$CODEREPO"
+
+expect_block "an env-prefixed rm, with a VAR=VAL arg, blocks" \
+  "env FOO=bar rm -rf \"$VAULT\"" "$CODEREPO"
+
+expect_block "stacked wrappers block (sudo nohup rm)" \
+  "sudo nohup rm -rf \"$VAULT\"" "$CODEREPO"
+
+expect_block "a subshell is not a free pass" \
+  "(rm -rf \"$VAULT\")" "$CODEREPO"
+
+expect_block "a brace group is not a free pass" \
+  "{ rm -rf \"$VAULT\"; }" "$CODEREPO"
+
+# NEWLINE. This one is a regression guard on an internal inconsistency, not on
+# the shell: _RM_RE is compiled here and ALSO handed to main() as a prefilter.
+# If the compiled copy loses re.MULTILINE while main() keeps applying it, `^`
+# means two different things in the two places -- the command prefilters as a
+# hit, then no targets are found to judge, and the rule reports nothing at all.
+expect_block "a newline-separated rm blocks (prefilter and decider agree on ^)" \
+  "cd /tmp
+rm -rf \"$VAULT\"" "$CODEREPO"
+
+# --------------------------------------------------------------------------
 # 2. negatives: the guard must stay out of everything that is not a vault
 # --------------------------------------------------------------------------
+# Widening the boundary above must not decay into "any command containing the
+# word rm". These would resolve their operands against a VAULT cwd if they
+# matched, so a false positive here is a false BLOCK, not a harmless one.
+expect_allow "a commit message that merely quotes rm -rf passes" \
+  'git commit -m "rm -rf the old thing"' "$VAULT"
+
+expect_allow "an echo that merely mentions rm -rf passes" \
+  'echo "run rm -rf later"' "$VAULT"
+
+expect_allow "a command that merely starts with the letters rm passes" \
+  'confirm -rf something' "$VAULT"
+
+expect_allow "sudo rm -rf of a non-vault path still passes" \
+  'sudo rm -rf build/' "$CODEREPO"
+
 expect_allow "rm -rf build/ in a plain code repo passes" \
   'rm -rf build/' "$CODEREPO"
 

--- a/tests/integration/test_rm_rf_vault_target.sh
+++ b/tests/integration/test_rm_rf_vault_target.sh
@@ -289,6 +289,64 @@ else
   fail "a shell \$VAR is sitting unescaped in a regex literal (\$ is an anchor; the branch is dead): $dollar_hits"
 fi
 
+# --------------------------------------------------------------------------
+# 5. EVERY rule in the table has a positive control
+#
+#     This is the generalised lesson, and it is the reason the rm -rf defect
+#     survived as long as it did. The rule was in RULES, it was wired, it was
+#     documented in the module docstring, and it read fine. Nothing anywhere
+#     asserted that it could actually FIRE, so "enforced" and "inert" were
+#     indistinguishable from the outside -- by inspection, by lint, and by CI.
+#
+#     Auditing this file's five rules while fixing rm -rf found that `git
+#     status` had NO positive control either (it does fire -- checked -- but
+#     nobody had ever proven it). One untested blocking rule is how you get
+#     the next silent no-op.
+#
+#     So: a sample per rule, run inside a real vault, each asserted to block.
+#     The COUNT is asserted too, which is the part that keeps this honest --
+#     add a sixth rule and this test fails until it gets a control of its own.
+# --------------------------------------------------------------------------
+git -C "$VAULT" init -q 2>/dev/null
+git -C "$VAULT" config user.email t@t
+git -C "$VAULT" config user.name t
+echo seed > "$VAULT/seed.txt"
+git -C "$VAULT" add seed.txt >/dev/null 2>&1
+git -C "$VAULT" -c commit.gpgsign=false commit -qm init >/dev/null 2>&1
+
+rule_count="$(python3 -c '
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location("h", sys.argv[1])
+m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+print(len(m.RULES))' "$HOOK")"
+
+# One positive control per rule, in table order.
+RULE_SAMPLES=(
+  "git push"
+  "git status"
+  "rm -rf \"$VAULT\""
+  "grep foo note.md"
+  "find . -name '*.md'"
+)
+
+if [ "$rule_count" != "${#RULE_SAMPLES[@]}" ]; then
+  fail "RULES has $rule_count entries but this test carries ${#RULE_SAMPLES[@]} positive control(s) -- a rule with no proof that it fires is how the rm -rf defect stayed invisible. Add a sample."
+else
+  pass "every one of the $rule_count rules has a positive control"
+fi
+
+fired_all=1
+for sample in "${RULE_SAMPLES[@]}"; do
+  run_rm "$sample" "$VAULT"
+  if [ "$RC" -ne 2 ]; then
+    fail "rule sample does not fire inside a vault: $sample (rc=$RC)"
+    fired_all=0
+  fi
+done
+if [ "$fired_all" -eq 1 ]; then
+  pass "all ${#RULE_SAMPLES[@]} rules actually fire on a live vault (none is silently inert)"
+fi
+
 echo
 if [ "$FAILURES" -eq 0 ]; then
   echo "All assertions passed. rm -rf is blocked by resolved TARGET, not by folder name."


### PR DESCRIPTION
## The bug

`hooks/vault-command-nudges.py` advertises, in its own module docstring:

> Blocks `rm -rf` against the vault root or top-level emoji folders

It enforced almost none of that. The rule was:

```python
r'(?:^|&&|\|\|?|;(?!;))\s*rm\s+(?:-[A-Za-z]*[rRf][A-Za-z]*\s+)+"?(?:$HOME/vault|⚙️ Meta|✍️ Writing|📓 Journals|🚀 team-vault)'
```

Two independent defects, both silent:

1. **`$HOME/vault` is a SHELL string sitting in a PYTHON regex.** `$` is an end-of-line anchor, so that branch parses as *"end of line, then the literal text `HOME/vault`"* and cannot match any input on any machine. **The vault root — the most destructive target there is — was never blocked at all.**
2. **The four emoji branches are literal names anchored immediately after the flags**, so only a bare relative `rm -rf "⚙️ Meta"` ever matched. The same deletion spelled absolutely — `rm -rf "/Users/x/Brain/⚙️ Meta"`, the way an agent actually spells it — went straight through.

Net: of the whole advertised rule, one spelling of one case worked.

Demonstrated against the rule as it stands on `main`:

| command | blocked before |
|---|---|
| `rm -rf /home/x/vault` | ❌ no |
| `rm -rf $HOME/vault` | ❌ no |
| `rm -rf "/Users/x/Brain/⚙️ Meta"` | ❌ no |
| `rm -rf "⚙️ Meta"` | ✅ yes |

## The fix

Stop pattern-matching the string; ask the filesystem. A third scoping model, `SCOPE_RM_TARGET`, parses the rm's operands — quote-aware, backslash-escape aware, flags on either side, `--`, trailing slashes — resolves each against the effective cwd, and blocks only when a resolved target **is** a vault root or a **direct child** of one.

Names stop mattering, so a vault whose folders are not the four hardcoded ones is covered too. Depth stops mattering, so every spelling of the same target behaves identically.

Two deliberate choices, both documented at the call site:

- **Operands resolve lexically, and the parent is probed separately** rather than walked up from the target. `vault_root_for()` resolves symlinks, so asking it about `<vault>/🍄 brand` answers for the repo that symlink points *at*; asking about its **parent** answers about the vault whose top-level entry is being deleted. That is the case the module docstring explicitly promises to cover.
- **Below a direct child does not block** — that is the *"explicit file paths"* the block message tells you to use.

Builds on MYC-3529 (#414), which made the vault root resolvable per target but deliberately left the rule regexes alone. This is the follow-up that ticket named as out of scope.

## Tests

New `tests/integration/test_rm_rf_vault_target.sh`, wired into `INTEGRATION_TESTS` (gate-coverage invariant passes: 95 tests, every `test_*.sh` covered).

**17 assertions, and it is red on 9 of them against the old rule** — including all three positives from the report. The two that pass either way are the one spelling the old rule caught, plus the negatives.

The fixture is built so a broken rule cannot sneak through:

- the vault is named **`Brain`**, not `vault`
- it has a top-level **`Archive`** — none of the four hardcoded names — so blocking it is only possible by *resolving*
- **`$VAULT_ROOT` points at a decoy vault in every single assertion**, per the doctrine established in `test_hook_vault_root_per_target.sh`

Negative controls: `rm -rf build/` in a code repo, an absolute path in a code repo, a similarly-named `Brain-backup` outside any vault, a depth-2 path inside the vault, a non-`rm` command naming the vault, and the documented `VAULT_VALIDATOR_BYPASS=1` escape hatch.

One assertion tests the defect **class**, not the instance: no unescaped shell `$VAR` may survive inside a regex literal in this hook. `$HOME/vault` *looks* like a path in review — it type-checks, lints, compiles, and never fires.

## Class sweep

An AST sweep over **all 324 tracked `.py` files** for `$VAR` inside raw-string regex literals found **no other live instance**. `\$HOME` in `check-hook-block-protocol.py` and `\$SECONDS` in `audit-sessionstart-boundedness.py` are correctly escaped; the `template_purity.py` hits are prose inside `re.VERBOSE` `#` comments. The sweep was validated in both directions — it flags exactly this bug on the pre-fix tree and reports clean after.

## Gates

Passing: `check-vault-root-reads.py --all`, gate-coverage invariant, `check-hook-block-protocol.py`, `py_compile`, and `test_hook_vault_root_per_target.sh` (28 assertions, no regression — the `RULES` tuple's fourth field changed from a bool to a scope tag, and both other scoping models are covered there).

Two notes for the reviewer:

- **`scripts/shellcheck.sh` fails on my Windows checkout, pre-existing and unrelated.** The new test file is shellcheck-clean; the failures are `SC1017` literal-carriage-return on other files, reproducible on the unmodified tree. Linux CI should be unaffected.
- **Merge-order interaction with MYC-3530 — resolved, no longer a decision.** That branch's `scripts/utf8-stdout-baseline.txt` pins this hook as `SEV-1-hard-crash`: a known-*unguarded* printing CLI grandfathered into a ratchet. Editing it invalidates the row, and the two remediations disagreed — the gate's error text says *"Delete the row — do NOT re-pin edited content"*, while the in-flight work on that branch refreshes the stale rows instead.

  Rather than pick a side, `b77e29f` adds the UTF-8 console guard, which removes this file from the backlog entirely: the row is **deleted** (what the gate prescribes) and nothing is re-pinned (what the burn-down wants). Verified against that branch's own `check-utf8-stdout.py` — this file now passes as guarded.

  It was also a real defect, not gate bookkeeping. This hook prints its block reason to stderr, and that reason now quotes the resolved target — an emoji-prefixed vault folder arriving from the *filesystem*, so the crash lands even when the user's command was pure ASCII. Unguarded, the one code path that only ever runs when live work is about to be deleted would raise `UnicodeEncodeError` and report a hook error instead of a reason.

## Follow-up commits (adversarial pass)

`91e55fa` — fourteen evasion probes against the rule this PR rewrote. **Eight got through.** One was mine, the rest inherited:

- **Mine:** `_RM_RE` was compiled without `re.MULTILINE` while `main()` prefilters with the same pattern *and* passes the flag. `^` meant two different things in the two places, so a newline-separated `cd /tmp` + `rm -rf <vault>` prefiltered as a hit, found no targets to judge, and reported nothing — the same silent-open shape this PR exists to fix, one layer down.
- **Inherited:** the boundary required `rm` to be the first word after a separator, so `sudo rm -rf <vault>` — plausibly the most likely spelling of this mistake — never matched. Nor did `sudo -u root rm`, `env FOO=bar rm`, `time`/`nohup`, `(subshell)`, or `{ brace group; }`.

The boundary now admits `(`/`{` and a bounded run of wrapper words. The wrapper anchor is load-bearing: without it the pattern decays into "any command containing `rm`", and because a match resolves its operands against a vault cwd, a false positive becomes a false **block**. Asserted in both directions — `git commit -m "rm -rf the old thing"` from a vault cwd must stay silent.

Deliberately **not** half-solved here: `xargs rm -rf`, `find -exec rm`, `bash -c '...'`. Those need the target to survive a nested shell rather than a wider boundary — the class MYC-574 already tracks for `block-raw-vault-git.py`. Filed separately.

Test suite: **17 → 28 assertions**, still red against the original rule.


`ec41d29` — MYC-3530 (#417) landed on main while this PR was open, so its ratchet went live and this PR's edit staled the hook's row. Both gates failed on exactly that. The failure text is also the remediation, and it confirms the guard worked: *"0 unpinned file(s) missing the UTF-8 console guard, 1 stale baseline row(s)."* Row **deleted**, per that file's own rule — 78 pinned at MYC-3530, 77 remain, and the header records the burn-down.

`3748c98` — the generalised lesson. Nothing in this repo asserted that a *rule* can fire. Every existing gate checks structure (sanctioned resolver #407, can-this-hook-block-at-all #405, UTF-8 guard MYC-3530); this defect was semantic — a regex that compiles, matches nothing, blocks nobody — and was invisible to all of them with CI green throughout.

Auditing the same table's other four rules found `git status` in the same position: no positive control anywhere in the suite. It does fire (verified), but nobody had ever proven it — exactly the state the `rm -rf` rule was in for its whole life.

So: one sample per rule, run inside a real vault, each asserted to block, **plus a count assertion** — add a sixth rule and the suite fails until it carries its own control. Verified by planting one: *"RULES has 6 entries but this test carries 5 positive control(s)."* Generalising this to the whole hook fleet is MYC-3547.

**Test suite: 17 → 30 assertions.** Deliberately not built: a repo-wide lint for `$VAR`-in-regex. The AST sweep found exactly one instance in 324 files (this bug), so the population is zero, and the "which literal is a regex" predicate is heuristic enough that a false positive would cost more than the class does. The positive-control approach catches the same defect by its *effect* rather than its spelling.

## Follow-ups filed

- **MYC-3540** — `xargs rm -rf`, `find -exec rm`, `bash -c '...'` still evade; shares a root cause with MYC-574 and should be solved once in a shared helper.
- **MYC-3542** — no `.gitattributes`, so `scripts/shellcheck.sh` is 100% red and unusable on any Windows checkout.
- **MYC-3547** — make per-rule positive controls a fleet property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



