### PR TITLE
fix(install): Node dies on a UAC prompt, and 3 wired hooks were never deployed (one inert on every platform)

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -50,6 +50,60 @@ function Err($msg)  { Write-Host "  X $msg" -ForegroundColor Red; $script:Failed
 function Dry($msg)  { Write-Host "  [dry-run] $msg" -ForegroundColor Magenta }
 function Have($cmd) { return [bool](Get-Command $cmd -ErrorAction SilentlyContinue) }
 
+# Is this process running elevated (Administrator)?
+# Decides per-MACHINE vs per-USER for every runtime we install. A per-machine
+# MSI run from a normal shell needs a UAC consent it can never obtain under
+# /quiet: msiexec aborts with 1925 ("insufficient privileges ... for all users
+# of the machine") or 1603, and Start-Process -Wait without -PassThru THREW
+# THAT AWAY. Net effect on a real Windows install: Node "installed" silently,
+# `Have node` was false, and the only surviving signal was a bare
+# "node install failed" with no reason. Cached once - elevation cannot change
+# mid-run.
+$script:IsElevated = $null
+function Test-Elevated {
+    if ($null -eq $script:IsElevated) {
+        try {
+            $id = [Security.Principal.WindowsIdentity]::GetCurrent()
+            $script:IsElevated = ([Security.Principal.WindowsPrincipal]$id).IsInRole(
+                [Security.Principal.WindowsBuiltInRole]::Administrator)
+        } catch {
+            # Non-Windows PowerShell (pwsh on macOS/Linux) has no WindowsIdentity.
+            # Treat as unelevated: the user-scoped path works everywhere.
+            $script:IsElevated = $false
+        }
+    }
+    return $script:IsElevated
+}
+
+# Run an installer and return its REAL exit code (0 when it never launched is a
+# lie, so a launch failure returns a sentinel). Start-Process -Wait alone
+# discards the exit status entirely - the bug this closes.
+function Invoke-Installer([string]$FilePath, [string[]]$ArgumentList) {
+    try {
+        $p = Start-Process -Wait -PassThru -FilePath $FilePath -ArgumentList $ArgumentList
+        return $p.ExitCode
+    } catch {
+        Warn "could not launch ${FilePath}: $_"
+        return -1
+    }
+}
+
+# Prepend a directory to the PERSISTED user PATH (and this process's PATH).
+# Used by the user-scoped runtime installs, which unpack somewhere the machine
+# PATH will never mention. Idempotent: re-running never duplicates the entry.
+function Add-UserPathEntry([string]$Dir) {
+    $userPath = [System.Environment]::GetEnvironmentVariable("Path", "User")
+    if ($null -eq $userPath) { $userPath = "" }
+    $already = $userPath -split ';' | Where-Object { $_.TrimEnd('\') -ieq $Dir.TrimEnd('\') }
+    if (-not $already) {
+        $newPath = if ($userPath.Trim()) { "$Dir;$userPath" } else { $Dir }
+        [System.Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+    }
+    if (-not (($env:Path -split ';') | Where-Object { $_.TrimEnd('\') -ieq $Dir.TrimEnd('\') })) {
+        $env:Path = "$Dir;$env:Path"
+    }
+}
+
 # Run a native command without letting benign stderr kill the install.
 # Under $ErrorActionPreference = "Stop", a native command that writes ANY
 # warning to stderr (pip's routine "not on PATH" note, npm progress, git
@@ -373,8 +427,30 @@ if (-not $pythonOk -and $CorporateProfile) {
         $pyInstaller = "$env:TEMP\python-installer.exe"
         try {
             Invoke-WebRequest -Uri "https://www.python.org/ftp/python/3.12.7/python-3.12.7-amd64.exe" -OutFile $pyInstaller -UseBasicParsing
-            Start-Process -Wait -FilePath $pyInstaller -ArgumentList "/quiet","InstallAllUsers=1","PrependPath=1"
+            # InstallAllUsers=1 is a per-machine install: it needs elevation,
+            # and under /quiet there is no UAC prompt to grant it, so it just
+            # fails. python.org's installer supports a per-user install with
+            # InstallAllUsers=0 and no privileges at all - use it when this
+            # shell is not already elevated.
+            $perUser = -not (Test-Elevated)
+            if ($perUser) {
+                Log (T "Not running as Administrator - installing Python for this user only." `
+                       "No estas como Administrador - instalando Python solo para este usuario.")
+            }
+            $pyArgs = @("/quiet", "PrependPath=1", "Include_pip=1",
+                        $(if ($perUser) { "InstallAllUsers=0" } else { "InstallAllUsers=1" }))
+            $code = Invoke-Installer $pyInstaller $pyArgs
             Remove-Item $pyInstaller -Force -ErrorAction SilentlyContinue
+            # 0 = installed, 3010 = installed, reboot pending. Anything else is
+            # a failure that used to be discarded silently.
+            if ($code -ne 0 -and $code -ne 3010) {
+                Err (T "Python installer exited $code (nothing was installed)." `
+                       "El instalador de Python salio con $code (no se instalo nada).")
+                if ($code -eq 1602 -or $code -eq 1603 -or $code -eq -1) {
+                    Warn (T "That is usually a denied elevation prompt. Re-run this script from an Administrator PowerShell, or install Python yourself from python.org." `
+                            "Normalmente es un prompt de elevacion denegado. Volve a correr este script desde un PowerShell como Administrador, o instala Python vos mismo desde python.org.")
+                }
+            }
         } catch {
             Err "Python install failed: $_"
         }
@@ -395,20 +471,80 @@ if (-not (Have node) -and $CorporateProfile) {
     Dry "would: winget install OpenJS.NodeJS.LTS (or direct download fallback)"
 } elseif (-not (Have node)) {
     Hdr "Installing Node.js"
+    $nodeVersion = "v20.18.0"
+    $wingetTried = $false
     if ($UseWinget) {
+        $wingetTried = $true
         winget install -e --id OpenJS.NodeJS.LTS --accept-source-agreements --accept-package-agreements
-    } else {
-        Log "winget unavailable, downloading Node.js LTS installer directly."
-        $nodeInstaller = "$env:TEMP\node-installer.msi"
+        # winget's Node package is per-machine too, so an unelevated run hits
+        # the same denied-elevation wall. Before this, a winget failure ended
+        # the attempt: no fallback ran, and the only trace was "node install
+        # failed" three lines later. Now it falls through to the direct path.
+        if ($LASTEXITCODE -ne 0) {
+            Warn (T "winget could not install Node.js (exit $LASTEXITCODE) - falling back to a direct download." `
+                    "winget no pudo instalar Node.js (salio $LASTEXITCODE) - probando con descarga directa.")
+        }
+        $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+    }
+    if (-not (Have node)) {
+        if ($wingetTried) { Log "Downloading Node.js LTS directly." }
+        else { Log "winget unavailable, downloading Node.js LTS directly." }
         try {
-            Invoke-WebRequest -Uri "https://nodejs.org/dist/v20.18.0/node-v20.18.0-x64.msi" -OutFile $nodeInstaller -UseBasicParsing
-            Start-Process -Wait -FilePath "msiexec" -ArgumentList "/i","$nodeInstaller","/quiet","/norestart"
-            Remove-Item $nodeInstaller -Force -ErrorAction SilentlyContinue
+            if (Test-Elevated) {
+                # Elevated: the per-machine MSI is the right install, and the
+                # UAC consent this needs is already granted.
+                $nodeInstaller = "$env:TEMP\node-installer.msi"
+                Invoke-WebRequest -Uri "https://nodejs.org/dist/$nodeVersion/node-$nodeVersion-x64.msi" -OutFile $nodeInstaller -UseBasicParsing
+                $code = Invoke-Installer "msiexec" @("/i", "`"$nodeInstaller`"", "/quiet", "/norestart")
+                Remove-Item $nodeInstaller -Force -ErrorAction SilentlyContinue
+                if ($code -ne 0 -and $code -ne 3010) {
+                    Err (T "Node.js MSI exited $code (nothing was installed)." `
+                           "El MSI de Node.js salio con $code (no se instalo nada).")
+                }
+            } else {
+                # NOT elevated. The MSI is per-machine and CANNOT be granted
+                # elevation under /quiet - it aborts with 1925/1603, and that
+                # exit code used to be thrown away, so the install looked like
+                # it worked. The official ZIP build needs no privileges at all:
+                # unpack it under LOCALAPPDATA and put it on the USER PATH.
+                Log (T "Not running as Administrator - installing Node.js for this user only (no UAC needed)." `
+                       "No estas como Administrador - instalando Node.js solo para este usuario (sin UAC).")
+                $nodeZip     = "$env:TEMP\node-$nodeVersion-win-x64.zip"
+                $stagingDir  = "$env:TEMP\node-unpack-$([System.Guid]::NewGuid().ToString('N'))"
+                $nodeHome    = "$env:LOCALAPPDATA\nodejs"
+                Invoke-WebRequest -Uri "https://nodejs.org/dist/$nodeVersion/node-$nodeVersion-win-x64.zip" -OutFile $nodeZip -UseBasicParsing
+                Expand-Archive -LiteralPath $nodeZip -DestinationPath $stagingDir -Force
+                $unpacked = Join-Path $stagingDir "node-$nodeVersion-win-x64"
+                if (-not (Test-Path (Join-Path $unpacked "node.exe"))) {
+                    throw "unpacked archive has no node.exe at $unpacked"
+                }
+                if (Test-Path $nodeHome) { Remove-Item $nodeHome -Recurse -Force -ErrorAction SilentlyContinue }
+                Move-Item -LiteralPath $unpacked -Destination $nodeHome
+                Remove-Item $nodeZip -Force -ErrorAction SilentlyContinue
+                Remove-Item $stagingDir -Recurse -Force -ErrorAction SilentlyContinue
+                Add-UserPathEntry $nodeHome
+                # npm's global prefix on Windows is %APPDATA%\npm. The MSI adds
+                # that to PATH; a ZIP install does not, so `npm install -g
+                # @anthropic-ai/claude-code` (the very next step) would succeed
+                # and still leave `claude` unrunnable. Put it on PATH too.
+                $npmGlobal = "$env:APPDATA\npm"
+                if (-not (Test-Path $npmGlobal)) { New-Item -ItemType Directory -Path $npmGlobal -Force | Out-Null }
+                Add-UserPathEntry $npmGlobal
+                Ok (T "Node.js installed at $nodeHome (user-scoped)." `
+                       "Node.js instalado en $nodeHome (solo para este usuario).")
+            }
         } catch {
             Err "Node install failed: $_"
         }
     }
     $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+    # A user-scoped install lives on the USER PATH, which the line above does
+    # pick up - but only after Add-UserPathEntry persisted it. Re-assert the
+    # in-process entries so this same run can call node/npm immediately.
+    if (Test-Path "$env:LOCALAPPDATA\nodejs\node.exe") {
+        Add-UserPathEntry "$env:LOCALAPPDATA\nodejs"
+        Add-UserPathEntry "$env:APPDATA\npm"
+    }
 }
 if (Have node) { Ok "node $(node --version)" } else { Err "node install failed" }
 

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -78,9 +78,21 @@ function Test-Elevated {
 # Run an installer and return its REAL exit code (0 when it never launched is a
 # lie, so a launch failure returns a sentinel). Start-Process -Wait alone
 # discards the exit status entirely - the bug this closes.
+# -PassThru WITHOUT -Wait, then WaitForExit() on the object we hold. `-Wait
+# -PassThru` also reports exit codes correctly (both forms verified against a
+# script exiting 0/1/3/42), but holding the object and waiting on it ourselves
+# keeps the handle open explicitly, and the $null guard below is what actually
+# matters: an exit code we could not read must never come back as 0. Returning
+# a false 0 here would rebuild, one layer up, the exact silent-success bug this
+# function exists to remove.
 function Invoke-Installer([string]$FilePath, [string[]]$ArgumentList) {
     try {
-        $p = Start-Process -Wait -PassThru -FilePath $FilePath -ArgumentList $ArgumentList
+        $p = Start-Process -PassThru -FilePath $FilePath -ArgumentList $ArgumentList
+        if ($null -eq $p) { return -1 }
+        $p.WaitForExit()
+        # A null ExitCode means we do not know what happened. That is the exact
+        # state this function exists to stop reading as success.
+        if ($null -eq $p.ExitCode) { return -1 }
         return $p.ExitCode
     } catch {
         Warn "could not launch ${FilePath}: $_"
@@ -91,6 +103,12 @@ function Invoke-Installer([string]$FilePath, [string[]]$ArgumentList) {
 # Prepend a directory to the PERSISTED user PATH (and this process's PATH).
 # Used by the user-scoped runtime installs, which unpack somewhere the machine
 # PATH will never mention. Idempotent: re-running never duplicates the entry.
+#
+# Known tradeoff: SetEnvironmentVariable rewrites the USER Path as a plain
+# string, so a `%VAR%` inside it is stored expanded. Accepted deliberately -
+# `setx` truncates at 1024 characters, which silently DESTROYS a long PATH, and
+# that is the worse failure. The machine PATH, where expandable entries
+# actually live, is never touched here.
 function Add-UserPathEntry([string]$Dir) {
     $userPath = [System.Environment]::GetEnvironmentVariable("Path", "User")
     if ($null -eq $userPath) { $userPath = "" }
@@ -473,6 +491,7 @@ if (-not (Have node) -and $CorporateProfile) {
     Hdr "Installing Node.js"
     $nodeVersion = "v20.18.0"
     $wingetTried = $false
+    $userScopedNode = $false
     if ($UseWinget) {
         $wingetTried = $true
         winget install -e --id OpenJS.NodeJS.LTS --accept-source-agreements --accept-package-agreements
@@ -518,8 +537,20 @@ if (-not (Have node) -and $CorporateProfile) {
                 if (-not (Test-Path (Join-Path $unpacked "node.exe"))) {
                     throw "unpacked archive has no node.exe at $unpacked"
                 }
-                if (Test-Path $nodeHome) { Remove-Item $nodeHome -Recurse -Force -ErrorAction SilentlyContinue }
+                # Move an existing folder aside rather than deleting it. We only
+                # get here because node is not on PATH, so whatever is there is
+                # broken or stale - but it is still the user's, and a silent
+                # recursive delete of a folder under LOCALAPPDATA is not ours to
+                # make. Same .bak-<stamp> convention the rest of the install uses.
+                if (Test-Path $nodeHome) {
+                    $shelved = "$nodeHome.bak-$(Get-Date -Format 'yyyy-MM-dd-HHmm')"
+                    Move-Item -LiteralPath $nodeHome -Destination $shelved -ErrorAction SilentlyContinue
+                    if (Test-Path $nodeHome) { throw "could not move the existing $nodeHome aside" }
+                    Warn (T "Moved a previous $nodeHome aside to $shelved." `
+                            "Se movio el $nodeHome anterior a $shelved.")
+                }
                 Move-Item -LiteralPath $unpacked -Destination $nodeHome
+                $userScopedNode = $true
                 Remove-Item $nodeZip -Force -ErrorAction SilentlyContinue
                 Remove-Item $stagingDir -Recurse -Force -ErrorAction SilentlyContinue
                 Add-UserPathEntry $nodeHome
@@ -541,7 +572,12 @@ if (-not (Have node) -and $CorporateProfile) {
     # A user-scoped install lives on the USER PATH, which the line above does
     # pick up - but only after Add-UserPathEntry persisted it. Re-assert the
     # in-process entries so this same run can call node/npm immediately.
-    if (Test-Path "$env:LOCALAPPDATA\nodejs\node.exe") {
+    #
+    # Gated on $userScopedNode, NOT on the folder existing: a LEFTOVER
+    # %LOCALAPPDATA%\nodejs from an earlier run would otherwise be prepended
+    # ahead of a per-machine install we just made, and the stale copy would win
+    # every `node` call from here on.
+    if ($userScopedNode) {
         Add-UserPathEntry "$env:LOCALAPPDATA\nodejs"
         Add-UserPathEntry "$env:APPDATA\npm"
     }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,34 @@ description: What's new in AI Brain Starter — plain English, no jargon
 
 ---
 
+## 2026-08-13: three helpers that were never actually installed, and a Windows setup that could fail without saying so
+
+**Who this affects:** everyone, for the second half. Windows users especially, for the first.
+
+Both of these came out of one real Windows install, where a person hit them, worked around them by hand, and told us.
+
+**Setup could fail to install Node.js and not say why.** Node's installer puts itself in a location that belongs to the whole machine, which Windows only allows after you approve a permission prompt. Setup ran that installer in silent mode, where no prompt can appear, so on a normal (non-Administrator) PowerShell the install simply refused. Worse, setup was throwing away the installer's answer entirely: whether it succeeded, failed, or never started, the next line of output looked the same. All you saw, several lines later, was a bare "node install failed" with no reason attached.
+
+Now setup checks whether it is running as Administrator first. If it is, nothing changes. If it is not, it installs Node just for you, from the official ZIP build, into your own user folder, and adds it to your PATH. That path needs no permission prompt at all, so it cannot fail this way. It also adds the folder npm uses for global tools, which the machine-wide installer would normally have added, so Claude Code installs and runs straight afterward. If winget was tried first and could not do it, setup now falls back to the direct download instead of giving up. And every installer's real exit code is now read and reported, so a failure says what happened and what to do about it. The same fix is applied to the Python installer beside it, which had the identical problem.
+
+**Three background helpers were being wired up but never copied into place.** `vault-context.py` (reads your priorities and open loops and puts them in front of Claude before it answers a strategic question), `retry-budget.py` (stops Claude looping on the same failing command), and `validate-mcp-json.py` (catches a broken `.mcp.json` before it silently disables every connector you have).
+
+Setup listed them in your settings, so they looked installed. But the actual copying was a `cp` command written inside one of the setup guides, meant to be run while Claude walked you through setup. `cp` is not a command on Windows, so there it could not run at all. And because each of these hooks is deliberately wired as "run this only if the file exists", a missing file produces no error, no warning, and no output. Nothing to notice, on any platform.
+
+There was a second layer to it. `vault-context.py` reads a small shared library that ships beside it, and nothing ever copied that library anywhere. So even where the `cp` did run, the hook loaded, found no library, fell back to its own do-nothing branch, and exited cleanly. It has been reporting healthy and injecting nothing, on every operating system, since it shipped.
+
+All three now install with everything else, on every platform, along with the library they need. Setup verifies them afterward instead of assuming.
+
+**What you should do:** run this once, and you are current:
+
+```
+python3 ~/.claude/skills/ai-brain-starter/scripts/install-hooks-user-level.py
+```
+
+If your session start mentions "background helpers not active", this is what it was pointing at. Nothing else changes, and re-running is safe: anything you edited by hand is backed up to `<file>.bak-YYYY-MM-DD-HHMM` before it is replaced.
+
+---
+
 ## 2026-08-05: on Mac and Linux, "daily backup scheduled" now means it really is
 
 **Who this affects:** anyone on macOS or Linux who set up the daily vault backup.

--- a/phases/phase-05-context-layer.md
+++ b/phases/phase-05-context-layer.md
@@ -132,12 +132,9 @@ Also add an auto-update hook that checks GitHub for updates at most once per wee
 
 Also add the **vault-context hook** — this one actually reads and injects file contents before responding to strategic questions, instead of just instructing Claude to read them. The difference matters: an instruction can be skipped or deferred; injected content is always there.
 
-Copy the hook file:
-```bash
-cp ~/.claude/skills/ai-brain-starter/hooks/vault-context.py ~/.claude/hooks/vault-context.py
-```
+**Nothing to copy.** `scripts/install-hooks-user-level.py` already deployed `~/.claude/hooks/vault-context.py` — and the `hooks/_lib/` package it imports — during bootstrap, on every platform. This step used to be a literal `cp` command run from this doc, which is why the hook never landed on Windows (`cp` is not a command there) and why its `_lib` dependency landed nowhere at all. The hook is wired with a `[ -f ]` guard, so both failures were completely silent.
 
-Then add it as an additional UserPromptSubmit hook in `.claude/settings.local.json`:
+Wire it as an additional UserPromptSubmit hook in `.claude/settings.local.json`:
 ```json
 {
   "type": "command",
@@ -152,22 +149,18 @@ To add your own project-specific files, edit `~/.claude/hooks/vault-context.py` 
 
 ### Additional PreToolUse hooks
 
-The starter ships five PreToolUse hooks under `hooks/`. Two install by default (they help every user with no behavior-change cost). Three are conditional — install only if the specific risk applies.
+The starter ships five PreToolUse hooks under `hooks/`. Two are installed for everyone by the bootstrap (they help every user with no behavior-change cost). Three are conditional — install only if the specific risk applies.
 
-**Install by default — run these two `cp` commands now:**
-
-```bash
-mkdir -p ~/.claude/hooks
-cp ~/.claude/skills/ai-brain-starter/hooks/retry-budget.py ~/.claude/hooks/
-cp ~/.claude/skills/ai-brain-starter/hooks/validate-mcp-json.py ~/.claude/hooks/
-```
+**Already installed — no command to run:**
 
 | Hook | What it does | Why it's default |
 |---|---|---|
 | `retry-budget.py` | Blocks the 4th identical Bash command within 30 minutes | Caps Claude's tendency to loop on failing commands and burn context. Bypass: `RETRY_BUDGET_BYPASS=1 <cmd>` |
 | `validate-mcp-json.py` | Blocks Write/Edit on `.mcp.json` if the result fails JSON parsing | Claude Code silently drops malformed `.mcp.json`, disabling every registered MCP. Catches a single misplaced brace before it takes the stack dark. |
 
-Both are already wired into `hooks.json` with file-exists guards — if the user removes the file, the hook chain stays clean (protection just goes away, no errors). To uninstall either: `rm ~/.claude/hooks/<name>.py`.
+`scripts/install-hooks-user-level.py` deploys both, cross-platform, and re-verifies them on every run. They were `cp` commands in this doc until 2026-08-13; on Windows that step could not run, and nothing checked afterwards, so both hooks were wired-and-absent — protection that reported as installed and never once fired.
+
+Both are wired into `hooks.json` with file-exists guards — if the user removes the file, the hook chain stays clean (protection just goes away, no errors). To uninstall either: `rm ~/.claude/hooks/<name>.py`. Note that a later bootstrap re-deploys it; to keep it off permanently, remove its entry from `settings.json` too.
 
 **Conditional opt-ins — install only if the risk applies (read each file first):**
 

--- a/scripts/check-cloud-safe-file-walkers.py
+++ b/scripts/check-cloud-safe-file-walkers.py
@@ -42,6 +42,14 @@ COPY_READERS = {"copy", "copy2", "copyfile", "copyfileobj"}
 class _Imports:
     os_modules: set[str] = field(default_factory=lambda: {"os"})
     os_walk_names: set[str] = field(default_factory=set)
+    # Modules whose `.walk()` traverses an IN-MEMORY tree, never a filesystem.
+    # Starts EMPTY and is populated only by a real `import ast [as X]`, unlike
+    # os_modules/shutil_modules which seed their own names. Seeding "ast" here
+    # would carve out `import os as ast; ast.walk(...)`, a real walker wearing
+    # the name. A module imported inside a function is not seen by this
+    # top-level scan, so its `.walk` stays flagged: conservative in the safe
+    # direction.
+    ast_modules: set[str] = field(default_factory=set)
     shutil_modules: set[str] = field(default_factory=lambda: {"shutil"})
     shutil_copy_names: dict[str, str] = field(default_factory=dict)
     safe_names: set[str] = field(default_factory=set)
@@ -348,7 +356,19 @@ class _BodyVisitor(ast.NodeVisitor):
             }
             or (isinstance(node.func, ast.Name) and node.func.id in self.imports.os_walk_names)
         )
-        path_walker = isinstance(node.func, ast.Attribute) and node.func.attr == "walk"
+        # `.walk()` on ANY object was treated as Path.walk. That matches by NAME
+        # against an open set: `ast.walk(tree)` traverses a parse tree in memory
+        # and cannot reach a filesystem, yet a lint that parses Python AND reads
+        # source files (which is what most of scripts/check-*.py are) was
+        # reported UNSAFE for pairing it with read_text. A false UNSAFE on a
+        # guard like this one is expensive: the reader's cheapest resolution is
+        # to weaken something real. Carve out only the in-memory walkers,
+        # resolved through the import table (see _Imports.ast_modules).
+        path_walker = (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == "walk"
+            and dotted not in {f"{module}.walk" for module in self.imports.ast_modules}
+        )
         imported_copy = self.imports.shutil_copy_names.get(leaf)
         copytree = (
             dotted in {f"{module}.copytree" for module in self.imports.shutil_modules}
@@ -494,6 +514,8 @@ def _imports(tree: ast.Module, local_function_names: set[str]) -> _Imports:
                 local = alias.asname or alias.name.split(".", 1)[0]
                 if alias.name == "os":
                     imports.os_modules.add(local)
+                elif alias.name == "ast":
+                    imports.ast_modules.add(local)
                 elif alias.name == "shutil":
                     imports.shutil_modules.add(local)
                 elif alias.name == "_lib.safe_read" or alias.name.endswith("._lib.safe_read"):

--- a/scripts/check-home-hook-deploy.py
+++ b/scripts/check-home-hook-deploy.py
@@ -70,6 +70,7 @@ Stdlib only. No network, no git, no writes.
 
 from __future__ import annotations
 
+import ast
 import importlib.util
 import json
 import re
@@ -113,27 +114,44 @@ def _load_installer_manifest() -> tuple[set[str], set[str]]:
             set(getattr(mod, "HOME_HOOKS_LIB_DEPS", ())))
 
 
-# Both spellings, because both are in use in this repo's hooks/ and a guard
-# that only knows one is a guard that passes on the other:
-#   from _lib.<mod> import name   /   import _lib.<mod>       -> _DOTTED
-#   from _lib import <mod>, <mod2>                            -> _FROM_PKG
-_LIB_IMPORT_DOTTED_RE = re.compile(r"^\s*(?:from|import)\s+_lib\.(\w+)", re.MULTILINE)
-_LIB_IMPORT_FROM_PKG_RE = re.compile(r"^\s*from\s+_lib\s+import\s+(.+)$", re.MULTILINE)
-
-
 def _imported_lib_modules(body: str) -> set[str]:
-    """Every `_lib` submodule a hook's source imports, in either spelling."""
-    mods = set(_LIB_IMPORT_DOTTED_RE.findall(body))
-    for clause in _LIB_IMPORT_FROM_PKG_RE.findall(body):
-        # `from _lib import a as x, b` -> {a, b}. Parenthesized multi-line
-        # forms only yield their first line here, which under-reports rather
-        # than over-reports: a missed name is caught the moment someone
-        # actually deploys a hook using it, and a FALSE violation would block
-        # CI on a correct repo.
-        for part in clause.split("#", 1)[0].split(","):
-            token = part.strip().lstrip("(").split(" as ")[0].strip()
-            if token.isidentifier():
-                mods.add(token)
+    """Every `_lib` submodule a hook's source imports, in any spelling.
+
+    Parsed with `ast`, not matched with a regex. Both spellings are in use in
+    this repo's hooks/ — `from _lib.<mod> import x`, `import _lib.<mod>`, and
+    `from _lib import <mod>` — so a guard that knows only one passes on the
+    other. A regex covering both then over-matches: hooks/ already contains the
+    line
+
+        f"from _lib.secret_patterns import redact; from pathlib import Path; "
+
+    inside a string, and a bare `from _lib import x` in a docstring sits at
+    column 0 like real code. A false violation blocks CI on a correct repo,
+    which is worse than the gap being closed. The AST sees imports and nothing
+    that merely looks like one, and it handles parenthesized multi-line and
+    aliased forms for free.
+
+    A file that does not parse yields nothing: gate (a) py_compiles every
+    tracked *.py and owns that failure, and a second, worse-worded report of it
+    here would only muddy attribution.
+    """
+    try:
+        tree = ast.parse(body)
+    except (SyntaxError, ValueError):
+        return set()
+    mods: set[str] = set()
+    for node in ast.walk(tree):
+        # from _lib import a, b   /   from _lib.mod import x
+        if isinstance(node, ast.ImportFrom) and node.module:
+            if node.module == "_lib":
+                mods.update(alias.name for alias in node.names)
+            elif node.module.startswith("_lib."):
+                mods.add(node.module.split(".")[1])
+        # import _lib.mod  /  import _lib.mod as m
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.startswith("_lib."):
+                    mods.add(alias.name.split(".")[1])
     return mods
 
 

--- a/scripts/check-home-hook-deploy.py
+++ b/scripts/check-home-hook-deploy.py
@@ -100,8 +100,28 @@ def _load_installer_manifest() -> tuple[set[str], set[str]]:
     return set(mod.HOME_HOOKS_INSTALLER_DEPLOYS), set(mod.HOME_HOOKS_LIB_DEPS)
 
 
-# `from _lib.<module> import ...` / `import _lib.<module>` in a hook's source.
-_LIB_IMPORT_RE = re.compile(r"^\s*(?:from|import)\s+_lib\.(\w+)", re.MULTILINE)
+# Both spellings, because both are in use in this repo's hooks/ and a guard
+# that only knows one is a guard that passes on the other:
+#   from _lib.<mod> import name   /   import _lib.<mod>       -> _DOTTED
+#   from _lib import <mod>, <mod2>                            -> _FROM_PKG
+_LIB_IMPORT_DOTTED_RE = re.compile(r"^\s*(?:from|import)\s+_lib\.(\w+)", re.MULTILINE)
+_LIB_IMPORT_FROM_PKG_RE = re.compile(r"^\s*from\s+_lib\s+import\s+(.+)$", re.MULTILINE)
+
+
+def _imported_lib_modules(body: str) -> set[str]:
+    """Every `_lib` submodule a hook's source imports, in either spelling."""
+    mods = set(_LIB_IMPORT_DOTTED_RE.findall(body))
+    for clause in _LIB_IMPORT_FROM_PKG_RE.findall(body):
+        # `from _lib import a as x, b` -> {a, b}. Parenthesized multi-line
+        # forms only yield their first line here, which under-reports rather
+        # than over-reports: a missed name is caught the moment someone
+        # actually deploys a hook using it, and a FALSE violation would block
+        # CI on a correct repo.
+        for part in clause.split("#", 1)[0].split(","):
+            token = part.strip().lstrip("(").split(" as ")[0].strip()
+            if token.isidentifier():
+                mods.add(token)
+    return mods
 
 
 def _lib_dependency_violations(deployed: set[str], lib_deps: set[str]) -> list[str]:
@@ -127,7 +147,7 @@ def _lib_dependency_violations(deployed: set[str], lib_deps: set[str]) -> list[s
             body = src.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             continue
-        for mod in sorted(set(_LIB_IMPORT_RE.findall(body))):
+        for mod in sorted(_imported_lib_modules(body)):
             if f"{mod}.py" not in lib_deps:
                 problems.append(
                     f"{name}: imports _lib.{mod}, but '{mod}.py' is not in "

--- a/scripts/check-home-hook-deploy.py
+++ b/scripts/check-home-hook-deploy.py
@@ -30,13 +30,26 @@ THE INVARIANT
 
       2. PHASE DOC — some phases/*.md carries a literal
          `cp .../hooks/<name> ~/.claude/hooks/` step, executed during
-         /setup-brain. For hooks that are conditional, vault-dependent, or
-         opt-in after a user decision (retry-budget.py, validate-mcp-json.py,
-         vault-context.py).
+         /setup-brain. For hooks that are genuinely conditional — installed
+         only after a user decision this installer cannot make for them.
 
     Neither route = the hook cannot fire. Both routes = the phase doc's
     copy-if-the-user-opts-in is silently pre-empted by the installer, so the
     documented choice is a lie. Both are failures.
+
+    Route 2 is a WEAK route and route 1 is preferred for anything installed by
+    default. A `cp` in a markdown file is POSIX-only (it cannot run on native
+    Windows at all) and model-executed (it happens if an agent reads the doc
+    and chooses to). retry-budget.py, validate-mcp-json.py and vault-context.py
+    took route 2 until 2026-08-13, when a Windows install turned up with all
+    three absent; they are installer-deployed now.
+
+    THE SECOND INVARIANT (2026-08-13)
+    Every `_lib.<mod>` imported by an installer-deployed hook is in
+    HOME_HOOKS_LIB_DEPS, so the dependency ships with its consumer. These hooks
+    catch the ImportError and fall back to a no-op, which means a missing _lib
+    produces a hook that runs, exits 0, and silently does nothing — the same
+    invisible failure, one layer down. See _lib_dependency_violations().
 
     The reverse direction is checked too: an entry in
     HOME_HOOKS_INSTALLER_DEPLOYS that hooks.json no longer references, or that
@@ -73,8 +86,8 @@ INSTALLER = ROOT / "scripts" / "install-hooks-user-level.py"
 _HOME_HOOK_RE = re.compile(r"~/\.claude/hooks/([\w.-]+\.(?:py|sh))")
 
 
-def _load_installer_manifest() -> set[str]:
-    """HOME_HOOKS_INSTALLER_DEPLOYS, read from the installer itself.
+def _load_installer_manifest() -> tuple[set[str], set[str]]:
+    """(HOME_HOOKS_INSTALLER_DEPLOYS, HOME_HOOKS_LIB_DEPS), from the installer.
 
     Imported rather than duplicated: a second hand-maintained copy of the list
     is exactly the drift this lint exists to prevent.
@@ -84,7 +97,57 @@ def _load_installer_manifest() -> set[str]:
         raise RuntimeError(f"cannot load {INSTALLER}")
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
-    return set(mod.HOME_HOOKS_INSTALLER_DEPLOYS)
+    return set(mod.HOME_HOOKS_INSTALLER_DEPLOYS), set(mod.HOME_HOOKS_LIB_DEPS)
+
+
+# `from _lib.<module> import ...` / `import _lib.<module>` in a hook's source.
+_LIB_IMPORT_RE = re.compile(r"^\s*(?:from|import)\s+_lib\.(\w+)", re.MULTILINE)
+
+
+def _lib_dependency_violations(deployed: set[str], lib_deps: set[str]) -> list[str]:
+    """Every `_lib.<mod>` a DEPLOYED hook imports must ship with it.
+
+    Second half of the same bug. A hook copied to ~/.claude/hooks/ without the
+    package it imports does NOT crash: these hooks wrap the import in a
+    try/except with a no-op fallback (correct — a context injector must never
+    break a prompt), so the hook runs, exits 0, and does nothing. From the
+    outside that is byte-identical to a hook with nothing to say.
+
+    vault-context.py shipped exactly that way on EVERY platform: the phase doc
+    copied the .py, nothing ever copied hooks/_lib/, and `vault_root_for` fell
+    back to the stub returning None — no vault resolved, nothing injected, no
+    error, forever.
+    """
+    problems: list[str] = []
+    for name in sorted(deployed):
+        src = HOOKS_DIR / name
+        if not src.is_file():
+            continue  # absence is already reported by the caller
+        try:
+            body = src.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for mod in sorted(set(_LIB_IMPORT_RE.findall(body))):
+            if f"{mod}.py" not in lib_deps:
+                problems.append(
+                    f"{name}: imports _lib.{mod}, but '{mod}.py' is not in "
+                    "HOME_HOOKS_LIB_DEPS in scripts/install-hooks-user-level.py "
+                    "— the hook deploys and its dependency does not. The import "
+                    "fails into a silent no-op fallback, so the hook reports "
+                    "healthy and never does anything."
+                )
+            elif not (HOOKS_DIR / "_lib" / f"{mod}.py").is_file():
+                problems.append(
+                    f"{name}: imports _lib.{mod}, but hooks/_lib/{mod}.py is not "
+                    "in this repo — nothing can deploy a file that does not exist."
+                )
+    if lib_deps and "__init__.py" not in lib_deps:
+        problems.append(
+            "HOME_HOOKS_LIB_DEPS is missing '__init__.py' — without it the "
+            "deployed _lib/ is not an importable package, so every "
+            "`from _lib.X import ...` fails into its silent fallback."
+        )
+    return problems
 
 
 def _referenced_home_hooks() -> set[str]:
@@ -120,10 +183,10 @@ def main() -> int:
     json.loads(HOOKS_JSON.read_text(encoding="utf-8"))
 
     referenced = _referenced_home_hooks()
-    installer_deploys = _load_installer_manifest()
+    installer_deploys, lib_deps = _load_installer_manifest()
     phase_copies = _phase_doc_copies()
 
-    violations: list[str] = []
+    violations: list[str] = _lib_dependency_violations(installer_deploys, lib_deps)
 
     for name in sorted(referenced):
         by_installer = name in installer_deploys
@@ -166,7 +229,8 @@ def main() -> int:
     print(
         f"OK — {len(referenced)} ~/.claude/hooks/ reference(s) all have a deploy "
         f"route ({len(referenced & installer_deploys)} installer, "
-        f"{len(referenced & set(phase_copies))} phase doc)."
+        f"{len(referenced & set(phase_copies))} phase doc); "
+        f"{len(lib_deps)} _lib dependency file(s) ship with them."
     )
     return 0
 

--- a/scripts/check-home-hook-deploy.py
+++ b/scripts/check-home-hook-deploy.py
@@ -97,7 +97,20 @@ def _load_installer_manifest() -> tuple[set[str], set[str]]:
         raise RuntimeError(f"cannot load {INSTALLER}")
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
-    return set(mod.HOME_HOOKS_INSTALLER_DEPLOYS), set(mod.HOME_HOOKS_LIB_DEPS)
+    # HOME_HOOKS_LIB_DEPS via getattr, and an absent one is EMPTY rather than an
+    # error: an installer that predates the constant is a valid installer, and
+    # scripts/test_windows_install_regressions.py deliberately synthesizes a
+    # one-constant installer to exercise this guard in isolation. Crashing there
+    # with an AttributeError traceback would be a worse failure mode than the
+    # clean violation this lint exists to print.
+    #
+    # Empty is NOT a bypass. It cannot pass on a repo that actually needs the
+    # manifest: _lib_dependency_violations() checks each import against this
+    # set, so an empty one turns EVERY `_lib.<mod>` in a deployed hook into a
+    # named violation. Deleting the constant from the real installer therefore
+    # reddens this gate loudly, which is the point.
+    return (set(mod.HOME_HOOKS_INSTALLER_DEPLOYS),
+            set(getattr(mod, "HOME_HOOKS_LIB_DEPS", ())))
 
 
 # Both spellings, because both are in use in this repo's hooks/ and a guard

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -459,7 +459,32 @@ WATCH_GLOBS = [
 #   trips    installer backup left behind (.bak-*)
 #   trips    the SessionStart snapshot rewritten
 #   ignores  append-only .log / .jsonl grows, lock dir churns, per-session
-#            scratch appears
+#            scratch appears, a hook runtime-state DOTFILE is rewritten
+#
+# DOTFILES, added 2026-08-13. ~/.claude/hooks/ is shared ground: this repo's
+# deployed hooks sit there alongside whatever private tooling the operator has
+# installed, and that tooling drops last-run stamps right beside them. Measured
+# on one machine: 8 dotfiles, 7 of them pure runtime state --
+# .mcp-config-secret-scan-last, .last-secret-scan, .last-secret-scan-full,
+# .secret-scan-findings.json, .pre-push-doubt-heeding.stamp,
+# .deployed-manifest.sha256, .secret-scan.lock. Only .gitignore is durable, and
+# nothing this gate protects is a dotfile.
+#
+# CHURN_SUFFIXES cannot catch them: .stamp, .sha256, .json and a bare
+# extensionless marker are four spellings of one behaviour, and the next hook
+# adds a fifth. That is the open set this file's own comment warns about ("a
+# denylist against an open set always loses"), so exclude by the PROPERTY that
+# separates them: deployed hook code is never a dotfile. Every entry in
+# install-hooks-user-level.py's HOME_HOOKS_INSTALLER_DEPLOYS and every
+# ABS-owned basename is a named *.py / *.sh.
+#
+# Caught live: a background secret-scan hook rewrote
+# hooks/.mcp-config-secret-scan-last 91 seconds into a gate run and reddened
+# test_bootstrap_dry_run -- a test that touches neither file. Re-running that
+# test alone, on that branch AND on a pristine origin/main, tripped nothing.
+# That is precisely the "reddens an unrelated test and trains a bypass" outcome
+# the quiet control below exists to prevent, arriving through a gap in the walk
+# the quiet control does not inspect.
 CHURN_SUFFIXES = (".log", ".jsonl")
 
 seen = []
@@ -475,6 +500,8 @@ for tree in WATCH_TREES:
             fp = Path(root) / name
             if fp.suffix in CHURN_SUFFIXES:
                 continue
+            if name.startswith("."):
+                continue  # hook runtime state, never deployed hook code
             try:
                 st = fp.stat()
             except OSError:
@@ -552,6 +579,12 @@ else:
                    "fingerprint walk")
     if 'endswith(".lock")' not in src:
         bad.append("the runtime lock-dir pruning is gone from the walk")
+    if 'name.startswith(".")' not in src:
+        bad.append('the dotfile exclusion is gone from the walk — ~/.claude/'
+                   'hooks/ is shared with the operator\'s private tooling, '
+                   'which drops last-run stamps (.stamp/.sha256/.json/no '
+                   'suffix) beside the deployed hooks; without this the gate '
+                   'reddens on whichever test happens to be running')
 
 if bad:
     print("::error::real-home tripwire quiet-control FAILED — the watched set "
@@ -561,7 +594,7 @@ if bad:
         print("::error::  - " + b)
     sys.exit(1)
 print("    tripwire quiet-control: fingerprint still excludes append-only "
-      "logs, lock dirs and per-session scratch")
+      "logs, lock dirs, runtime-state dotfiles and per-session scratch")
 PY
 }
 _home_before_suite="$(real_home_fingerprint)"

--- a/scripts/install-hooks-user-level.py
+++ b/scripts/install-hooks-user-level.py
@@ -266,6 +266,11 @@ ABS_OWNED_BASENAMES = {
     # committed basenames against owned deployed ones — every Windows user would
     # get a "1 background helper is not active" nag that no action can clear.
     "pre-write-settings-lint.py", "lint-claude-settings.py",
+    # Phase-05 hooks, moved to the installer route 2026-08-13 (see
+    # HOME_HOOKS_INSTALLER_DEPLOYS). Owned for the same reason as the two
+    # above: unowned means verify_paths_on_disk() never looks at them, and a
+    # never-deployed hook then reports as a clean install forever.
+    "retry-budget.py", "validate-mcp-json.py", "vault-context.py",
 }
 
 # Hooks that hooks.json invokes from ~/.claude/hooks/ and that THIS INSTALLER is
@@ -279,15 +284,51 @@ ABS_OWNED_BASENAMES = {
 # settings.json, present on disk 0 times, reported OK. Shipped-but-never-once-
 # executed, on every install, since they were merged (#313's follow-on).
 #
-# The complement — retry-budget.py, validate-mcp-json.py, vault-context.py — is
-# deliberately NOT here: phase-05 copies those during /setup-brain, some only
-# when the user opts in. scripts/check-home-hook-deploy.py asserts that every
-# ~/.claude/hooks/ reference in hooks.json is covered by exactly one of the two
-# routes, so the next hook added to the template cannot land in neither.
+# retry-budget.py, validate-mcp-json.py and vault-context.py joined this set
+# 2026-08-13, from a field report on a Windows install where all three were
+# absent from ~/.claude/hooks/. They used to take the PHASE-DOC route: three
+# literal `cp` lines in phases/phase-05-context-layer.md, executed by the MODEL
+# during /setup-brain. Three things were wrong with that:
+#
+#   1. POSIX-ONLY. `cp` and `mkdir -p` are not commands on native Windows, so
+#      the step could not run there at all — and its failure is invisible,
+#      because the `[ -f ]` guard turns every missing hook into silence.
+#   2. MODEL-EXECUTED. A copy step that depends on an agent reading a markdown
+#      table and choosing to run it is not a deploy route; it is a suggestion.
+#      Nothing verified it afterwards on any platform.
+#   3. THE DEPENDENCY WAS NEVER SHIPPED. vault-context.py does
+#      `from _lib.vault_root import vault_root_for` and falls back to a stub
+#      returning None when that import fails. Nothing ever copied hooks/_lib/
+#      to ~/.claude/hooks/, so even a SUCCESSFUL `cp` of the .py landed a hook
+#      that resolved no vault and injected nothing, on every platform, forever
+#      — fail-open, exit 0, no output. See HOME_HOOKS_LIB_DEPS.
+#
+# The phase doc no longer copies them (its `cp` lines are gone). Do not add one
+# back: scripts/check-home-hook-deploy.py fails on BOTH routes as loudly as on
+# neither, because a phase doc offering a choice the installer already made is
+# a documented lie.
 HOME_HOOKS_INSTALLER_DEPLOYS = {
     "pre-write-settings-lint.py",   # PreToolUse(Write|Edit) settings-integrity blocker
     "lint-claude-settings.py",      # SessionStart settings drift lint (+ --test self-check)
     "check-claude-code-version.sh",  # SessionStart version check (POSIX only; bash)
+    "retry-budget.py",              # PreToolUse(Bash) 4th-identical-command blocker
+    "validate-mcp-json.py",         # PreToolUse(Write|Edit) .mcp.json parse gate
+    "vault-context.py",             # UserPromptSubmit vault-context injector
+}
+
+# Package files under hooks/_lib/ that a HOME_HOOKS_INSTALLER_DEPLOYS hook
+# imports, and that therefore have to land in ~/.claude/hooks/_lib/ in the SAME
+# install. "Ship the dep with the consumer, same commit."
+#
+# A deployed hook does `sys.path.insert(0, <its own dir>)` and then
+# `from _lib.X import ...`. Deploy the hook alone and that import raises
+# ImportError inside a try/except whose fallback is a silent no-op — the hook
+# runs, exits 0, and does nothing, which is indistinguishable from a hook with
+# nothing to say. scripts/check-home-hook-deploy.py statically asserts that
+# every `_lib` module imported by a deployed hook appears here.
+HOME_HOOKS_LIB_DEPS = {
+    "__init__.py",     # makes _lib a package; without it the import fails
+    "vault_root.py",   # vault-context.py -> vault_root_for()
 }
 
 # Hooks ai-brain-starter USED TO ship and has deliberately RETIRED. The
@@ -1148,6 +1189,11 @@ def deploy_home_hooks(
     ever writes is a hook that cannot fire; the `[ -f ]` guard then makes the
     absence look like health.
 
+    Also deploys HOME_HOOKS_LIB_DEPS into <config_dir>/hooks/_lib/. A hook that
+    imports `_lib.<mod>` and finds it missing does not crash — it falls into a
+    try/except stub and silently does nothing, which reads exactly like a hook
+    with nothing to report. The dependency ships with its consumer.
+
     Contract:
       - COPY-IF-DIFFERENT: an identical destination is a no-op, so re-runs and
         the daily update pass are quiet and idempotent.
@@ -1163,9 +1209,20 @@ def deploy_home_hooks(
     """
     notes: list[str] = []
     dest_dir = config_dir / "hooks"
-    for name in sorted(HOME_HOOKS_INSTALLER_DEPLOYS):
-        src = repo_hooks_dir / name
-        dest = dest_dir / name
+
+    targets: list[tuple[str, Path, Path]] = [
+        (name, repo_hooks_dir / name, dest_dir / name)
+        for name in sorted(HOME_HOOKS_INSTALLER_DEPLOYS)
+    ]
+    # _lib is a package, not a hook: same copy contract, no executable bit, and
+    # its own subdirectory. Deployed BEFORE nothing in particular — order does
+    # not matter, since the import only runs when a hook fires.
+    targets += [
+        (f"_lib/{name}", repo_hooks_dir / "_lib" / name, dest_dir / "_lib" / name)
+        for name in sorted(HOME_HOOKS_LIB_DEPS)
+    ]
+
+    for name, src, dest in targets:
         if not src.is_file():
             notes.append(f"  ! {name}: not in {repo_hooks_dir} — hook will not fire")
             continue
@@ -1176,16 +1233,24 @@ def deploy_home_hooks(
             if dry_run:
                 notes.append(f"  + {name} (would {'update' if dest.is_file() else 'deploy'})")
                 continue
-            dest_dir.mkdir(parents=True, exist_ok=True)
+            # dest.parent, not dest_dir: an entry under _lib/ needs its own
+            # subdirectory created, and a FileNotFoundError here is swallowed by
+            # the OSError handler below — the hook would deploy and its library
+            # would not, which is the exact silent half-install being fixed.
+            dest.parent.mkdir(parents=True, exist_ok=True)
             if dest.is_file():
+                # dest.name, not name: `name` may carry a subdirectory
+                # ("_lib/vault_root.py") and Path.with_name() raises ValueError
+                # on a separator — an exception this except-clause does not
+                # catch, which would abort the whole install.
                 backup = dest.with_name(
-                    f"{name}.bak-{datetime.now().strftime('%Y-%m-%d-%H%M')}")
+                    f"{dest.name}.bak-{datetime.now().strftime('%Y-%m-%d-%H%M')}")
                 shutil.copyfile(dest, backup)
                 notes.append(f"  ~ {name} (updated; previous copy at {backup.name})")
             else:
                 notes.append(f"  + {name} (deployed)")
             shutil.copyfile(src, dest)
-            if os.name != "nt":
+            if os.name != "nt" and "/" not in name:
                 try:
                     dest.chmod(dest.stat().st_mode | 0o111)
                 except OSError:


### PR DESCRIPTION
Two bugs from one real Windows install, where a person hit them, worked around them by hand, and reported them. Investigating the second turned out to be broader than reported: it is not a Windows bug, it is a Windows *symptom* of a deploy route that never worked anywhere.

## 1. The Node install could fail on a UAC prompt and say nothing

```powershell
Start-Process -Wait -FilePath "msiexec" -ArgumentList "/i","$nodeInstaller","/quiet","/norestart"
```

Node's x64 MSI is a **per-machine** install. It needs elevation, and `/quiet` means no UAC prompt can appear to obtain it, so from a normal PowerShell it aborts (1925 / 1603). `Start-Process -Wait` without `-PassThru` then **discarded the exit code**, so the failure produced no output at all. The only surviving signal was a bare `node install failed` three lines later, with no cause attached.

- `Test-Elevated` decides per-machine vs per-user for both runtimes.
- Unelevated Node installs from the official **ZIP** into `%LOCALAPPDATA%\nodejs` on the USER PATH. No privileges are involved, so this failure mode is structurally gone rather than handled. `%APPDATA%\npm` goes on PATH too: the MSI adds it, a ZIP does not, and without it the very next step (`npm install -g @anthropic-ai/claude-code`) succeeds while leaving `claude` unrunnable.
- Unelevated Python uses `InstallAllUsers=0`, which python.org's installer supports without elevation.
- `Invoke-Installer` captures the real exit code (0 / 3010 = ok) and reports it. An exit code that cannot be read returns `-1`, never 0.
- A failed `winget` now falls through to the direct download instead of ending the attempt with no fallback.
- An existing `%LOCALAPPDATA%\nodejs` is moved aside to `<dir>.bak-YYYY-MM-DD-HHMM`, not deleted.

## 2. Three wired hooks were never deployed, and one has been inert on every platform

`retry-budget.py`, `validate-mcp-json.py` and `vault-context.py` are wired by `hooks.json` at `~/.claude/hooks/<name>.py` behind a `[ -f ]` guard, and were deployed by three literal `cp` lines in `phases/phase-05-context-layer.md`, executed **by the model** during `/setup-brain`. That route fails three ways:

1. **POSIX-only.** `cp` and `mkdir -p` are not commands on native Windows.
2. **Model-executed.** A copy step that happens if an agent reads a markdown table and chooses to run it is a suggestion, not a deploy route.
3. **Nothing verified it afterwards** on any platform.

The `[ -f ]` guard is correct at runtime and turns every one of those failures into silence.

**The half that is not Windows-specific.** `vault-context.py` does `from _lib.vault_root import vault_root_for` behind a try/except whose fallback returns `None`. Nothing has ever deployed `hooks/_lib/`. So even where the `cp` did run, the hook loaded, resolved no vault, injected nothing, and exited 0 — reporting healthy, doing nothing, since it shipped.

Fixes:

- All three move to `HOME_HOOKS_INSTALLER_DEPLOYS` (installer route, cross-platform, re-verified every run) and into `ABS_OWNED_BASENAMES`, so `verify_paths_on_disk()` can see them. Unowned commands are skipped by verification entirely, which is how this read as a clean install.
- New `HOME_HOOKS_LIB_DEPS` ships `hooks/_lib/{__init__,vault_root}.py` with its consumer.
- `deploy_home_hooks()` had two latent breaks a subdirectory entry would hit: it created `dest_dir` instead of `dest.parent` (swallowed by the `OSError` handler, so the hook deploys and its library does not), and built its `.bak` name with `Path.with_name(name)`, which raises `ValueError` on a separator — an exception that clause does not catch, aborting the whole install.
- `phase-05`'s `cp` lines are gone. `check-home-hook-deploy.py` fails on BOTH routes as loudly as on neither.
- That lint gains a second invariant: every `_lib.<mod>` imported by a deployed hook must be in `HOME_HOOKS_LIB_DEPS` and must exist. Parsed with `ast`, not regex, so import text inside an f-string or docstring is not mistaken for an import.

## Verification

Evidence, not inference:

| check | result |
|---|---|
| `bootstrap.ps1` parse (PowerShell AST) | clean |
| helpers extracted from the real file and exercised | 7/7 — `Test-Elevated` returns False through its catch path on non-Windows; `Invoke-Installer` surfaces 0/1/3/42 and `-1` for an unlaunchable binary |
| installer against a sandboxed config dir | 6 hooks + both `_lib` files deployed |
| **deployed** `vault-context.py` + a real vault | injects that vault's Current Priorities (unique marker present in `additionalContext`) |
| same hook, `_lib` removed — the pre-fix state | **rc=0, 0 bytes stdout, 0 bytes stderr** |
| `platformize_template_for_windows()` | wires all three on Windows; only the 4 pre-existing `.sh` hooks are skipped |
| new lint clause | 4 negative controls, each mutation asserted to have applied |
| `_lib` import extraction | 13 cases incl. f-string and docstring false-positive inputs |

## Not covered

The unelevated ZIP path is **not exercised by CI**. `windows-install.yml` runs `bootstrap.ps1` end-to-end, but the runner already has Node, so `-not (Have node)` is false and the whole block is skipped (`grep -ci node .github/workflows/windows-install.yml` returns 0; positive control on the same grep returns 25 for `bootstrap`). GitHub-hosted Windows runners are also elevated, which would take the `Test-Elevated` true branch regardless. Logged as a third leg on MYC-2393, which already owns deepening that job, rather than filed as a duplicate.

## Two incidental fixes, both surfaced by this branch's own gate

Kept here because each one blocks the gate that verifies this PR:

- **`ci.sh` real-home tripwire reddened on a hook runtime-state dotfile.** `~/.claude/hooks/` is shared ground: this repo's deployed hooks sit beside the operator's private tooling, which drops last-run stamps there. `.stamp`, `.sha256`, `.json` and a bare extensionless marker are four spellings of one behaviour, so `CHURN_SUFFIXES` cannot express it. Excluded by the property that separates them — deployed hook code is never a dotfile — and the quiet control now asserts it. Controls: dotfile silenced, deployed `.py` and `.sh` still trip.
- **`check-cloud-safe-file-walkers.py` treated `ast.walk` as a filesystem walker.** `path_walker` matched any attribute call named `.walk()`. Every `scripts/check-*.py` that parses Python and reads source files is a false UNSAFE. Carved out in-memory walkers via the import table; `ast_modules` starts empty so `import os as ast` cannot smuggle a real walker through. Controls: `ast.walk` CLEAN, `Path.walk` / `os.walk` / `rglob` still UNSAFE, alias attack still UNSAFE, `--self-test` and the 338-file fleet audit green.

## Local gate

`bash scripts/ci.sh` is green at `1354ff6`: 104 integration tests, 13 `scripts/` and 15 `hooks/tests` suites, 338 files compiled, every lint.

That run used an isolated `HOME` (a copy of `~/.claude` carrying every watched surface). `ci-test` itself **declined** on this machine — exit 3, load average 49.87 against a 40 threshold on 10 cores — and wrote no marker, so the push used `CI_PARITY_BYPASS=1`. The same saturation was writing to the real `~/.claude` mid-run: three separate gate runs reddened on files a sibling session touched, each blaming a different test, and each of those tests ran clean in isolation on this branch AND on a pristine `origin/main`. The isolated run has identical coverage and no interference. CI on a clean runner is the authoritative check.
