### PR TITLE
test(ci): the real-HOME fingerprint regression test #455 shipped without (MYC-3507)

### DIFF
--- a/hooks/block-git-mutation-mid-operation.py
+++ b/hooks/block-git-mutation-mid-operation.py
@@ -149,6 +149,18 @@ IN_FLIGHT_MARKERS = [
     ("CHERRY_PICK_HEAD", "cherry-pick stopped at conflicts", "cherry-pick"),
     ("REVERT_HEAD", "revert stopped at conflicts", "revert"),
     ("BISECT_LOG", "bisect in progress", "bisect"),
+    # LAST on purpose. `.git/sequencer` is the multi-commit cherry-pick/revert
+    # queue, and it OUTLIVES the per-stop markers above: when a sequence stops
+    # on a conflict you get CHERRY_PICK_HEAD *and* sequencer, and the entry
+    # above wins with the more specific message. But once the conflict is
+    # resolved and COMMITTED, git clears CHERRY_PICK_HEAD while the remaining
+    # picks stay queued — leaving `sequencer` as the only evidence that the
+    # operation is still in flight. Verified empirically: after
+    # `git cherry-pick A B` stops on A and the resolution is committed,
+    # sequencer is present and all six markers above are absent, so without
+    # this entry the guard goes quiet mid-sequence and a commit lands inside
+    # someone else's unfinished cherry-pick.
+    ("sequencer", "multi-commit cherry-pick/revert sequence, mid-run", "cherry-pick"),
 ]
 
 GIT_TIMEOUT_SEC = 5

