### PR TITLE
feat(maintenance): activate the phase-contract check for every install

### DIFF
--- a/scripts/vault-daily-maintenance.sh
+++ b/scripts/vault-daily-maintenance.sh
@@ -209,6 +209,20 @@ fi
 RULECONF="$SCRIPT_DIR/check-rule-conflicts.py"
 [ -f "$RULECONF" ] && VAULT_ROOT="$VAULT" run "check-rule-conflicts" /usr/bin/env python3 "$RULECONF" --scan-all
 
+# Session-close phase contract: this install's session-close rule vs the numbered
+# cascade detect-closing-signal.py injects at close. Both reach the model, so a
+# number that means different things in the two is worse than no number — and the
+# drift is silent, because each file reads fine on its own. STRUCTURAL tier only
+# (duplicate numbers, orphan sub-phases): an installed rule is customised prose,
+# and pinning its wording would fail on legitimate edits, which is how a check
+# earns itself an --ignore. Skips cleanly when either file is absent.
+PHASECHECK="$SCRIPT_DIR/check-close-phase-contract.py"
+CLOSE_RULE="$META_DIR/rules/session-close.md"
+CLOSE_CASCADE="$SCRIPT_DIR/../hooks/detect-closing-signal.py"
+[ -f "$PHASECHECK" ] && [ -f "$CLOSE_RULE" ] && [ -f "$CLOSE_CASCADE" ] && \
+  run "close-phase-contract" /usr/bin/env python3 "$PHASECHECK" \
+    --rule "$CLOSE_RULE" --cascade "$CLOSE_CASCADE"
+
 # Passive capture of the day's content (full-tree scan of today's transcripts).
 PASSIVE="$SCRIPT_DIR/passive-capture.py"
 [ -f "$PASSIVE" ] && VAULT_ROOT="$VAULT" run "passive-capture" /usr/bin/env python3 "$PASSIVE" --scan-today


### PR DESCRIPTION
feat(maintenance): activate the phase-contract check for every install

#419 shipped scripts/check-close-phase-contract.py. Shipping a checker is not
the same as running one: as merged it was a file every install received and no
install executed — dormant by construction, the ARTIFACT-WITHOUT-ACTIVATION
shape. The defect it exists to catch had already occurred twice, and both times
in a rule file, not in this repo's copy.

Wire it into vault-daily-maintenance.sh so it runs where the drift happens: on
each install, against that install's own session-close rule.

STRUCTURAL tier only (duplicate phase numbers, orphan sub-phases). An installed
rule is customised prose — one vault renames Phase 4 to "Summary format" — so
pinning wording would fail on legitimate edits, and a check that fails on
correct files is one that earns itself an --ignore. The meaning pins stay on
this repo's canonical copy, enforced in CI.

Guarded on all three paths (checker, rule, cascade), so an install missing any
of them skips silently rather than logging a failure; run() never aborts the
pass. Verified the paths resolve on a real install: checker + cascade under the
deployed skill, rule under the resolved META_DIR.
