### PR TITLE
fix(skills): [VAULT_PATH] is never substituted in a skill file, and insights spelled it two ways

### DIFF
--- a/scripts/test_skill_vault_path_placeholder.py
+++ b/scripts/test_skill_vault_path_placeholder.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Guards the vault-root placeholder convention in skills/*/SKILL.md.
+
+THE BUG THIS GUARDS (SKILL-PLACEHOLDER-NEVER-RENDERED): a skill file may quote a
+vault path as `[VAULT_PATH]/...`, but NOTHING in this repo substitutes that token
+inside a skill file. normalize_path_substitutions() in
+scripts/install-hooks-user-level.py resolves `[VAULT_PATH]`, and it resolves it
+only in the settings.json HOOK TEMPLATE -- never in markdown. So the token
+reaches every install verbatim, and both of its failure modes are silent:
+
+  * a command keeps a literal `[VAULT_PATH]` and runs against a path that cannot
+    exist;
+  * a step phrased "if <path> exists" simply never fires, so a report loses a
+    section and nothing is raised.
+
+skills/insights/SKILL.md carried BOTH spellings -- 12 `[VAULT_PATH]` and 8
+`<VAULT_PATH]`-style angle-bracket ones -- so a reader who learned to substitute
+one still passed the other through. The angle-bracket spelling is the worse of
+the two: inside the `VAULT_ROOT="<VAULT_PATH>"` snippets it is also shell
+redirection syntax, so a copy-paste is a syntax error rather than a bad path.
+
+Two invariants, both cheap:
+
+  1. ONE spelling. `[VAULT_PATH]` is the token the repo already substitutes
+     elsewhere, so it is the one that survives. `<VAULT_PATH>` is banned outright.
+  2. A skill that uses the token must SAY it is a placeholder, in the file, so the
+     instruction travels with the thing it governs instead of living in a doc
+     nobody reads at the moment of substitution.
+
+Deliberately NOT solved by rendering the token at copy time: that would make every
+installed copy differ from canonical, and classify_drift() in sync-skills.py would
+then report all four skills as locally-modified forever -- the same nag this repo
+already fought in test_skill_copy_drift.py. Keeping copies byte-identical to
+canonical and resolving at read time is what keeps that surface quiet.
+
+Run directly (the scripts/ci.sh gate globs scripts/test_*.py):
+    python3 scripts/test_skill_vault_path_placeholder.py
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILLS_DIR = REPO_ROOT / "skills"
+
+CANONICAL = "[VAULT_PATH]"
+BANNED = re.compile(r"<VAULT_PATH>")
+
+# The note must name the token and the word "placeholder". Kept this loose on
+# purpose: the wording is free to improve, the two load-bearing words are not.
+NOTE = re.compile(r"`?\[VAULT_PATH\]`?[^\n]{0,120}placeholder", re.IGNORECASE)
+
+
+def skill_files() -> list[Path]:
+    return sorted(SKILLS_DIR.glob("*/SKILL.md"))
+
+
+class TestVaultPathPlaceholder(unittest.TestCase):
+    def setUp(self) -> None:
+        self.assertTrue(SKILLS_DIR.is_dir(), f"no skills/ dir at {SKILLS_DIR}")
+        self.files = skill_files()
+        self.assertTrue(self.files, "no skills/*/SKILL.md found -- glob broke")
+
+    def test_no_angle_bracket_spelling(self) -> None:
+        """<VAULT_PATH> is banned: nothing substitutes it and it collides with
+        shell redirection inside the VAULT_ROOT="..." snippets."""
+        offenders = []
+        for f in self.files:
+            hits = BANNED.findall(f.read_text(encoding="utf-8"))
+            if hits:
+                offenders.append(f"{f.relative_to(REPO_ROOT)} ({len(hits)}x)")
+        self.assertEqual(
+            [], offenders,
+            "use [VAULT_PATH], the spelling the repo already substitutes:\n  "
+            + "\n  ".join(offenders),
+        )
+
+    def test_users_of_the_token_declare_it_a_placeholder(self) -> None:
+        """A skill quoting [VAULT_PATH] must say in-file that it is a placeholder."""
+        missing = []
+        for f in self.files:
+            text = f.read_text(encoding="utf-8")
+            if CANONICAL in text and not NOTE.search(text):
+                missing.append(str(f.relative_to(REPO_ROOT)))
+        self.assertEqual(
+            [], missing,
+            "these skills quote [VAULT_PATH] without saying it is a placeholder "
+            "to resolve before running anything:\n  " + "\n  ".join(missing),
+        )
+
+    def test_guard_still_bites(self) -> None:
+        """Negative controls -- a guard that cannot fail is worse than none."""
+        self.assertTrue(BANNED.search('VAULT_ROOT="<VAULT_PATH>" python3 x.py'))
+        self.assertFalse(BANNED.search('VAULT_ROOT="[VAULT_PATH]" python3 x.py'))
+        self.assertTrue(NOTE.search("`[VAULT_PATH]` below is a placeholder, not a path."))
+        self.assertFalse(NOTE.search("Read `[VAULT_PATH]/Meta/journal-index.json` first."))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/skills/backfill-journal-body-context/SKILL.md
+++ b/skills/backfill-journal-body-context/SKILL.md
@@ -5,6 +5,12 @@ description: Use when the user says /backfill-journal-body-context, wants existi
 
 # backfill-journal-body-context
 
