### PR TITLE
docs(utf8-baseline): stop hand-maintaining a count that is already computed

### DIFF
--- a/scripts/utf8-stdout-baseline.txt
+++ b/scripts/utf8-stdout-baseline.txt
@@ -11,8 +11,14 @@
 # already have flagged. Pinning them lets the CLASS-level guard cover hooks/
 # without a 78-file rewrite, while still failing the build for anything new.
 #
-# BURN-DOWN: 78 pinned at MYC-3530, 77 remain.
-#   - hooks/vault-command-nudges.py  guarded + unpinned in PR #416. It was
+# BURN-DOWN LOG. 78 rows were pinned at MYC-3530. For how many REMAIN, run
+# `python3 scripts/check-utf8-stdout.py` -- it prints the live count and the
+# per-tag split. Deliberately not restated here as a number: two rows came off
+# in PRs that merged 22 minutes apart (#420, then #416), and the second one's
+# hand-written "77 remain" was already wrong by the time it landed. A ledger
+# that has to be hand-decremented is a ledger that lies.
+#   - hooks/auto-capture-public-ships.py   guarded + unpinned in PR #420.
+#   - hooks/vault-command-nudges.py        guarded + unpinned in PR #416. It was
 #     edited there (the rm -rf rule now quotes the RESOLVED target back to the
 #     user, so an emoji vault folder reaches stderr from the filesystem), which
 #     staled its row and forced the choice this file already documents below:


### PR DESCRIPTION
Follow-up to #416, fixing an inaccuracy that PR introduced.

## What was wrong

#416 added a burn-down note to `scripts/utf8-stdout-baseline.txt` reading **"78 pinned at MYC-3530, 77 remain."**

It was wrong on arrival. #420 unpinned `hooks/auto-capture-public-ships.py` and merged 22 minutes earlier, so the true figure was **76** the moment #416 landed. Two independent burn-downs, neither aware of the other, and the one that wrote a number down lost.

Caught while verifying #416 had actually landed correctly on main — the row count didn't match what I'd written.

## The fix

`check-utf8-stdout.py` already prints the live count and per-tag split on every run:

```
76 content-pinned legacy file(s) remain [SEV-1-hard-crash=20, SEV-2-ascii-pipe=9, SEV-3-doc-only=6, SEV-4-json-encoded=41]
```

Restating that in a comment creates a second source of truth that only a human can update, in a file whose entire value is being exact. So the note now records **which** files came off (append-only, cannot go stale) and points at the checker for **how many** remain (derived, cannot drift). #420's missing entry is added.

Correcting 77→76 would have fixed the instance and left the class — the next burn-down would stale it again.

## Verification

Comment-only. No row added, changed, or removed.

- `python3 scripts/check-utf8-stdout.py` — passes
- `git diff` — 8 insertions, 2 deletions, all in the header comment block

🤖 Generated with [Claude Code](https://claude.com/claude-code)