### PR TITLE
fix(session-lock): allow a provably scoped `git commit -o <paths>`, and say when the gate is dormant

### DIFF
--- a/docs/HOOKS_INSTALL.md
+++ b/docs/HOOKS_INSTALL.md
@@ -98,8 +98,12 @@ The hooks shipped by ai-brain-starter (per [`hooks.json`](../hooks.json) source-
 
 The lock runs in three modes off one shared file (`<repo>/.claude/.session-lock.json`, a multi-session map):
 
-- **SessionStart** — warns (informationally) if another session was active in this repo in the last 5 minutes.
+- **SessionStart** — warns (informationally) if another session was active in this repo in the last 5 minutes. It also tells you when the enforcement layer below **cannot fire in this repo at all**: if the git dir lives outside the checkout (a mirror or `--separate-git-dir` layout), no command resolves as "this repo" and nothing is gated. Without that line a dormant gate and a quiet one look identical, and the warning reads like protection you do not have.
 - **PreToolUse(Bash)** — the *enforcement* layer. While a sibling is live, a **git-mutating** command (commit / push / checkout / switch / branch-create / merge / rebase / reset / cherry-pick / revert / pull / am / apply) that targets *this* repo is warn-blocked every time (exit 2); any other command warns once, then stays quiet so read-only parallel work isn't nagged. A `cd` into another repo, or an explicit `-C` / `--work-tree` / `--git-dir` pointed elsewhere, is correctly attributed to that other repo and let through (no false-block).
+
+  **One exemption — a provably scoped commit.** `git commit -o <path> [<path>…]` (equivalently `--only`) is **allowed** while a sibling is live, provided it names at least one literal path and the index is empty. `-o` commits the working-tree contents of the paths you name and disregards the index, so it cannot absorb a sibling's staged work — which is the whole harm this gate exists to stop. Without this carve-out the only way to make a safe commit was to disable the gate session-wide, which is how a guard teaches you to turn it off.
+
+  Still blocked, deliberately: a bare `git commit`, `-a`/`--all`, `-i`/`--include`, `--amend` (it takes the staged index even alongside `-o`), `--interactive`, `--patch`, a `.`/glob/magic pathspec (those sweep files you did not name), an unrecognised option (the parse refuses to guess), an explicit `--git-dir`, pathspecs without an explicit `-o`, and a multi-line `-m` message — that last one cannot be tokenised safely, so use `-F <message-file>` instead.
 - **Stop / SessionEnd** — heartbeat + cleanup so the live-session count stays honest.
 
 It never *hard*-blocks: every block is bypassable, only same-repo siblings are ever gated, and different repos worked in parallel never interfere. It pairs with the worktree pattern (which prevents the shared-HEAD collision structurally); the lock covers the case where two sessions still pick the *same* checkout.

--- a/hooks/session-lock.py
+++ b/hooks/session-lock.py
@@ -647,7 +647,8 @@ def _index_is_empty(dirpath):
     try:
         r = subprocess.run(
             ["git", "-C", dirpath, "diff", "--cached", "--quiet"],
-            capture_output=True, text=True, timeout=GIT_TIMEOUT_SEC,
+            capture_output=True, text=True,
+            encoding="utf-8", errors="replace", timeout=GIT_TIMEOUT_SEC,
             env=_GIT_CLEAN_ENV,
         )
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError):

