### PR TITLE
fix(gc): the live-session guard on both deleting tools was dead in production

### DIFF
--- a/hooks/_lib/dev_repo_scan.py
+++ b/hooks/_lib/dev_repo_scan.py
@@ -208,6 +208,11 @@ def find_modules_in_flight(repo: Path) -> list[ModuleInFlight]:
             ["git", "-C", str(repo), "status", "--porcelain=v1", "-uall"],
             capture_output=True,
             text=True,
+            # Pinned explicitly: `text=True` alone decodes with the console code
+            # page, and on a non-UTF-8 Windows console any path carrying a
+            # non-ASCII byte raises before the caller sees a line.
+            encoding="utf-8",
+            errors="replace",
             timeout=10,
         )
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
@@ -264,6 +269,8 @@ def find_wip_stashes(repo: Path) -> list[StashEntry]:
             ["git", "-C", str(repo), "stash", "list"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=10,
         )
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
@@ -338,6 +345,8 @@ def find_unpushed_local_commits(
             ],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=10,
         )
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
@@ -416,6 +425,8 @@ def _resolve_upstream(repo: Path, branch: str) -> Optional[str]:
             ],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=5,
         )
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
@@ -466,6 +477,8 @@ def _git(repo: Path, *args: str, timeout: int = 15):
             ["git", "-C", str(repo), *args],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=timeout,
         )
         return r.returncode, r.stdout.strip(), r.stderr.strip()
@@ -551,6 +564,8 @@ def _gh(repo: Path, *args: str, timeout: int = 20):
             env=_gh_env(),
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=timeout,
         )
         return r.returncode, r.stdout.strip(), r.stderr.strip()
@@ -817,11 +832,106 @@ def _has_live_session_lock(repo: Path, now_ts: Optional[float] = None) -> bool:
         return False
     if not isinstance(data, dict):
         return False
-    for s in data.get("sessions", []):
-        la = s.get("last_activity_at") if isinstance(s, dict) else None
+    for s in _lock_entries(data):
+        la = s.get("last_activity_at")
         if isinstance(la, (int, float)) and (now_ts - la) < SESSION_LOCK_LIVE_WINDOW_SEC:
             return True
     return False
