### PR TITLE
fix(diagnose): a hook wired to a file that isn't there reported healthy

### DIFF
--- a/scripts/diagnose.ps1
+++ b/scripts/diagnose.ps1
@@ -114,6 +114,54 @@ if (-not $hookFound) {
   Warn "No hooks registered" "/setup-brain Phase 5 wires them. Without them, no auto context-loading."
 }
 
+# Wired-but-absent: a hook command naming ~/.claude/hooks/<file> that is not on
+# disk. Every such command carries a `[ -f ]` guard (or hook_runner's
+# --fallback silent), so the miss is a SILENT no-op -- the hook never fires and
+# nothing says so. Checking that settings.json merely CONTAINS "hooks" (above)
+# passes even when every referenced file is gone.
+#
+# Observed on a real install: vault-context.py wired 7 times, present 0 times,
+# alongside retry-budget.py and validate-mcp-json.py -- all three are
+# phase-05 "install by default" copies that never ran. scripts/check-home-hook-deploy.py
+# does NOT cover this: it is a static REPO lint proving each hook has a
+# documented deploy route, and it cannot see whether that route ever executed here.
+#
+# Reported as a WARNING, not an error, because phase-05 documents
+# `rm ~/.claude/hooks/<name>.py` as the supported uninstall -- an absent file is
+# genuinely ambiguous between never-installed and deliberately-removed. Naming
+# the file lets the reader tell which; silence does not.
+$absHooksDir = Join-Path $env:USERPROFILE ".claude\hooks"
+$wiredNames  = New-Object System.Collections.Generic.HashSet[string]
+foreach ($f in @($settings, $localSettings)) {
+  if (-not (Test-Path -LiteralPath $f)) { continue }
+  $raw = Get-Content -LiteralPath $f -Raw -ErrorAction SilentlyContinue
+  if (-not $raw) { continue }
+  # Anchor on .claude/hooks/ so the skill's own hooks dir
+  # (.claude/skills/ai-brain-starter/hooks/) is not swept in. Separator class
+  # covers POSIX "/" and JSON-escaped Windows "\\".
+  foreach ($m in [regex]::Matches($raw, '\.claude[\\/]+hooks[\\/]+([A-Za-z0-9_.-]+\.(?:py|sh))')) {
+    [void]$wiredNames.Add($m.Groups[1].Value)
+  }
+}
+if ($wiredNames.Count -gt 0) {
+  $missingHooks = @($wiredNames | Where-Object { -not (Test-Path -LiteralPath (Join-Path $absHooksDir $_)) } | Sort-Object)
+  if ($missingHooks.Count -eq 0) {
+    Ok ("all {0} wired ~/.claude/hooks/ file(s) present on disk" -f $wiredNames.Count)
+  } else {
+    $src = Join-Path $env:USERPROFILE ".claude\skills\ai-brain-starter\hooks"
+    $restorable = @($missingHooks | Where-Object { Test-Path -LiteralPath (Join-Path $src $_) })
+    $hint = "These never fire and report no error. "
+    if ($restorable.Count -gt 0) {
+      $hint += ("Reinstall: Copy-Item '{0}\{1}' -Destination '{2}\'" -f $src, ($restorable -join "','$src\"), $absHooksDir)
+      $hint += " -- or, if you removed them on purpose, this is expected."
+    } else {
+      $hint += "No source copy found in the starter's hooks/ dir either."
+    }
+    $msg = "{0} of {1} wired ~/.claude/hooks/ file(s) MISSING: {2}" -f $missingHooks.Count, $wiredNames.Count, ($missingHooks -join ", ")
+    Warn $msg $hint
+  }
+}
+
 $gch = Join-Path $meta "scripts\graph-context-hook.sh"
 if (Test-Path -LiteralPath $gch) {
   Ok "graph-context-hook.sh present (Bash, runs in WSL/Git Bash on Windows)"

--- a/scripts/diagnose.sh
+++ b/scripts/diagnose.sh
@@ -139,6 +139,57 @@ if [ "$hook_found" -eq 0 ]; then
     "/setup-brain Phase 5 wires them. Without them, no auto context-loading."
 fi
 
+# Wired-but-absent: a hook command naming ~/.claude/hooks/<file> that is not on
+# disk. Every such command carries a `[ -f ]` guard (or hook_runner's
+# --fallback silent), so the miss is a SILENT no-op -- the hook never fires and
+# nothing says so. The `grep -q '"hooks"'` check above passes even when every
+# referenced file is gone.
+#
+# Observed on a real install: vault-context.py wired 7 times, present 0 times,
+# alongside retry-budget.py and validate-mcp-json.py -- all three are phase-05
+# "install by default" copies that never ran. scripts/check-home-hook-deploy.py
+# does NOT cover this: it is a static REPO lint proving each hook has a
+# documented deploy route, and cannot see whether that route ever executed here.
+#
+# WARNING, not error: phase-05 documents `rm ~/.claude/hooks/<name>.py` as the
+# supported uninstall, so an absent file is genuinely ambiguous between
+# never-installed and deliberately-removed. Naming it lets the reader tell which.
+ABS_HOOKS_DIR="$HOME/.claude/hooks"
+ABS_HOOKS_SRC="$HOME/.claude/skills/ai-brain-starter/hooks"
+wired_names=""
+for f in "$SETTINGS" "$LOCAL_SETTINGS"; do
+  [ -f "$f" ] || continue
+  # Anchor on .claude/hooks/ so the starter's own hooks dir
+  # (.claude/skills/ai-brain-starter/hooks/) is not swept in. The separator
+  # class covers POSIX "/" and JSON-escaped Windows "\\".
+  names=$(grep -oE '\.claude[\\/]+hooks[\\/]+[A-Za-z0-9_.-]+\.(py|sh)' "$f" 2>/dev/null \
+          | sed 's#.*[\\/]##')
+  [ -n "$names" ] && wired_names="$wired_names$names
+"
+done
+wired_names=$(printf '%s' "$wired_names" | grep -v '^$' | sort -u)
+if [ -n "$wired_names" ]; then
+  wired_count=$(printf '%s\n' "$wired_names" | grep -c .)
+  missing=""
+  for n in $wired_names; do
+    [ -f "$ABS_HOOKS_DIR/$n" ] || missing="$missing $n"
+  done
+  missing=$(printf '%s' "$missing" | sed 's/^ //')
+  if [ -z "$missing" ]; then
+    ok "all $wired_count wired ~/.claude/hooks/ file(s) present on disk"
+  else
+    missing_count=$(printf '%s\n' "$missing" | tr ' ' '\n' | grep -c .)
+    hint="These never fire and report no error."
+    for n in $missing; do
+      if [ -f "$ABS_HOOKS_SRC/$n" ]; then
+        hint="$hint Reinstall: cp $ABS_HOOKS_SRC/{$(printf '%s' "$missing" | tr ' ' ',')} $ABS_HOOKS_DIR/ -- or, if you removed them on purpose, this is expected."
+        break
+      fi
+    done
+    warn "$missing_count of $wired_count wired ~/.claude/hooks/ file(s) MISSING: $(printf '%s' "$missing" | tr ' ' ' ')" "$hint"
+  fi
+fi
+
 # graph-context-hook script (the one that bit Windows users)
 GCH="$META/scripts/graph-context-hook.sh"
 if [ -f "$GCH" ]; then


### PR DESCRIPTION
## The gap

`/diagnose`'s hooks section checked that settings.json **contains the string** `"hooks"`:

```powershell
if ((Test-Path $f) -and (Select-String -Pattern '"hooks"' -Quiet)) { Ok "hooks registered in $f" }
```

That passes even when every referenced hook file is absent from `~/.claude/hooks/`.

## Found on a real install

`vault-context.py` wired **7 times**, present **0 times** — alongside `retry-budget.py` and `validate-mcp-json.py`. All three are phase-05 *"install by default"* copies whose `cp` step never ran.

Every one of those commands carries a `[ -f ]` guard (or `hook_runner --fallback silent`). That is correct at runtime — a user who removes an optional hook should get silence, not an error on every prompt — and it is exactly what makes the miss invisible. The hook never fires, nothing errors, and `/diagnose` said green.

Net effect for that user: no vault context injection on strategic prompts, no retry cap, and no `.mcp.json` validation, for as long as the install has existed.

## Why `check-home-hook-deploy.py` didn't catch it

It isn't supposed to, and it isn't broken. That script is a static **repo lint** proving every hook wired in `hooks.json` has a documented deploy route (installer manifest or a phase-doc `cp`). It reports `OK — 6 references all have a deploy route` and that is accurate: the routes exist in the repo.

What no check covered is whether the route **ever executed on a given machine**. The two are complementary:

| Check | Guards | Sees |
|---|---|---|
| `check-home-hook-deploy.py` | the ship | repo: is a route documented? |
| `/diagnose` (this PR) | the install | machine: did the file land? |

## The fix

Both diagnose scripts now extract every `~/.claude/hooks/<file>` referenced in `settings.json` / `settings.local.json` and stat it. The regex anchors on `.claude/hooks/` so the starter's own `.claude/skills/ai-brain-starter/hooks/` dir is not swept in, and its separator class covers POSIX `/` and JSON-escaped Windows `\`.

**WARN, not error** — phase-05 documents `rm ~/.claude/hooks/<name>.py` as the supported uninstall, so an absent file is genuinely ambiguous between never-installed and deliberately-removed. Naming the file lets the reader tell which; silence does not. The hint offers the reinstall command only when a source copy exists in the starter's `hooks/`.

## Verification

Fixture covering all three path shapes — a POSIX tilde path, a JSON-escaped Windows absolute path, and a skills-dir path that must **not** count — plus one file present and two absent. Both implementations independently report the same `3 wired / 2 missing`, and both correctly exclude the skills-dir path.

End-to-end:

```
# fixture HOME
WARN  2 of 3 wired ~/.claude/hooks/ file(s) MISSING: missing-abs.py missing-posix.sh
# repaired real install
OK    all 6 wired ~/.claude/hooks/ file(s) present on disk
```

`bash -n` and the PowerShell AST parser both clean. `diagnose.ps1` keeps its BOM and the addition is ASCII-only.

## Note

This is the same failure family as the `[ -f ]` guard documented in `check-home-hook-deploy.py`'s own docstring — *"Shipped, wired, verified — and never once executed."* That docstring predicted this exact class; it just scoped the defense to authoring time, where a route that never runs on a real machine can't be seen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)