--- a/hooks/session-lock.py
+++ b/hooks/session-lock.py
@@ -137,6 +137,44 @@ ALWAYS_MUTATING = {
 # git global options that consume the FOLLOWING token as their value.
 GIT_GLOBAL_VALUE_OPTS = {"-C", "-c", "--git-dir", "--work-tree", "--namespace", "--exec-path"}
 
+# ---- `git commit` option tables (for the scoped-commit exemption) -----------
+# The parse has ONE catastrophic failure mode: mistaking an option's VALUE for a
+# pathspec. `git commit -o -m msg` would then look like "-o plus the pathspec
+# 'msg'" and be ALLOWED while naming no paths at all -- a false-ALLOW, strictly
+# worse than the false-block this exemption exists to remove. So every option is
+# classified, and anything UNCLASSIFIED forfeits the exemption rather than being
+# guessed at.
+
+# Consume the FOLLOWING token as their value when written without `=`.
+COMMIT_LONG_VALUE_OPTS = {
+    "--message", "--file", "--author", "--date", "--template", "--cleanup",
+    "--reedit-message", "--reuse-message", "--fixup", "--squash", "--trailer",
+    "--pathspec-from-file",
+}
+# Consume nothing. (Options with an OPTIONAL value -- `--gpg-sign`,
+# `--untracked-files` -- only accept it attached with `=`, so bare they are
+# value-less and the `=` form is split off before lookup.)
+COMMIT_LONG_BOOL_OPTS = {
+    "--only", "--all", "--include", "--amend", "--interactive", "--patch",
+    "--signoff", "--no-signoff", "--verify", "--no-verify", "--edit", "--no-edit",
+    "--allow-empty", "--allow-empty-message", "--no-post-rewrite", "--reset-author",
+    "--short", "--branch", "--no-branch", "--porcelain", "--long", "--null",
+    "--dry-run", "--status", "--no-status", "--verbose", "--quiet",
+    "--pathspec-file-nul", "--gpg-sign", "--no-gpg-sign", "--untracked-files",
+    "--ahead-behind", "--no-ahead-behind",
+}
+COMMIT_SHORT_VALUE = set("mFcCt")   # -m <msg>, -F <file>, -c/-C <commit>, -t <file>
+COMMIT_SHORT_BOOL = set("ensvqz")   # -e -n -s -v -q -z
+COMMIT_SHORT_OPTARG = set("uS")     # -u[<mode>], -S[<keyid>]: value only ever attached
+
+# Flags that make a commit take content BEYOND the named pathspecs, so they defeat
+# the whole point of the exemption. `--amend` is here on measurement, not theory:
+# `git commit -o --amend` with no paths took the staged index (a file staged by
+# another process was swept into the amended commit), and it rewrites a HEAD a
+# sibling session may already have built on.
+COMMIT_UNSAFE_LONG = {"--all", "--include", "--amend", "--interactive", "--patch"}
+COMMIT_UNSAFE_SHORT = set("aip")    # -a (all), -i (include), -p (patch)
+
 
 def _emit(obj):
     sys.stdout.write(json.dumps(obj))
@@ -405,6 +443,36 @@ def _update_sessions(lock_path, mutate, now):
     return sessions
 
 
+def _git_gate_active(cwd, main_root):
+    """Can the PreToolUse git-mutation gate actually FIRE in this repo?
+
+    _is_home_repo_git_mutation attributes a command to the home repo by asking
+    whether its target sits INSIDE main_root. main_root comes from
+    `git rev-parse --git-common-dir`, which is right for LOCATING the shared lock
+    but wrong for that containment test whenever the git dir lives OUTSIDE the
+    checkout (a mirror or `--separate-git-dir` layout). There, main_root IS that
+    outside path, no working-tree command is ever inside it, and the gate silently
+    never fires -- while the once-per-session heads-up keeps firing, so it still
+    LOOKS alive.
+
+    Measured in such a repo with several live siblings and no bypass set: a live
+    `git commit --dry-run` ran unblocked and the detector returned False for a
+    bare commit, `reset --hard` and `push`. Passing main_root == cwd instead
+    returned True, isolating the cause to the path mismatch. Repos with an in-tree
+    `.git` gate normally.
+
+    Reported, not repaired: making the gate live in those repos changes WHICH
+    repos are gated at all, which is a behavior change with its own blast radius.
+    Surfacing it is what stops a dead guard and a quiet one emitting the same
+    signal.
+    """
+    if not cwd or not main_root:
+        return True                      # unknown -> never claim it is broken
+    cwd = os.path.normpath(cwd)
+    main_root = os.path.normpath(main_root)
+    return cwd == main_root or cwd.startswith(main_root + os.sep)
+
+
 def _sibling_summary(live, now, main_root):
     sid, e = live[0]
     la = e.get("last_activity_at")
@@ -461,6 +529,130 @@ def _tag_is_mutating(rest):
         if not tok.startswith("-"):
             return True  # positional tag name => creating
     return False
+
+
+def _is_literal_pathspec(tok):
+    """True for a plainly-named path; False for anything that sweeps unnamed files.
+
+    "Explicitly named" is the load-bearing word. `git commit -o .` is scoped in
+    the -o sense (it still ignores the index) but it commits EVERY modified file
+    under cwd -- including a sibling session's unstaged edits in the shared
+    working tree. That is the same harm through a different door, so whole-tree
+    and glob pathspecs forfeit the exemption. A named subdirectory is still a
+    deliberate scope and stays allowed.
+    """
+    if not tok or tok == "-":
+        return False
+    if tok.startswith(":"):                     # pathspec magic: :/ , :(glob), :!x
+        return False
+    if any(c in tok for c in "*?["):            # glob -> matches files you did not name
+        return False
+    if tok.rstrip("/") in {"", ".", ".."}:      # . ./ .. ../ -> whole tree
+        return False
+    return True
+
+
+def _commit_is_scoped_to_pathspecs(rest):
+    """PURE. True only if these `git commit` args PROVE the commit takes nothing
+    but explicitly named paths -- i.e. `-o`/`--only` plus >=1 literal pathspec,
+    with no index-widening flag.
+
+    `rest` is the token list AFTER the `commit` subcommand. Returns False on the
+    slightest doubt (unknown option, no pathspec, no -o): the caller then blocks,
+    which is the pre-existing behavior, so every ambiguity fails safe.
+
+    Why -o is genuinely safe here (measured, not read off the man page): it
+    commits the working-tree contents of the named paths and disregards anything
+    staged for other paths. With a file B staged, `git commit -o A` produced a
+    commit containing only A and left B still staged; the same commit run bare
+    swept B in. That bare sweep IS
+    SIBLING-SESSION-PARALLEL-COMMIT-COLLISION.
+
+    Short options cluster (`-om "msg"` really does parse as `-o -m "msg"`), so the
+    cluster walk is required, not defensive padding -- without it "msg" reads as a
+    pathspec and a commit naming no paths would be allowed.
+    """
+    only = False
+    pathspecs = []
+    i = 0
+    while i < len(rest):
+        tok = rest[i]
+        if tok == "--":
+            pathspecs.extend(rest[i + 1:])      # everything after -- is a pathspec
+            break
+        if tok.startswith("--"):
+            name, has_eq, _ = tok.partition("=")
+            if name in COMMIT_UNSAFE_LONG:
+                return False
+            if name == "--only":
+                only = True
+                i += 1
+                continue
+            if name in COMMIT_LONG_VALUE_OPTS:
+                i += 1 if has_eq else 2         # `--opt=v` self-contained; `--opt v` eats next
+                continue
+            if name in COMMIT_LONG_BOOL_OPTS:
+                i += 1
+                continue
+            return False                        # unclassified option -> cannot prove safety
+        if tok.startswith("-") and tok != "-":
+            j = 1
+            eats_next = False
+            while j < len(tok):
+                ch = tok[j]
+                if ch in COMMIT_UNSAFE_SHORT:
+                    return False
+                if ch == "o":
+                    only = True
+                    j += 1
+                    continue
+                if ch in COMMIT_SHORT_VALUE:
+                    # remainder of the cluster is the value (`-mmsg`); if the
+                    # cluster ends here (`-m msg`), the NEXT token is the value.
+                    eats_next = (j + 1 == len(tok))
+                    break
+                if ch in COMMIT_SHORT_OPTARG:
+                    break                       # optional value is attached; rest is it
+                if ch in COMMIT_SHORT_BOOL:
+                    j += 1
+                    continue
+                return False                    # unclassified flag -> cannot prove safety
+            i += 2 if eats_next else 1
+            continue
+        pathspecs.append(tok)
+        i += 1
+
+    if not only or not pathspecs:
+        return False
+    return all(_is_literal_pathspec(p) for p in pathspecs)
+
+
+def _index_is_empty(dirpath):
+    """True only if `dirpath`'s repo has NOTHING staged (index == HEAD).
+
+    `git diff --cached --quiet`: rc 0 = clean index, rc 1 = staged changes, other
+    = error. Anything but a clean 0 returns False so the caller keeps blocking --
+    an unreadable index is not an empty one.
+
+    Works on an UNBORN HEAD (verified: rc 0 with an empty index, rc 1 with a
+    staged file), so a first-commit repo needs no special case. Compares index to
+    HEAD without walking the working tree, so it stays cheap even on a very large
+    repository, and it only ever runs after the syntactic check has already passed
+    -- never on the hot path for ordinary commands.
+
+    NOTE this is belt-and-braces, not the primary safety property: `-o` ignores
+    the index whatever it holds, so the TOCTOU gap between this probe and the real
+    commit cannot reintroduce the collision.
+    """
+    try:
+        r = subprocess.run(
+            ["git", "-C", dirpath, "diff", "--cached", "--quiet"],
+            capture_output=True, text=True, timeout=GIT_TIMEOUT_SEC,
+            env=_GIT_CLEAN_ENV,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return False
+    return r.returncode == 0
 
 
 def _git_mutation_target(tokens):
@@ -536,7 +728,7 @@ def _git_mutation_target(tokens):
 
     if not mutating:
         return False
-    return (True, cdir, gdir)
+    return (True, cdir, gdir, sub, rest)
 
 
 def _apply_cd(tokens, effective_cwd, cwd_known):
@@ -563,7 +755,7 @@ def _apply_cd(tokens, effective_cwd, cwd_known):
     return os.path.normpath(os.path.join(effective_cwd, dest)), True
 
 
-def _is_home_repo_git_mutation(command, cwd, main_root):
+def _is_home_repo_git_mutation(command, cwd, main_root, index_probe=None):
     """True if `command` runs a git-mutating op against the session's home repo.
 
     Tracks an in-command `cd` so a compound `cd /other-repo && git commit` is
@@ -576,6 +768,7 @@ def _is_home_repo_git_mutation(command, cwd, main_root):
     `git -C <path>` still wins over the tracked cwd."""
     if not command or "git" not in command:
         return False
+    probe = _index_is_empty if index_probe is None else index_probe
     main_root = os.path.normpath(main_root)
     effective_cwd = os.path.normpath(cwd) if cwd else main_root
     cwd_known = True
@@ -666,7 +859,7 @@ def _is_home_repo_git_mutation(command, cwd, main_root):
         res = _git_mutation_target(tokens)
         if not res:
             continue
-        _, cdir, gdir = res
+        _, cdir, gdir, sub, rest = res
         # `-C` changes git's working dir BEFORE the rest of the command resolves,
         # so apply it first to get the cwd this segment's git actually runs in.
         seg_cwd, seg_cwd_known = effective_cwd, cwd_known
@@ -705,6 +898,25 @@ def _is_home_repo_git_mutation(command, cwd, main_root):
                 continue  # bare git in an unknown dir (post unresolvable cd) → let through
             target = seg_cwd
         if _in_home(target):
+            # The one exemption: a commit that provably takes ONLY the paths it
+            # names and ignores the index cannot sweep a sibling's staged work, so
+            # it is not the collision this gate exists to stop. Every condition is
+            # required:
+            #   sub == "commit"        -- no other verb is exempt, ever
+            #   not gdir               -- an explicit git-dir means the index we
+            #                             probe may not be the one git commits
+            #                             against; do not reason about it, block
+            #   seg_cwd_known          -- must know WHERE to probe
+            #   _commit_is_scoped_...  -- -o + >=1 literal pathspec, no -a/-i/
+            #                             --amend/--interactive/--patch
+            #   probe(seg_cwd)         -- and nothing is staged right now
+            # Order matters for cost: the pure syntactic check runs first, so the
+            # git subprocess only ever fires for a command already shaped like a
+            # scoped commit.
+            if (sub == "commit" and not gdir and seg_cwd_known
+                    and _commit_is_scoped_to_pathspecs(rest)
+                    and probe(seg_cwd)):
+                continue
             return True
         # a git mutation pointed at a DIFFERENT repo is not a collision on this
         # repo's HEAD/index — let it through.
@@ -745,6 +957,16 @@ def _session_start(payload):
             "separate repo, or wait for the other session to finish.\n"
             f"Bypass: {BYPASS_ENV}=1 (intentional parallel / collaborative work)."
         )
+        # Say plainly when the enforcement arm CANNOT fire here, so this warning
+        # is never mistaken for active protection. Without this line the notice
+        # reads identically in a gated repo and an ungated one.
+        if not _git_gate_active(cwd, main_root):
+            warn += (
+                "\n\nHEADS-UP: the git-mutation gate is DORMANT in this repo. Its git dir\n"
+                f"({main_root}) sits OUTSIDE the checkout ({cwd}), so no command\n"
+                "resolves as 'this repo' and commits / resets / pushes here are NOT blocked.\n"
+                "The warning above is informational only -- coordinate by hand."
+            )
 
     try:
         os.makedirs(CACHE_DIR, exist_ok=True)
@@ -846,7 +1068,16 @@ def _pretooluse(payload):
             "exactly the SIBLING-SESSION-PARALLEL-COMMIT-COLLISION that can wipe "
             "in-flight work. Coordinate with the other session before mutating "
             "shared git state.\n\n"
-            f"Bypass (intentional parallel / collaborative work): {BYPASS_ENV}=1\n"
+            "If this is a COMMIT there is a way through that keeps the gate on.\n"
+            "Stage nothing, and name every path you are committing:\n"
+            "    git commit -o <path> [<path>...] -F <message-file>\n"
+            "`-o`/`--only` commits the working-tree contents of the named paths and\n"
+            "disregards the index, so it cannot sweep a sibling's staged work. That\n"
+            "form is ALLOWED here while the index is empty. It needs at least one\n"
+            "literal path (not `.`, not a glob) and no -a / -i / --amend / --patch;\n"
+            "use -F <file> or a single-line -m (a multi-line -m cannot be parsed\n"
+            "safely, so it stays blocked).\n\n"
+            f"Blanket bypass, disables this gate session-wide: {BYPASS_ENV}=1\n"
         )
         return 2
 