+
+
+def _lock_entries(data: dict) -> list:
+    """Session entries from a lock file, across every schema it has worn.
+
+    THE bug this exists to kill (measured 2026-08-06): the live file is v2,
+    `{"version": 2, "sessions": {"<sid>": {...}}}` — sessions is a **dict**.
+    The reader iterated `data.get("sessions", [])` as a LIST, so iterating the
+    dict yielded its string KEYS, every `isinstance(entry, dict)` was False, and
+    the function returned "no live session" on a file that had two live ones.
+    It was documented as reading THE REAL lock and had been dead the whole time.
+
+    Mirrors `_load_sessions` in session-lock.py, the writer, so the reader and
+    the writer can no longer disagree about shape:
+      v2      -> {"sessions": {sid: entry}}
+      legacy  -> {"sessions": [entry, ...]}
+      v1 flat -> the top-level object IS one entry
+    """
+    sessions = data.get("sessions")
+    if isinstance(sessions, dict):
+        return [v for v in sessions.values() if isinstance(v, dict)]
+    if isinstance(sessions, list):
+        return [v for v in sessions if isinstance(v, dict)]
+    if "last_activity_at" in data:
+        return [data]
+    return []
+
+
+def has_live_session_lock(path: Path, now_ts: Optional[float] = None) -> bool:
+    """Is a Claude session live in this working tree? THE one answer.
+
+    Public because two DESTRUCTIVE tools need it and each had grown its own,
+    wrong, copy. Measured 2026-08-06: across the entire dev root there were ZERO
+    files named `.session-lock` — the probe both copies used. session-lock.py
+    writes `<main_root>/.claude/.session-lock.json`, a multi-session MAP keyed on
+    `last_activity_at`, and it resolves `main_root` through
+    `git rev-parse --git-common-dir`, so a sibling worktree's lock does not live
+    inside the worktree at all. Both guards were therefore dead in production
+    while reading, correctly, as "no session here".
+
+    That is not a cosmetic miss. `dev-build-reclaim.py`'s bottom pressure rung
+    sets the idle threshold to 0 days, which every worktree passes, so the
+    session lock is the ONLY thing standing between an actively-compiling
+    worktree and having its `target/` deleted. `dev-worktree-prune.py` deletes
+    the whole worktree.
+
+    Three probes, in order of authority. Legacy mtime probes are kept because
+    they cost one stat and any future tool that drops a plain `.session-lock`
+    still gets protected.
+
+    An OSError anywhere reads as LOCKED, never unlocked: "I could not tell" and
+    "nobody is here" are different answers, and only one is safe to act on when
+    the action is deletion.
+    """
+    now_ts = now_ts or time.time()
+
+    # 1. Legacy per-worktree marker files (cheap, and back-compatible).
+    for cand in (path / ".session-lock", path / ".claude" / ".session-lock"):
+        try:
+            if cand.exists() and (now_ts - cand.stat().st_mtime) < SESSION_LOCK_LIVE_WINDOW_SEC:
+                return True
+        except OSError:
+            return True
+
+    # 2. The REAL lock, in this tree.
+    if _has_live_session_lock(path, now_ts):
+        return True
+
+    # 3. The REAL lock, at the shared root a worktree points back to. This is
+    #    the case that was missing: `~/dev/<repo>-<slug>` keeps its lock at the
+    #    main checkout, so probing only the worktree finds nothing, forever.
+    root = session_lock_root(path)
+    if root is not None and root != path:
+        return _has_live_session_lock(root, now_ts)
+    return False
+
+
+def session_lock_root(path: Path) -> Optional[Path]:
+    """The checkout whose `.claude/.session-lock.json` covers `path`.
+
+    Mirrors session-lock.py: resolve `--git-common-dir`, then strip the trailing
+    `.git` to get the main working tree. Returns None when `path` is not in a
+    git repo or git is unavailable — callers treat None as "no extra place to
+    look", never as "unlocked".
+    """
+    rc, out, _ = _git(path, "rev-parse", "--path-format=absolute", "--git-common-dir")
+    if rc != 0 or not out:
+        rc, out, _ = _git(path, "rev-parse", "--git-common-dir")
+    if rc != 0 or not out:
+        return None
+    common = Path(out.rstrip("/"))
+    if not common.is_absolute():
+        common = (path / common).resolve()
+    # common is typically <main_root>/.git; for a bare repo it is the repo dir.
+    return common.parent if common.name == ".git" else common
 
 
 def _plan_stash_reap(
@@ -1060,6 +1170,8 @@ def has_recent_session_commits(repo: Path, minutes: int = 30) -> bool:
             ],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=5,
         )
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError):

--- a/scripts/dev-build-reclaim.py
+++ b/scripts/dev-build-reclaim.py
@@ -112,7 +112,7 @@ if not _add_lib_to_path():
 
 try:
     from _lib.dev_repo_scan import (  # noqa: E402
-        SESSION_LOCK_LIVE_WINDOW_SEC,
+        has_live_session_lock,
         resolve_dev_root,
     )
 except ImportError as exc:
@@ -130,12 +130,12 @@ CONDITIONAL = {"target": "Cargo.toml"}
 
 # Session machinery, never source — excluded from the idle reading for the same
 # reason the root dir is (defect [1]): a file the TOOLING writes must not look
-# like a human edit. A `.session-lock` is touched by every session that opens the
+# like a human edit. A session lock is touched by every session that opens the
 # worktree, so counting it would make a worktree read "active" for a full idle
 # window after the last session ended — and, since the lock is checked AFTER the
 # idle threshold, the honest "preserved: live session lock" report would never
 # print. Liveness is decided by has_live_session_lock(), on the lock's own clock.
