### PR TITLE
fix(vault-safe-commit): required VAULT_ROOT made Phase 2b commit nothing, then blocked the close

### DIFF
--- a/scripts/vault-safe-commit.sh
+++ b/scripts/vault-safe-commit.sh
@@ -8,7 +8,9 @@
 #   VAULT_ROOT="/path/to/vault" vault-safe-commit.sh [--kill-leaked] "commit message" path1 path2 ...
 #
 # Configuration:
-#   VAULT_ROOT   Absolute path to the vault. Required.
+#   VAULT_ROOT   Absolute path to the vault. Optional — when unset, falls back
+#                to `git rev-parse --show-toplevel` from the current directory.
+#                Set it explicitly when running from outside the vault.
 #
 # Flags:
 #   --kill-leaked   Kill leaked git-status/diff children of Claude.app
@@ -48,9 +50,17 @@ else
     vault_git_index_lock() { echo ""; return 1; }
 fi
 
+# VAULT_ROOT is optional: when unset, derive it from the repo the caller is
+# standing in. The session-close cascade (Phase 2b) and the block-raw-vault-git
+# hook both prescribe this script WITHOUT the env var, and a hard exit there
+# meant the close committed nothing AND the verify-session-close-cascade Stop
+# hook then blocked the close over those same uncommitted artifacts.
 if [ -z "${VAULT_ROOT:-}" ]; then
-    echo "vault-safe-commit: VAULT_ROOT env var not set" >&2
-    exit 1
+    VAULT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || true)
+    if [ -z "${VAULT_ROOT}" ]; then
+        echo "vault-safe-commit: VAULT_ROOT not set and cwd ($(pwd)) is not a git repo" >&2
+        exit 1
+    fi
 fi
 
 LOCK_FILE="$(vault_git_index_lock "${VAULT_ROOT}" || true)"


### PR DESCRIPTION
## The bug

`vault-safe-commit.sh` exits 1 when `VAULT_ROOT` is unset. Both places in this repo that prescribe the script pass no such env var:

**`hooks/detect-closing-signal.py`, Phase 2b** (injected into the model's context at every close):

> vault-safe-commit IS YOUR MANUAL JOB (codified 2026-05-25 after the cascade double-fire incident). You MUST run vault-safe-commit.sh with explicit paths for every session-close artifact you wrote […] BEFORE drafting the goodbye.

**`hooks/block-raw-vault-git.py`**, the message printed whenever raw `git commit` is blocked in a vault:

```
    bash "⚙️ Meta/scripts/vault-safe-commit.sh" \
        "session: <slug> — <one-line summary>" "path/one.md" "path/two.md"
```

Both are copy-pasted as printed. The wrapper exits 1 and commits nothing.

## Why it compounds

The exit is not the end of it. `verify-session-close-cascade.py` runs next, finds the session file, decision files and captures still uncommitted, and **hard-blocks the close** — over exactly the artifacts the wrapper just refused to commit. The re-run follows the same instructions and lands in the same place.

So the user-visible failure is not "a script needed an env var". It is a session close that will not complete, on the one path whose entire purpose is making sure nothing the session produced is lost.

## The fix

`VAULT_ROOT` becomes optional and is derived from `git rev-parse --show-toplevel` when absent — the caller is standing in the vault in every prescribed invocation.

An explicit `VAULT_ROOT` still wins, so running from outside the vault is unchanged. With neither, it still fails loudly, and now names the cwd it tried instead of only the missing variable.

## How it was verified

Three paths, against a scratch repo:

| Case | Result |
|---|---|
| Inside a repo, no env var | Derives root, commits: `vault-safe-commit: 999ce0f — test: commit sin VAULT_ROOT`, exit 0 |
| Outside any git repo, no env var | `VAULT_ROOT not set and cwd (…/norepo) is not a git repo`, exit 1 |
| Explicit `VAULT_ROOT`, unrelated cwd | Still targets the named vault, exit 0 |

## Note

Independent of #464 and #465 — different file, no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)