### PR TITLE
fix(install): settings.json written raw-UTF-8 killed every hook on a non-ASCII Windows profile (#397)

### DIFF
--- a/scripts/install-hooks-user-level.py
+++ b/scripts/install-hooks-user-level.py
@@ -1058,9 +1058,33 @@ def backup_settings(settings_path: Path) -> Path | None:
 
 
 def write_settings_with_verify(settings_path: Path, settings: dict, backup: Path | None) -> bool:
-    """Write settings.json, verify it parses, rollback on failure."""
+    """Write settings.json, verify it parses, rollback on failure.
+
+    ensure_ascii=True (JSON's default) is load-bearing, not style (#397). This is
+    the ONE place settings become BYTES, and those bytes are read back by a
+    consumer whose encoding we do not control. On Windows, Claude Code hands hook
+    commands to a shell running a legacy code page: a settings.json carrying raw
+    UTF-8 gets decoded there as cp1252/cp437, an account directory named "Ñoño"
+    comes back as "Ã‘oÃ±o", the absolute hook path stops resolving, and EVERY hook
+    fails — which blocks Bash and Grep for the whole session (47, then 132, then
+    104 dead paths across one reporter's three reinstalls). Escaping non-ASCII to
+    \\uXXXX makes the file pure ASCII, which decodes identically under UTF-8,
+    cp1252, cp437 and latin-1, so no consumer's code page can corrupt a path.
+
+    JSON semantics are untouched — "\\u00f3" and "ó" parse to the same string — so
+    merge/dedup/uninstall, which all match on these command strings, see exactly
+    what they saw before. Same escaping already relied on as cp1252 protection
+    elsewhere in this repo (SEV-4-json-encoded, scripts/utf8-stdout-baseline.txt).
+
+    This is the byte-level half of the fix whose path-level half is
+    _ascii_safe_win_path() (#430). That one is necessary but not sufficient: 8.3
+    short-name creation is disabled by default on many modern volumes, and there
+    it degrades to returning the path unchanged; it also covers only the Windows
+    hook-command rewrite, never the substituted vault path or the user's own
+    pre-existing entries. Locked by scripts/test_settings_json_codepage_safe.py.
+    """
     settings_path.parent.mkdir(parents=True, exist_ok=True)
-    new_text = json.dumps(settings, indent=2, ensure_ascii=False) + "\n"
+    new_text = json.dumps(settings, indent=2, ensure_ascii=True) + "\n"
     try:
         settings_path.write_text(new_text, encoding="utf-8")
     except OSError as e:

--- a/scripts/test_settings_json_codepage_safe.py
+++ b/scripts/test_settings_json_codepage_safe.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Regression lock for #397 — settings.json must be code-page-proof on disk.
+
+THE DEFECT. write_settings_with_verify() serialized with ensure_ascii=False, so
+every non-ASCII character in a hook path landed on disk as its raw UTF-8 bytes.
+The file itself was valid UTF-8; the problem is who reads it. Claude Code hands
+hook commands to a Windows shell running a legacy code page, and a settings.json
+carrying raw UTF-8 gets decoded there as cp1252/cp437: an account directory named
+"Ñoño" is read back as "Ã‘oÃ±o", the absolute hook path stops resolving, and
+EVERY hook fails — which blocks Bash and Grep for the whole session. The reporter
+saw 47, then 132, then 104 dead paths across three reinstalls.
+
+WHY THE 8.3 SHORT-PATH FIX (#430) IS NOT ENOUGH. _ascii_safe_win_path() rewrites
+Windows hook paths to their 8.3 form, which is ASCII by construction. But 8.3
+name creation is DISABLED by default on many modern volumes, and on those the
+helper degrades by returning the path unchanged (it only warns). It also covers
+the Windows hook-command rewrite alone — the vault path substituted into POSIX
+commands, the user's own pre-existing settings entries, and every non-Windows
+consumer are all still written raw. The byte-level fix belongs at the one place
+that turns settings into bytes.
+
+THE INVARIANT. settings.json is written with JSON's default ensure_ascii=True, so
+the file is pure ASCII: non-ASCII is escaped to \\uXXXX before it ever reaches
+the disk. Pure-ASCII bytes decode identically under UTF-8, cp1252, cp437 and
+latin-1, so no consumer's code page can corrupt a path. JSON semantics are
+unchanged — "\\u00f3" and "ó" parse to the same string — so nothing downstream
+sees a different value. The same escaping is already relied on elsewhere in this
+repo as cp1252 protection (see the SEV-4-json-encoded class in
+scripts/utf8-stdout-baseline.txt).
+
+These asserts fail against ensure_ascii=False and pass against the fix.
+
+Auto-discovered by scripts/ci.sh via the scripts/test_*.py glob.
+Stdlib only. No network. Never writes outside a tempdir.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+INSTALLER = ROOT / "scripts" / "install-hooks-user-level.py"
+
+# A neutral non-ASCII profile directory of the reported shape (accented Latin
+# letters in the Windows account name). Never a real reporter's name.
+WIN_HOME = "C:\\Users\\Usuario Prueba \u00d1o\u00f1o"
+GEAR = "\u2699\ufe0f"  # the "⚙️" of "⚙️ Meta" — in every vault path we substitute
+# The "💼" of "💼 Work", also a real vault folder, and NON-BMP: ensure_ascii
+# escapes it to a SURROGATE PAIR (\ud83d\udcbc), a different code path from the
+# single \uXXXX a BMP character gets. A round trip that only ever exercised BMP
+# characters would not prove the pair is reassembled on read.
+BRIEFCASE = "\U0001f4bc"
+
+# The legacy code pages a Windows consumer of settings.json actually uses.
+# latin-1 is included because it decodes ANY byte: it never raises, it just
+# silently returns the wrong characters, which is the exact failure shape here.
+LEGACY_CODEPAGES = ("cp1252", "cp437", "latin-1")
+
+PASS = 0
+FAIL = 0
+
+
+def ok(msg: str) -> None:
+    global PASS
+    PASS += 1
+    print(f"PASS  {msg}")
+
+
+def bad(msg: str, detail: str = "") -> None:
+    global FAIL
+    FAIL += 1
+    print(f"FAIL  {msg}" + (f" :: {detail}" if detail else ""))
+
+
+def load_installer():
+    spec = importlib.util.spec_from_file_location("_abs_installer_397", INSTALLER)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _settings_fixture() -> dict:
+    """The production shape: a Windows hook_runner command whose absolute paths
+    sit under a non-ASCII profile dir, plus a POSIX command carrying a vault path
+    with the gear emoji, plus an unowned user entry we must not disturb."""
+    runner = f"{WIN_HOME}\\.claude\\skills\\ai-brain-starter\\scripts\\hook_runner.py"
+    target = f"{WIN_HOME}\\.claude\\hooks\\session-start-context.py"
+    vault_hook = f"/home/u/vault/{GEAR} Meta/{BRIEFCASE} Work/scripts/graph-context-hook.sh"
+    return {
+        "hooks": {
+            "PreToolUse": [{
+                "matcher": "Bash",
+                "hooks": [{
+                    "type": "command",
+                    "command": f'py -3 "{runner}" --fallback silent "{target}"',
+                }],
+            }],
+            "SessionStart": [{
+                "hooks": [
+                    {"type": "command", "command": f"bash '{vault_hook}'"},
+                    {"type": "command", "command": "echo mine"},  # unowned user entry
+                ],
+            }],
+        },
+    }
+
+
+def _write(ins, path: Path, settings: dict) -> bool:
+    return bool(ins.write_settings_with_verify(path, settings, None))
+
+
+# --------------------------------------------------------------------------
+# 1. the file's BYTES must survive any code page
+# --------------------------------------------------------------------------
+def test_settings_bytes_are_pure_ascii(ins) -> None:
+    settings = _settings_fixture()
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "settings.json"
+        if not _write(ins, path, settings):
+            bad("write_settings_with_verify succeeds on a non-ASCII settings dict")
+            return
+        raw = path.read_bytes()
+        if raw.isascii():
+            ok("settings.json is written as pure-ASCII bytes (no code page can corrupt it)")
+        else:
+            offenders = sorted({b for b in raw if b > 0x7F})
+            bad("settings.json is written as pure-ASCII bytes",
+                f"{len(offenders)} non-ASCII byte value(s), e.g. {offenders[:4]}")
+
+
+# --------------------------------------------------------------------------
+# 2. the ROUND TRIP a Windows consumer actually performs
+# --------------------------------------------------------------------------
+def _commands(doc: dict) -> list:
+    out = []
+    for groups in (doc.get("hooks") or {}).values():
+        for g in groups:
+            for h in g.get("hooks", []):
+                out.append(h.get("command", ""))
+    return out
+
+
+def test_paths_round_trip_through_legacy_codepages(ins) -> None:
+    """Written by us as UTF-8, read back by a consumer using the console code
+    page. Every hook command must come back byte-identical; the reported bug is
+    exactly this comparison failing with "Ñoño" -> "Ã‘oÃ±o"."""
+    settings = _settings_fixture()
+    expected = _commands(settings)
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "settings.json"
+        if not _write(ins, path, settings):
+            bad("write_settings_with_verify succeeds on a non-ASCII settings dict")
+            return
+        raw = path.read_bytes()
+        for codec in LEGACY_CODEPAGES:
+            try:
+                doc = json.loads(raw.decode(codec))
+            except (UnicodeDecodeError, json.JSONDecodeError) as e:
+                bad(f"settings.json parses when decoded as {codec}",
+                    f"{type(e).__name__}: {e}")
+                continue
+            got = _commands(doc)
+            if got == expected:
+                ok(f"every hook command round-trips identically through {codec}")
+            else:
+                diff = next((f"{a!r} != {b!r}" for a, b in zip(expected, got) if a != b), "")
+                bad(f"every hook command round-trips identically through {codec}", diff)
+
+
+def test_locale_default_reader_sees_the_same_paths(ins) -> None:
+    """The same round trip through open()'s TEXT layer rather than raw bytes —
+    a consumer that simply omits encoding= and inherits the locale, which is
+    cp1252 on the affected machines."""
+    settings = _settings_fixture()
+    expected = _commands(settings)
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "settings.json"
+        if not _write(ins, path, settings):
+            bad("write_settings_with_verify succeeds on a non-ASCII settings dict")
+            return
+        for codec in LEGACY_CODEPAGES:
+            try:
+                with path.open("r", encoding=codec) as f:
+                    doc = json.load(f)
+            except (UnicodeDecodeError, json.JSONDecodeError) as e:
+                bad(f"a reader whose default encoding is {codec} parses settings.json",
+                    f"{type(e).__name__}: {e}")
+                continue
+            if _commands(doc) == expected:
+                ok(f"a reader whose default encoding is {codec} sees the real paths")
+            else:
+                bad(f"a reader whose default encoding is {codec} sees the real paths")
+
+
+# --------------------------------------------------------------------------
+# 3. escaping must not change what anything reads back (no-regression)
+# --------------------------------------------------------------------------
+def test_utf8_reader_semantics_unchanged(ins) -> None:
+    """ASCII-escaping is a byte-level change only. The installer's own reader
+    (read_text(encoding='utf-8') -> json.loads) must get the identical dict, or
+    the fix would break merge/dedup/uninstall, which all match on these strings."""
+    settings = _settings_fixture()
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "settings.json"
+        if not _write(ins, path, settings):
+            bad("write_settings_with_verify succeeds on a non-ASCII settings dict")
+            return
+        doc = json.loads(path.read_text(encoding="utf-8"))
+        if doc == settings:
+            ok("a UTF-8 reader gets the identical settings dict (semantics unchanged)")
+        else:
+            bad("a UTF-8 reader gets the identical settings dict", repr(doc)[:200])
+        cmds = _commands(doc)
+        if any(WIN_HOME in c for c in cmds) and any(GEAR in c for c in cmds):
+            ok("the non-ASCII home path and the gear vault path both decode back intact")
+        else:
+            bad("the non-ASCII home path and the gear vault path both decode back intact")
+        # Non-BMP: escaped as a surrogate PAIR, so this proves the pair is
+        # reassembled into one character rather than left as two lone halves.
+        if any(BRIEFCASE in c for c in cmds):
+            ok("a non-BMP vault folder survives the surrogate-pair escape round trip")
+        else:
+            bad("a non-BMP vault folder survives the surrogate-pair escape round trip",
+                next((c for c in cmds if "Work" in c), ""))
+
+
+def test_write_is_idempotent_across_a_reinstall(ins) -> None:
+    """The reporter's install regressed on EVERY reinstall, so the second write
+    matters as much as the first: read what we wrote, write it again, and the
+    bytes must be identical. A file that drifts on re-serialization is how a
+    mojibake path gets baked in permanently."""
+    settings = _settings_fixture()
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "settings.json"
+        if not _write(ins, path, settings):
+            bad("write_settings_with_verify succeeds on a non-ASCII settings dict")
+            return
+        first = path.read_bytes()
+        reread = json.loads(path.read_text(encoding="utf-8"))
+        if not _write(ins, path, reread):
+            bad("a reinstall re-writes settings.json successfully")
+            return
+        if path.read_bytes() == first:
+            ok("a reinstall writes byte-identical settings.json (no drift on re-serialization)")
+        else:
+            bad("a reinstall writes byte-identical settings.json")
+
+
+def _run(label, fn, *a) -> None:
+    """Run one check; an exception is a FAILURE, not an abort. Each check locks
+    an independent property, so letting the first raise kill the process would
+    hide every later result — the false-green shape these tests prevent."""
+    try:
+        fn(*a)
+    except Exception as e:  # noqa: BLE001 — a raising check is a failing check
+        bad(label, f"{type(e).__name__}: {e}")
+
+
+def main() -> int:
+    try:
+        ins = load_installer()
+    except Exception as e:  # noqa: BLE001
+        print(f"FAIL  install-hooks-user-level.py does not import :: {e}")
+        return 1
+    print("=== 1. settings.json bytes are code-page-proof ===")
+    _run("settings bytes are pure ascii", test_settings_bytes_are_pure_ascii, ins)
+    print("=== 2. hook paths round-trip through a legacy code page ===")
+    _run("round trip through legacy codepages",
+         test_paths_round_trip_through_legacy_codepages, ins)
+    _run("locale-default reader sees the same paths",
+         test_locale_default_reader_sees_the_same_paths, ins)
+    print("=== 3. escaping changes bytes only, never semantics ===")
+    _run("utf8 reader semantics unchanged", test_utf8_reader_semantics_unchanged, ins)
+    _run("reinstall is byte-idempotent", test_write_is_idempotent_across_a_reinstall, ins)
+    print(f"\n=== summary: {PASS} passed, {FAIL} failed ===")
+    return 1 if FAIL else 0
+
+
+if __name__ == "__main__":
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
+    sys.exit(main())

--- a/tests/integration/test_bootstrap_omits_vault_hooks.sh
+++ b/tests/integration/test_bootstrap_omits_vault_hooks.sh
@@ -17,8 +17,9 @@
 # (no vault) they must simply be OMITTED.
 #
 # Asserts:
-#   1. With NO --vault-path: settings.json contains ZERO "⚙️ Meta/scripts/"
-#      references (none of the three vault-content hooks were written).
+#   1. With NO --vault-path: NO wired hook command references "⚙️ Meta/scripts/"
+#      (none of the three vault-content hooks were written). Read from the
+#      PARSED commands, not the raw file — see hook_commands_matching below.
 #   2. With NO --vault-path: the hooks that resolve correctly without a vault
 #      (detect-closing-signal.py, which has a ~/.claude fallback) ARE still
 #      wired — the omission is surgical, not a blanket skip of UserPromptSubmit.
@@ -54,6 +55,36 @@ trap 'rm -rf "$TMP"' EXIT
 sandbox_home "$TMP"
 fail() { echo "FAIL: $1" >&2; exit 1; }
 
+# Ask the PARSED hook commands, never the file's raw bytes.
+#
+# settings.json is written ASCII-escaped (\uXXXX) so that no Windows code page
+# can corrupt a path stored in it (#397) — which means a raw
+# `grep "⚙️ Meta/scripts/"` over the file can no longer match. Assert 1 below is
+# a check that must be ABLE to fail, so a grep that silently never matches would
+# turn this whole guard into a no-op reporting green forever. These assertions
+# were always about what got WIRED, not about how the file encodes it.
+#
+# Prints every matching command; exits 0 if any matched, 1 if none, so it reads
+# like `grep -q` at the call sites. Exercised in BOTH directions in this file
+# (assert 1 needs no match, assert 3 needs one), so it cannot go quietly dead.
+hook_commands_matching() {
+  python3 - "$1" "$2" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as fh:
+    doc = json.load(fh)
+needle, hits = sys.argv[2], []
+for groups in (doc.get("hooks") or {}).values():
+    for group in groups:
+        for hook in group.get("hooks", []):
+            command = hook.get("command", "")
+            if needle in command:
+                hits.append(command)
+for hit in hits:
+    print(hit)
+sys.exit(0 if hits else 1)
+PY
+}
+
 # ── 1 + 2. No --vault-path: vault-content hooks OMITTED, fallback hooks KEPT ──
 SETTINGS_NOVAULT="$TMP/settings-novault.json"
 echo '{}' > "$SETTINGS_NOVAULT"
@@ -67,9 +98,9 @@ OUT="$(env -u VAULT_ROOT python3 "$INSTALLER" --hooks-source "$HOOKS_SRC" --sett
 python3 -c "import json; json.load(open('$SETTINGS_NOVAULT'))" \
   || { echo "$OUT"; fail "4: settings.json not valid JSON after no-vault install"; }
 
-if grep -q "⚙️ Meta/scripts/" "$SETTINGS_NOVAULT"; then
+if OFFENDING="$(hook_commands_matching "$SETTINGS_NOVAULT" "⚙️ Meta/scripts/")"; then
   echo "--- offending settings.json entries ---" >&2
-  grep "⚙️ Meta/scripts/" "$SETTINGS_NOVAULT" >&2
+  echo "$OFFENDING" >&2
   fail "1: vault-content hook(s) wired with no vault — these resolve to a dead \$HOME/⚙️ Meta/scripts/ path and error on every event"
 fi
 
@@ -95,7 +126,7 @@ for marker in graph-context-hook.sh session-end-hook.sh write-hook.sh; do
     || { echo "$OUT2"; fail "3 (negative control): $marker NOT wired even WITH --vault-path — they were deleted, not deferred"; }
 done
 # And they must carry the real vault path, not the [VAULT_PATH] placeholder.
-grep -q "$VAULT/⚙️ Meta/scripts/" "$SETTINGS_VAULT" \
+hook_commands_matching "$SETTINGS_VAULT" "$VAULT/⚙️ Meta/scripts/" >/dev/null \
   || { echo "$OUT2"; fail "3: vault-content hooks not substituted to the real vault path"; }
 grep -q "\[VAULT_PATH\]" "$SETTINGS_VAULT" \
   && fail "3: unresolved [VAULT_PATH] placeholder left in settings.json"


### PR DESCRIPTION
Closes #397.

## What was broken

On a Windows account whose profile folder carries a non-ASCII character, every hook in `~/.claude/settings.json` failed to execute after an install, which blocks the Bash and Grep tools for the whole session. The reporter hit it three times on the same machine: 47, then 132, then 104 dead paths, regressing on every reinstall.

## Root cause

`write_settings_with_verify()` serialized with `ensure_ascii=False`, so non-ASCII path characters landed on disk as their raw UTF-8 bytes.

The file itself was valid UTF-8. The problem is who reads it. Claude Code hands hook commands to a Windows shell running a legacy code page, which decodes those bytes as cp1252/cp437, so an accented directory comes back mojibake, the absolute hook path stops resolving, and the launcher cannot open `hook_runner.py` at all. That is the `GÃ³mez` in the reported error.

Reproduced without Windows by writing through the real function and decoding the file bytes with each legacy code page.

## The fix

One keyword. `write_settings_with_verify()` now uses JSON's default `ensure_ascii=True`, so non-ASCII is escaped to `\uXXXX` and the file is pure ASCII — which decodes identically under UTF-8, cp1252, cp437 and latin-1. No consumer's code page can corrupt a path.

JSON semantics are unchanged (`"ó"` and `"ó"` parse to the same string), so merge/dedup/uninstall — which all match on these command strings — see exactly what they saw before, and a UTF-8 reader gets a byte-identical dict.

This is the byte-level half of the fix whose path-level half shipped in #430. That one is necessary but not sufficient: `_ascii_safe_win_path()` rewrites Windows hook paths to their 8.3 form, but 8.3 name creation is disabled by default on many modern volumes and there it degrades to returning the path unchanged (it only warns). It also covers only the Windows hook-command rewrite, never the substituted vault path or the user's own pre-existing entries. The reporter was on `878d71d`, which predates #430, so they had neither half.

## Regression test

`scripts/test_settings_json_codepage_safe.py`, auto-discovered by the `scripts/test_*.py` glob in `ci.sh`. It writes a settings dict whose hook paths sit under a non-ASCII profile directory, then reads the file back through cp1252/cp437/latin-1 as both raw bytes and `open()`'s text layer, and asserts every hook command round-trips byte-identical. It also covers a non-BMP vault folder, which `ensure_ascii` escapes as a surrogate **pair** — a different code path from the single `\uXXXX` a BMP character gets.

**Negative control:** 7 of its 11 asserts fail against `ensure_ascii=False`, with the reported mojibake visible in the diff output. All 11 pass against the fix.

## One test had to change, and it mattered

`tests/integration/test_bootstrap_omits_vault_hooks.sh` asserted on the file's **raw bytes**, grepping for a literal `⚙️ Meta/scripts/`. Once the file is ASCII-escaped that grep can never match — and the direction that matters is the dangerous one. Its assert 1 ("no vault-content hook was wired when there is no vault") is a check that must be *able* to fail, so a never-matching grep turns it into a no-op that reports green forever.

Both byte-level greps now read the **parsed** hook commands, which is what the assertions were always about. Verified against a settings.json that *does* wire the offending hook: the old grep finds 0 and passes vacuously, the new check detects it and fails. The helper is exercised in both directions in that file (assert 1 needs no match, assert 3 needs one), so it cannot go quietly dead.

Swept the rest of `tests/` and `scripts/test_*.py` for the same pattern — no other raw-text non-ASCII assertion against settings.json exists.

## Not verified

No real Windows machine was involved. The code-page corruption is reproduced by decoding the written bytes with cp1252/cp437/latin-1 on macOS, which models the consumer faithfully but is not the same as observing Claude Code load these hooks on Windows 11. The reporter offered a deterministic repro on their machine and is the right confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
