### PR TITLE
fix(memory-index): the announcement prescribed fixes that had not fired

### DIFF
--- a/hooks/_lib/memory_index.py
+++ b/hooks/_lib/memory_index.py
@@ -64,6 +64,19 @@ WARN_BYTES = 17_000
 # emits a readable message rather than a wall of text.
 MAX_NAMED = 12
 
+# Each finding carries the remediation that fixes IT, so the closing advice
+# names only what actually fired. A blanket "trim the oversized index" printed
+# for an index well under budget sends the reader to do work that is not needed
+# — and an announcement that prescribes the wrong fix teaches them to discount
+# the whole thing, which is exactly the silence this module exists to prevent.
+FIX_SIZE = ("split the oversized index by topic into `_index_*.md` files "
+            "linked from MEMORY.md")
+FIX_UNREADABLE = ("fix the unreadable tier-2 index file(s) before trusting any "
+                  "reachability result")
+FIX_ORPHAN = "link the orphaned `_index_*.md` file(s) from MEMORY.md"
+FIX_UNREACHABLE = ("add the unindexed memory file(s) to MEMORY.md or to a "
+                   "linked `_index_*.md`")
+
 # Structural link forms, used to find which tier-2 files tier 1 actually links
 # to. Tolerates `<...>`, a title, an anchor and a path prefix.
 LINK_RE = re.compile(r"\]\(\s*<?([^)>\s]+?\.md)(?:#[^)>\s]*)?>?(?:\s+[^)]*)?\)")
@@ -133,7 +146,16 @@ def _linked_tier2(mdir: Path, tier1_text: str):
 
 
 def audit(mdir: Path):
-    """Problems for one memory dir. Empty list = healthy."""
+    """Problems for one memory dir, as text. Empty list = healthy."""
+    return [text for text, _fix in _audit_tagged(mdir)]
+
+
+def _audit_tagged(mdir: Path):
+    """(problem text, remediation) pairs for one memory dir.
+
+    The remediation travels WITH the finding so the caller can close on the
+    fixes that actually fired instead of reciting every fix this module knows.
+    """
     tier1 = mdir / "MEMORY.md"
     if not tier1.exists():
         return []
@@ -144,7 +166,7 @@ def audit(mdir: Path):
         return []
 
     problems = []
-    problems.extend(_size_problems("MEMORY.md", size))
+    problems.extend((t, FIX_SIZE) for t in _size_problems("MEMORY.md", size))
 
     linked, orphans = _linked_tier2(mdir, text)
 
@@ -155,24 +177,27 @@ def audit(mdir: Path):
     for sub in linked:
         try:
             loaded_text.append(sub.read_text(encoding="utf-8", errors="replace"))
-            problems.extend(_size_problems(sub.name, sub.stat().st_size))
+            problems.extend(
+                (t, FIX_SIZE) for t in _size_problems(sub.name, sub.stat().st_size))
         except OSError as exc:
             unreadable.append("{} ({})".format(sub.name, exc.__class__.__name__))
     haystack = "\n".join(loaded_text)
 
     if unreadable:
-        problems.append(
+        problems.append((
             "{} tier-2 index file(s) could not be READ, so what they list is "
             "unknown, not absent: {}. Fix the read before trusting any "
-            "reachability result below.".format(len(unreadable), ", ".join(unreadable))
-        )
+            "reachability result below.".format(len(unreadable), ", ".join(unreadable)),
+            FIX_UNREADABLE,
+        ))
 
     if orphans:
-        problems.append(
+        problems.append((
             "{} tier-2 index file(s) are not linked from MEMORY.md, so nothing "
             "loads them and any memory only they list is invisible: {}.".format(
-                len(orphans), ", ".join(p.name for p in orphans))
-        )
+                len(orphans), ", ".join(p.name for p in orphans)),
+            FIX_ORPHAN,
+        ))
 
     unreachable = [p.name for p in _topic_files(mdir) if p.name not in haystack]
     if unreachable:
@@ -184,11 +209,12 @@ def audit(mdir: Path):
             if linked
             else " (no linked tier-2 `_index_*.md` files; a large corpus needs them)"
         )
-        problems.append(
+        problems.append((
             "{} memory file(s) are referenced by NO index{} — invisible to this "
             "and every future session: {}{}.".format(
-                len(unreachable), tier_note, shown, more)
-        )
+                len(unreachable), tier_note, shown, more),
+            FIX_UNREACHABLE,
+        ))
     return problems
 
 
@@ -210,21 +236,23 @@ def report() -> str:
     if os.environ.get("MEMORY_INDEX_TRUNCATION_BYPASS") == "1":
         return ""
     lines = []
