### PR TITLE
fix(footprint): scale the low-disk floor to the volume, not a flat 5 GB

### DIFF
--- a/hooks/test_footprint_disk_floor.py
+++ b/hooks/test_footprint_disk_floor.py
@@ -142,4 +142,12 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so the non-ASCII control
+    # names can't crash this test on a Windows console.
+    import sys as _sys
+    for _stream in (_sys.stdout, _sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     raise SystemExit(main())

--- a/hooks/test_footprint_disk_floor.py
+++ b/hooks/test_footprint_disk_floor.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import importlib.util
 import shutil
+import tempfile
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -101,16 +102,26 @@ def main() -> int:
     GIB = 1024 ** 3
 
     def emit_with_volume(free_gb: float, total_gb: float) -> str:
-        """Run the hook's real disk branch against a faked volume."""
-        real = shutil.disk_usage
+        """Run the hook's real disk branch against a faked volume.
+
+        find_main_repo() is pinned to a temp dir as well as disk_usage being
+        faked: the hook discovers its repo from the ambient cwd, so without the
+        pin these controls pass or fail depending on where the suite is invoked
+        from — green in a vault, red from the repo root, which is exactly the
+        cwd-dependent flake CI would hit.
+        """
+        real_usage, real_find = shutil.disk_usage, mod.find_main_repo
         shutil.disk_usage = lambda _p: SimpleNamespace(  # type: ignore[assignment]
             total=int(total_gb * GIB), used=int((total_gb - free_gb) * GIB),
             free=int(free_gb * GIB),
         )
-        try:
-            out = mod.main_text() if hasattr(mod, "main_text") else _emit_via_main(mod)
-        finally:
-            shutil.disk_usage = real  # type: ignore[assignment]
+        with tempfile.TemporaryDirectory() as td:
+            mod.find_main_repo = lambda: Path(td)  # type: ignore[assignment]
+            try:
+                out = _emit_via_main(mod)
+            finally:
+                shutil.disk_usage = real_usage    # type: ignore[assignment]
+                mod.find_main_repo = real_find    # type: ignore[assignment]
         return out or ""
 
     def _emit_via_main(m):

--- a/hooks/test_footprint_disk_floor.py
+++ b/hooks/test_footprint_disk_floor.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Controls for the low-free-disk floor in worktree-footprint-signal.py.
+
+The bug this closes (measured 2026-08-05, 926 GB machine): the only disk line
+was a flat 5 GB. Regenerable build output filled the volume from healthy to
+2.3 GB free and this hook stayed silent the entire way down, because 5 GB on a
+1 TB disk is not an early warning — by then builds already fail and sync daemons
+already stall. The floor is now max(5 GB, 5% of the volume), so it fires while
+the fix is still cheap.
+
+A threshold that never fires and a threshold that fires too late are the same
+bug, so the controls assert BOTH directions:
+
+  * 2.3 GB free of 926 GB (the real incident) -> FIRES   (old flat floor: also fired, but only here)
+  * 40 GB free of 926 GB                      -> FIRES   (old flat floor: SILENT — the regression)
+  * 300 GB free of 926 GB                     -> silent  (healthy disk stays quiet)
+  * 10 GB free of 120 GB small disk           -> FIRES   (proportional floor scales down)
+  * 8 GB free of 60 GB small disk             -> silent  (5% = 3 GB; absolute 5 GB floor governs)
+  * WORKTREE_FREE_GB pins the floor explicitly
+  * the message states free GB, the percentage, and the floor it warned against
+
+[13]-[15] drive the hook's REAL code path with a faked volume, because the
+arithmetic controls above would all still pass if the derivation were never
+wired into the emitted output.
+
+Run: python3 hooks/test_footprint_disk_floor.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import shutil
+from pathlib import Path
+from types import SimpleNamespace
+
+HOOKS = Path(__file__).resolve().parent
+FAILED = []
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "worktree_footprint_signal", HOOKS / "worktree-footprint-signal.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def floor_for(mod, total_gb: float, pinned: str | None = None) -> float:
+    """Reproduce the hook's floor derivation for a volume of `total_gb`."""
+    if pinned:
+        return float(pinned)
+    return max(mod.DEFAULT_FREE_GB, total_gb * mod.DEFAULT_FREE_PCT)
+
+
+def check(name: str, got, want):
+    if got == want:
+        print(f"  ok   {name}")
+    else:
+        print(f"  FAIL {name}: got {got!r}, want {want!r}")
+        FAILED.append(name)
+
+
+def main() -> int:
+    mod = _load()
+
+    # --- the real incident and the corridor above it -------------------------
+    big = 926.0
+    fires = lambda free, total, pinned=None: free < floor_for(mod, total, pinned)
+
+    check("[1] 2.3 GB free of 926 GB fires", fires(2.3, big), True)
+    check("[2] 40 GB free of 926 GB fires (old flat 5 GB floor was SILENT here)",
+          fires(40.0, big), True)
+    check("[3] 300 GB free of 926 GB stays silent", fires(300.0, big), False)
+
+    # The regression, stated directly: the old behaviour is the flat floor alone.
+    old_floor_silent_at_40 = 40.0 >= mod.DEFAULT_FREE_GB
+    check("[4] the old flat floor demonstrably missed 40 GB free",
+          old_floor_silent_at_40, True)
+
+    # --- proportional floor must scale DOWN, not just up --------------------
+    check("[5] 10 GB free of 120 GB stays silent (above the 6 GB floor)",
+          fires(10.0, 120.0), False)
+    check("[6] 5 GB free of 120 GB fires (below the 6 GB proportional floor)",
+          fires(5.0, 120.0), True)
+    check("[7] 8 GB free of 60 GB stays silent (5% = 3 GB, absolute 5 GB governs)",
+          fires(8.0, 60.0), False)
+    check("[8] 4 GB free of 60 GB fires (below the absolute 5 GB floor)",
+          fires(4.0, 60.0), True)
+
+    # --- explicit pin still wins -------------------------------------------
+    check("[9] WORKTREE_FREE_GB=200 pins the floor", fires(150.0, big, "200"), True)
+    check("[10] WORKTREE_FREE_GB=1 pins the floor low", fires(2.3, big, "1"), False)
+
+    # --- the floor is actually derived from the volume, not hardcoded -------
+    check("[11] floor on a 926 GB volume is ~46 GB",
+          round(floor_for(mod, big)), 46)
+    check("[12] floor never drops below the absolute minimum",
+          floor_for(mod, 1.0), mod.DEFAULT_FREE_GB)
+
+    # --- end-to-end: the derivation must reach the EMITTED text --------------
+    GIB = 1024 ** 3
+
+    def emit_with_volume(free_gb: float, total_gb: float) -> str:
+        """Run the hook's real disk branch against a faked volume."""
+        real = shutil.disk_usage
+        shutil.disk_usage = lambda _p: SimpleNamespace(  # type: ignore[assignment]
+            total=int(total_gb * GIB), used=int((total_gb - free_gb) * GIB),
+            free=int(free_gb * GIB),
+        )
+        try:
+            out = mod.main_text() if hasattr(mod, "main_text") else _emit_via_main(mod)
+        finally:
+            shutil.disk_usage = real  # type: ignore[assignment]
+        return out or ""
+
+    def _emit_via_main(m):
+        """Capture whatever the hook writes to stdout for one invocation."""
+        import contextlib, io
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            try:
+                m.main()
+            except SystemExit:
+                pass
+        return buf.getvalue()
+
+    warned = emit_with_volume(40.0, 926.0)
+    check("[13] 40 GB of 926 GB reaches the emitted output",
+          "Low free disk" in warned, True)
+    check("[14] the message names the floor it warned against",
+          ("46" in warned) if "Low free disk" in warned else False, True)
+    quiet = emit_with_volume(300.0, 926.0)
+    check("[15] 300 GB of 926 GB emits no disk warning",
+          "Low free disk" in quiet, False)
+
+    print()
+    if FAILED:
+        print(f"FAIL test_footprint_disk_floor.py ({len(FAILED)} failed)")
+        return 1
+    print("PASS test_footprint_disk_floor.py")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hooks/worktree-footprint-signal.py
+++ b/hooks/worktree-footprint-signal.py
@@ -168,6 +168,12 @@ def _candidate_vaults(main_repo: Path | None) -> list[Path]:
     if cwd_root is not None:
         cands.append(cwd_root)
     cands.extend(obsidian_vault_paths())
+    # vault-root-ok: enumerates CANDIDATE vaults, never resolves "the" root. This
+    # signal must observe every vault on the machine (the cloud-sync check has to
+    # see a vault cwd is not in), so vault_root_for(target) answers the wrong
+    # question here — it picks one governing root for one target. VAULT_ROOT joins
+    # project-dir / cwd-git-root / the Obsidian registry as one more candidate, and
+    # a wrong value adds a path that simply fails its own is_dir/stat checks below.
     vr = os.environ.get("VAULT_ROOT")
     if vr:
         cands.append(Path(vr).expanduser())

--- a/hooks/worktree-footprint-signal.py
+++ b/hooks/worktree-footprint-signal.py
@@ -66,7 +66,17 @@ from _lib.worktree_safety import (  # noqa: E402
 )
 
 DEFAULT_WARN = 8
+
+# Absolute floor: below this, any machine is in trouble.
 DEFAULT_FREE_GB = 5.0
+# Proportional floor, because an absolute number does not scale with the disk.
+# A flat 5 GB on a 1 TB volume is not an early warning, it is a post-mortem: by
+# then builds already fail and sync daemons already stall. Measured 2026-08-05 on
+# a 926 GB machine — build artifacts filled it to 2.3 GB free and this hook stayed
+# silent the whole way down, because 5 GB is the only line it had. 5% (≈46 GB
+# there, ≈13 GB on a 256 GB laptop) fires while the fix is still cheap.
+# The effective floor is max(absolute, proportional); WORKTREE_FREE_GB pins it.
+DEFAULT_FREE_PCT = 0.05
 
 # ── aggregate bloat-dir footprint (MYC-577) ──────────────────────────────────
 # Default warn at 80K files across the bloat-prone dirs — a deliberate fraction
@@ -694,10 +704,12 @@ def main() -> int:
             warn_at = max(1, int(os.environ.get("WORKTREE_WARN", DEFAULT_WARN)))
         except ValueError:
             warn_at = DEFAULT_WARN
+        # None => derive from the volume; an explicit WORKTREE_FREE_GB pins it.
         try:
-            free_floor = float(os.environ.get("WORKTREE_FREE_GB", DEFAULT_FREE_GB))
+            pinned_floor = os.environ.get("WORKTREE_FREE_GB")
+            free_floor = float(pinned_floor) if pinned_floor else None
         except ValueError:
-            free_floor = DEFAULT_FREE_GB
+            free_floor = None
 
         # Count only scratch worktrees for the cap warning; deliberate sibling
         # worktrees (~/dev/<repo>-<slug>) are not part of the pileup problem.
@@ -726,11 +738,22 @@ def main() -> int:
 
         free_gb = None
         try:
-            free_gb = shutil.disk_usage(main_repo).free / 1024 ** 3
+            usage = shutil.disk_usage(main_repo)
+            free_gb = usage.free / 1024 ** 3
+            if free_floor is None:
+                free_floor = max(
+                    DEFAULT_FREE_GB, (usage.total / 1024 ** 3) * DEFAULT_FREE_PCT
+                )
         except OSError:
             pass
-        if free_gb is not None and free_gb < free_floor:
-            lines.append(f"⚠️  [footprint] Low free disk: {free_gb:.1f} GB on the vault volume.")
+        if free_gb is not None and free_floor is not None and free_gb < free_floor:
+            pct = free_gb / (usage.total / 1024 ** 3) * 100
+            lines.append(
+                f"⚠️  [footprint] Low free disk: {free_gb:.1f} GB free "
+                f"({pct:.0f}% of the volume) — warns below {free_floor:.0f} GB. "
+                f"Biggest reclaimable win is usually regenerable build output "
+                f"(node_modules / target / .venv / .next) in idle worktrees."
+            )
 
     return _emit("\n".join(lines) if lines else None)
 

--- a/hooks/worktree-footprint-signal.py
+++ b/hooks/worktree-footprint-signal.py
@@ -759,6 +759,13 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so the non-ASCII signal
+    # text (the warning glyphs) can't crash the hook on a Windows console.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     try:
         sys.exit(main())
     except Exception:

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -753,6 +753,7 @@ PY_DIRECT=(
   hooks/test_check_fabricated_verification.py
   hooks/test_warn_chained_state_command.py
   hooks/test_footprint_aggregate_bloat.py
+  hooks/test_footprint_disk_floor.py
   hooks/test_unpushed_drift_surface.py
   hooks/test_claim_surface_honesty.py
   hooks/test_narrow_refspec_falsealarm.py

--- a/scripts/utf8-stdout-baseline.txt
+++ b/scripts/utf8-stdout-baseline.txt
@@ -148,4 +148,3 @@ bde2c3d7a3b64f2828d4b6a7be9e33381c7496877cf11eea0fdbb6068382b4e1 SEV-4-json-enco
 a201c72df70798c65e0a3db62587a38eec99b1989b83b808826604dcf2f42fd2 SEV-4-json-encoded hooks/warn-stale-dev-checkout.py
 effe9f0dc7226a8ea9456ec6be5112ea357ef8795adde5375499f19c6db000fc SEV-4-json-encoded hooks/warn-uncommitted-builds-on-stop.py
 dfba549e5cd609ddde59d63aac175d884d0224a6703265e0b04c1a0eac315b20 SEV-4-json-encoded hooks/whatsapp-mcp-auto-export.py
-fe6732085fc9a60ca52539a9d4ca30307b5d37d214a00eec58c86353d69cb56f SEV-4-json-encoded hooks/worktree-footprint-signal.py

--- a/scripts/vault-root-read-baseline.txt
+++ b/scripts/vault-root-read-baseline.txt
@@ -92,7 +92,6 @@ fd7dcaf462d1fe6a8a3d350573c2b63c896ca4089a02b7888048b70e9807b459 SEV-C-script-lo
 85006d7e25f42ba787b2ce616bd1c71590c3990f89f3153a6f958156c93029ed SEV-E-no-default hooks/coach-auto-prescribe-on-journal.py
 33804a89b8c6ac80575f93ea2a5e0f9f6e47aeb3bb6e8dab0413729fd3fc8c94 SEV-E-no-default hooks/inject-love-language-context.py
 439b81f59712732d566301a7a1fe2b7f4f61c8f49a48c56a2b45f69a331c3087 SEV-E-no-default hooks/inject-meeting-workflow-on-trigger.py
-fe6732085fc9a60ca52539a9d4ca30307b5d37d214a00eec58c86353d69cb56f SEV-E-no-default hooks/worktree-footprint-signal.py
 d11e46cfd26ba07935e39f6bd73c36095e242d4a2a5a6856d12a07f7b929195b SEV-E-no-default scripts/backfill-journal-body-context.py
 66295b6759ce0653131ffa32fcbdb4e2c467fb833fe9770f1d72948ece7df513 SEV-E-no-default scripts/extractors/_base.py
 9ceedddb923461f4c803b48b1d8349c9e54f9f6ff73e40969aeb3332206c8824 SEV-E-no-default scripts/granola_core.py


### PR DESCRIPTION
## The bug

A flat 5 GB low-disk threshold is not an early warning on a large volume, it is a post-mortem.

Measured on a 926 GB machine: regenerable build output (Rust `target/` and `node_modules` across per-session worktrees) filled the disk from healthy to **2.3 GB free**, and this hook stayed silent the whole way down. By the time 5 GB is crossed, builds already fail and sync daemons already stall.

Worse, the reclaim automation on that machine engaged at 150 GB free while the human alarm sat at 5 GB — a ~145 GB corridor in which reclaim was quietly losing a race against worktree creation and nothing surfaced it.

## The change

Floor is now `max(5 GB, 5% of the volume)`:

| Volume | Old floor | New floor |
|---|---|---|
| 926 GB | 5 GB | ~46 GB |
| 256 GB | 5 GB | ~13 GB |
| 60 GB  | 5 GB | 5 GB (absolute governs) |

The message now states free GB, percentage of volume, and the floor it warned against, and points at the usual biggest win. `WORKTREE_FREE_GB` still pins it explicitly.

## Controls

`hooks/test_footprint_disk_floor.py` — 15 controls. A threshold that never fires and one that fires too late are the same bug, so both directions are asserted:

- 40 GB free of 926 GB now **fires** (the flat floor was silent here — the regression)
- 300 GB free of 926 GB stays **silent**
- the proportional floor scales **down** too: 8 GB free of 60 GB stays silent, because 5% is 3 GB and the absolute 5 GB governs
- `[13]`-`[15]` drive the hook's **real emitted output** against a faked volume, so the derivation is proven wired in rather than merely correct in isolation

Sibling `test_footprint_aggregate_bloat.py` re-run green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
