### PR TITLE
fix(test): canonicalise the tmpdir so the vault-root suite passes on macOS

### DIFF
--- a/tests/integration/test_hook_vault_root_per_target.sh
+++ b/tests/integration/test_hook_vault_root_per_target.sh
@@ -75,7 +75,7 @@ show_streams() {
 # SHELL produced against a path PYTHON resolved, so the two must agree on what a
 # path is or the suite tests nothing. python's tempfile answers in the same
 # namespace the hooks run in, on both platforms.
-TMP="$(python3 -c 'import tempfile; print(tempfile.mkdtemp(prefix="abs-vault-root-").replace(chr(92), "/"))')"
+TMP="$(python3 -c 'import os,tempfile; print(os.path.realpath(tempfile.mkdtemp(prefix="abs-vault-root-")).replace(chr(92), "/"))')"
 if [ -z "$TMP" ] || [ ! -d "$TMP" ]; then
   echo "FAIL: could not create a tmpdir python and the shell both agree on" >&2
   exit 1


### PR DESCRIPTION
fix(test): canonicalise the tmpdir so the vault-root suite passes on macOS

test_hook_vault_root_per_target.sh has been RED on every macOS checkout while
green in CI. On macOS `tempfile.mkdtemp()` hands back /var/folders/..., which is
a symlink to /private/var/folders/.... The hooks under test resolve their paths;
the test compared the unresolved string. Same directory, two spellings, three
assertions failing on a difference that is not the thing being tested:

  FAIL: vault-command-nudges namespace rule missed a path inside the OTHER vault
  FAIL: surface-stale-automation-failures reported the OTHER vault's failures
  FAIL: auto-capture-public-ships resolved '/private/var/...'; expected '/var/...'

os.path.realpath() at tmpdir creation fixes the first and third. Linux CI is
unaffected: /tmp is not a symlink there, so realpath is a no-op — which is also
why this never showed up in CI.

Why it matters beyond the three lines: this is the local pre-push gate. A gate
that is permanently red on a whole platform, for a reason unrelated to any
change, is a gate people route around — and a bypass habit learned on a false
red is spent on the next true one.

The second assertion is NOT fixed here, and is a different class:
surface-stale-automation-failures reads the real machine's launchd state, so on
any machine that genuinely has failing com.adelaida.* agents it reports them and
the decoy-vault assertion fails. It passes on a clean runner because a clean
runner has no such agents. Isolating that hook from real machine state is its own
change; leaving it visible rather than papering over it.

Found while a phase-contract change was blocked by this suite. Verified by
holding the artifact constant and varying only the tree: clean origin/main
produces the identical three failures on this machine, so the RED was never
about the change under test.