--- a/hooks/test_session_lock_enforcement.py
+++ b/hooks/test_session_lock_enforcement.py
@@ -123,20 +123,105 @@ for label, cmd, cwd, home, want in CASES:
     check(label, mut(cmd, cwd, home), want)
 
 # --- _git_mutation_target (cdir, gdir) unit checks ---
-check("gmt: -C captured as cdir, --work-tree ignored", mod._git_mutation_target(shlex.split(
-    "git -C /x --work-tree /y commit")), (True, "/x", None))
-check("gmt: --git-dir captured as gdir, --work-tree ignored", mod._git_mutation_target(shlex.split(
-    "git --work-tree /y --git-dir /z/.git commit")), (True, None, "/z/.git"))
-check("gmt: --git-dir= form -> gdir", mod._git_mutation_target(shlex.split(
-    "git --git-dir=/z/.git commit")), (True, None, "/z/.git"))
-check("gmt: GIT_DIR= env -> gdir", mod._git_mutation_target(shlex.split(
-    "GIT_DIR=/z/.git git commit")), (True, None, "/z/.git"))
-check("gmt: -C + --git-dir both captured", mod._git_mutation_target(shlex.split(
-    "git -C /x --git-dir /z/.git commit")), (True, "/x", "/z/.git"))
-check("gmt: no redirect -> (True,None,None)", mod._git_mutation_target(shlex.split(
-    "git commit -m x")), (True, None, None))
-check("gmt: read-only -> False", mod._git_mutation_target(shlex.split(
-    "git status")), False)
+# These assert the REDIRECT fields only. _git_mutation_target also carries the
+# subcommand and its remaining tokens (the scoped-commit exemption needs both), so
+# comparing the whole tuple made all six fail on a change that did not touch
+# redirect detection at all. Slicing to [:3] keeps them testing what they are named
+# for instead of tracking the tuple's width; the carried fields get their own check.
+def redirect(cmd):
+    res = mod._git_mutation_target(shlex.split(cmd))
+    return res if res is False else tuple(res[:3])
 