+> **`[VAULT_PATH]` below is a placeholder, not a path.** Resolve it to the vault root before
+> running anything. Passing it through literally is the failure this note exists to prevent:
+> nothing in the repo substitutes it inside a skill file, so a command keeps a path that cannot
+> exist, and a step that merely *checks* such a path skips silently — the report loses a section
+> and no error is raised.
+
 Reads existing daily journals, pulls health-mcp data for each entry's date, and appends a "Body track" section BELOW the original verbatim content. The original entry text is NEVER modified — the rule from `feedback_journal_verbatim_words.md` is non-negotiable.
 
 ## When to use

--- a/skills/daily-journal/SKILL.md
+++ b/skills/daily-journal/SKILL.md
@@ -5,6 +5,12 @@ description: Use when the user wants to journal, do a daily or end-of-day check-
 
 # Daily Journal — Interview & Log
 
+> **`[VAULT_PATH]` below is a placeholder, not a path.** Resolve it to the vault root before
+> running anything. Passing it through literally is the failure this note exists to prevent:
+> nothing in the repo substitutes it inside a skill file, so a command keeps a path that cannot
+> exist, and a step that merely *checks* such a path skips silently — the report loses a section
+> and no error is raised.
+
 A conversational journaling skill that interviews the user, identifies their emotional floor, runs a behavior accountability check, consults the advisory panel, and saves a properly formatted journal entry to their Obsidian vault.
 
 ## Language

--- a/skills/insights/SKILL.md
+++ b/skills/insights/SKILL.md
@@ -6,6 +6,12 @@ argument-hint: "[week or month -- e.g. 'this week', 'last month', or leave blank
 
 When the user types /weekly or /monthly, generate an insight report from their recent journal entries.
 
+> **`[VAULT_PATH]` below is a placeholder, not a path.** Resolve it to the vault root before
+> running anything. Passing it through literally is the failure this note exists to prevent:
+> nothing in the repo substitutes it inside a skill file, so a command keeps a path that cannot
+> exist, and a step that merely *checks* such a path skips silently — the report loses a section
+> and no error is raised.
+
 ## Language
 
 Generate the entire report in the language the user writes in. If Spanish, all sections — coach, therapist, panel, floor notes — are in Spanish.
@@ -58,10 +64,10 @@ If the vault has `scripts/token-usage-report.py`, run it to surface real per-ses
 
 ```bash
 # /weekly: 7-day window
-VAULT_ROOT="<VAULT_PATH>" python3 "<VAULT_PATH>/scripts/token-usage-report.py" --days 7 --top 10
+VAULT_ROOT="[VAULT_PATH]" python3 "[VAULT_PATH]/scripts/token-usage-report.py" --days 7 --top 10
 
 # /monthly: 30-day window
-VAULT_ROOT="<VAULT_PATH>" python3 "<VAULT_PATH>/scripts/token-usage-report.py" --days 30 --top 20
+VAULT_ROOT="[VAULT_PATH]" python3 "[VAULT_PATH]/scripts/token-usage-report.py" --days 30 --top 20
 ```
 
 The script writes `⚙️ Meta/Token Usage Report.md`. Read it and surface a compact block in the report. If `Opus cost share` >60% or `Sessions ≥60 turns` >3, surface as a coach line in Section 3 (model-routing or session-length drift). Single-session cost outliers (>$200) get one bullet in Section 2.
@@ -73,7 +79,7 @@ This replaces guess-work with real numbers from `~/.claude/projects/<vault-hash>
 If the vault has `scripts/compress-vault-doc.py`, run the compression-candidate sweep on docs flagged by Drift Audit:
 
 ```bash
-VAULT_ROOT="<VAULT_PATH>" python3 "<VAULT_PATH>/scripts/compress-vault-doc.py" --auto-from-drift --dry-run
+VAULT_ROOT="[VAULT_PATH]" python3 "[VAULT_PATH]/scripts/compress-vault-doc.py" --auto-from-drift --dry-run
 ```
 
 If candidates show >2KB savings, surface as a compact block. If <2KB, skip silently.
@@ -85,7 +91,7 @@ If candidates show >2KB savings, surface as a compact block. If <2KB, skip silen
 If the vault has `scripts/monthly-baseline.py`, run it for the target period:
 
 ```bash
