### PR TITLE
backup: exclude nested foreign checkouts by property, not by name

### DIFF
--- a/scripts/test-vault-nested-repos.sh
+++ b/scripts/test-vault-nested-repos.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Controls for the property-based nested-checkout exclusion.
+#
+# The bug: vault-backup.sh's exclude list names `./.claude/worktrees`, which is a
+# denylist against an open set. On a real install a second agent CLI used a name
+# the list did not cover, parked eleven checkouts of three unrelated repos in the
+# vault, and added 37 GB to the backup source — pushing the offsite provider past
+# its storage cap and leaving the offsite copy stale for 50+ days.
+#
+# These controls prove the property-based scan, and prove the fail-safe half: a
+# nested repo with NO remote must stay IN the backup, because the vault may be
+# its only copy. The last case asserts against a REAL tar archive, not just the
+# scanner's opinion — the archive is what actually ships.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCANNER="$HERE/vault-nested-repos.py"
+FAILS=0
+
+ok()   { echo "  ok   $*"; }
+bad()  { echo "  FAIL $*"; FAILS=$((FAILS+1)); }
+have() { grep -qxF "$1" "$2"; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+VAULT="$TMP/vault"
+mkdir -p "$VAULT/notes"
+git init -q "$VAULT"; git -C "$VAULT" config user.email t@t; git -C "$VAULT" config user.name t
+echo hi > "$VAULT/notes/a.md"
+
+mkrepo() { # <path> [remote]
+  mkdir -p "$1"; git init -q "$1"
+  git -C "$1" config user.email t@t; git -C "$1" config user.name t
+  echo x > "$1/f.txt"; git -C "$1" add f.txt; git -C "$1" commit -qm c
+  [ -n "${2:-}" ] && git -C "$1" remote add origin "$2"
+  return 0
+}
+
+# A checkout under a directory name NOTHING in this repo has ever listed.
+mkrepo "$VAULT/.some-other-agent-worktrees/proj" "https://example.invalid/proj.git"
+# A no-remote project: irreplaceable, must be KEPT.
+mkrepo "$VAULT/media/no-remote-project"
+
+OUT="$TMP/excl.txt"
+python3 "$SCANNER" --vault-root "$VAULT" --relative --exclude-file "$OUT" >/dev/null 2>&1
+
+echo "- property-based detection"
+have "./.some-other-agent-worktrees/proj" "$OUT" \
+  && ok "checkout under an unlisted directory name is excluded" \
+  || bad "unlisted-name checkout NOT excluded (this is the whole bug)"
+
+echo "- fail-safe: no-remote repos are never silently dropped"
+if have "./media/no-remote-project" "$OUT"; then
+  bad "a no-remote repo was excluded — that is data loss, not a fix"
+else
+  ok "no-remote repo kept in the backup"
+fi
+
+echo "- the vault's own history is never excluded"
+if have "./.git" "$OUT" || have "." "$OUT"; then
+  bad "the vault itself/its .git was excluded"
+else
+  ok "vault root and its .git are untouched"
+fi
+
+echo "- negative control: a clean vault yields nothing"
+CLEAN="$TMP/clean"; mkdir -p "$CLEAN/notes"; git init -q "$CLEAN"
+python3 "$SCANNER" --vault-root "$CLEAN" --relative --exclude-file "$TMP/clean.txt" >/dev/null 2>&1
+if [ "$(grep -cvE '^#|^$' "$TMP/clean.txt")" = "0" ]; then
+  ok "no false positives on a vault with no foreign checkout"
+else
+  bad "false positive on a clean vault: $(grep -vE '^#|^$' "$TMP/clean.txt")"
+fi
+
+echo "- END-TO-END: the real tar archive must not contain the foreign checkout"
+# This is the predicate the RECIPIENT exercises — the archive, not the opinion.
+excl=()
+while IFS= read -r l; do
+  case "$l" in ''|'#'*) continue;; esac
+  excl+=("--exclude=$l")
+done < "$OUT"
+tar -czf "$TMP/a.tar.gz" "${excl[@]}" -C "$VAULT" . 2>/dev/null
+LIST="$TMP/list.txt"; tar -tzf "$TMP/a.tar.gz" > "$LIST" 2>/dev/null
+# Assert on the checkout's CONTENTS, which is what costs storage. tar still
+# emits a zero-byte entry for the parent directory that merely CONTAINS the
+# excluded checkout; that is correct and carries no data, so a substring match
+# on the parent's name would be a false failure.
+if grep -q 'some-other-agent-worktrees/proj' "$LIST"; then
+  bad "foreign checkout contents ARE in the archive"
+else
+  ok "foreign checkout contents absent from the archive"
+fi
+if [ "$(grep -c 'some-other-agent-worktrees' "$LIST")" -le 1 ]; then
+  ok "only the empty parent dir entry remains (no payload)"
+else
+  bad "more than the parent dir survived: $(grep 'some-other-agent-worktrees' "$LIST")"
+fi
+if grep -q 'no-remote-project/f.txt' "$LIST"; then
+  ok "no-remote project IS in the archive (its only copy survives)"
+else
+  bad "no-remote project missing from the archive — data loss"
+fi
+if grep -q 'notes/a.md' "$LIST"; then
+  ok "ordinary vault notes are still archived"
+else
+  bad "vault notes missing from the archive"
+fi
+
+echo
+if [ "$FAILS" -gt 0 ]; then echo "FAILED ($FAILS)"; exit 1; fi
+echo "all green"

