### PR TITLE
test: lock the CRLF frontmatter regression that denied every Windows write

### DIFF
--- a/scripts/vault-schema-validator.py
+++ b/scripts/vault-schema-validator.py
@@ -350,10 +350,37 @@ def run_self_test() -> int:
             print(f"FAIL [{desc}]: expected pass={should_pass}, got pass={actual_pass}")
         else:
             print(f"PASS [{desc}]")
+    # Line-ending regression (the bug behind the Windows total-denial incident).
+    # safe_read_text decodes raw bytes with NO universal-newline translation, so a
+    # file authored on Windows -- or a temp file written in text mode -- reaches
+    # extract_frontmatter with \r\n intact. An LF-only delimiter pattern rejected
+    # it as "not properly closed", which denied EVERY Write/Edit of a vault .md
+    # file on Windows regardless of content.
+    #
+    # Asserting "no error" alone is not enough: a pattern that matched but captured
+    # the wrong span would still look clean. Assert the captured frontmatter too.
+    body = "creationDate: 2026-04-30\nfloor: 16"
+    line_ending_cases = [
+        ("LF line endings", "---\n" + body + "\n---\n\nbody\n"),
+        ("CRLF line endings", ("---\n" + body + "\n---\n\nbody\n").replace("\n", "\r\n")),
+    ]
+    for desc, text in line_ending_cases:
+        fm, err = extract_frontmatter(text)
+        normalized = (fm or "").replace("\r\n", "\n")
+        if err or fm is None:
+            failures += 1
+            print(f"FAIL [{desc}]: {err or 'no frontmatter extracted'}")
+        elif normalized != body:
+            failures += 1
+            print(f"FAIL [{desc}]: captured {normalized!r}, expected {body!r}")
+        else:
+            print(f"PASS [{desc}]")
+
+    total = len(fixtures) + len(line_ending_cases)
     if failures:
-        print(f"\n{failures}/{len(fixtures)} fixtures failed.")
+        print(f"\n{failures}/{total} fixtures failed.")
         return 1
-    print(f"\n{len(fixtures)}/{len(fixtures)} fixtures passed.")
+    print(f"\n{total}/{total} fixtures passed.")
     return 0
 
 


### PR DESCRIPTION
PR #409 fixed the Windows CRLF frontmatter bug but **shipped no test for it**, so the fix could be reverted silently. Nothing in the self-test exercised `extract_frontmatter` at all — every fixture went straight to schema validation.

## The bug being locked

`safe_read_text` decodes raw bytes with **no** universal-newline translation, so a file authored on Windows (or a temp file written in text mode) reaches `extract_frontmatter` with `\r\n` intact. An LF-only delimiter pattern rejected it as `"not properly closed"` — denying **every** `Write`/`Edit` of a vault `.md` file on Windows, regardless of content.

## What this adds

LF and CRLF cases, both asserting the **captured frontmatter**, not merely the absence of an error. A pattern that matched but captured the wrong span would otherwise still look clean.

## Negative control

```
with the \r?\n fix        ->  PASS [LF], PASS [CRLF]   13/13
regex reverted to LF-only ->  PASS [LF], FAIL [CRLF]   exit 1
restored                  ->  13/13
```

The test genuinely fails against the broken code — it is not decorative.

## Credit

**PR #334** (open since 2026-07-16) identified this same bug and carried a CRLF self-test. It predates #409 and should have landed first; #409 was written without knowledge of it. This ports the coverage #334 was blocked on. #334 still contains unrelated fixes and remains worth landing.

Guards: vault-root OK (274 files), cloud-safe walkers CLEAN (326 files), `test_handoff_frontmatter_guard.sh` 11/11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)