-print(f"\n=== {len(CASES) + 7} assertions, {len(fails)} failed ===")
+
+check("gmt: -C captured as cdir, --work-tree ignored",
+      redirect("git -C /x --work-tree /y commit"), (True, "/x", None))
+check("gmt: --git-dir captured as gdir, --work-tree ignored",
+      redirect("git --work-tree /y --git-dir /z/.git commit"), (True, None, "/z/.git"))
+check("gmt: --git-dir= form -> gdir",
+      redirect("git --git-dir=/z/.git commit"), (True, None, "/z/.git"))
+check("gmt: GIT_DIR= env -> gdir",
+      redirect("GIT_DIR=/z/.git git commit"), (True, None, "/z/.git"))
+check("gmt: -C + --git-dir both captured",
+      redirect("git -C /x --git-dir /z/.git commit"), (True, "/x", "/z/.git"))
+check("gmt: no redirect -> (True,None,None)",
+      redirect("git commit -m x"), (True, None, None))
+check("gmt: read-only -> False", redirect("git status"), False)
+check("gmt: carries the subcommand + its remaining tokens",
+      mod._git_mutation_target(shlex.split("git commit -o A.txt -m x"))[3:],
+      ("commit", ["-o", "A.txt", "-m", "x"]))
+
+# --- scoped-commit exemption: `git commit -o <literal paths>` with an empty index -
+# `-o`/`--only` commits the working-tree contents of the NAMED paths and ignores the
+# index, so it cannot sweep a sibling's staged work — the harm this gate exists to
+# stop. Everything else about commit stays blocked. The index probe is injected so
+# these stay pure; empty=False simulates a sibling having staged something.
+def blocked(cmd, empty=True, cwd=HOME):
+    return mod._is_home_repo_git_mutation(cmd, cwd, HOME, index_probe=lambda d: empty)
+
+
+SCOPED_ALLOWED = [
+    "git commit -o A.txt -m x",
+    "git commit --only A.txt -m x",
+    "git commit -o A.txt B.txt C.txt -F /tmp/msg",
+    "git commit -o -- A.txt",
+    "git commit -oq A.txt -m x",
+    'git commit -om x A.txt',                 # -om == -o -m, so x is the MESSAGE
+    "git commit -o notes/ -m x",
+    "git commit -o A.txt -uno -m x",
+]
+# Each of these would be ALLOWED by a parser that reads an option's VALUE as a
+# pathspec — the one catastrophic direction, so most of the matrix pins it.
+SCOPED_BLOCKED = [
+    "git commit -m x",                        # bare
+    "git commit -o -m x",                     # -m eats the only positional
+    "git commit -om x",                       # cluster: x is the message
+    "git commit -o -F /tmp/msg",
+    "git commit -o -C HEAD",
+    "git commit -o --message x",
+    "git commit -o --pathspec-from-file /tmp/l",
+    "git commit -o",
+    "git commit -o -a A.txt -m x",            # -a widens to the whole tree
+    "git commit -o -i A.txt -m x",            # --include ADDS the index
+    "git commit -o --amend A.txt -m x",       # measured: --amend takes the index
+    "git commit -o -p A.txt",
+    "git commit -o . -m x",                   # sweeps files you did not name
+    "git commit -o '*.md' -m x",
+    "git commit -o ':/' -m x",
+    "git commit -o A.txt . -m x",             # one bad pathspec poisons it
+    "git commit A.txt -m x",                  # pathspecs but no explicit -o
+    "git commit -o --frobnicate A.txt",       # unclassified option -> cannot prove
+    "git push -o ci.skip",                    # -o is a PUSH option, not scoping
+    "git reset --hard",                       # no other verb is ever exempt
+    'git commit -o A.txt -m "l1\nl2"',        # multi-line -m: unparseable
+]
+for _c in SCOPED_ALLOWED:
+    check(f"scoped ALLOWED: {_c!r}", blocked(_c), False)
+for _c in SCOPED_BLOCKED:
+    check(f"scoped BLOCKED: {_c!r}", blocked(_c), True)
+# the index condition, both directions on the SAME command
+check("scoped commit BLOCKED when the index is not empty",
+      blocked("git commit -o A.txt -m x", empty=False), True)
+check("scoped commit ALLOWED when the index is empty",
+      blocked("git commit -o A.txt -m x", empty=True), False)
+# an explicit git-dir withholds the exemption: the index we probe may not be the
+# one git commits against
+check("scoped commit with explicit --git-dir at home BLOCKED",
+      blocked(f"git --git-dir={HOME}/.git commit -o A.txt -m x"), True)
+check("scoped commit at ANOTHER repo still allowed",
+      blocked(f"git -C {OTHER} commit -o A.txt -m x"), False)
+
+# --- gate liveness: can the enforcement arm fire in this repo at all? ------------
+# A mirror / --separate-git-dir layout puts main_root OUTSIDE the checkout, so
+# nothing ever attributes as "this repo" and the gate is dormant while the
+# once-per-session heads-up still fires, making it look alive.
+check("gate active: in-tree .git (cwd == main_root)", mod._git_gate_active(HOME, HOME), True)
+check("gate active: cwd below main_root", mod._git_gate_active(HOME + "/src", HOME), True)
+check("gate DORMANT: git dir outside the checkout",
+      mod._git_gate_active("/home/proj", "/home/mirrors/proj"), False)
+check("gate DORMANT: sibling-prefix path is not containment",
+      mod._git_gate_active(HOME + "-other/src", HOME), False)
+check("gate active: unknown inputs never claim breakage", mod._git_gate_active("", ""), True)
+
+print(f"\n=== {len(CASES) + 8 + len(SCOPED_ALLOWED) + len(SCOPED_BLOCKED) + 9} "
+      f"assertions, {len(fails)} failed ===")
 sys.exit(1 if fails else 0)