-VAULT_ROOT="<VAULT_PATH>" python3 "<VAULT_PATH>/scripts/monthly-baseline.py" --month YYYY-MM --pretty
+VAULT_ROOT="[VAULT_PATH]" python3 "[VAULT_PATH]/scripts/monthly-baseline.py" --month YYYY-MM --pretty
 ```
 
 The script outputs floor distribution shifts ≥3pp from baseline, word-frequency anomalies ≥2× or ≤0.5× baseline, numeric metric deltas ≥10%, activity deltas, top people mentions, and missing-data flags. **Use this output as the FIRST DATA SECTION** (sections 0a/0b/0c below). Don't bury it under "Month at a glance." Anomaly-led framing means the reader sees what's different before they see what's present.

--- a/skills/longitudinal/SKILL.md
+++ b/skills/longitudinal/SKILL.md
@@ -6,6 +6,12 @@ argument-hint: "[scope -- e.g. 'all', '5y', '1y', leave blank for 1y default]"
 
 When the user types /longitudinal, run the multi-year correlation pass and surface only the strongest signals across years of health-mcp + journal data.
 
+> **`[VAULT_PATH]` below is a placeholder, not a path.** Resolve it to the vault root before
+> running anything. Passing it through literally is the failure this note exists to prevent:
+> nothing in the repo substitutes it inside a skill file, so a command keeps a path that cannot
+> exist, and a step that merely *checks* such a path skips silently — the report loses a section
+> and no error is raised.
+
 ## Language
 
 Generate the report in the language the user writes in. If Spanish, all sections including the panel commentary are in Spanish.


### PR DESCRIPTION
## The bug

`normalize_path_substitutions()` in `scripts/install-hooks-user-level.py` resolves `[VAULT_PATH]` — and it resolves it **only in the settings.json hook template**. Nothing in the repo substitutes the token inside a skill file. It reaches every install verbatim, in four skills: `insights`, `daily-journal`, `longitudinal`, `backfill-journal-body-context`.

Both failure modes are silent, which is why this has stayed invisible:

- a command keeps a literal `[VAULT_PATH]` and runs against a path that cannot exist;
- a step phrased *"if `<path>` exists"* simply never fires, so a report loses a section and nothing is raised.

`skills/insights/SKILL.md` made it worse by carrying **both spellings** — 12 `[VAULT_PATH]` and 8 angle-bracket `<VAULT_PATH>` — so a reader who learned to substitute one still passed the other through. The angle-bracket spelling is the worse of the two: inside the `VAULT_ROOT="<VAULT_PATH>"` snippets it is also shell redirection, so a copy-paste is a syntax error rather than merely a bad path.

## The fix

Keeps the token and makes it honest, rather than inventing machinery:

1. **One spelling.** `[VAULT_PATH]` wins because it is the one the repo already substitutes elsewhere. The 8 angle-bracket occurrences are converted.
2. **Each of the four skills states in-file that the token is a placeholder** to resolve before running anything, so the instruction travels with the thing it governs instead of living in a doc nobody reads at the moment of substitution.
3. **`scripts/test_skill_vault_path_placeholder.py`** holds both invariants (picked up by the `scripts/test_*.py` glob in `scripts/ci.sh`, so it can't go dormant).

Diff is 28 insertions / 4 deletions across the four skills, plus the test.

## Verification

- The new guard **fails on this tree before the change**, naming all four skills and the 8 occurrences, and **passes after**. Both directions checked with `git stash`, not assumed.
- `test_guard_still_bites` carries negative controls, so the guard cannot silently stop biting.
- Existing guards still green locally: `check-meta-resolution.sh`, `check-vault-root-reads.py` (both `--self-test` and the tree pass), `test_skill_copy_drift.py`, `py_compile`.

## Why not render the token at copy time

That would make every installed copy differ from canonical, and `classify_drift()` in `sync-skills.py` would then report all four skills as locally-modified forever — the same nag `test_skill_copy_drift.py` already exists to prevent. Byte-identical copies plus resolution at read time is what keeps that surface quiet.

## Out of scope (spotted while reading)

Several of these paths are also stale in the other direction: they say `Meta/` and `Journals/` where the current default layout is the emoji-prefixed `⚙️ Meta/` and `📓 Journals/`. `insights` line 27 and `backfill` line 25 handle both spellings; the remaining ~10 do not. That is a behaviour change and deserves its own PR — happy to open it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
