### PR TITLE
feat: one phase-contract checker that also covers INSTALLED close rules

### DIFF
--- a/scripts/check-close-phase-contract.py
+++ b/scripts/check-close-phase-contract.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Validate a session-close rule file against the close cascade's phase contract.
+
+`hooks/detect-closing-signal.py` injects a numbered cascade into the model's
+context at close. A rule file describes the same process for the same reader.
+When the two disagree about what a NUMBER means, the number is worse than no
+number at all — and the failure is silent, because each file is internally
+consistent.
+
+That is not hypothetical. ai-brain-starter#400 added a `/goal clear` reminder to
+the shipped rule and labelled it "Phase 4b" using the cascade's numbering; under
+the rule's own numbering Phase 4 was the step that happens automatically with no
+involvement from the reader, so the label announced that the goal clears itself.
+#415 aligned the shipped rule. Then the SAME defect turned up in an installed,
+heavily customised copy of that rule: it carried a "Phase 4b" with no Phase 4
+anywhere in the file. A guard that only ever ran against the file in this repo
+could not see it.
+
+So this checker takes a PATH. The shipped template is the default; `--rule`
+points it at an installed copy, which is where rules actually drift.
+
+Two tiers, deliberately:
+
+  STRUCTURAL (always on, no false positives possible)
+    - no duplicate phase numbers          a number must head exactly one section
+    - no orphan sub-phase                 "4b" requires a "4" to belong to
+    These are properties of the file alone. An installed rule may legitimately
+    rename, reorder, add and drop phases; it may never define 4b without 4.
+
+  MEANING (--strict-meaning, canonical files only)
+    - a number present in BOTH the rule and the cascade must denote the same step
+    Enforced on the file this repo ships. NOT enforced by default, because an
+    installed rule is customised prose ("Summary format" for "Final summary") and
+    a checker that fails on legitimate customisation teaches people to bypass it,
+    which then hides the structural failures that matter.
+
+Exit 0 = pass. Exit 1 = contract violated. Exit 2 = could not check (fail loud;
+a checker that cannot read its inputs must never report success).
+
+Pure stdlib. Usage:
+    python3 scripts/check-close-phase-contract.py                    # shipped template
+    python3 scripts/check-close-phase-contract.py --strict-meaning   # + meaning pins
+    python3 scripts/check-close-phase-contract.py --rule ~/vault/rules/session-close.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_RULE = REPO_ROOT / "templates" / "rules" / "session-close.md"
+DEFAULT_CASCADE = REPO_ROOT / "hooks" / "detect-closing-signal.py"
+
+# "## Phase 4b — Goodbye" / "## Phase 2b: Commit what you wrote"
+#
+# The separator is REQUIRED. A rule may also carry meta-headings that merely
+# mention a phase — "## Phase 1 MUST show its work" is guidance ABOUT Phase 1,
+# not the definition of it. Without this, such a heading counts as a second
+# Phase 1 and the duplicate check fires on a file that is perfectly correct;
+# a checker that cries wolf on real prose is one people learn to bypass.
+RULE_PHASE_RE = re.compile(
+    r"^##\s+Phase\s+(?P<num>\d+(?:\.\d+)?[a-z]?)\s*[—:–]\s*(?P<title>.*)$",
+    re.MULTILINE,
+)
+# "PHASE 4b — CLEAR THE SESSION GOAL"
+CASCADE_PHASE_RE = re.compile(
+    r"^PHASE\s+(?P<num>\d+(?:\.\d+)?[a-z]?)\s*[—:–-]\s*(?P<title>.*)$",
+    re.MULTILINE,
+)
+
+# A number present in both files must mean the same step. Keyed by phase number;
+# each value is a pair of substrings (rule-side, cascade-side) that must appear,
+# case-insensitively, in that phase's title. Pinning SUBSTRINGS rather than whole
+# titles leaves wording free while holding the meaning still.
+MEANING_PINS = {
+    "0b": ("unfinished business", "incomplete-work"),
+    "1": ("scan the conversation", "conversation scan"),
+    "2": ("write to the vault", "batch writes"),
+    "2b": ("commit", "vault-safe-commit"),
+    "3": ("functional audit", "functional audit"),
+    "4": ("goodbye", "final summary"),
+}
+
+
+def _parse(text: str, pattern: re.Pattern) -> list[tuple[str, str]]:
+    return [(m.group("num"), m.group("title").strip()) for m in pattern.finditer(text)]
+
+
+def _base_number(num: str) -> str:
+    """'4b' -> '4'. '1.8' -> '1.8' (a dotted number is its own phase, not a sub)."""
+    return num[:-1] if num and num[-1].isalpha() else num
+
+
+def check(rule_path: Path, cascade_path: Path, strict_meaning: bool) -> int:
+    try:
+        rule_text = rule_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"CANNOT CHECK: rule file unreadable: {rule_path} ({exc})", file=sys.stderr)
+        return 2
+    try:
+        cascade_text = cascade_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"CANNOT CHECK: cascade unreadable: {cascade_path} ({exc})", file=sys.stderr)
+        return 2
+
+    rule_phases = _parse(rule_text, RULE_PHASE_RE)
+    cascade_phases = _parse(cascade_text, CASCADE_PHASE_RE)
+
+    if not rule_phases:
+        print(f"CANNOT CHECK: no '## Phase N' headings in {rule_path}", file=sys.stderr)
+        return 2
+    if not cascade_phases:
+        print(f"CANNOT CHECK: no 'PHASE N' lines in {cascade_path}", file=sys.stderr)
+        return 2
+
+    failures: list[str] = []
+
+    # --- STRUCTURAL 1: no duplicate numbers ---------------------------------
+    seen: dict[str, int] = {}
+    for num, _title in rule_phases:
+        seen[num] = seen.get(num, 0) + 1
+    for num, n in sorted(seen.items()):
+        if n > 1:
+            failures.append(
+                f"phase {num} heads {n} sections — a number must name exactly one step"
+            )
+
+    # --- STRUCTURAL 2: no orphan sub-phase ----------------------------------
+    # An orphan is a sub-phase whose PARENT the cascade defines but the rule
+    # dropped: the rule says "4b" while the cascade has both 4 and 4b, so the
+    # reader is pointed at a parent that does not exist in front of them.
+    #
+    # Keyed to the cascade rather than to bare structure on purpose. The 0-series
+    # (0a/0b/0c) legitimately has no bare "Phase 0" in EITHER file — that is the
+    # established convention, not drift, and flagging it would be exactly the
+    # over-strict failure that gets a guard switched off.
+    numbers = {num for num, _ in rule_phases}
+    cascade_numbers = {num for num, _ in cascade_phases}
+    for num in sorted(numbers):
+        base = _base_number(num)
+        if base != num and base not in numbers and base in cascade_numbers:
+            failures.append(
+                f"phase {num} is an orphan — the cascade defines phase {base}, "
+                f"but this rule has no phase {base} for {num} to belong to"
+            )
+
+    # --- MEANING (opt-in) ---------------------------------------------------
+    if strict_meaning:
+        rule_by_num = {num: title for num, title in rule_phases}
+        cascade_by_num = {num: title for num, title in cascade_phases}
+        for num, (want_rule, want_cascade) in sorted(MEANING_PINS.items()):
+            r_title = rule_by_num.get(num)
+            c_title = cascade_by_num.get(num)
+            if r_title is None:
+                failures.append(f"phase {num}: rule has no such phase (expected {want_rule!r})")
+                continue
+            if c_title is None:
+                failures.append(f"phase {num}: cascade has no such phase (expected {want_cascade!r})")
+                continue
+            if want_rule.lower() not in r_title.lower():
+                failures.append(
+                    f"phase {num}: rule says {r_title!r}, expected it to mean {want_rule!r}"
+                )
+            if want_cascade.lower() not in c_title.lower():
+                failures.append(
+                    f"phase {num}: cascade says {c_title!r}, expected it to mean {want_cascade!r}"
+                )
+
+    print(f"rule:    {rule_path}  ({len(rule_phases)} phase heading(s))")
+    print(f"cascade: {cascade_path}  ({len(cascade_phases)} phase line(s))")
+    print(f"mode:    structural{' + meaning pins' if strict_meaning else ''}")
+    if failures:
+        print("")
+        for f in failures:
+            print(f"  FAIL: {f}")
+        print(f"\nFAILED: {len(failures)} phase-contract violation(s)")
+        return 1
+    print("OK - phase contract holds")
+    return 0
+
+
+def main() -> int:
+    # This CLI prints em dashes and vault paths that contain non-ASCII (the
+    # "gear Meta" folder). On a Windows cp1252 console print() would raise
+    # UnicodeEncodeError and the caller would read the empty output as failure
+    # (ai-brain-starter#313). scripts/check-utf8-stdout.py enforces this block.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
+
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--rule", default=str(DEFAULT_RULE),
+                    help="session-close rule file to check (default: the shipped template)")
+    ap.add_argument("--cascade", default=str(DEFAULT_CASCADE),
+                    help="the hook that injects the numbered cascade")
+    ap.add_argument("--strict-meaning", action="store_true",
+                    help="also pin what each shared number MEANS (canonical files only)")
+    args = ap.parse_args()
+    return check(Path(args.rule).expanduser(), Path(args.cascade).expanduser(),
+                 args.strict_meaning)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integration/test_close_phase_numbering_aligned.sh
+++ b/tests/integration/test_close_phase_numbering_aligned.sh
@@ -1,119 +1,151 @@
 #!/usr/bin/env bash