-SKIP_SOURCE_NAMES = {".session-lock"}
+SKIP_SOURCE_NAMES = {".session-lock", ".session-lock.json"}
 
 # Free space -> idle threshold (days). Each rung's trigger is
 # max(absolute_gb, pct_of_volume), mirroring the proportional floor in
@@ -266,22 +266,12 @@ def is_link(p: Path) -> bool:
     return False
 
 
-def has_live_session_lock(wt: Path, now: float) -> bool:
-    """True when a session was active in this worktree inside the live window.
-
-    Existence alone is NOT enough: a crashed session leaves its lock behind, and
-    a permanent lock would shield a dead worktree's artifacts forever — which
-    defeats the 0-day pressure rung exactly when the disk is full. Same
-    live-window semantics as the sibling destructive tool (dev-worktree-prune).
-    """
-    for cand in (wt / ".session-lock", wt / ".claude" / ".session-lock"):
-        try:
-            if cand.exists() and (now - cand.stat().st_mtime) < SESSION_LOCK_LIVE_WINDOW_SEC:
-                return True
-        except OSError:
-            # Unreadable lock: err toward PRESERVE, this tool deletes.
-            return True
-    return False
+# Liveness is decided by _lib.has_live_session_lock, never a copy living here.
+# This file shipped with its own, which probed `<wt>/.session-lock` — a filename
+# that exists nowhere on a real machine — so the guard was dead in production
+# while reading, correctly, as "no session here". At the 0-day pressure rung
+# every worktree passes the idle gate, which makes this the ONLY protection
+# between an actively-compiling worktree and losing its `target/`.
 
 
 def find_artifacts(wt: Path):

--- a/scripts/dev-worktree-prune.py
+++ b/scripts/dev-worktree-prune.py
@@ -70,6 +70,9 @@ try:
         SESSION_LOCK_LIVE_WINDOW_SEC,
         resolve_dev_root,
     )
+    from _lib.dev_repo_scan import (  # noqa: E402
+        has_live_session_lock as _shared_has_live_session_lock,
+    )
 except ImportError as exc:
     print(f"dev-worktree-prune: the _lib/dev_repo_scan.py on sys.path is older "
           f"than this script ({exc}). Re-run scripts/install-hooks-user-level.py. "
@@ -94,8 +97,12 @@ SURFACE = "surface"
 
 def _git(cwd, *args, timeout: int = 20):
     try:
+        # encoding pinned: `text=True` alone decodes with the console code page,
+        # and on a non-UTF-8 Windows console a path with any non-ASCII byte
+        # raises before this returns — on the tool that decides what to DELETE.
         r = subprocess.run(["git", "-C", str(cwd), *args],
-                           capture_output=True, text=True, timeout=timeout)
+                           capture_output=True, text=True,
+                           encoding="utf-8", errors="replace", timeout=timeout)
         return r.returncode, r.stdout.strip(), r.stderr.strip()
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
         return 99, "", str(exc)
@@ -127,16 +134,18 @@ def has_live_session_lock(path: Path, now_ts: float) -> bool:
     """A session actively working in this worktree. Removing it out from under a
     live run is how a 45-minute gate loses its files mid-flight.
 
+    Delegates to the shared `_lib.has_live_session_lock`. This function used to
+    carry its own probe of `<path>/.session-lock` — a filename that, measured
+    2026-08-06, exists NOWHERE under the dev root. session-lock.py writes
+    `.claude/.session-lock.json` at the git-common-dir root, so a sibling
+    worktree's lock is not inside the worktree. The guard was dead in production
+    while reading as "no session here", on a tool that deletes whole worktrees.
+
     An OSError while probing a lock reads as LOCKED, not unlocked. "I could not
     tell" and "nobody is here" are different answers, and only one of them is
     safe to act on when the action is deletion.
     """