+    fixes = []  # fired remediations, first-seen order, deduped across dirs
     for mdir in memory_dirs():
         try:
-            problems = audit(mdir)
+            problems = _audit_tagged(mdir)
         except Exception:
             continue  # one bad dir must not suppress the others
         label = mdir.parent.name or str(mdir)
-        for p in problems:
-            lines.append("  [{}] {}".format(label, p))
+        for text, fix in problems:
+            lines.append("  [{}] {}".format(label, text))
+            if fix not in fixes:
+                fixes.append(fix)
     if not lines:
         return ""
     return (
-        "**[memory-index]** The memory index cannot be fully loaded. An indexed "
-        "entry is either loaded or its omission is announced — this is the "
-        "announcement.\n\n" + "\n".join(lines) + "\n\n"
-        "Trim the oversized index, link any orphaned `_index_*.md` from "
-        "MEMORY.md, and index anything listed as unreachable, so nothing is "
-        "dropped in silence. Bypass: MEMORY_INDEX_TRUNCATION_BYPASS=1"
+        "**[memory-index]** Something in the memory system will not reach a "
+        "future session. An indexed entry is either loaded or its omission is "
+        "announced — this is the announcement.\n\n" + "\n".join(lines) + "\n\n"
+        "Fix: " + "; ".join(fixes) + " — so nothing is dropped in silence. "
+        "Bypass: MEMORY_INDEX_TRUNCATION_BYPASS=1"
     )

--- a/hooks/test_memory_index.py
+++ b/hooks/test_memory_index.py
@@ -278,20 +278,31 @@ def main() -> int:
         locked.write_text("# L\n\n- [D](deep.md) - h\n", encoding="utf-8")
         try:
             os.chmod(locked, 0o000)
+            # Probe whether the mode is actually ENFORCED rather than inferring
+            # it from the uid. chmod 000 denies reads only where POSIX
+            # permissions bite: root bypasses them, and on Windows chmod only
+            # toggles the read-only bit so the file stays readable and there is
+            # nothing for the guard to report. The old proxy called
+            # os.geteuid(), which does not exist on Windows at all -- it raised
+            # AttributeError and took the whole suite down with it.
+            try:
+                locked.read_text(encoding="utf-8")
+                denied = False
+            except OSError:
+                denied = True
             r = report_for(d)
-            readable_again = True
         except Exception:
-            r, readable_again = "", False
+            r, denied = "", False
         finally:
             try:
                 os.chmod(locked, 0o644)
             except Exception:
                 pass
-        if readable_again and os.geteuid() != 0:
+        if denied:
             check("unreadable tier-2 is announced as unknown",
                   "could not be READ" in r, r[:250])
         else:
-            check("unreadable tier-2 (skipped: running as root)", True)
+            check("unreadable tier-2 (skipped: file mode not enforced here)", True)
 
     # 17. MAX_NAMED truncation path is exercised. Mutation killed: corrupting
     #     the "and N more" arithmetic, which no fixture previously reached.
@@ -313,6 +324,38 @@ def main() -> int:
           "over the" in _size_labels(memory_index.READ_CLIFF_BYTES))
     check("size == CLIFF+1 is loss",
           "NOT being loaded" in _size_labels(memory_index.READ_CLIFF_BYTES + 1))
+
+    # 19. The closing advice names ONLY the fix that fired. The report used to
+    #     recite every remediation this module knows, so an index well under
+    #     budget was still told to "trim the oversized index" -- work that is
+    #     not needed, on a reading that is not true. Advice that is wrong for
+    #     the finding in front of you teaches you to discount the whole
+    #     announcement, which is the silence this module exists to prevent.
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td)
+        memo(d, "alpha.md")
+        memo(d, "unindexed.md")
+        (d / "MEMORY.md").write_text(
+            "# Index\n\n- [A](alpha.md) - h\n", encoding="utf-8")
+        r = report_for(d)
+        check("unreachable-only names the indexing fix",
+              memory_index.FIX_UNREACHABLE in r, r[:250])
+        check("unreachable-only does NOT prescribe trimming",
+              memory_index.FIX_SIZE not in r and "oversized" not in r, r[:250])
+
+    # 20. ...and the converse, so 19 cannot pass by the advice going silent.
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td)
+        memo(d, "alpha.md")
+        pad = "\n".join("- [P{}](alpha.md) - {}".format(i, "p" * 60)
+                        for i in range(600))
+        (d / "MEMORY.md").write_text(
+            "# Index\n\n- [A](alpha.md) - h\n" + pad, encoding="utf-8")
+        r = report_for(d)
+        check("oversized-only names the split fix",
+              memory_index.FIX_SIZE in r, r[:250])
+        check("oversized-only does NOT prescribe indexing memories",
+              memory_index.FIX_UNREACHABLE not in r, r[:250])
 
     print("\n{} passed, {} failed".format(PASS, FAIL))
     return 1 if FAIL else 0