--- a/scripts/vault-backup.sh
+++ b/scripts/vault-backup.sh
@@ -34,6 +34,11 @@
 #           stay hermetic and not depend on ~/.claude existing. Defaults to ~/.claude.
 set -uo pipefail
 
+# Resolve this script's own directory so sibling helpers (vault-nested-repos.py)
+# are found no matter where the script is invoked from. No hardcoded install
+# path: the repo may live anywhere on a client's machine.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 CONF="${VAULT_BACKUP_CONF:-$HOME/.claude/.vault-backup.conf}"
 MARKER="${VAULT_BACKUP_MARKER:-$HOME/.claude/.vault-backup-last}"
 KEYCHAIN_SERVICE="ai-brain-starter-vault-backup"
@@ -166,6 +171,33 @@ make_archive() { # <vault> <out-base-no-ext> <encrypt 0|1> <slug> <store-kind> -
   for e in "${EXCLUDES[@]}"; do excl+=("--exclude=$e"); done
   # Always exclude any prior archives that happen to live under the vault.
   excl+=("--exclude=./*.tar.gz" "--exclude=./*.tar.gz.gpg" "--exclude=./*.tar.gz.enc")
+
+  # FOREIGN CHECKOUTS NESTED IN THE VAULT — excluded by PROPERTY, not by name.
+  #
+  # `EXCLUDES` above is a denylist against an open set: it names
+  # `./.claude/worktrees`, so it covers the Desktop app's worktrees and nothing
+  # else. Measured on a real install: a second agent CLI used a directory the
+  # list did not name, parked eleven checkouts of three unrelated repos in the
+  # vault, and added 37 GB to the backup source — which pushed the offsite
+  # provider past its storage cap and left the offsite copy stale for 50+ days.
+  # Adding one more name fixes one tool and loses to the next.
+  #
+  # The scanner excludes only checkouts recoverable from a git remote; a nested
+  # repo with NO remote is kept and reported, because the vault may be its only
+  # copy. FAIL-OPEN: if the scan cannot run we back up MORE, never less.
+  local nested; nested="$(mktemp)"
+  if command -v python3 >/dev/null 2>&1 \
+     && python3 "$SCRIPT_DIR/vault-nested-repos.py" --vault-root "$vault" \
+          --relative --exclude-file "$nested" >/dev/null; then
+    while IFS= read -r line; do
+      case "$line" in ''|'#'*) continue;; esac
+      excl+=("--exclude=$line")
+    done < "$nested"
+  else
+    warn "nested-checkout scan unavailable — a foreign git checkout under a new"
+    warn "directory name would be included in this archive."
+  fi
+  rm -f "$nested"
 
   # Capture the encryption tool's stderr to a temp file so a failure surfaces the
   # REAL error (gpg/openssl/tar) instead of dying with a bare "encryption failed".

