### PR TITLE
fix(hooks): surface a never-installed team-broadcast, not just a failing one

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -108,6 +108,16 @@ If your session start mentions "background helpers not active", this is what it 
 
 ---
 
+## 2026-08-10: a missing team-broadcast install looked exactly like a healthy one
+
+**Who this affects:** anyone using the team-broadcast skill (Slack session-close recaps) across more than one machine.
+
+**The silent-failure watchdog (`surface-stale-automation-failures.py`) couldn't tell "never installed" from "installed and fine."** It works by scanning a log file for recent failures — no recent failures, no warning. But a machine that never had `auto-send.py` installed also has no log file, for the same reason: nothing ever ran there. Both cases produced exactly zero signal, on every session, forever. That's a stricter silence than an outright failure would have been — a broken install eventually leaves an error in the log; a missing install leaves nothing to ever go wrong. The watchdog now checks installation directly (the script's presence, then whether the daily launchd job is registered) before it ever looks at the log, and says so specifically instead of staying quiet. The launchd job is matched by its name ending, so it is found whatever reverse-DNS namespace you installed it under.
+
+**If you never set up team-broadcast, you will not hear about this at all.** This starter does not install that skill, so a missing one is the normal state for most people, and a warning about a component you never asked for is just noise that teaches you to ignore the rest. The check only speaks up when there is evidence you did set it up here and it since broke: a scheduled job that refers to it, a log from a previous run, or a half-present skill folder.
+
+**Also:** this file's non-ASCII console output (the warning emoji, some em dashes) was carried over from before the UTF-8 console-crash lint was widened to cover `hooks/`. It's provably safe — the only print is `json.dumps(...)`, which escapes non-ASCII before it reaches stdout — so it's now marked `# utf8-stdout-ok` and dropped from the legacy pin list instead of staying silently grandfathered in.
+
 ## 2026-08-05: on Mac and Linux, "daily backup scheduled" now means it really is
 
 **Who this affects:** anyone on macOS or Linux who set up the daily vault backup.

--- a/hooks/surface-stale-automation-failures.py
+++ b/hooks/surface-stale-automation-failures.py
@@ -20,6 +20,14 @@ Codified 2026-05-14 as the meta-fix for the stranded-files class.
 
 from __future__ import annotations
 
+# utf8-stdout-ok: the only console write in this module is
+# `print(json.dumps({"systemMessage": msg}))`, and json.dumps defaults to
+# ensure_ascii=True, so the warning emoji and em dashes in `msg` are escaped to
+# \uXXXX before they reach stdout -- there is no cp1252 console crash to guard
+# against here. Replaces this file's SEV-4-json-encoded row in
+# scripts/utf8-stdout-baseline.txt, per that file's rule: rows are DELETED,
+# never re-pinned to stay quiet.
+
 import datetime
 import json
 import os
@@ -364,6 +372,105 @@ BESPOKE_LAUNCHD_SUFFIXES = (".team-broadcast-daily",)
 # down every session start. This caps total probes per run regardless of how
 # many "mine, loaded, status==0" candidates exist.
 MAX_LAUNCHD_PRINT_PROBES = 25
+TEAM_BROADCAST_SCRIPT = (
+    HOME / ".claude" / "skills" / "team-broadcast" / "scripts" / "auto-send.py"
+)
+
+
+def registered_bespoke_label() -> tuple[bool, str | None]:
+    """The operator's OWN daily-broadcast launchd label, if launchd has it loaded.
+
+    Resolved BY SUFFIX off `launchctl list`, never by a literal namespace. The
+    label is `com.<operator>.team-broadcast-daily` and the `<operator>` half is
+    chosen by whoever installed it, so a hardcoded reverse-DNS prefix would
+    query a label that exists on exactly one machine — reporting "not
+    registered" to every other operator who HAS installed it, and reporting it
+    forever. That is the same dead-for-everyone-else failure
+    user_launchd_labels() above exists to avoid, and this file ships in a
+    public repo that other people install.
+
+    Returns (queried, label). `queried` is False when launchd could not be
+    asked at all (no `launchctl` — Linux, Windows), which is evidence of
+    nothing and must not produce a finding.
+    """
+    try:
+        result = subprocess.run(
+            ["launchctl", "list"],
+            capture_output=True, text=True, encoding="utf-8",
+            errors="replace", timeout=10, check=False,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return (False, None)
+    if result.returncode != 0:
+        return (False, None)
+    for line in result.stdout.splitlines():
+        parts = line.split("\t")
+        if len(parts) != 3:
+            continue
+        _pid, _status, label = parts
+        if any(label.endswith(suffix) for suffix in BESPOKE_LAUNCHD_SUFFIXES):
+            return (True, label)
+    return (True, None)
+
+
+def team_broadcast_opted_in(label: str | None) -> bool:
+    """Did this operator ever ask for a daily broadcast at all?
+
+    This substrate does NOT install team-broadcast: no phase, no bootstrap
+    step, and no skill in this repo ships it. "auto-send.py is missing" is
+    therefore the NORMAL, correct state for nearly everyone who installs
+    this, and reporting it as a fault would nag every one of them, on every
+    session, forever, about a component they never asked for and cannot get
+    from here. A watchdog that cries on a healthy default install is how
+    operators learn to ignore the watchdog.
+
+    So fire only on evidence the operator opted IN and the install then
+    broke: a registered daily job, a log from a run that already happened,
+    or a half-present skill directory. No evidence at all -> silence.
+    """
+    if label:
+        return True  # a daily job is registered, so the script should be here
+    if (HOME / ".claude" / "logs" / "team-broadcast-daily.log").exists():
+        return True  # it has run on this machine before
+    return TEAM_BROADCAST_SCRIPT.parent.parent.exists()  # partial install
+
+
+def team_broadcast_install_gap() -> str | None:
+    """Distinguish 'never installed here' from 'installed and quiet'.
+
+    team_broadcast_findings() below returns [] both when the daily broadcast
+    is healthy and quiet AND when it was never installed at all — a missing
+    log file reads the same either way. That gap is how a machine can go
+    through every session-close cascade silently skipping the mandatory
+    broadcast (a vault CLAUDE.md's Session End step) with nothing ever
+    flagging it: there's no failure to log because there's nothing to fail.
+    Check installation directly instead of inferring it from log absence.
+    auto-send.py is the shared dependency of both the live session-close
+    broadcast and this daily cron, so its absence is the more serious of the
+    two findings; the launchd lookup above is resolved once and reused by
+    both branches.
+    """
+    queried, label = registered_bespoke_label()
+    if not TEAM_BROADCAST_SCRIPT.exists():
+        if not team_broadcast_opted_in(label):
+            return None  # never set up here, and this substrate never installs it
+        return (
+            "  - team-broadcast: set up on this machine but NOT INSTALLED — "
+            f"{TEAM_BROADCAST_SCRIPT} does not exist. Session-close broadcasts "
+            "(invoked live by Claude at session close) and the daily-summary "
+            "cron are both unreachable from here. Reinstall the "
+            "team-broadcast skill to restore them."
+        )
+    if not queried:
+        return None  # can't check launchd here; don't false-positive on that alone
+    if label is None:
+        return (
+            "  - team-broadcast-daily: script is installed but no "
+            "*.team-broadcast-daily launchd job is registered — the daily "
+            "summary cron will never fire. (Session-close broadcasts, "
+            "triggered live by Claude rather than this cron, are unaffected.)"
+        )
+    return None
 
 
 def team_broadcast_findings(log_path: Path | None = None) -> list[str]:
@@ -381,6 +488,10 @@ def team_broadcast_findings(log_path: Path | None = None) -> list[str]:
     so a recovered failure self-clears instead of nagging for 72h. Also flags
     the cron going stale (no run in 48h).
     """
+    install_gap = team_broadcast_install_gap()
+    if install_gap:
+        return [install_gap]
+
     if log_path is None:
         log_path = HOME / ".claude" / "logs" / "team-broadcast-daily.log"
     if not log_path.exists():

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -437,6 +437,7 @@ INTEGRATION_TESTS=(
   # — silently, on a whole platform. Two layers must hold (the path gate AND the
   # vault-root resolve); fixing only the first looks right and still fails open.
   test_journal_guard_windows_paths
+  test_team_broadcast_install_gap
 )
 # ---- Gate-coverage invariant -------------------------------------------------
 # The list above is an explicit allow-list, and allow-lists rot: a new

--- a/tests/integration/test_team_broadcast_install_gap.sh
+++ b/tests/integration/test_team_broadcast_install_gap.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Regression test for team_broadcast_install_gap() in
+# hooks/surface-stale-automation-failures.py.
+#
+# WHY THIS EXISTS: team_broadcast_findings() infers health from a log file
+# (~/.claude/logs/team-broadcast-daily.log). A machine where team-broadcast was
+# NEVER installed has no log file for the same reason a HEALTHY, quiet install
+# has no log file yet: nothing has run. Both read as team_broadcast_findings()
+# returning [] -- so "never installed" produced zero signal, on every session,
+# indefinitely. That is a stricter silence than an outright failure would have
+# been. team_broadcast_install_gap() checks installation directly (script
+# presence, then the launchd job) instead of inferring it from a log.
+#
+# THE LABEL IS MATCHED BY SUFFIX, NEVER BY A LITERAL NAMESPACE. The job is
+# `com.<operator>.team-broadcast-daily`, and the `<operator>` half is chosen by
+# whoever installed it. A hardcoded reverse-DNS prefix would query a label that
+# exists on exactly one machine and report "not registered" forever to every
+# other operator who HAS installed it. Cases 3 and 4 are the control for that:
+# two DIFFERENT fictional namespaces must both read as installed.
+#
+# Asserts, in order:
+#   0. DEFAULT INSTALL: never set up here -> SILENT. This substrate ships no
+#      team-broadcast skill, so a missing auto-send.py is the NORMAL state and
+#      nagging about it would train every operator to ignore this watchdog.
+#   1. OPTED-IN BUT BROKEN: set up here, script gone -> FIRES, names the path.
+#   2. CRON-GAP: script present, no *.team-broadcast-daily job -> FIRES, names
+#      the suffix it looked for, and does NOT claim session-close broadcasts (a
+#      separate, live-invoked path) are affected.
+#   3. NEG-CONTROL: script present, job registered under one namespace -> SILENT.
+#   4. ANY-OPERATOR: same, under a completely different namespace -> SILENT.
+#      Case 3 alone would still pass if the suffix match were secretly a literal.
+#   5. END-TO-END: the finding reaches the real SessionStart entrypoint
+#      (main()'s systemMessage), not just the helper function in isolation.
+#
+# launchctl is macOS-only; CI runs ubuntu (CONTRIBUTING.md). A fake launchctl on
+# PATH makes cases 2-5 deterministic on any OS instead of skipping Linux CI.
+# Stdlib python3 + bash only. No network, no real launchd/git. Tmpdir on exit.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HOOK="$REPO_ROOT/hooks/surface-stale-automation-failures.py"
+# HOME alone does not sandbox ~ on Windows — see lib/sandbox_home.sh.
+# shellcheck source=tests/integration/lib/sandbox_home.sh
+. "$SCRIPT_DIR/lib/sandbox_home.sh"
+
+PASS=0
+FAIL=0
+TMPDIRS=()
+cleanup() { for d in "${TMPDIRS[@]:-}"; do [ -n "$d" ] && rm -rf "$d"; done; }
+trap cleanup EXIT
+
+ok()  { PASS=$((PASS+1)); echo "PASS  $1"; }
+bad() { FAIL=$((FAIL+1)); echo "FAIL  $1 :: $2"; }
+assert_fires()  { case "$OUT" in *additionalContext*|*systemMessage*) ok "$1" ;; *) bad "$1" "no finding (out=${OUT:0:120})" ;; esac; }
+assert_silent() { case "$OUT" in "") ok "$1" ;; *) bad "$1" "unexpected output (out=${OUT:0:120})" ;; esac; }
+assert_has()    { case "$OUT" in *"$2"*) ok "$1" ;; *) bad "$1" "missing '$2' (out=${OUT:0:150})" ;; esac; }
+assert_lacks()  { case "$OUT" in *"$2"*) bad "$1" "unexpectedly present: '$2'" ;; *) ok "$1" ;; esac; }
+
+newhome() { local d; d="$(mktemp -d)"; TMPDIRS+=("$d"); mkdir -p "$d/.claude"; echo "$d"; }
+
+install_broadcast_script() {  # <home> -- make auto-send.py exist
+  mkdir -p "$1/.claude/skills/team-broadcast/scripts"
+  touch "$1/.claude/skills/team-broadcast/scripts/auto-send.py"
+}
+
+opt_in_but_broken() {  # <home> -- skill dir present, auto-send.py MISSING
+  mkdir -p "$1/.claude/skills/team-broadcast"
+}
+
+# fake_launchctl HOME REGISTERED_LABEL_OR_EMPTY -- puts a fake `launchctl` ahead
+# of the real one on PATH. The hook calls bare `launchctl list` and parses the
+# tab-separated PID/Status/Label table, so the stub prints that table: a header
+# plus one row for REGISTERED, or a header alone when nothing is registered.
+fake_launchctl() {
+  local home="$1" registered="$2" bin="$1/fakebin" row=""
+  mkdir -p "$bin"
+  [ -n "$registered" ] && row="printf -- '-\t0\t%s\n' '$registered'"
+  cat > "$bin/launchctl" <<EOF
+#!/usr/bin/env bash
+if [ "\$1" = "list" ] && [ -z "\${2:-}" ]; then
+  printf 'PID\tStatus\tLabel\n'
+  $row
+  exit 0
+fi
+exit 0
+EOF
+  chmod +x "$bin/launchctl"
+}
+
+# run_hook HOME -- invokes the real SessionStart entrypoint, sandboxed fakebin
+# first on PATH so it beats any real launchctl on the runner.
+run_hook() {
+  local home="$1"
+  OUT="$(PATH="$home/fakebin:$PATH" run_sandboxed "$home" python3 "$HOOK" <<<'{}' 2>/dev/null)"
+}
+
+echo "=== precondition ==="
+[ -f "$HOOK" ] && ok "hook exists" || bad "hook exists" "missing $HOOK"
+
+echo "=== 0. DEFAULT INSTALL: never set up here -> SILENT ==="
+# THE control for this whole hook. This substrate never installs team-broadcast,
+# so a missing auto-send.py is the normal state for nearly every install. If
+# this case ever fires, every stranger who installs the repo is nagged on every
+# session about a component they never asked for.
+H0="$(newhome)"
+fake_launchctl "$H0" ""
+run_hook "$H0"
+assert_silent "a clean install that never had team-broadcast is not nagged about it"
+
+echo "=== 1. OPTED-IN BUT BROKEN: set up here, auto-send.py gone -> FIRES ==="
+H1="$(newhome)"
+opt_in_but_broken "$H1"
+fake_launchctl "$H1" ""
+run_hook "$H1"
+assert_fires "fires when the operator set it up and the script went missing"
+assert_has   "names the missing script path" "team-broadcast/scripts/auto-send.py"
+assert_has   "says how to restore it" "Reinstall the team-broadcast skill"
+
+echo "=== 2. CRON-GAP: script present, no *.team-broadcast-daily job -> FIRES ==="
+H2="$(newhome)"
+install_broadcast_script "$H2"
+fake_launchctl "$H2" ""   # nothing registered
+run_hook "$H2"
+assert_fires "fires when the daily-broadcast launchd job is unregistered"
+assert_has   "names the label suffix it looked for" ".team-broadcast-daily"
+assert_lacks "reports the suffix, not any literal reverse-DNS namespace" "com."
+assert_has   "clarifies session-close broadcasts are unaffected" "unaffected"
+assert_lacks "does not claim broadcasts are unreachable (that's case 1's wording)" "unreachable"
+
+echo "=== 3. NEG-CONTROL: registered under one namespace -> SILENT ==="
+H3="$(newhome)"
+install_broadcast_script "$H3"
+fake_launchctl "$H3" "com.example.team-broadcast-daily"
+run_hook "$H3"
+assert_silent "no finding when installed and the cron is registered (no cry-wolf)"
+
+echo "=== 4. ANY-OPERATOR: a totally different namespace -> ALSO SILENT ==="
+H4="$(newhome)"
+install_broadcast_script "$H4"
+fake_launchctl "$H4" "io.someone-else.team-broadcast-daily"
+run_hook "$H4"
+assert_silent "the suffix match is not secretly a literal: another operator's label also counts as installed"
+
+echo "=== 5. END-TO-END: reaches main()'s systemMessage, not just the helper ==="
+H5="$(newhome)"
+opt_in_but_broken "$H5"
+fake_launchctl "$H5" ""
+run_hook "$H5"
+assert_has "the missing-install finding rides the real systemMessage envelope" "systemMessage"
+assert_has "carries the shared incident framing" "191-file strand"
+
+echo ""
+echo "=== SUMMARY: $PASS passed, $FAIL failed ==="
+[ "$FAIL" = 0 ]


### PR DESCRIPTION
## Summary
- `surface-stale-automation-failures.py` inferred health from a log file; "no log" meant both "healthy and quiet" and "never installed," so a missing `auto-send.py` install produced zero signal, ever. `team_broadcast_install_gap()` checks the script's presence + launchd registration directly and names the gap specifically.
- Resolves this file's SEV-4-json-encoded `utf8-stdout-baseline.txt` pin per that file's own rule (prove it's ASCII-safe, mark it, delete the row — never re-pin).
- Tightens a pre-existing assertion in `test_hook_vault_root_per_target.sh` that a bare `"auto-snapshot"` substring grep was satisfying via this hook's unrelated static footer text, once this hook always produces output in that fixture.
- New regression test: `tests/integration/test_team_broadcast_install_gap.sh` (missing / cron-unregistered / healthy / end-to-end), wired into `scripts/ci.sh`'s `INTEGRATION_TESTS`.

## Test plan
- [x] `bash tests/integration/test_team_broadcast_install_gap.sh` — 11/11 pass
- [x] `bash tests/integration/test_hook_vault_root_per_target.sh` — full suite passes
- [x] `python3 -m py_compile` clean on both touched `.py` files
- [x] `python3 scripts/check-utf8-stdout.py` — clean, no violations
- [ ] Full `bash scripts/ci.sh` — blocked on this machine by a **pre-existing, unrelated** bash-3.2 syntax error in `test_rm_rf_vault_target.sh` (filed as #471; this machine has no Homebrew bash, only macOS's stock 3.2.57). Confirmed via `git status`/`git diff`/`git show <last-commit>` that the file is untouched by this branch and was already broken on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)