### PR TITLE
fix(journal-index): on Windows the index is written in cp1252, so nothing can read it back

### DIFF
--- a/scripts/build-journal-index.py
+++ b/scripts/build-journal-index.py
@@ -217,7 +217,10 @@ def main():
         "last_updated": datetime.now().strftime("%Y-%m-%dT%H:%M"),
         "entries": entries,
     }
-    with open(output_path, "w") as f:
+    # encoding is explicit: on Windows the default is the ANSI codepage, and
+    # with ensure_ascii=False that writes accented titles as cp1252 bytes —
+    # the resulting file is not valid UTF-8 and every reader of it fails.
+    with open(output_path, "w", encoding="utf-8", newline="\n") as f:
         json.dump(output, f, indent=2, ensure_ascii=False)
 
     print(f"Indexed {len(entries)} entries → {output_path}")


### PR DESCRIPTION
## The bug

`build-journal-index.py` writes the index with `open(output_path, "w")`, which takes its encoding from the platform default. On Windows that is the ANSI codepage — cp1252 on a Spanish install — not UTF-8.

Paired with `ensure_ascii=False` (which is what puts real accented characters into the file instead of `\u` escapes), every non-ASCII journal title lands as cp1252 bytes inside a file that every consumer opens as UTF-8.

The failure is not a mangled title, it is an **unreadable index**. On a vault with titled Spanish entries — `Día tranquilo y agradecido.md`, `Sábado de Gimnasio y Video.md` — `json.load` raises `UnicodeDecodeError`, and `/weekly`, `/monthly` and `/patterns` all die at the point where they read the index. For the first two that is step 0.

macOS and Linux default to UTF-8, so this never reproduces there. It only bites Windows users, and only once a title contains a non-ASCII character — which on a non-English vault is essentially every entry.

## The fix

Pass `encoding="utf-8"` explicitly. Also pins `newline="\n"` so the file does not pick up CRLF on Windows and read as fully rewritten in git on every rebuild.

## How it was verified

Reproduced on Windows 11 (Spanish locale, cp1252 console) against a real vault of 27 Spanish-titled entries: before the change, reading the index back raised `UnicodeDecodeError`; after it, all 27 entries parse and the accented titles round-trip intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)