-    for cand in (path / ".session-lock", path / ".claude" / ".session-lock"):
-        try:
-            if cand.exists() and (now_ts - cand.stat().st_mtime) < SESSION_LOCK_LIVE_WINDOW_SEC:
-                return True
-        except OSError:
-            return True  # unreadable lock -> assume a session holds it
+    return _shared_has_live_session_lock(path, now_ts)
     return False
 
 

--- a/scripts/test_dev_build_reclaim.py
+++ b/scripts/test_dev_build_reclaim.py
@@ -354,6 +354,93 @@ def main() -> int:  # noqa: C901
         ok("[15] --min-free-gb 0 never deletes", (wt / "node_modules").is_dir())
         ok("[15] and reports the no-op", "no-op" in r.stdout)
 
+    # ---- [17] the session lock is read in its REAL shape and REAL location ---
+    # The guard that shipped probed `<wt>/.session-lock`. Measured 2026-08-06:
+    # ZERO files of that name existed anywhere under the dev root, so the guard
+    # was dead in production while reading as "no session here". These controls
+    # use the shape session-lock.py actually writes — `.claude/.session-lock.json`,
+    # a multi-session map keyed on `last_activity_at` — and the second puts it at
+    # the git-common-dir root, where a sibling worktree's lock really lives.
+    # Both would have passed silently before the fix.
+    import subprocess as _sp
+    from _lib.dev_repo_scan import has_live_session_lock as _live
+
+    def lock_payload(age_sec: float, schema: str = "v2") -> dict:
+        """A lock in the shape the WRITER actually produces.
+
+        `v2` is what session-lock.py writes today: sessions is a **dict** keyed
+        by session id. An earlier version of this control wrote a LIST, which is
+        why it passed against a reader that could only handle lists — a control
+        in the wrong shape proves nothing about the real file. The other shapes
+        are kept because the reader must still handle a lock written by an older
+        install mid-upgrade.
+        """
+        entry = {"started_at": time.time() - age_sec - 60,
+                 "last_activity_at": time.time() - age_sec,
+                 "cwd": "/tmp/x", "pid": 1234}
+        if schema == "v2":
+            return {"version": 2, "sessions": {"sid-1": entry}}
+        if schema == "legacy-list":
+            return {"version": 1, "sessions": [entry]}
+        return {"session_id": "sid-1", **entry}          # v1 flat
+
+    def write_real_lock(where: Path, age_sec: float, schema: str = "v2") -> None:
+        (where / ".claude").mkdir(parents=True, exist_ok=True)
+        (where / ".claude" / ".session-lock.json").write_text(
+            json.dumps(lock_payload(age_sec, schema)), encoding="utf-8")
+
+    # Every schema the lock has worn must read live. v2 is the load-bearing one:
+    # the shipped reader iterated `sessions` as a list, so on the real v2 dict it
+    # yielded string KEYS, failed every isinstance check, and reported "no live
+    # session" on a file holding two.
+    with tempfile.TemporaryDirectory() as td:
+        probe = Path(td)
+        for schema in ("v2", "legacy-list", "v1-flat"):
+            (probe / ".claude").mkdir(parents=True, exist_ok=True)
+            (probe / ".claude" / ".session-lock.json").write_text(
+                json.dumps(lock_payload(5, schema)), encoding="utf-8")
+            ok(f"[17] lock schema `{schema}` reads as LIVE", _live(probe))
+        # ...and the pre-fix list-only parse is proven inadequate for v2.
+        v2 = lock_payload(5, "v2")
+        listish = [s for s in v2.get("sessions", []) if isinstance(s, dict)]
+        ok("[17] a list-only parse finds ZERO entries in the real v2 lock",
+           listish == [])
+
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        wt = mkwt(root, "real-lock-wt")
+        backdate(wt, 30)
+        write_real_lock(wt, age_sec=5)
+        ok("[17] a REAL .session-lock.json in the worktree is detected", _live(wt))
+        # The load-bearing half: the RETIRED probe set would have found nothing,
+        # so this control fails against the pre-fix code rather than passing anyway.
+        ok("[17] and the retired `.session-lock` probe would have MISSED it",
+           not (wt / ".session-lock").exists()
+           and not (wt / ".claude" / ".session-lock").exists())
+        items, skipped = mod.plan(root, 7.0, time.time())
+        ok("[17] so the worktree is PRESERVED end-to-end", items == [])
+        ok("[17] and reported as a live session lock",
+           any("live session lock" in s for s in skipped))
+
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        # A sibling worktree keeps its lock at the MAIN checkout, never inside
+        # itself. This is the case that was invisible in production.
+        main = root / "mainrepo"
+        main.mkdir()
+        _sp.run(["git", "-C", str(main), "init", "-q"], check=True, capture_output=True)
+        (main / "f.txt").write_text("x", encoding="utf-8")
+        _sp.run(["git", "-C", str(main), "add", "-A"], check=True, capture_output=True)
+        _sp.run(["git", "-C", str(main), "-c", "user.email=t@t", "-c", "user.name=t",
+                 "commit", "-qm", "init"], check=True, capture_output=True)
+        wt = root / "mainrepo-slug"
+        _sp.run(["git", "-C", str(main), "worktree", "add", "-q", "--detach", str(wt)],
+                check=True, capture_output=True)
+        write_real_lock(main, age_sec=5)          # lock at the MAIN checkout only
+        ok("[17] a worktree finds the lock at its git-common-dir root", _live(wt))
+        write_real_lock(main, age_sec=99_999)     # same lock, now stale
+        ok("[17] a STALE root lock does not shield forever", not _live(wt))
+
     if FAILED:
         print(f"\nFAILED — dev-build-reclaim (MYC-3727): {len(FAILED)} control(s)")
         for f in FAILED:

--- a/scripts/utf8-subprocess-baseline.txt
+++ b/scripts/utf8-subprocess-baseline.txt
@@ -2,7 +2,6 @@
 # LOCALE encoding instead of an explicit one. Editing a pinned file, or
 # adding a new offender, fails scripts/check-utf8-subprocess.py.
 # Fix by adding: encoding="utf-8", errors="replace"
-1d0f500d2294ca21926ff1a7b146b72853613bec6fc7bfa10c6f8f1d72beb0db hooks/_lib/dev_repo_scan.py
 e2f343536da6ef508c45d335a9d2fbe9977f40aaa152f5c86913ddeb82f9c531 hooks/_lib/git_locks.py
 987aca2ae82229a42d29a8c89fed690e9de7e6fad4182dea564bc92557a81922 hooks/auto-capture-public-ships.py
 03d0966a13e6d14e1257d2b115894ac52bc350d3b955ec2ca1c7c9266107de51 hooks/block-raw-vault-git.py
@@ -46,7 +45,6 @@ c380a6d7d5cb52c1076962540c9eb7707baee5c9080a205de97d89d40f647c9b scripts/check-w
 715275131b0929513373df32ee4224ada0a0a66a8077b1ffa1a175e20c25e9b8 scripts/closed-loop-week-report.py
 c608cc6897ce3366e45301acd6c6bfe46eac6c4bfa2a1d066b1fa931eef97e6e scripts/context-audit.py
 4db3441131d4ca0e0a7e81f6933bfc963bd3d64503369e92da96e567c30c3200 scripts/dev-repo-reaper.py
-3cb4935d56eea6f9cd44723e80c8ea591a67ea356fa3184f8b318deb37d3373e scripts/dev-worktree-prune.py
 926b37dcb6f6b689dab5c69b74f169a74e911887f20e7ed6aeb3c1b51e507b58 scripts/drift-detection.py
 9c2b94c22cb78ad78aa2a3e9b464518a1f5912642ed26575b7007957e31eda43 scripts/graphify_minimax_preprocess.py
 c41c1955f5ecc763a067cff06cd3c6cbe0a8aa47ad20625dd8eb7e779f8fd20d scripts/hallucination-sample-audit.py


### PR DESCRIPTION
Follow-up to #460, found by asking "is this actually in the best shape for our paid clients?"