### PR DESCRIPTION
## The problem

`ALWAYS_MUTATING` hard-lists `commit`, so while a sibling session is live **every** commit is blocked — including `git commit -o <paths>`, which cannot cause the collision the gate exists to stop. The only escape was `SIBLING_SESSION_LOCK_BYPASS=1`, which disables the guard **session-wide**.

A guard whose only exit is "turn me off" teaches people to turn it off. This hook has already been fixed twice for exactly that reason (the `cd`-to-other-repo and `-C`/`--git-dir` false-blocks), and the same failure is documented a third time for a sibling hook where three agents independently self-authorized a bypass.

## What changed

**1. One exemption, narrowly proven.** `git commit -o`/`--only` + at least one *literal* pathspec + an empty index.

Still blocked: bare commit, `-a`, `-i`, `--amend`, `--interactive`, `--patch`, `.`/glob/magic pathspecs, unrecognised options, multi-line `-m`, explicit `--git-dir`, pathspecs without `-o`, every non-commit verb.

**2. The gate now says when it cannot fire.** If the git dir lives outside the checkout (mirror / `--separate-git-dir`), `main_root` is that outside path, no working-tree command is ever inside it, and the gate silently never fires — while the once-per-session heads-up keeps appearing and still claims commits are gated. A dead guard and a quiet one were emitting the same signal. This **reports** it; it does not repair it, because activating a gate that has been dormant changes which repos are gated at all and deserves its own change.