### PR DESCRIPTION
Two defects in the guard whose entire job is to be believed. Both found by using it for real, not by reading it.

## 1. The advice prescribed fixes that had not fired

The closing line recited every remediation the module knows, regardless of which check tripped:

> Trim the oversized index, link any orphaned `_index_*.md` from MEMORY.md, and index anything listed as unreachable…

On the vault that triggered it, the only finding was **two unindexed memories**. The index was **13,578 bytes** against `WARN_BYTES = 17_000`, so `_size_problems()` returned nothing — no size finding fired. The corpus had **zero** `_index_*.md` files, so there were no orphans either. Two of the three instructions were noise.

**This is lived, not theoretical.** Acting on that text meant beginning a rewrite of all 40 index entries and inventing tier-2 index files for a corpus that needed neither. The actual fix was adding two lines. Only checking the thresholds in the source stopped the wasted work.

An announcement that prescribes the wrong work teaches the reader to discount it — which is exactly the silence this module exists to prevent.

The header had the same problem: it claimed *"The memory index cannot be fully loaded"* when the index loads perfectly and some memories simply aren't listed in it.

**Fix.** Each finding now carries the remediation that fixes *it*. `report()` closes on the fixes that actually fired, deduped, in first-seen order.

```
Fix: add the unindexed memory file(s) to MEMORY.md or to a linked `_index_*.md` — so nothing is dropped in silence.
```

```
Fix: split the oversized index by topic into `_index_*.md` files linked from MEMORY.md — so nothing is dropped in silence.
```

`audit()` still returns plain strings for its callers; the pairing lives in a new `_audit_tagged()`. `_size_problems()` keeps its list-of-str shape, because the suite joins its return directly.

## 2. The test suite could not run on Windows at all

Test 16 called `os.geteuid()` — POSIX-only — as a proxy for *"am I root, so `chmod 000` won't deny me?"*. On Windows the attribute doesn't exist:

```
AttributeError: module 'os' has no attribute 'geteuid'
```

The process died after 17 assertions. **The remaining tests had never executed on Windows.**

It now probes the real precondition — read the file back and see whether the mode was actually enforced — which is what the uid check was approximating. That's correct for root *and* for Windows, where `chmod` only toggles the read-only bit so the file stays readable and there's genuinely nothing for the guard to report.

Suite goes from crashing at 17 to **37 passed** on Windows.

This is another instance of [MYC-3543](https://linear.app/myceliumai/issue/MYC-3543) — the ci gate runs `ubuntu-latest` only, so a POSIX-only call in a test file was invisible.

## Coverage

Four new assertions pin **both** directions:

| assertion | guards against |
|---|---|
| unreachable-only names the indexing fix | the advice going missing |
| unreachable-only does **not** mention trimming | the original bug |
| oversized-only names the split fix | the advice going missing |
| oversized-only does **not** mention indexing | over-correcting into silence |

Without the converse pair, the first two would pass if the advice disappeared entirely. Confirmed load-bearing — restoring the old blanket text reds three of them:

```
FAIL  unreachable-only names the indexing fix
FAIL  unreachable-only does NOT prescribe trimming
FAIL  oversized-only names the split fix
34 passed, 3 failed
```

## What I deliberately did NOT change

`audit()` returns `[]` when `MEMORY.md` is absent, so a dir with memories and no index reports healthy. I proved it — 30 memory files, no index, `audit()` says CLEAN.

But test 8 already pins this on purpose:

```python
# 8. No MEMORY.md -> silent; not our gap to report.
memo(d, "alpha.md")
check("missing MEMORY.md is silent", report_for(d) == "")
```

It creates a real memory and asserts silence. That's a documented scope boundary, not an oversight, and overriding it on my own inference would be the wrong call. Left alone and raised separately.

## Verification

- `hooks/test_memory_index.py` — **37 passed, 0 failed** (was: crash at 17 on Windows)
- `tests/integration/test_session_start_announces_memory_index.sh` — 6/6
- walker fleet ratchet, vault-root read guard, UTF-8 stdout guard — all pass
- `report()` still CLEAN across both real vaults on this box

No new test file, so `INTEGRATION_TESTS` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
