### PR TITLE
fix(graphify): god-node reports crash on 'edges' key; nested cache counted as 0

### DIFF
--- a/scripts/graphify_stage_finish.py
+++ b/scripts/graphify_stage_finish.py
@@ -422,7 +422,7 @@ def main():
     lines.append("")
     lines.append("## Top God Nodes")
     for i, n in enumerate(gn, 1):
-        lines.append(f"{i}. `{n['label']}` ({n['edges']} edges)")
+        lines.append(f"{i}. `{n['label']}` ({n.get('degree', n.get('edges', 0))} edges)")
     lines.append("")
     lines.append("## Surprising Connections")
     for s in sc[:10]:
@@ -610,7 +610,7 @@ def main():
         cutoff = time.time() - 3600  # last hour
         upgraded = 0
         recent = 0
-        for c in cache_dir.glob("*.json"):
+        for c in cache_dir.rglob("*.json"):
             if c.stat().st_mtime < cutoff:
                 continue
             recent += 1
@@ -632,7 +632,7 @@ def main():
     print(f"TOP 15 GOD NODES (post-{args.stage_name})")
     print("=" * 60)
     for i, n in enumerate(gn[:15], 1):
-        print(f"  {i:2d}. {n['label']} ({n['edges']})")
+        print(f"  {i:2d}. {n['label']} ({n.get('degree', n.get('edges', 0))})")
 
     print()
     print(f"{args.stage_name.upper()} FINISH COMPLETE")

--- a/skills/graphify/scripts/graphify_stage_finish.py
+++ b/skills/graphify/scripts/graphify_stage_finish.py
@@ -252,7 +252,7 @@ def main():
     lines.append("")
     lines.append("## Top God Nodes")
     for i, n in enumerate(gn, 1):
-        lines.append(f"{i}. `{n['label']}` — {n['edges']} edges")
+        lines.append(f"{i}. `{n['label']}` — {n.get('degree', n.get('edges', 0))} edges")
     lines.append("")
     lines.append("## Surprising Connections")
     for s in sc[:10]:
@@ -301,7 +301,7 @@ def main():
         cutoff = time.time() - 3600  # last hour
         upgraded = 0
         recent = 0
-        for c in cache_dir.glob("*.json"):
+        for c in cache_dir.rglob("*.json"):
             if c.stat().st_mtime < cutoff:
                 continue
             recent += 1
@@ -323,7 +323,7 @@ def main():
     print(f"TOP 15 GOD NODES (post-{args.stage_name})")
     print("=" * 60)
     for i, n in enumerate(gn[:15], 1):
-        print(f"  {i:2d}. {n['label']} ({n['edges']})")
+        print(f"  {i:2d}. {n['label']} ({n.get('degree', n.get('edges', 0))})")
 
     print()
     print(f"{args.stage_name.upper()} FINISH COMPLETE")


### PR DESCRIPTION
## Two bugs in `graphify_stage_finish.py` (both copies: `scripts/` and `skills/graphify/scripts/`)

1. **KeyError on god-node reports.** `graphify.analyze.god_nodes()` returns the key `degree`; the report step reads `n['edges']` and raises. The crash lands in step 4 (report), **after** the merged graph is written but **before** step 5 saves the semantic cache — so the run looks successful (the graph is fine) while the cache silently never persists, and the next `--update` run pays for full re-extraction again. Fix: `n.get('degree', n.get('edges', 0))`.

2. **Nested cache counted as 0.** The cache count uses `cache_dir.glob("*.json")`, but current graphify versions nest the cache (`cache/semantic/`, `cache/ast/`), so the count is always 0. Fix: `rglob`.

Both found in production 2026-08-01 during a vault mapping refresh. Both files compile (`py_compile`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