-# Test: the shipped close rule and the injected close cascade agree on what each
-# phase NUMBER means.
+# Test: scripts/check-close-phase-contract.py holds the session-close rule and
+# the injected cascade to one phase-number contract.
 #
-# Why: templates/rules/session-close.md and hooks/detect-closing-signal.py both
-# reach the model — the template when it reads the rule, the cascade when the
-# hook injects it at close. They describe ONE process. Before this test they
-# disagreed:
+# History this locks (all real, all shipped):
+#   #400 added a `/goal clear` reminder to the shipped rule labelled "Phase 4b",
+#        borrowing the cascade's numbering. Under the rule's own numbering Phase 4
+#        was the automatic step ("you do nothing"), so the label announced that the
+#        goal clears itself — the opposite of the truth.
+#   #401 removed the label.
+#   #415 aligned the rule's numbers to the cascade's.
+#   Then the SAME defect appeared in an installed, customised copy of the rule:
+#        a "Phase 4b" with no Phase 4 anywhere in the file. A guard that only ran
+#        against this repo's own copy could not see it — hence a checker that
+#        takes a --rule PATH.
 #
-#   number   template said              cascade said
-#   3        Goodbye                    Functional audit
-#   4        Automatic finalization     Final summary (the goodbye)
-#             ("you do nothing")
-#
-# That shipped a live trap: #400 added a `/goal clear` reminder to the template
-# and labelled it "Phase 4b", borrowing the cascade's numbering. Under the
-# template's own numbering Phase 4 is the part that happens automatically with
-# no involvement from the reader — so the label said the goal clears itself,
-# which is the exact opposite of the truth.
-#
-# The rule this locks: a phase number present in BOTH files must denote the same
-# step in both. Numbers unique to one file are fine (the cascade is more
-# granular: 0a, 0c/0d/0e, 1.8 have no template section).
+# The checker is two-tier on purpose: STRUCTURAL checks (duplicate numbers,
+# orphan sub-phases) run on any rule file and cannot false-positive; MEANING pins
+# run only with --strict-meaning, on the canonical file, because an installed
+# rule is customised prose and a checker that fails on legitimate customisation
+# is one people switch off.
 #
 # Assertions:
-#   1. Every phase number the template defines is either absent from the cascade
-#      or carries a matching meaning there.
-#   2. The specific historical collisions stay fixed: template 3 is the audit,
-#      template 4 is the goodbye.
-#   3. The template does not reintroduce a bare "Phase 4b" label (#401).
+#   1. The shipped template passes structural + meaning.
+#   2. The #401 regression: no bare "Phase 4b" label in the template.
+#   3. NEGATIVE — a duplicate phase number fails.
+#   4. NEGATIVE — an orphan sub-phase (4b with no 4) fails.
+#   5. NEGATIVE — a meaning swap (Phase 3/4 traded, i.e. the #415 state) fails
+#      under --strict-meaning.
+#   6. POSITIVE control on the exemption — the 0-series (0a/0b with no bare
+#      Phase 0) must NOT fail; it is convention in both files, and flagging it
+#      would teach bypass.
+#   7. FAIL LOUD — an unreadable or phase-less rule exits 2, never 0.
 #
 # Exit 0 = pass, 1 = fail.
 
 set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHECKER="$REPO_ROOT/scripts/check-close-phase-contract.py"
 RULE="$REPO_ROOT/templates/rules/session-close.md"
-HOOK="$REPO_ROOT/hooks/detect-closing-signal.py"
+CASCADE="$REPO_ROOT/hooks/detect-closing-signal.py"
 