--- a/scripts/vault-nested-repos.py
+++ b/scripts/vault-nested-repos.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Find foreign git checkouts nested inside a vault — by PROPERTY, not by name.
+
+WHY THIS IS NOT A NAME LIST
+---------------------------
+`vault-backup.sh` excludes machine-exhaust by name, and that list included
+`./.claude/worktrees` — the per-session worktree directory the Claude Desktop
+app creates. That is a denylist against an open set, and it loses to the next
+tool that picks a different name.
+
+Measured on a real install: a second agent CLI created its worktrees in a
+directory the list did not name, parked eleven checkouts of three unrelated
+repositories inside the vault, and added 37 GB to the backup source. Nothing
+noticed for weeks; the first symptom was the offsite backup provider refusing
+uploads because the storage cap was exceeded, which left the offsite copy
+silently stale for 50+ days.
+
+So this keys on the CHARACTERISTIC — a directory under the vault that carries
+its own `.git` — which catches any tool regardless of what it names its
+directory. Keep the named excludes too; they are cheap and they cover the
+non-repo exhaust this cannot see.
+
+WHY IT DOES NOT JUST EXCLUDE EVERY NESTED REPO
+----------------------------------------------
+A vault can legitimately contain a project directory that is a git repo with **no
+remote** — a writing project, a rendered media folder, a scratch experiment. Its
+bulk is usually working-tree content, not `.git`. Excluding "any nested repo"
+would silently drop irreplaceable files from the only backup that exists, which
+is a worse bug than the one being fixed.
+
+So the classification is RECOVERABILITY, not repo-ness:
+
+  RECOVERABLE   the checkout (or, for a linked worktree, its owning repo) has a
+                git remote -> its content exists on a server -> EXCLUDE it.
+  UNRECOVERABLE no remote anywhere -> the vault may be its only copy -> NEVER
+                exclude. Report it loudly instead, so it gets a remote or moves
+                out of the vault, but keep backing it up until a human decides.
+
+Fail-open by construction: anything unclassifiable stays IN the backup. For a
+backup, backing up too much costs storage; backing up too little loses data.
+
+Usage:
+  vault-nested-repos.py --vault-root DIR [--relative] [--exclude-file OUT] [--json]
+
+  --relative      emit vault-relative `./path` entries (for `tar --exclude=`)
+                  instead of absolute paths (for tools that take absolute).
+Exit: 0 when it produced a usable answer (fail-open); 2 on bad usage.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# Deliberately SHORT. Only directories that can never themselves be a checkout
+# root belong here: dependency and byte-cache dirs. Do not add `dist`, `build`,
+# `target` or an editor config dir — plugin managers really do `git clone` into
+# editor config directories, and pruning there would recreate the same blind
+# spot somewhere new. Finding a checkout prunes its whole subtree anyway, so a
+# nested repo's own dependency dirs are never walked regardless.
+PRUNE_NAMES = {"node_modules", "__pycache__", ".venv", "venv", ".Trash", ".trash"}
+
+_GLOB_META = "*?[]\\"
+
+
+def _escape_glob(p: str) -> str:
+    """Escape glob metacharacters so a literal path stays literal."""
+    return "".join("\\" + c if c in _GLOB_META else c for c in p)
+
+
+def _git(args: list[str], cwd: str) -> str | None:
+    try:
+        r = subprocess.run(
+            ["git", *args], cwd=cwd,
+            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+            text=True, timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return r.stdout.strip() if r.returncode == 0 else None
+
+
+def classify(checkout: Path) -> dict:
+    """Decide whether `checkout` is recoverable from a git remote.
+
+    Handles a primary clone (`.git` is a directory) and a linked worktree
+    (`.git` is a file holding a `gitdir:` pointer); `git remote` inside a
+    worktree already resolves through to the owning repo.
+    """
+    d = str(checkout)
+    info: dict = {"path": d, "kind": "worktree" if (checkout / ".git").is_file() else "clone",
+                  "remote": None, "recoverable": False, "reason": ""}
+
+    remote = _git(["remote"], d)
+    if remote is None:
+        info["reason"] = "could not query git; left IN the backup (fail-open)"
+        return info
+    if not remote:
+        info["reason"] = "no git remote — the vault may be its only copy"
+        return info
+
+    info["remote"] = _git(["remote", "get-url", remote.splitlines()[0]], d) or remote.splitlines()[0]
+    info["recoverable"] = True
+    info["reason"] = "content lives on a remote; a vault backup is a duplicate"
+    return info
+
+
+def scan(vault_root: Path) -> list[dict]:
+    found: list[dict] = []
+    root = str(vault_root)
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+        dirnames[:] = [d for d in dirnames if d not in PRUNE_NAMES]
+        if dirpath == root:
+            # The vault's OWN .git must never be excluded — it is the history.
+            dirnames[:] = [d for d in dirnames if d != ".git"]
+            continue
+        if ".git" in dirnames or ".git" in filenames:
+            found.append(classify(Path(dirpath)))
+            dirnames[:] = []          # do not descend into a classified checkout
+    return sorted(found, key=lambda i: i["path"])
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--vault-root", required=True)
+    ap.add_argument("--exclude-file")
+    ap.add_argument("--relative", action="store_true",
+                    help="emit ./vault-relative paths (tar --exclude= form)")
+    ap.add_argument("--json", action="store_true")
+    a = ap.parse_args()
+
+    vault = Path(a.vault_root)
+    if not vault.is_dir():
+        print(f"vault-nested-repos: vault not found: {vault}", file=sys.stderr)
+        return 2
+    vault = vault.resolve()
+
+    items = scan(vault)
+    excl = [i for i in items if i["recoverable"]]
+    keep = [i for i in items if not i["recoverable"]]
+
+    def render(p: str) -> str:
+        if not a.relative:
+            return _escape_glob(p)
+        try:
+            return _escape_glob("./" + str(Path(p).relative_to(vault)))
+        except ValueError:
+            return _escape_glob(p)
+
+    if a.exclude_file:
+        lines = ["# GENERATED by vault-nested-repos.py — do not edit.",
+                 "# Foreign checkouts recoverable from a git remote, found by property."]
+        lines += [render(i["path"]) for i in excl]
+        Path(a.exclude_file).write_text("\n".join(lines) + "\n")
+
+    for i in excl:
+        print(f"vault-nested-repos: EXCLUDE {render(i['path'])}  ({i['kind']}, remote {i['remote']})")
+
+    for i in keep:
+        print(
+            f"vault-nested-repos: WARN nested repo with NO REMOTE kept in the backup: {i['path']}\n"
+            f"vault-nested-repos:      {i['reason']}. It inflates every backup AND exists\n"
+            f"vault-nested-repos:      nowhere else. Give it a remote and push, or move it\n"
+            f"vault-nested-repos:      out of the vault.",
+            file=sys.stderr,
+        )
+
+    if a.json:
+        print(json.dumps({"excluded": excl, "kept_no_remote": keep}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as e:   # fail-open: never break a backup
+        print(f"vault-nested-repos: ERROR {e} — excluding nothing (fail-open)", file=sys.stderr)
+        sys.exit(0)

--- a/scripts/vault-nested-repos.py
+++ b/scripts/vault-nested-repos.py
@@ -76,7 +76,11 @@ def _git(args: list[str], cwd: str) -> str | None:
         r = subprocess.run(
             ["git", *args], cwd=cwd,
             stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
-            text=True, timeout=30,
+            # Pin UTF-8 rather than inheriting the locale: git echoes vault paths,
+            # and a vault path routinely carries non-ASCII (emoji folder names).
+            # On a non-UTF-8 Windows console the locale decode raises
+            # UnicodeDecodeError and this helper dies mid-backup.
+            encoding="utf-8", errors="replace", timeout=30,
         )
     except (OSError, subprocess.SubprocessError):
         return None
@@ -174,6 +178,14 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # This CLI prints vault paths, which routinely carry non-ASCII (emoji folder
+    # names). Without this, a non-UTF-8 Windows console raises UnicodeEncodeError
+    # on the very paths the operator needs to see.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     try:
         sys.exit(main())
     except Exception as e:   # fail-open: never break a backup


### PR DESCRIPTION
## Why

`vault-backup.sh`'s `EXCLUDES` is a denylist against an open set. It names `./.claude/worktrees` — the Desktop app's per-session worktree directory — and nothing else.

Measured on a real install: a second agent CLI wrote its worktrees to a directory the list did not name, parked **eleven checkouts of three unrelated repositories** inside the vault, and added **37 GB** to the backup source. Nothing noticed for weeks. The first symptom was the offsite provider refusing uploads because the storage cap was exceeded, which left the offsite copy silently stale for **50+ days**.

Adding one more name fixes one tool and loses to the next.

## What

`scripts/vault-nested-repos.py` finds checkouts by the **characteristic** — a directory under the vault carrying its own `.git` — so any tool's naming is caught. The static list stays as belt-and-braces for non-repo exhaust.

It excludes only checkouts **recoverable from a git remote**. A nested repo with **no remote** is KEPT and reported loudly: a vault can hold a writing or media project that is a local-only repo whose bulk is working-tree content, and excluding "any nested repo" would silently drop the only copy — a worse bug than the one being fixed. Anything unclassifiable **fails open** (stays in the backup), because too much backup costs storage while too little loses data.

`vault-backup.sh` gains a portable `SCRIPT_DIR` (no hardcoded install path) and feeds the generated vault-relative excludes to `tar` alongside the static list, warning if the scan cannot run.

## Controls (all proven to fire)

`scripts/test-vault-nested-repos.sh`:

- reverting to the name-based match turns the suite **red**
- a checkout under a never-before-listed directory name **is** excluded
- a no-remote repo **survives into the archive** (its only copy)
- the vault's own `.git` is never excluded
- a clean vault yields no false positives

The decisive assertions run against a **real tar archive**, not the scanner's opinion. That is what caught that `tar` still emits a zero-byte entry for the *parent* directory of an excluded checkout — so the suite asserts on contents and payload count, not a substring of the parent's name.

`test-vault-backup-roundtrip.sh` and `test-vault-backup-guard.sh` both stay green (`make_archive` was modified).

## Local gate note

`ci-test` was run in full (not a subset), twice. Both runs failed **only** on the suite's HOME-integrity postcondition — a *different* test each time (`test_ai_brain_auto_update`, then `test_bootstrap_dry_run`), with `settings.json` byte-identical across both (same hash, same mtime, `baks=309`, `files=1736`; only the tree hash moved). That is ambient background writes into `~/.claude` on a live machine, not this diff: every functional assertion passed in both runs, and this diff touches only `scripts/vault-*`, which neither failing test references. A prior commit (86f1626) fixed this same HOME-sandbox class for this suite. Pushed with the documented parity bypass so CI adjudicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
