### PR TITLE
fix: the High-Rise vendor pin described the checkout, not the content

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -278,6 +278,12 @@ INTEGRATION_TESTS=(
   # escaped) against a vault named neither "vault" nor by any hardcoded folder
   # name, so a rule that pattern-matches names cannot pass it.
   test_rm_rf_vault_target
+  # The High-Rise vendor pin is a content hash like the two ratchets above, and
+  # had the same defect: hashing raw bytes made a CRLF checkout report all three
+  # vendored files as hand-edited. Proves the pin is line-ending independent AND
+  # -- the control that matters -- that normalizing did not make the drift guard
+  # blind to a genuine hand-edit on either line ending.
+  test_high_rise_pin
 )
 # ---- Gate-coverage invariant -------------------------------------------------
 # The list above is an explicit allow-list, and allow-lists rot: a new

--- a/scripts/sync-high-rise.py
+++ b/scripts/sync-high-rise.py
@@ -65,8 +65,24 @@ VENDOR_DIR = ROOT / "vendor" / "high-rise"
 PIN_FILE = VENDOR_DIR / "PIN.json"
 
 
-def _sha256(data: bytes) -> str:
-    return hashlib.sha256(data).hexdigest()
+def _normalize(data: bytes) -> bytes:
+    """CRLF/CR -> LF."""
+    return data.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+
+
+def _content_sha256(data: bytes) -> str:
+    """Hash the vendored CONTENT, not the checkout.
+
+    This repo has no per-file eol pin its clones are guaranteed to honor, so a
+    Windows clone with core.autocrlf=true has CRLF on disk while PIN.json was
+    recorded from LF.  Hashing raw bytes then reports every vendored file as
+    "edited locally" when nothing was touched.  Worse, the advertised remedy is
+    to re-sync -- which would write CRLF hashes into PIN.json and invert the
+    breakage onto every other platform.  Same defect class as the cloud-safe
+    walker ratchet (#411); the pin must describe content or it describes the
+    machine that last ran the sync.
+    """
+    return hashlib.sha256(_normalize(data)).hexdigest()
 
 
 def _load_pin() -> dict:
@@ -110,7 +126,7 @@ def check() -> int:
         if not dest.exists():
             problems.append(f"{rel}: vendored file missing at {dest.relative_to(ROOT)}")
             continue