--- a/hooks/block-git-mutation-mid-operation.py
+++ b/hooks/block-git-mutation-mid-operation.py
@@ -154,7 +154,7 @@ IN_FLIGHT_MARKERS = [
     # on a conflict you get CHERRY_PICK_HEAD *and* sequencer, and the entry
     # above wins with the more specific message. But once the conflict is
     # resolved and COMMITTED, git clears CHERRY_PICK_HEAD while the remaining
-    # picks stay queued — leaving `sequencer` as the only evidence that the
+    # picks stay queued, leaving `sequencer` as the only evidence that the
     # operation is still in flight. Verified empirically: after
     # `git cherry-pick A B` stops on A and the resolution is committed,
     # sequencer is present and all six markers above are absent, so without

--- a/hooks/test_git_inflight_op_guard.py
+++ b/hooks/test_git_inflight_op_guard.py
@@ -160,6 +160,32 @@ def stall_cherry_pick(repo):
     return os.path.exists(os.path.join(gd, "CHERRY_PICK_HEAD"))
 
 
+def stall_sequencer_mid_run(repo):
+    """A multi-commit cherry-pick stopped on a conflict, then RESOLVED AND
+    COMMITTED. That commit clears CHERRY_PICK_HEAD while the remaining picks
+    stay queued, leaving .git/sequencer as the only in-flight evidence.
+    Returns True only if that exact state was produced -- sequencer present
+    AND every per-stop marker absent -- so the leg cannot pass vacuously."""
+    base_commit(repo)
+    git(repo, "checkout", "-q", "-b", "topic")
+    write(os.path.join(repo, "f.txt"), "one\n")
+    git(repo, "commit", "-q", "-am", "pick one")
+    write(os.path.join(repo, "f.txt"), "two\n")
+    git(repo, "commit", "-q", "-am", "pick two")
+    git(repo, "checkout", "-q", "main")
+    write(os.path.join(repo, "f.txt"), "main\n")
+    git(repo, "commit", "-q", "-am", "main change")
+    git(repo, "cherry-pick", "topic~1", "topic")      # stops on the first pick
+    write(os.path.join(repo, "f.txt"), "resolved\n")  # resolve + commit it
+    git(repo, "add", "f.txt")
+    git(repo, "commit", "-q", "-m", "resolved")
+    gd = os.path.normpath(os.path.join(repo, git(repo, "rev-parse", "--git-dir").stdout.strip()))
+    per_stop = ("CHERRY_PICK_HEAD", "REVERT_HEAD", "MERGE_HEAD",
+                "rebase-merge", "rebase-apply", "BISECT_LOG")
+    return (os.path.exists(os.path.join(gd, "sequencer"))
+            and not any(os.path.exists(os.path.join(gd, m)) for m in per_stop))
+
+
 def main():
     tmp = tempfile.mkdtemp(prefix="inflight-guard-")
 
@@ -405,6 +431,27 @@ def main():
         ok("13c. Resolution hint tracks the operation (merge -> `git merge --abort`)")
     else:
         bad("13c. resolution hint (merge)", "hint did not follow the marker")
+
+    # 14. Regression: a multi-commit cherry-pick sequence whose conflict has
+    # been RESOLVED AND COMMITTED. git clears CHERRY_PICK_HEAD at that commit
+    # but leaves the remaining picks queued in .git/sequencer, so every
+    # per-stop marker is gone while the operation is still in flight. Before
+    # `sequencer` joined IN_FLIGHT_MARKERS the guard went silent here and a
+    # commit could land inside someone else's unfinished sequence.
+    seq = init_repo(os.path.join(tmp, "sequencer"))
+    if stall_sequencer_mid_run(seq):
+        ok("14. setup: sequence mid-run, CHERRY_PICK_HEAD already cleared")
+        code, _, serr = run_hook("git commit -m x", cwd=seq)
+        if code == 2:
+            ok("14a. Guard still BLOCKS mid-sequence (sequencer alone)")
+        else:
+            bad("14a. mid-sequence", "guard went silent: exit %s" % code)
+        if "cherry-pick" in serr:
+            ok("14b. Hint names cherry-pick as the in-flight op")
+        else:
+            bad("14b. mid-sequence hint", "wrong verb: %r" % serr[-200:])
+    else:
+        bad("14. setup", "could not produce a mid-run sequencer state")
 
     subprocess.run(["rm", "-rf", tmp], capture_output=True)
 

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -206,6 +206,7 @@ INTEGRATION_TESTS=(
   test_vault_safety_guards
   test_vault_backup_conf_bom
   test_backup_staleness_surfaces
+  test_home_fingerprint_noise
   test_scheduled_task_registration
   test_vault_backup_task_healing
   test_resource_aware_session_close

--- a/scripts/install-hooks-user-level.py
+++ b/scripts/install-hooks-user-level.py
@@ -79,8 +79,30 @@ _TEXT_UTF8 = {"text": True, "encoding": "utf-8", "errors": "replace"}
 
 # Fingerprint substrings — any hook command containing one of these is
 # considered "owned by ai-brain-starter" and may be replaced or removed.
-# Extend this list when adding new hooks; the name must be unique enough
-# that no third-party hook would accidentally include it.
+# The name must be unique enough that no third-party hook would accidentally
+# include it.
+#
+# !! THIS LIST DOES NOT INSTALL ANYTHING. !!
+#
+# Membership here confers OWNERSHIP only: dedup, replace, retire, uninstall
+# recognition. `merge_hooks()` wires exactly what `hooks.json` declares and
+# nothing else, so **hooks.json is the ONLY activation predicate**. A hook
+# added here but not to hooks.json is an "owned dormant hook": the installer
+# claims it, inspection makes it look registered, and it never fires.
+#
+# Adding a hook therefore takes BOTH:
+#   1. an entry in hooks.json  <- this is what actually installs it
+#   2. an entry here (+ ABS_OWNED_BASENAMES) so re-installs dedup it properly
+#
+# If it signals by EXIT CODE 2 (a blocking gate), wire it in hooks.json as
+# `if [ -f <path> ]; then <path>; else <allow-json>; fi` — the common
+# `<path> 2>/dev/null || echo <allow-json>` idiom discards the stderr message
+# AND rewrites the block into an allow.
+#
+# This comment replaced "Extend this list when adding new hooks", which read as
+# the complete instruction and is how the most recent dormant hook happened:
+# the author registered in both lists below, believed it was active, and said
+# so in the commit message. Tracked as MYC-1031 (structural CI gate).
 ABS_FINGERPRINTS = [
     "ai-brain-starter/hooks/detect-closing-signal.py",
     "ai-brain-starter/hooks/verify-session-close-cascade.py",

--- a/tests/integration/test_backup_staleness_surfaces.sh
+++ b/tests/integration/test_backup_staleness_surfaces.sh
@@ -31,8 +31,20 @@ REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 # Consumers only. Excluded on purpose:
 #   check-vault-backup.py  — the PRODUCER; it computes the age, it does not judge it.
 #   test-*                 — harnesses that fabricate the token as fixture input.
+#   __pycache__/           — COMPILED BYTECODE, not source. `grep -rl` matches
+#                            binaries too, and the token survives into a .pyc's
+#                            string table, so `check-vault-backup.cpython-*.pyc`
+#                            slipped past the exclusion above: that exclusion is
+#                            by exact filename, and the compiled twin has a
+#                            different one. Bytecode cannot be inspected for a
+#                            threshold, so it failed unconditionally. Worse, the
+#                            __pycache__ is created by THIS gate — ci.sh step (a)
+#                            py_compiles every tracked *.py before the
+#                            integration tests run — so the gate manufactured the
+#                            artifact that then failed it.
 age_consumers() {
   grep -rl 'BACKED_UP:vault-backup' "$REPO/hooks" "$REPO/scripts" 2>/dev/null \
+    | grep -v '/__pycache__/' \
     | grep -v '/check-vault-backup\.py$' \
     | grep -v '/test-'
 }

--- a/tests/integration/test_home_fingerprint_noise.sh
+++ b/tests/integration/test_home_fingerprint_noise.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Controls for real_home_fingerprint() in scripts/ci.sh.
+#
+# The guard exists to red-flag a test that escapes its sandbox and writes into
+# the real ~/.claude. It watches deployed CODE. It must NOT react to the logs,
+# lock files and append-only state that ordinary session machinery writes into
+# those same directories continuously — reacting to those produced a RED the
+# harness could not support (MYC-3507).
+#
+# Both directions are asserted. A fingerprint that ignores everything is as
+# useless as one that fires on everything, so every "must not react" case is
+# paired with a "must still react" case.
+#
+# Tests the REAL function, extracted from ci.sh rather than reimplemented, so
+# the assertions cannot drift from the implementation they describe.
+set -u
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CI="$REPO_ROOT/scripts/ci.sh"
+[ -f "$CI" ] || { echo "FAIL: scripts/ci.sh not found"; exit 1; }
+
+TD=$(mktemp -d); trap 'rm -rf "$TD"' EXIT
+PASS=0; FAIL=0
+ok()  { echo "  PASS  $1"; PASS=$((PASS+1)); }
+no()  { echo "  FAIL  $1"; FAIL=$((FAIL+1)); }
+
+# Extract just the function so the whole gate does not run.
+FN="$TD/fn.sh"
+sed -n '/^real_home_fingerprint()/,/^}/p' "$CI" > "$FN"
+grep -q "real_home_fingerprint" "$FN" || { echo "FAIL: could not extract the function"; exit 1; }
+
+FAKE="$TD/home"
+mkdir -p "$FAKE/.claude/hooks/sync.demo.lock" \
+         "$FAKE/.claude/state" \
+         "$FAKE/.claude/skills/ai-brain-starter/hooks" \
+         "$FAKE/.claude/skills/ai-brain-starter/scripts"
+printf '{"hooks":{}}\n'      > "$FAKE/.claude/settings.json"
+printf 'print("deployed")\n' > "$FAKE/.claude/hooks/real-hook.py"
+printf 'log line\n'          > "$FAKE/.claude/hooks/cwd-changed.log"
+printf 'sync line\n'         > "$FAKE/.claude/hooks/sync-my-skills.log"
+printf '4242\n'              > "$FAKE/.claude/hooks/sync.demo.lock/pid"
+printf '{"e":1}\n'           > "$FAKE/.claude/state/settings-hook-integrity.jsonl"
+
+fp() { HOME="$FAKE" bash -c "source '$FN'; real_home_fingerprint"; }
+
+BASE=$(fp)
+[ -n "$BASE" ] || { echo "FAIL: empty fingerprint"; exit 1; }
+
+echo "=== MUST NOT react: runtime noise the session machinery writes ==="
+for f in ".claude/hooks/cwd-changed.log" \
+         ".claude/hooks/sync-my-skills.log" \
+         ".claude/hooks/sync.demo.lock/pid" \
+         ".claude/state/settings-hook-integrity.jsonl"; do
+  printf 'churn %s\n' "$RANDOM" >> "$FAKE/$f"
+  touch "$FAKE/$f"
+  if [ "$(fp)" = "$BASE" ]; then ok "ignores $(basename "$f")"; else no "reacted to $(basename "$f") (false RED source)"; fi
+done
+
+echo
+echo "=== MUST still react: the escapes this guard exists to catch ==="
+printf 'print("TAMPERED")\n' >> "$FAKE/.claude/hooks/real-hook.py"
+if [ "$(fp)" != "$BASE" ]; then ok "catches a rewritten deployed hook (.py)"; else no "MISSED a rewritten deployed hook"; fi
+BASE=$(fp)
+
+printf 'print("x")\n' > "$FAKE/.claude/skills/ai-brain-starter/scripts/new-script.py"
+if [ "$(fp)" != "$BASE" ]; then ok "catches a new file in the skill scripts tree"; else no "MISSED a new skill script"; fi
+BASE=$(fp)
+
+printf '{"hooks":{"tampered":1}}\n' > "$FAKE/.claude/settings.json"
+if [ "$(fp)" != "$BASE" ]; then ok "catches a settings.json rewrite (the catastrophic one)"; else no "MISSED a settings.json rewrite"; fi
+BASE=$(fp)
+
+touch "$FAKE/.claude/settings.json.bak-20260101"
+if [ "$(fp)" != "$BASE" ]; then ok "catches a new installer .bak-* (write-then-rollback)"; else no "MISSED a new .bak-*"; fi
+
+echo
+echo "test_home_fingerprint_noise: $PASS passed, $FAIL failed"
+[ "$FAIL" = 0 ] || exit 1

--- a/tests/integration/test_home_fingerprint_noise.sh
+++ b/tests/integration/test_home_fingerprint_noise.sh
@@ -17,6 +17,13 @@ set -u
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CI="$REPO_ROOT/scripts/ci.sh"
 [ -f "$CI" ] || { echo "FAIL: scripts/ci.sh not found"; exit 1; }
+# HOME alone does NOT sandbox on Windows: ntpath.expanduser reads USERPROFILE and
+# ignores HOME, so `HOME=... bash -c` would run this against the developer's REAL
+# ~/.claude — the exact catastrophic class the guard under test exists to catch
+# (2026-07-30: 95 of 111 hook entries repointed at a deleted worktree, every tool
+# call denied in every later session). run_sandboxed sets HOME *and* USERPROFILE
+# and neutralises the HOMEDRIVE/HOMEPATH fallback. MYC-3536.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/sandbox_home.sh"
 
 TD=$(mktemp -d); trap 'rm -rf "$TD"' EXIT
 PASS=0; FAIL=0
@@ -40,7 +47,7 @@ printf 'sync line\n'         > "$FAKE/.claude/hooks/sync-my-skills.log"
 printf '4242\n'              > "$FAKE/.claude/hooks/sync.demo.lock/pid"
 printf '{"e":1}\n'           > "$FAKE/.claude/state/settings-hook-integrity.jsonl"
 
-fp() { HOME="$FAKE" bash -c "source '$FN'; real_home_fingerprint"; }
+fp() { run_sandboxed "$FAKE" bash -c "source '$FN'; real_home_fingerprint"; }
 
 BASE=$(fp)
 [ -n "$BASE" ] || { echo "FAIL: empty fingerprint"; exit 1; }

--- a/tests/integration/test_inject_meeting_workflow_truncation_flag.sh
+++ b/tests/integration/test_inject_meeting_workflow_truncation_flag.sh
@@ -94,11 +94,26 @@ CASCADE_POS=$(echo "$OUT" | grep -bF "Run the FULL cascade" | head -1 | cut -d: 
     fail "TRUNCATED flag must come BEFORE the cascade-instruction. Got flag at $FLAG_POS, cascade at $CASCADE_POS"
 
 # 4. TRUNCATED flag names the rule file path.
-echo "$OUT" | head -c 600 | grep -qF "$TMP_VAULT/Meta/rules/meeting-workflow.md" || \
-    fail "TRUNCATED flag should name the rule-file path in the first 600 chars. Got:\n$(echo "$OUT" | head -c 600)"
+# No pipes on purpose. `echo "$OUT" | head -c 600 | grep -qF ...` has TWO
+# SIGPIPE sources under `set -o pipefail` (line 27): head closes the stream
+# after 600 bytes, and grep -qF exits the instant it matches. Either one hands
+# the upstream writer EPIPE, pipefail promotes that non-zero to the pipeline,
+# and `|| fail` fires even though the match SUCCEEDED. Observed live as
+# "line 97: echo: write error: Broken pipe" followed by a failure whose own
+# "Got:" dump plainly contained the path it claimed was missing.
+# Bash substring expansion does the same job in-process: no pipe, no race.
+HEAD600="${OUT:0:600}"
+case "$HEAD600" in
+    *"$TMP_VAULT/Meta/rules/meeting-workflow.md"*) : ;;
+    *) fail "TRUNCATED flag should name the rule-file path in the first 600 chars. Got:\n$HEAD600" ;;
+esac
 
 # 5. TRUNCATED flag warns about silent-drop categories explicitly.
-TOP=$(echo "$OUT" | head -c 800)
+# Substring expansion, not `| head -c 800`: head closes the stream after 800
+# bytes while echo is still writing the full injected block, so echo takes
+# EPIPE and pipefail fails the substitution under `set -e`. Same race as #4
+# above; a byte-bounded reader races no matter how small the input is.
+TOP="${OUT:0:800}"
 echo "$TOP" | grep -qiE "decision log|crm|humanizer|backlinks|late step" || \
     fail "TRUNCATED flag should warn about the silent-drop categories (Decision Log / CRM / humanizer / backlinks / late steps). Got top 800 chars:\n$TOP"
 


### PR DESCRIPTION
Part of MYC-3507 (`GATE-EMITS-A-VERDICT-IT-CANNOT-SUPPORT`). The `ci-test` half shipped separately in `local-machinery` `cbd57f9`.

**Rebased onto current `main` and reduced to what is still needed.** The original branch was 21 commits behind, conflicted, and its headline fix had already shipped. Each commit was triaged against `main` individually rather than assumed, because file-level diffing cannot separate "superseded" from "novel" across 21 intervening commits.

## Dropped as already shipped

| commit | why |
|---|---|
| `af0832f` the `scripts/ci.sh` churn fix | **superseded by #455**, which landed the same `CHURN_SUFFIXES` / lock-dir-pruning approach. This was the conflict. |
| `1f4cd2c` SIGPIPE in `test_dry_run_purity.sh` | `main` already has 0 `\| head -c` in that file |
| `5c4b610` ASCII-only… | …as a standalone concern: `main` is already ASCII-clean. **Kept in sequence anyway**, because it repairs an em dash that `870d69f` itself introduces — dropping it would have reintroduced the defect. |

## Kept, each verified `main` still has the bug

| commit | evidence |
|---|---|
| `9cddd84` in-flight-guard sequencer gap | `main` has **0** `"sequencer"` entries. After `git cherry-pick A B` stops on A and the resolution is committed, git clears `CHERRY_PICK_HEAD` while the remaining picks stay queued — so `sequencer` is the only surviving evidence and the guard went quiet mid-sequence. |
| `52aa9e8` `__pycache__` exclusion | `main` has **0** `__pycache__` mentions in that test. The gate `py_compile`s every tracked `.py` before integration tests, so it *manufactured* the bytecode that then failed it. |
| `6014c20` SIGPIPE in the meeting-workflow test | `main` still has **4** `\| head -c` there — races at any output size under `pipefail`, inverting the check exactly when it should pass. |
| `cb5640a` **the fingerprint regression test** | absent from `main` entirely. |

## The test is the point of this PR

#455 shipped the real-HOME tripwire fix **without a regression test**. This is that test — and it was verified against #455's implementation, not the one it was written for:

- **8/8 passing** against current `main`.
- **Mutation-tested in both directions.** Disabling the `CHURN_SUFFIXES` filter turns all four "ignores" assertions red; making the fingerprint blind to size/mtime turns "catches a rewritten deployed hook" red. Neither half is vacuous.

It extracts the real `real_home_fingerprint()` out of `ci.sh` with `sed` and runs it against a fake `HOME`, so the assertions cannot drift from the implementation and the real `~/.claude` is never touched. If the function is ever renamed, extraction fails loudly rather than silently passing.

Both directions matter. The guard exists because on 2026-07-30 the suite rewrote a developer's real `settings.json` and repointed 95 of 111 hook entries at a throwaway worktree, denying every tool call in every later session. Loosening it must never go unnoticed — but reacting to ordinary session churn is what produced a RED the harness could not support, with three consecutive runs each blaming a **different** innocent test.

`248f384` wires the test into `INTEGRATION_TESTS`. That wiring originally rode along with the dropped `ci.sh` hunk; without it the file would sit in the repo and never run. The gate caught exactly that (`integration test file(s) not wired into the gate`) — the ARTIFACT-WITHOUT-ACTIVATION guard doing its job on my own diff.

## Verification

- `ci-test` **GREEN** on the final commit, marker `248f384e.ok`. The fingerprint test ran inside that gate: `test_home_fingerprint_noise: 8 passed, 0 failed`.
- Personal-data + API-key scrub on the full branch diff, with positive controls confirming both scans actually match: clean.
- Authored diff on high-risk surface is one `INTEGRATION_TESTS` entry; the `install-hooks-user-level.py` change carried here is comment-only.

**Why this sat for 10 days:** it was pushed for backup and never opened as a PR, so no reviewer and no CI ever saw it — the bug class *A Claim Is Only Real Once It Is Visible to Other Sessions*, landing on the very ticket that documents it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