## Measured, not read off the man page

| Claim | Result |
|---|---|
| `-o` ignores the index | file `B` staged, `git commit -o A` committed **only** `A`, left `B` staged |
| the harm is real | the same commit run **bare** swept `B` in |
| `--amend` is unsafe even with `-o` | `git commit -o --amend` (no paths) **did** take the staged index |
| short options cluster | `-om "msg"` really parses as `-o -m "msg"` |
| unborn HEAD needs no special case | `git diff --cached --quiet` returns 0 empty / 1 staged with no commits |
| bare pathspecs are already `--only` | `git commit A` left staged `B` alone — still blocked here, deliberately |

That last one matters: git treats `git commit <paths>` as `--only` already, so it is not dangerous. It stays blocked so the exemption keys off an **explicit, auditable marker** rather than a subtle default, and a test pins it so relaxing it is a decision rather than an accident.

## The failure mode this guards against

Mistaking an option's **value** for a pathspec. `git commit -o -m msg` would otherwise look like "`-o` plus the pathspec `msg`" and be **allowed** while naming no paths at all. That is a false-ALLOW, strictly worse than the false-block being removed, so every option is classified and anything unclassified forfeits the exemption. The parse never guesses whether an option consumes the next token.

## Verification

- `hooks/test_session_lock_enforcement.py`: **50 → 89 assertions**, 0 failed.
- `tests/integration/test_session_coordination_guards.sh`: **33/33**, unchanged.
- **10 deliberate mutations** of the guard each confirmed to turn the suite RED against a GREEN control, with every mutation verified to have actually applied (anchor matched exactly once *and* the file hash changed) — a mutation that silently no-ops reads exactly like a guard correctly detecting nothing.