-        got = _sha256(dest.read_bytes())
+        got = _content_sha256(dest.read_bytes())
         if got != want:
             problems.append(
                 f"{rel}: sha256 drift - vendored file was edited locally "
@@ -184,10 +200,13 @@ def refresh(tag: str, *, dry_run: bool) -> int:
         changes = []
         for rel in VENDORED_FILES:
             data = (src / rel).read_bytes()
-            new_hashes[rel] = _sha256(data)
+            new_hashes[rel] = _content_sha256(data)
             dest = VENDOR_DIR / rel
             old = dest.read_bytes() if dest.exists() else None
-            if old != data:
+            # Compare content, for the same reason the pin hashes content: on a
+            # CRLF checkout a raw compare reports every file as changed even
+            # when upstream shipped nothing new.
+            if old is None or _normalize(old) != _normalize(data):
                 changes.append(("update" if old is not None else "add", rel))
             if not dry_run:
                 dest.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/integration/test_high_rise_pin.sh
+++ b/tests/integration/test_high_rise_pin.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# High-Rise vendor pin: the pin must describe the vendored CONTENT, not the
+# checkout that last ran the sync. Every claim here has a negative control,
+# because normalizing line endings is only correct if the drift guard still
+# bites on a real hand-edit.
+set -u
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SYNC="$ROOT/scripts/sync-high-rise.py"
+FAIL=0
+
+ok() { echo "PASS  $1"; }
+bad() { echo "FAIL  $1"; FAIL=$((FAIL + 1)); }
+run() {
+  local label="$1"; shift
+  if "$@"; then ok "$label"; else bad "$label"; fi
+}
+
+# The real vendored tree must match its pin on THIS checkout, whatever line
+# endings this platform happens to use.
+run "vendored High-Rise files match PIN.json on this checkout" \
+  python3 "$SYNC" --check
+
+# ---- the pin must describe CONTENT, not the checkout ------------------------
+# A Windows clone with core.autocrlf=true has CRLF on disk while PIN.json was
+# recorded from LF. Hashing raw bytes reported all three vendored files as
+# "edited locally" when nothing was touched -- and the advertised remedy
+# (re-sync) would have written CRLF hashes into PIN.json and inverted the
+# breakage onto every other platform. Same defect class as the cloud-safe
+# walker ratchet (#411).
+if python3 - "$SYNC" <<'PY'
+import importlib.util, json, shutil, sys, tempfile
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location("synchr", sys.argv[1])
+m = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = m
+spec.loader.exec_module(m)
+
+body = b"# Floors\n\nGround floor.\nSecond floor.\n"
+crlf = body.replace(b"\n", b"\r\n")
+
+# 1. Same content, two line endings, one digest.
+assert m._content_sha256(body) == m._content_sha256(crlf), "pin hash differs across line endings"
+
+# 2. Negative control: normalizing must not make the hash blind to real edits.
+assert m._content_sha256(body) != m._content_sha256(body + b"local edit\n"), \
+    "pin hash ignores a genuine content edit"
+
+tmp = Path(tempfile.mkdtemp())
+try:
+    m.VENDOR_DIR = tmp
+    m.PIN_FILE = tmp / "PIN.json"
+    m.VENDORED_FILES = ("floors.md",)
+    (tmp / "PIN.json").write_text(json.dumps({
+        "tag": "v0.0.0",
+        "commit": "0" * 40,
+        "files": {"floors.md": m._content_sha256(body)},
+    }), encoding="utf-8")
+
+    # 3. End to end: a CRLF working tree against an LF-recorded pin is clean.
+    (tmp / "floors.md").write_bytes(crlf)
+    assert m.check() == 0, "CRLF checkout of LF-pinned content reported false drift"
+
+    # 4. Negative control: a hand-edit still trips, on either line ending.
+    (tmp / "floors.md").write_bytes(crlf + b"hand edit\r\n")
+    assert m.check() != 0, "hand-edited vendored file did not trip the drift guard"
+    (tmp / "floors.md").write_bytes(body + b"hand edit\n")
+    assert m.check() != 0, "hand-edited LF vendored file did not trip the drift guard"
+finally:
+    shutil.rmtree(tmp, ignore_errors=True)
+PY
+then
+  ok "pin is line-ending independent and still bites on a real hand-edit"
+else
+  bad "pin hash contract broken - either it tracks the checkout, or it went blind to edits"
+fi
+
+if [ "$FAIL" -ne 0 ]; then
+  echo "FAILED: $FAIL"
+  exit 1
+fi
+echo "ALL TESTS PASSED"


### PR DESCRIPTION
Second live instance of the defect fixed in #411 — found by going looking for the pattern rather than waiting for it to be reported.

## The bug

`scripts/sync-high-rise.py` hashed raw bytes and compared to `vendor/high-rise/PIN.json`:

```python
got = _sha256(dest.read_bytes())
```

The pin was recorded from LF. A Windows clone with `core.autocrlf=true` has CRLF on disk. So on Windows, `--check` reports **all three** vendored files as drifted:

```
$ python scripts/sync-high-rise.py --check
sync-high-rise: DRIFT against pin v0.1.0 (da692df83c08):
  - floors.md: sha256 drift - vendored file was edited locally (expected 7406aa27ec5c..., found fc5b509badab...). The framework is upstream's; edit Fundacion-Lontananza/high-rise and re-sync, do not patch vendor/ by hand.
  - methodology/journaling.md: sha256 drift - ...
  - methodology/coaching.md: sha256 drift - ...
exit 2
```

Nothing had been edited.

## Why it's worse than a false alarm

The message accuses the operator of hand-patching `vendor/` and instructs them to re-sync. **Following that advice is the actual damage:** a re-sync on Windows writes CRLF hashes into `PIN.json`, which inverts the breakage onto every other platform and commits it. A local annoyance becomes a repo-wide one, applied by someone doing exactly what the tool told them to do.

It is **not wired into CI** — no workflow, no test, no `ci.sh` call site. That is precisely why it survived: it never reddened a build, it only ever misled a human. That's the failure mode that gets normalized.

## The fix

Hash normalized content, matching `normalize()` in `check-cloud-safe-file-walkers.py` (#411) and `check-vault-root-reads.py` (#407). Applied in **both** directions:

- the `--check` path, and
- the path that records new hashes during a sync — so a re-sync from either platform writes the same pin, which is what stops the inversion above.

The change-detection compare is normalized for the same reason, so a CRLF checkout doesn't report every file as `update` when upstream shipped nothing new.

`_sha256` is renamed `_content_sha256`, because a helper that no longer returns the sha256 of its argument shouldn't still be called `_sha256`.

## PIN.json needs no changes

Same happy property as #411. The LF-normalized digest already equals all three committed values:

```
floors.md                  pinned=7406aa27ec5c  raw_match=False  lfnorm_match=True
methodology/journaling.md  pinned=c7cde240293f  raw_match=False  lfnorm_match=True
methodology/coaching.md    pinned=967474b56651  raw_match=False  lfnorm_match=True
```

`git diff --stat vendor/high-rise/PIN.json` is empty. After the fix, on the same CRLF checkout:

```
sync-high-rise: OK - 3 vendored file(s) match pin v0.1.0 (da692df83c08).
```

## The control that actually matters

Normalizing a drift guard is only correct if the guard still bites. New `tests/integration/test_high_rise_pin.sh` asserts both halves:

| assertion | guards against |
|---|---|
| same body as LF and CRLF → same digest | the original bug |
| body vs body+edit → different digest | normalizing making the hash blind |
| CRLF working tree vs LF-recorded pin → `check()` returns 0 | the end-to-end false positive |
| hand-edited file, LF **and** CRLF → `check()` returns non-zero | the guard going silently useless |

Confirmed load-bearing — reverting just the normalize reds both:

```
FAIL  vendored High-Rise files match PIN.json on this checkout
FAIL  pin hash contract broken - either it tracks the checkout, or it went blind to edits
```

Wired into `INTEGRATION_TESTS` in `scripts/ci.sh` as required. Verified the gate-coverage invariant still holds: 95 test files on disk, 95 names in the gate lists, none missing.

## Relationship to the other two PRs

Independent of both; merges in any order.

- **#411** (merged) fixed the walker ratchet — the first instance.
- **#421** (`.gitattributes`) would also mask this one by making checkouts LF everywhere, but it can't be the fix: it doesn't retroactively rewrite existing working trees, and a contributor can override `core.eol`. The in-tool normalize holds regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