-for f in "$RULE" "$HOOK"; do
+for f in "$CHECKER" "$RULE" "$CASCADE"; do
   [ -f "$f" ] || { echo "ERROR: $f not found" >&2; exit 1; }
 done
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
 
 failed=0
 fail() { echo "FAIL: $*" >&2; failed=1; }
 ok() { echo "ok   $*"; }
 
-# --- 1 + 2. Shared numbers must denote the same step ------------------------
-# Pairs of "<number>|<regex the template heading must match>|<regex the cascade
-# phase line must match>". Kept explicit rather than derived: the whole point is
-# to pin MEANING, and a derivation would just re-encode whatever is there today.
-check_pair() {
-  local num="$1" want_rule="$2" want_hook="$3"
-  local rule_line hook_line
-  rule_line="$(grep -iE "^## Phase ${num} " "$RULE" | head -1)"
-  hook_line="$(grep -iE "^PHASE ${num} " "$HOOK" | head -1)"
-
-  if [ -z "$rule_line" ]; then fail "template has no '## Phase ${num}' heading"; return; fi
-  if [ -z "$hook_line" ]; then fail "cascade has no 'PHASE ${num}' line"; return; fi
-
-  echo "$rule_line" | grep -qiE "$want_rule" \
-    || fail "template Phase ${num} should be ${want_rule}, got: ${rule_line}"
-  echo "$hook_line" | grep -qiE "$want_hook" \
-    || fail "cascade PHASE ${num} should be ${want_hook}, got: ${hook_line}"
-
-  ok "Phase ${num} means the same thing in both"
+run_checker() {  # <rule-file> [extra args...] -> echoes exit code
+  local rule="$1"; shift
+  python3 "$CHECKER" --rule "$rule" --cascade "$CASCADE" "$@" >/dev/null 2>&1
+  echo $?
 }
 
-check_pair 1  "scan the conversation" "conversation scan"
-check_pair 2  "write to the vault"    "batch writes"
-check_pair 3  "functional audit"      "functional audit"
-check_pair 4  "goodbye"               "final summary"
+# --- 1. The shipped template passes both tiers ------------------------------
+rc="$(run_checker "$RULE" --strict-meaning)"
+[ "$rc" = "0" ] && ok "shipped template passes structural + meaning" \
+  || fail "shipped template violates the phase contract (exit $rc) — run: python3 $CHECKER --strict-meaning"
 
-# --- 2b. Each number may head at most ONE template section ------------------
-# Without this, re-adding a second "## Phase 4 —" heading is invisible: the
-# meaning checks above read the FIRST match and pass while the file defines the
-# same number twice. Found by mutating the template (mutant B) — the original
-# version of this test was blind to it.
-dupes="$(grep -oE "^## Phase [0-9]+[a-z]? " "$RULE" | sort | uniq -d)"
-if [ -n "$dupes" ]; then
-  fail "template defines the same phase number more than once:"
-  echo "$dupes" | sed 's/^/       /' >&2
-else
-  ok "every template phase number heads exactly one section"
-fi
-
-# --- 2c. Phase 2b (commit) must stay present --------------------------------
-# It is the step whose absence causes a hard block: verify-session-close-cascade
-# fires before the Stop hook and refuses the close while artifacts are
-# uncommitted. A template without it teaches a model to skip the commit.
-if grep -qE "^## Phase 2b " "$RULE"; then
-  ok "template keeps the Phase 2b commit step"
-else
-  fail "template lost its Phase 2b commit step (the close will hard-block)"
-fi
-
-# --- 3. The #401 regression: no bare "Phase 4b" label in the template -------
+# --- 2. #401 regression: no cross-numbered label in the template ------------
 if grep -q "Phase 4b" "$RULE"; then
-  fail "template reintroduced a 'Phase 4b' label (see #401 — the cascade owns that number)"
+  fail "template reintroduced a 'Phase 4b' label (#401 — the cascade owns that number)"
 else
   ok "template carries no cross-numbered 'Phase 4b' label"
 fi
 
-# --- Negative control -------------------------------------------------------
-# Prove the comparison can actually fail: a deliberately wrong expectation must
-# be rejected. Without this, a check_pair that silently matched everything would
-# look identical to a passing suite.
-control="$(grep -iE "^## Phase 4 " "$RULE" | head -1)"
-if echo "$control" | grep -qiE "automatic finalization"; then
-  fail "negative control: template Phase 4 still reads as the automatic step"
-else
-  ok "negative control: a wrong meaning for Phase 4 would be caught"
-fi
+# --- 3. NEGATIVE: duplicate phase number ------------------------------------
+cat > "$TMP/dupe.md" <<'EOF'
+## Phase 1 — Scan the conversation
+body
+## Phase 4 — Goodbye
+body
+## Phase 4 — Automatic finalization
+body
+EOF
+rc="$(run_checker "$TMP/dupe.md")"
+[ "$rc" = "1" ] && ok "duplicate phase number is rejected" \
+  || fail "duplicate phase number NOT caught (exit $rc)"
+
+# --- 4. NEGATIVE: orphan sub-phase (the installed-rule defect) --------------
+cat > "$TMP/orphan.md" <<'EOF'
+## Phase 1 — Scan the conversation
+body
+## Phase 3 — Verification
+body
+## Phase 4b — Clear the session goal
+body
+EOF
+rc="$(run_checker "$TMP/orphan.md")"
+[ "$rc" = "1" ] && ok "orphan sub-phase (4b with no 4) is rejected" \
+  || fail "orphan sub-phase NOT caught (exit $rc)"
+
+# --- 5. NEGATIVE: the #415 state — Phase 3/4 meanings traded ---------------
+cat > "$TMP/swapped.md" <<'EOF'
+## Phase 0b — Unfinished business
+body
+## Phase 1 — Scan the conversation
+body
+## Phase 2 — Write to the vault
+body
+## Phase 2b — Commit what you wrote
+body
+## Phase 3 — Goodbye
+body
+## Phase 4 — Automatic finalization
+body
+EOF
+rc="$(run_checker "$TMP/swapped.md" --strict-meaning)"
+[ "$rc" = "1" ] && ok "swapped Phase 3/4 meanings rejected under --strict-meaning" \
+  || fail "the original #415 collision NOT caught (exit $rc)"
+# ...and the SAME file must pass structurally: it is internally consistent, which
+# is precisely why the collision went unnoticed. If this fails, the structural
+# tier has become over-strict.
+rc="$(run_checker "$TMP/swapped.md")"
+[ "$rc" = "0" ] && ok "that same file passes structurally (tiers are genuinely separate)" \
+  || fail "structural tier over-reached into meaning (exit $rc)"
+
+# --- 6. POSITIVE control: the 0-series exemption ---------------------------
+cat > "$TMP/zeroes.md" <<'EOF'
+## Phase 0a — Run the canonical runner
+body
+## Phase 0b — Unfinished business
+body
+## Phase 1 — Scan the conversation
+body
+EOF
+rc="$(run_checker "$TMP/zeroes.md")"
+[ "$rc" = "0" ] && ok "0-series (0a/0b with no bare Phase 0) is not flagged" \
+  || fail "0-series wrongly flagged as orphans (exit $rc) — this teaches bypass"
+
+# --- 7. FAIL LOUD on unusable input ----------------------------------------
+rc="$(run_checker "$TMP/does-not-exist.md")"
+[ "$rc" = "2" ] && ok "missing rule file exits 2 (cannot-check, not pass)" \
+  || fail "missing rule file returned $rc, expected 2"
+
+printf 'no phase headings here\n' > "$TMP/empty.md"
+rc="$(run_checker "$TMP/empty.md")"
+[ "$rc" = "2" ] && ok "phase-less rule exits 2 (cannot-check, not pass)" \
+  || fail "phase-less rule returned $rc, expected 2"
 
 if [ "$failed" -ne 0 ]; then
-  echo "FAILED: close phase numbering drifted between the rule and the cascade" >&2
+  echo "FAILED: close phase contract" >&2
   exit 1
 fi
-echo "PASS: close phase numbering is aligned between the shipped rule and the cascade"
+echo "PASS: close phase contract holds, and the checker rejects every known defect"


### PR DESCRIPTION
feat: one phase-contract checker that also covers INSTALLED close rules

#415 aligned the phase numbers between the shipped rule and the injected
cascade, and locked it with a test. That test could only ever see the copy in
this repo. The same defect then turned up in an installed, heavily customised
copy of the rule: a "Phase 4b" with no Phase 4 anywhere in the file — a
sub-step pointing at a parent the reader does not have.

Installed rules are where this drifts, because that is where people edit. So
the check now takes a PATH:

    python3 scripts/check-close-phase-contract.py                     # shipped template
    python3 scripts/check-close-phase-contract.py --strict-meaning    # + meaning pins
    python3 scripts/check-close-phase-contract.py --rule <installed>  # a client's own

Two tiers, and the split is the whole design:

  STRUCTURAL (always on, cannot false-positive)
    no duplicate phase numbers; no orphan sub-phase. Properties of the file
    alone. An installed rule may rename, reorder, add and drop phases freely;
    it may never define 4b without 4.

  MEANING (--strict-meaning, canonical files only)
    a number in BOTH files must denote the same step. NOT on by default: an
    installed rule is customised prose ("Summary format" for "Final summary"),
    and a checker that fails on legitimate customisation is one people switch
    off — which then hides the structural failures that matter.

Two over-strict readings were found by running it against real files and fixed
rather than shipped:

  - The 0-series. 0a/0b legitimately have no bare "Phase 0" in EITHER file.
    The orphan rule is now keyed to the cascade — Nx is an orphan only when the
    cascade defines N and the rule dropped it — so convention passes and the
    real defect still fails.
  - Meta-headings. "## Phase 1 MUST show its work" is guidance ABOUT Phase 1,
    not its definition; it was counting as a second Phase 1. The heading pattern
    now requires a separator.

Fails loud: unreadable or phase-less input exits 2, never 0.

Test rewritten to drive the checker instead of reimplementing it (one source of
truth for the rule), with negative controls for every known defect: duplicate
number, orphan sub-phase, the #415 meaning swap, plus a control proving that
swapped file still passes STRUCTURALLY — which is exactly why the collision went
unnoticed for so long — and a positive control that the 0-series is not flagged.

Verified against the real historical defect, not just synthetic fixtures: the
pre-fix installed rule read straight out of git history fails with
"phase 4b is an orphan — the cascade defines phase 4".

Carries the repo's UTF-8 console guard: the CLI prints em dashes and vault
paths containing non-ASCII, which on a Windows cp1252 console would raise
UnicodeEncodeError and hand the caller empty output that reads as failure
(#313). scripts/check-utf8-stdout.py caught this on the first gate run;
verified under PYTHONIOENCODING=cp1252 (exit 0, path printed intact).
