### PR TITLE
fix(journal-index): stop indexing insight reports as journal entries

### DIFF
--- a/scripts/build-journal-index.py
+++ b/scripts/build-journal-index.py
@@ -75,6 +75,13 @@ def _parse_inline_list(v):
     return v
 
 
+# Frontmatter `type:` values that mark a file as OUTPUT of the insights pipeline
+# rather than a journal entry feeding it. `insight` is what insights/SKILL.md's
+# Format block emits today; the older values are kept so a vault carrying reports
+# written by an earlier version is cleaned up by the same pass.
+DERIVED_TYPES = frozenset({"insight", "weekly-review", "monthly-review"})
+
+
 JOURNAL_DIR_CANDIDATES = (
     "📓 Journals", "Journals",       # en (Phase 3 default)
     "📔 Journal", "Journal",
@@ -160,6 +167,7 @@ def main():
     output_path = os.path.join(meta_dir, "journal-index.json")
     entries = []
     skipped = []
+    derived = []
 
     # Recursive walk: indexes journals nested under year-month subfolders
     # (e.g. Journals/2026-04/2026-04-15.md), not just top-level files.
@@ -191,6 +199,22 @@ def main():
                         meta[k.strip()] = v.strip().strip("'\"")
                 if i > 15:
                     break
+            if meta.get("type") in DERIVED_TYPES:
+                # A /weekly or /monthly report is DERIVED FROM this index, not an
+                # input to it. Its canonical frontmatter (insights/SKILL.md, the
+                # "Format:" block) carries `creationDate` and `type: insight`, and
+                # the walk below is recursive over the whole journal folder, so
+                # every report lands back in the index as a floorless pseudo-entry
+                # that inflates `total` and dilutes the floor distribution the next
+                # report is computed from. The error compounds: each run indexes the
+                # previous run's output.
+                #
+                # Folder placement does NOT protect against this and never did.
+                # `os.walk(journal_dir)` reaches `Weekly Insights/` exactly as it
+                # reaches `June 2026/`, so the 2026-Q2 move of reports into month
+                # folders neither caused nor fixed it. `type` is the honest signal.
+                derived.append(os.path.relpath(fpath, journal_dir))
+                continue
             if "creationDate" in meta:
                 # Store path relative to journal_dir so subfoldered entries
                 # with colliding basenames stay distinct.
@@ -210,6 +234,12 @@ def main():
         preview = ", ".join(f"{f} [{s}]" for f, s in skipped[:5])
         more = " ..." if len(skipped) > 5 else ""
         print(f"  note: skipped {len(skipped)} unreadable file(s): {preview}{more}",
+              file=sys.stderr)
+    if derived:
+        preview = ", ".join(derived[:5])
+        more = " ..." if len(derived) > 5 else ""
+        print(f"  note: excluded {len(derived)} derived report(s) from the index "
+              f"(insight output, not journal input): {preview}{more}",
               file=sys.stderr)
     entries.sort(key=lambda x: x["date"])
     output = {

--- a/scripts/test_journal_index_derived.py
+++ b/scripts/test_journal_index_derived.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Unit suite for the derived-report exclusion in build-journal-index.py.
+
+THE BUG THIS GUARDS (INSIGHT-REPORTS-INDEXED-AS-ENTRIES): the /weekly and
+/monthly reports are DERIVED FROM the journal index, and the canonical report
+frontmatter in insights/SKILL.md ("Format:" block) carries `creationDate` plus
+`type: insight`. The indexer's only admission test was `if "creationDate" in
+meta`, and its walk is recursive over the whole journal folder, so every report
+was re-admitted as a floorless pseudo-entry: `total` inflates, the floor
+distribution the NEXT report is computed from gets diluted, and the error
+compounds run over run because each pass indexes the previous pass's output.
+
+Folder placement never protected against this. `os.walk(journal_dir)` reaches
+`Weekly Insights/` exactly as it reaches `June 2026/`, so the move of reports
+into month folders neither caused nor fixed it. `type` is the honest signal, so
+that is what the exclusion keys on.
+
+Run directly (the ci.sh gate globs scripts/test_*.py):
+    python3 scripts/test_journal_index_derived.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_SCRIPT = _HERE / "build-journal-index.py"
+
+
+def _load_indexer():
+    """Load build-journal-index.py (hyphenated -> importlib) so the constants
+    under test are the SHIPPED ones, not a copy."""
+    spec = importlib.util.spec_from_file_location("journal_index_under_test", _SCRIPT)
+    assert spec is not None and spec.loader is not None, f"cannot load {_SCRIPT}"
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+IDX = _load_indexer()
+
+
+ENTRY = """---
+creationDate: 2026-06-11
+floor: Reason
+floor_level: high
+---
+
+# A real day
+
+Body.
+"""
+
+# The canonical report shape, copied from insights/SKILL.md's Format block.
+REPORT = """---
+creationDate: 2026-06-15
+type: insight
+period: weekly
+date_range: 2026-06-09 to 2026-06-15
+entries_analyzed: 4
+primary_floor: Reason
+---
+
+# Weekly report
+
+Body.
+"""
+
+
+class DerivedReportExclusionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.vault = Path(self._tmp.name)
+        self.journals = self.vault / "📓 Journals"
+        self.meta = self.vault / "⚙️ Meta"
+        (self.journals / "June 2026").mkdir(parents=True)
+        (self.journals / "Weekly Insights").mkdir(parents=True)
+        self.meta.mkdir(parents=True)
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def _write(self, rel: str, text: str) -> None:
+        p = self.journals / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(text, encoding="utf-8")
+
+    def _run(self) -> dict:
+        proc = subprocess.run(
+            [sys.executable, str(_SCRIPT), "--vault-root", str(self.vault)],
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            timeout=60,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self._stderr = proc.stderr
+        return json.loads((self.meta / "journal-index.json").read_text(encoding="utf-8"))
+
+    # --- the headline case --------------------------------------------------
+    def test_report_in_month_folder_is_not_indexed(self):
+        self._write("June 2026/2026-06-11 A Real Day.md", ENTRY)
+        self._write("June 2026/Jun. 9-15, 2026 Weekly.md", REPORT)
+        idx = self._run()
+        self.assertEqual(idx["total"], 1)
+        self.assertEqual([e["file"] for e in idx["entries"]],
+                         ["June 2026/2026-06-11 A Real Day.md"])
+
+    def test_report_in_insights_folder_is_not_indexed_either(self):
+        # The exclusion is by `type`, not by folder, so BOTH save conventions
+        # behave identically. This is the test that would have failed under a
+        # folder-based fix.
+        self._write("June 2026/2026-06-11 A Real Day.md", ENTRY)
+        self._write("Weekly Insights/weekly-review-2026-06-15.md", REPORT)
+        idx = self._run()
+        self.assertEqual(idx["total"], 1)
+
+    def test_legacy_report_types_are_excluded(self):
+        self._write("June 2026/2026-06-11 A Real Day.md", ENTRY)
+        self._write("Weekly Insights/old-weekly.md",
+                    REPORT.replace("type: insight", "type: weekly-review"))
+        self._write("Weekly Insights/old-monthly.md",
+                    REPORT.replace("type: insight", "type: monthly-review"))
+        idx = self._run()
+        self.assertEqual(idx["total"], 1)
+
+    # --- scoping guards: the exclusion must not eat real entries ------------
+    def test_real_entries_are_untouched(self):
+        self._write("June 2026/2026-06-11 A Real Day.md", ENTRY)
+        self._write("June 2026/2026-06-14 Another.md",
+                    ENTRY.replace("2026-06-11", "2026-06-14").replace("Reason", "Courage"))
+        idx = self._run()
+        self.assertEqual(idx["total"], 2)
+        self.assertEqual({e["floor"] for e in idx["entries"]}, {"Reason", "Courage"})
+
+    def test_entry_with_an_unrelated_type_is_still_indexed(self):
+        # Only the derived-output types are excluded. A journal entry that
+        # happens to carry `type: journal` (or anything else) stays in.
+        self._write("June 2026/2026-06-11 Typed.md",
+                    ENTRY.replace("floor: Reason", "type: journal\nfloor: Reason"))
+        idx = self._run()
+        self.assertEqual(idx["total"], 1)
+
+    def test_exclusion_is_reported_never_silent(self):
+        # The house rule: nothing disappears without saying so.
+        self._write("June 2026/2026-06-11 A Real Day.md", ENTRY)
+        self._write("Weekly Insights/weekly-review-2026-06-15.md", REPORT)
+        self._run()
+        self.assertIn("excluded 1 derived report", self._stderr)
+        self.assertIn("weekly-review-2026-06-15.md", self._stderr)
+
+    def test_no_reports_means_no_note(self):
+        self._write("June 2026/2026-06-11 A Real Day.md", ENTRY)
+        self._run()
+        self.assertNotIn("derived report", self._stderr)
+
+    # --- the constant itself ------------------------------------------------
+    def test_derived_types_cover_the_shipped_report_format(self):
+        self.assertIn("insight", IDX.DERIVED_TYPES)
+        self.assertNotIn("journal", IDX.DERIVED_TYPES)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## The bug

The `/weekly` and `/monthly` reports are derived **from** the journal index. The canonical report frontmatter in `skills/insights/SKILL.md` (the `Format:` block) carries both `creationDate` and `type: insight`:

```markdown
---
creationDate: [today]
type: insight
period: weekly OR monthly
...
---
```

`scripts/build-journal-index.py` admits a file on one test: `if "creationDate" in meta`. So every report generated is re-admitted to the index as a journal entry with no `floor`.

Three consequences, in increasing severity:

1. `total` overstates how much the user has actually journaled.
2. The floor distribution that the **next** report is computed from is diluted by entries that have no floor.
3. It compounds. Each pass indexes the previous pass's output, so the ratio of real entries to reports decays for as long as the user keeps running `/weekly`.

## Why the fix keys on `type` and not on folder

Because folder placement never protected against this, in either direction.

`os.walk(journal_dir)` is recursive over the whole journal folder, so it reaches `Weekly Insights/` exactly as it reaches `June 2026/`. The 2026-Q2 move of reports into month folders (`docs/CHANGELOG.md`, "Insights skill save path updated") neither caused nor fixed the bug, and moving them back would not fix it either.

A folder-based fix would also have to pick a side in a convention this repo is currently inconsistent about:

- `skills/insights/SKILL.md` says to save inside the month folder
- `templates/generated/insights-skill-template.md` says `📓 Journals/Weekly Insights/`
- `phases/phase-02-03-plugins-folders.md` still creates `📓 Journals/Weekly Insights/` and `Monthly Insights/` at setup
- `scripts/organize-journals.py` actively moves `Weekly Insights/` contents into month folders

That inconsistency is worth resolving on its own, but it is a separate question, and a folder-based fix would silently regress for whichever half of the user base is on the other convention. `type` is true under both, so this PR does not touch the save path at all.

`DERIVED_TYPES` also covers the older `weekly-review` / `monthly-review` values, so a vault carrying reports written by an earlier version is cleaned up by the same pass with no migration step.

## Never-fail-silently

Exclusions print to stderr with a count and a file preview, alongside the existing unreadable-file note. A file dropping out of the index has to say so.

## Tests

8 new cases in `scripts/test_journal_index_derived.py`:

- a report in a month folder is not indexed
- the same report in `Weekly Insights/` is not indexed either (the case a folder-based fix would fail)
- legacy `weekly-review` / `monthly-review` types are excluded
- two scoping guards: real entries are untouched, and an entry with an unrelated `type:` still indexes
- the stderr note fires, and stays quiet when there is nothing to report

Verified failing against the unfixed script **for the real reason** (`AssertionError: 2 != 1`, the report counted as an entry), not an import or fixture error.

Full `bash scripts/ci.sh` passes: py_compile 338 files, 102 integration tests, 14 scripts suites, 15 hooks suites.