### PR TITLE
chore: pin line endings to LF so a checkout cannot change file content

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,23 @@
+# Line endings are a property of this repo, not of whoever cloned it.
+#
+# Every blob already stores LF (verified at the commit that added this file: 0
+# of 862 tracked blobs contained CRLF or a bare CR), so this rewrites NO
+# history -- `git add --renormalize .` is a no-op here. What it changes is the
+# WORKING TREE: every clone now checks out LF on every platform instead of
+# deferring to each machine's core.autocrlf.
+#
+# Why that is worth pinning: without it, a Windows clone with core.autocrlf=true
+# has CRLF on disk while the Linux CI runner has LF. Any tool that hashes or
+# byte-compares file content then disagrees across platforms for reasons that
+# have nothing to do with the content. That is not hypothetical -- the
+# cloud-safe walker ratchet reported all 41 of its reviewed rows STALE on a
+# Windows checkout while CI stayed green (#411).
+#
+# This is defense in depth and NOT the primary fix. Any tool that pins a content
+# hash must still normalize internally -- see normalize() in
+# scripts/check-cloud-safe-file-walkers.py and scripts/check-vault-root-reads.py
+# -- because .gitattributes only governs checkouts that honor it. An existing
+# working tree keeps its CRLF until each file is next written, and a contributor
+# can always override core.eol locally. The in-tool normalize holds regardless;
+# this file just stops the mismatch from being created in the first place.
+* text=auto eol=lf


### PR DESCRIPTION
Follow-up to #411, which I deliberately kept out of that PR so the bugfix and the policy change could be reverted independently.

## Why

#411 fixed the cloud-safe walker ratchet by normalizing newlines before hashing. The underlying condition was that this repo had no `.gitattributes`, so a Windows clone with `core.autocrlf=true` had CRLF on disk while the Linux CI runner had LF — the same content hashed to two different digests, all 41 reviewed rows reported `STALE` on Windows, and CI stayed green the whole time.

**#411 fixed the tool. This fixes the source of the mismatch**, so the next tool that hashes or byte-compares file content doesn't have to rediscover it.

## This rewrites no history

I want to correct something I wrote in #411's description. I estimated this would mean "~849 files of churn." That was wrong, and I checked rather than shipping the estimate.

Every blob in the repo **already stores LF**. Verified across all 862 tracked blobs at `03020ee`:

```
blobs at main: 862
  pure LF (or no newline): 859   empty: 3
  containing CRLF: 0
  containing bare CR: 0
```

So `git add --renormalize .` over the entire tree stages nothing but this file. Confirmed before committing:

```
$ git add .gitattributes && git add --renormalize .
$ git status --short
A  .gitattributes
```

The diff is one file, 23 lines, all of them comment except the last.

## What it actually changes

The **working tree**, not history. Clones now check out LF on every platform instead of deferring to each machine's `core.autocrlf`.

Existing Windows working trees are **not** retroactively rewritten — each file converts the next time Git writes it. And `git status` stays clean throughout, because `text=auto` normalizes on comparison, so a CRLF working file still matches its LF blob. No spurious dirty state for anyone mid-branch.

## Still not the primary fix

Worth being explicit, because this is the failure mode that would make this file dangerous — if it were mistaken for sufficient:

`.gitattributes` only governs checkouts that honor it. An existing working tree keeps its CRLF until each file is next written, and a contributor can override `core.eol` locally. **Any tool that pins a content hash must still normalize internally** — see `normalize()` in `scripts/check-cloud-safe-file-walkers.py` (#411) and `scripts/check-vault-root-reads.py` (#407). Those hold regardless of checkout config. This file just stops the mismatch from being created in the first place.

That reasoning is written into the file itself, so the next person to touch it doesn't have to reconstruct it from the git log.

## Deliberately minimal — one line of actual rule

No per-extension `binary` rules. `* text=auto` already treats NUL-containing files as binary, and this repo tracks no binary files today (321 `.py`, 280 `.md`, 168 `.sh`, 30 `.json`, 13 `.yml`, 11 `.ps1`, no images or archives), so pinning file types that don't exist would be speculative.

The 11 `.ps1` files are the ones worth watching: the `bootstrap.ps1 end-to-end (clean Windows runner)` job will now exercise them with **LF rather than CRLF**, which is a real behavior change on the surface most likely to care. That job is the evidence. If it objects, the answer is a narrow `*.ps1 text eol=crlf`, not dropping `eol=lf` — and that is exactly why this is its own PR rather than a rider on a bugfix.

## Verification

On a CRLF working tree with this staged, all three content guards pass:

| gate | result |
|---|---|
| cloud-safe walker fleet ratchet | `CLEAN fleet: 324 Python files; 41 content-pinned legacy exception(s)` |
| vault-root read guard (#407) | `OK (272 file(s) scanned; 37 legacy file(s), 39 pinned read(s))` |
| UTF-8 stdout guard | `OK - 159 script(s) checked` |

No root-file allowlist in `scripts/ci.sh` to trip, and no test file added, so `INTEGRATION_TESTS` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