## Two tools that delete things had a guard that never fired

Each carried its own "is a session live here?" check. All of them answered *"nobody is here"* regardless of the truth. **Measured, not inferred:**

- Files named `.session-lock` anywhere under the dev root: **ZERO**. That was the only path `dev-build-reclaim.py` and `dev-worktree-prune.py` probed.
- `session-lock.py` writes `<main_root>/.claude/.session-lock.json` and resolves `main_root` via `git rev-parse --git-common-dir` — so **a sibling worktree's lock is not inside the worktree**. Probing only the worktree finds nothing, forever.
- The live file is **v2**: `{"version": 2, "sessions": {"<sid>": {...}}}` — `sessions` is a **dict**. `_lib._has_live_session_lock`, whose docstring says it reads *"the REAL shared lock ... (NOT `.session-lock`, NOT `pid`)"*, iterated it as a **list**, so it yielded string KEYS, failed every `isinstance` check, and returned `False` on a file holding two live sessions. **The one implementation documented as correct was dead too.**

## Why this is worse than it looks

`dev-build-reclaim.py`'s bottom pressure rung sets the idle threshold to **0 days**, which every worktree passes. At that rung the session lock is the *only* thing between an actively-compiling worktree and losing its `target/`. `dev-worktree-prune.py` deletes the **whole worktree**. Both promise in their own docstrings not to touch a live one.

Measured at that rung on the real fleet: **771 artifact dirs across 136 worktrees, 76.6 GB**, with **0** protected by the lock.

## Fix: consolidation, not a fourth copy

One public `_lib.has_live_session_lock(path)`, probing in order:

1. legacy per-worktree marker files (kept — one stat, back-compatible with any tool that drops one),
2. the real lock in this tree,
3. the real lock at the **git-common-dir root** — the case that was missing.

`_lock_entries` accepts every schema the file has worn (v2 dict, legacy list, v1 flat) and mirrors `_load_sessions` in `session-lock.py` — **the writer** — so reader and writer can no longer disagree about shape. `OSError` anywhere still reads as LOCKED, never unlocked: "I could not tell" and "nobody is here" are different answers, and only one is safe when the action is deletion.

Both tools now call it; `dev-worktree-prune.py`'s local copy is gone.

## Proven in production, not only on fixtures

Before this change the helper returned `False` for the vault checkout **while a session was actively running in it**; after, `True`. That round trip is what caught the schema bug — the path fix alone still reported "no session here".

It also exposed a flaw in my own control: the first version wrote the lock in the **legacy list** shape, so it passed against the broken reader and proved nothing. The control now writes the **v2 shape the writer actually produces**, asserts every schema reads live, and asserts that *a list-only parse finds zero entries in the real v2 lock* — so it fails against the pre-fix code instead of passing anyway.

## Also, because the repo's own ratchet demanded it

Pinned `encoding="utf-8"` on every locale-decoding subprocess call in both touched files (8 sites). On a non-UTF-8 Windows console a path with one non-ASCII byte raised before the caller saw a line — on the tools that decide what to delete. Both files **drop out of** `utf8-subprocess-baseline.txt`; the baseline only loses rows, never gains any.

## Doubt-pass on the flagged `except OSError`

Both broad handlers were traced. In `has_live_session_lock` the handler returns `True` (preserve) — the safe direction. In `dev-build-reclaim.py` the idle-walk handler is the one that produced the infinite-idle hazard fixed in #460; it is unchanged here and still routes an all-unreadable walk to "unmeasurable → preserve". In `dev-worktree-prune.py` the handler is pre-existing and untouched except for the encoding pin.

## Gate

`ci-test` GREEN on the pushed commit — 336 files py_compile, 101 integration tests, 13 `scripts/` suites, 14 hooks/tests suites, shellcheck, cloud-safe walker, utf8 console, subprocess decode. Personal-data and secret scrub clean.

Bug class: `GUARD-DEAD-IN-PRODUCTION-WHILE-READING-AS-CLEAN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