One mutation is deliberately two edits: removing `-a`/`-i`/`-p` from the unsafe set alone changes nothing, because they appear in no other table and fall through to "unclassified → block". Only *also* classifying them as harmless booleans opens the hole. Layered defense, not coverage.

## Notes for review

- `_is_home_repo_git_mutation` stays **pure** for existing callers: the index probe is injectable and only reached after the syntactic check passes, so no git subprocess runs on the hot path for ordinary commands.
- The index check is belt-and-braces, not the primary safety property — `-o` ignores the index regardless, so the TOCTOU gap between probe and commit cannot reintroduce the collision.
- The six `_git_mutation_target` tuple assertions now compare the **redirect fields only** (`[:3]`). Comparing the whole tuple made all six fail on a change that did not touch redirect detection; they now test what they are named for, and the carried subcommand/args get their own dedicated check.
- `docs/HOOKS_INSTALL.md` updated: it previously said a git-mutating command is warn-blocked *"every time"*, which is no longer true. **`session-lock` remains opt-in by design** — this does **not** add it to `hooks.json`, because that doc records the deliberate reason it is not auto-installed.
- The existing `SCOPE LIMIT` docstring (this hook gates the *verb*, not the repo's in-flight state) is preserved — ported into, not over.

---

### Local `ci-test` parity gate: bypassed deliberately, with evidence

The local gate went RED twice on a **real-home tripwire**, and both reds are environmental rather than caused by this diff. Holding the artifact constant (same commit `9517791`) and varying only the environment:

| run | test blamed | tripwire before → after |
|---|---|---|
| 1 | `test_bootstrap_dry_run` | `ab1f6769d4a734c0` → `664983c0b9c9524e` |
| 2 | `test_machinery_sidecar` | `664983c0b9c9524e` → `11e4c89ebd55e6e8` |

Same commit, **different test blamed each run** — so the write is not coming from the test that gets named. In both runs `settings.json`'s content sha, its mtime, the `baks` count and `files=1726` were all *identical* before and after; only the size/mtime tree hash moved, and no file was added or removed.

Measured separately: the fingerprint is **stable at rest** (two samples 50s apart, and two more a tool-call apart, all identical), and no file under the watch trees has an mtime inside the run window. So it moves exactly once per long-running window and then holds.

This diff touches `hooks/session-lock.py`, its unit test, and one doc — none of which either named test exercises. The relevant suites are green: the hook's own unit suite 89/89, and `tests/integration/test_session_coordination_guards.sh` 33/33.

Bypassing the *local parity* gate only. CI here is authoritative and runs in a clean container without the local `~/.claude` churn.
