### PR TITLE
fix(windows): resolve the vault root from a Windows hook command, not just POSIX

### DIFF
--- a/scripts/heal-journal-guard.py
+++ b/scripts/heal-journal-guard.py
@@ -74,9 +74,19 @@ _GUARD_PATH_RE = re.compile(
     r"|'([^'\n]*" + re.escape(GUARD_BASENAME) + r")'"
     r"|((?:~|/|[A-Za-z]:[\\/])[^\s'\"|&;]*" + re.escape(GUARD_BASENAME) + r")"
 )
-# The installed vault hooks embed the absolute vault path right before the meta folder;
-# same regex sync-vault-scripts.sh uses, so both resolve the identical root.
-_VAULT_FROM_CMD_RE = re.compile(r"(/[^'\"]+?)/(?:⚙️ Meta|Meta)/scripts/")
+# The installed vault hooks embed the absolute vault path right before the meta folder.
+# SAME three roots as the guard regex above (POSIX / drive letter / UNC share) and EITHER
+# separator, because the Windows installer writes `C:\...\<vault>\⚙️ Meta\scripts\...`.
+# A `/`-only pattern matched no Windows command at all, so resolve_vault() returned "" and
+# preflight_state() answered 'no-vault' on every Windows box -- which has_gap() does not
+# count, so the preflight check AND its repair were structurally dead there. That is the
+# quiet half of issues #370/#394: not a false nag, a SILENT no-op (a Windows account with
+# journal-preflight.py missing reads as healthy). Kept byte-identical to the regex inlined
+# in sync-vault-scripts.sh + .ps1 so all three resolve the identical root; the self-test
+# pins that parity. Over-matching stays harmless: the caller still is_dir()s the result.
+_VAULT_FROM_CMD_RE = re.compile(
+    r"((?:[A-Za-z]:)?[\\/][^'\"]+?)[\\/](?:⚙️ Meta|Meta)[\\/]scripts[\\/]"
+)
 
 
 # --------------------------------------------------------------------------- helpers
@@ -565,6 +575,63 @@ def self_test() -> int:
         check("path-win-space-in-home",
               guard_path_in(f'py "{runner}" --fallback allow "{win_s}"') == win_s)
         check("path-absent-is-none", guard_path_in("python3 /some/other-hook.py") is None)
+
+        # VAULT-PATH controls (issues #370, #394). resolve_vault() parses the vault root
+        # out of an installed vault-hook command. A `/`-only pattern matched NO Windows
+        # command, so preflight_state() answered 'no-vault' on every Windows box and the
+        # preflight check + repair branch never ran there. That is a SILENT no-op, not a
+        # visible nag: a Windows account MISSING journal-preflight.py reads as healthy.
+        # The win-*/unc-* cases below FAIL on the pre-fix regex - they are its negative
+        # control; the posix-* ones pin that widening it did not regress macOS/Linux.
+        def vroot(cmd):
+            m = _VAULT_FROM_CMD_RE.search(cmd)
+            return m.group(1) if m else None
+
+        win_v = "C:\\Users\\dev\\vault"
+        unc_v = "\\\\server\\share\\vault"
+        check("vault-posix-decorated",
+              vroot(f"python3 /Users/d/vault/⚙️ Meta/scripts/{PREFLIGHT_BASENAME}")
+              == "/Users/d/vault")
+        check("vault-posix-plain-meta",
+              vroot(f"python3 /home/u/v/Meta/scripts/{PREFLIGHT_BASENAME}") == "/home/u/v")
+        check("vault-posix-quoted-space",
+              vroot(f'python3 "/Users/d/my vault/⚙️ Meta/scripts/{PREFLIGHT_BASENAME}"')
+              == "/Users/d/my vault")
+        check("vault-win-quoted",
+              vroot(f'py -3 "{win_v}\\⚙️ Meta\\scripts\\{PREFLIGHT_BASENAME}"') == win_v)
+        check("vault-win-space-in-home",
+              vroot(f'py -3 "C:\\Users\\dev user\\vault\\⚙️ Meta\\scripts\\{PREFLIGHT_BASENAME}"')
+              == "C:\\Users\\dev user\\vault")
+        # Full installed Windows form. The runner path ALSO contains `\scripts\`, so this
+        # proves the anchor is <meta>\scripts\ and we pick the VAULT, not the first path.
+        check("vault-win-full-command",
+              vroot(f'py -3 "{runner}" --fallback allow '
+                    f'"{win_v}\\⚙️ Meta\\scripts\\{PREFLIGHT_BASENAME}"') == win_v)
+        check("vault-unc-share",
+              vroot(f'py -3 "{unc_v}\\⚙️ Meta\\scripts\\{PREFLIGHT_BASENAME}"') == unc_v)
+        # Over-matching is the other failure mode: a path regex that matches arbitrary
+        # text is its own bug. Neither of these names a vault.
+        check("vault-absent-is-none", vroot("python3 /some/other-hook.py") is None)
+        check("vault-absent-win-is-none",
+              vroot('py -3 "C:\\Users\\dev\\.claude\\hooks\\other.py"') is None)
+        # END-TO-END on THIS platform: resolve_vault() must still return a REAL directory
+        # parsed out of a command. Its is_dir() half can only hold where the path exists,
+        # so the Windows forms above are proven at the PARSE layer - which is where the
+        # bug lived - and this control proves the parse still feeds the real resolver.
+        e2e_vault = root / "e2e vault"
+        (e2e_vault / "⚙️ Meta" / "scripts").mkdir(parents=True)
+        check("vault-resolve-end-to-end", resolve_vault({"hooks": {"SessionStart": [
+            {"hooks": [{"type": "command", "command":
+                        f'python3 "{e2e_vault}/⚙️ Meta/scripts/{PREFLIGHT_BASENAME}"'}]}]}})
+              == str(e2e_vault))
+        # PARITY: the identical regex is inlined in sync-vault-scripts.sh and .ps1, which
+        # resolve the same vault for the repair this healer invokes. Pin the three together
+        # so a fix to one can never silently leave the others POSIX-only.
+        for _sib in ("sync-vault-scripts.sh", "sync-vault-scripts.ps1"):
+            _p = clone_root() / "scripts" / _sib
+            if _p.is_file():
+                check("vault-regex-parity-" + _sib,
+                      _VAULT_FROM_CMD_RE.pattern in _p.read_text(encoding="utf-8"))
 
         # PREFLIGHT diagnose: no vault -> 'no-vault'; vault with the file -> 'ok'; without
         # -> 'missing'. (The subprocess repair is exercised end-to-end in the .sh test.)

--- a/scripts/heal-journal-guard.py
+++ b/scripts/heal-journal-guard.py
@@ -178,6 +178,12 @@ def healthy_matchers(settings: dict) -> "set":
 def resolve_vault(settings: dict) -> "str":
     """Vault root from $VAULT_ROOT, else parsed out of an installed vault-hook command.
     Empty string when no vault can be resolved (a box with no vault set up yet)."""
+    # vault-root-ok: per-ACCOUNT healer (it repairs ~/.claude, not a vault file), so
+    # there is no target file to resolve a root from - the installed commands ARE the
+    # per-vault signal, and they are the fallback below. No default: unset falls through
+    # to that parse and then to "", never to a guessed ~/vault. Set is honored only when
+    # it names a real directory, and repair_preflight threads the same value into
+    # sync-vault-scripts, so the check and the repair cannot disagree about the vault.
     env = os.environ.get("VAULT_ROOT")
     if env and Path(env).is_dir():
         return env

--- a/scripts/sync-vault-scripts.ps1
+++ b/scripts/sync-vault-scripts.ps1
@@ -99,7 +99,11 @@ if (-not $Vault) {
     $settings = Join-Path $HOME ".claude/settings.json"
     if ((Test-Path $settings) -and $Py) {
         # Reuse the exact regex the .sh uses: the installed hook commands embed
-        # "<vault>/⚙️ Meta/scripts/..." - grab that prefix.
+        # "<vault>/⚙️ Meta/scripts/..." - grab that prefix. POSIX root, Windows
+        # drive letter or UNC share, either separator; byte-identical to
+        # heal-journal-guard.py's _VAULT_FROM_CMD_RE, whose self-test pins it.
+        # This is the WINDOWS leg, so a `/`-only pattern never resolved a vault
+        # here and the sync silently skipped as "no vault resolved" (#370/#394).
         $pyCode = @'
 import json, re, sys
 try:
@@ -109,7 +113,7 @@ except Exception:
 for _ev, groups in (data.get("hooks") or {}).items():
     for g in groups:
         for h in g.get("hooks", []):
-            m = re.search(r"(/[^'\"]+?)/(?:⚙️ Meta|Meta)/scripts/", h.get("command",""))
+            m = re.search(r"((?:[A-Za-z]:)?[\\/][^'\"]+?)[\\/](?:⚙️ Meta|Meta)[\\/]scripts[\\/]", h.get("command",""))
             if m:
                 print(m.group(1)); sys.exit(0)
 sys.exit(1)

--- a/scripts/sync-vault-scripts.sh
+++ b/scripts/sync-vault-scripts.sh
@@ -165,7 +165,10 @@ for _ev, groups in (data.get("hooks") or {}).items():
             cmd = h.get("command", "")
             # The installed hook commands embed the absolute vault path right
             # before the meta-folder + /scripts/. Grab the longest such prefix.
-            m = re.search(r"(/[^'\"]+?)/(?:⚙️ Meta|Meta)/scripts/", cmd)
+            # POSIX root, Windows drive letter or UNC share, either separator -
+            # byte-identical to heal-journal-guard.py's _VAULT_FROM_CMD_RE (its
+            # self-test pins the parity) and to the copy in the .ps1 sibling.
+            m = re.search(r"((?:[A-Za-z]:)?[\\/][^'\"]+?)[\\/](?:⚙️ Meta|Meta)[\\/]scripts[\\/]", cmd)
             if m:
                 print(m.group(1))
                 sys.exit(0)

--- a/scripts/vault-root-read-baseline.txt
+++ b/scripts/vault-root-read-baseline.txt
@@ -98,7 +98,6 @@ d11e46cfd26ba07935e39f6bd73c36095e242d4a2a5a6856d12a07f7b929195b SEV-E-no-defaul
 63fb9c590ff9d6f690249a4238094e595229adda50a5cfc8d55e87c1115b7a9d SEV-E-no-default scripts/graph-to-neo4j.py
 c41c1955f5ecc763a067cff06cd3c6cbe0a8aa47ad20625dd8eb7e779f8fd20d SEV-E-no-default scripts/hallucination-sample-audit.py
 24f7876383293d84f9524173e1e1b795b90eb4f18cee25dc64f5adaa57f59783 SEV-E-no-default scripts/hallucination-watch.py
-6670bcec0a1d80f8ea0d75ae7a8aae27993c4c5790e2e53f5029f9d2b1be7dea SEV-E-no-default scripts/heal-journal-guard.py
 6082be21cce7a61305998c0b07dd6c1148aebe660dcf364d8998d317b7cdcc57 SEV-E-no-default scripts/insight-fact-check.py
 a5aed49db53aae2474b33dd27da96d15a3fb4d13676974aa3d43e6c7d1d900c9 SEV-E-no-default scripts/rotate-last-session.py
 094e856feb69cd63ac7602b4d763d2067201d9b88c79aa7edc6f50fca9f7038a SEV-E-no-default scripts/security-snapshot.py


### PR DESCRIPTION
## The reported bug was already fixed; a second one in the same file was not

Issues #335, #370 and #394 all report the same thing: `_GUARD_PATH_RE` in
`scripts/heal-journal-guard.py` matches only `~` or `/`, so a healthy Windows
install is diagnosed as a gap and self-heals on every SessionStart.

**That half already shipped** in c62f2f7 (#402). All three were filed against
older checkouts — #394 names HEAD `2876687` (2026-07-15). `--self-test` already
carries `path-win-bare`, `path-win-quoted`, `path-win-full-command` and
`path-win-space-in-home` controls, and they pass on `main` today. Nothing to redo.

**One cause, three reports** — but the reports also name a *second* regex, and
that one is still live on `main`.

## What is actually broken: `_VAULT_FROM_CMD_RE`

#370 files it as a "secondary note", #394 as "root cause 2". It parses the vault
root out of an installed hook command and accepts forward slashes only:

```python
_VAULT_FROM_CMD_RE = re.compile(r"(/[^'\"]+?)/(?:⚙️ Meta|Meta)/scripts/")
```

The Windows installer writes `C:\...\<vault>\⚙️ Meta\scripts\...`, which never
matches, so `resolve_vault()` returns `""` and `preflight_state()` answers
`no-vault` on every Windows box.

`has_gap()` does not count `no-vault`, so **this one never nags — it fails the
other way.** The preflight check *and* its repair are structurally dead on
Windows, and an account that is genuinely missing `journal-preflight.py` reads as
healthy. A silent no-op in the layer whose whole job is to stop `/journal`
shipping an entry with zero context.

## The fix

Same three roots the guard regex already accepts — POSIX, drive letter, UNC
share — with either separator:

```python
_VAULT_FROM_CMD_RE = re.compile(
    r"((?:[A-Za-z]:)?[\\/][^'\"]+?)[\\/](?:⚙️ Meta|Meta)[\\/]scripts[\\/]"
)
```

Still anchored on the literal `<meta>\scripts\` suffix, so it does not drift into
matching arbitrary text. A command naming only `hook_runner.py` — which also sits
under a `\scripts\` dir — still yields no vault, and over-matching stays harmless
because the caller `is_dir()`s the result anyway.

### Fixed the class, not the instance

The identical regex is inlined in `sync-vault-scripts.sh` and
`sync-vault-scripts.ps1`, which resolve the vault for the repair this healer
invokes. **The `.ps1` is the Windows leg and was POSIX-only too**, so a standalone
run there always skipped with "no vault resolved". All three now carry the same
pattern, and `self_test()` pins the parity so a future fix to one cannot silently
leave the others behind.

## Negative control, run before the fix

New `vault-*` controls added to `self_test()`, run against the **pre-fix** regex:

```
self-test FAIL: vault-win-quoted, vault-win-space-in-home,
                vault-win-full-command, vault-unc-share
```

After the fix: `self-test OK`, and `tests/integration/test_heal_journal_guard.sh`
is 12/12. The `posix-*` controls pin that the widening did not regress
macOS/Linux; the `absent-*` ones pin that it did not start over-matching.

The parity check is mutation-tested rather than assumed: reverting the `.sh`
copy to the old pattern in a throwaway tree reds
`vault-regex-parity-sync-vault-scripts.sh`. (The first mutation attempt silently
failed to apply — a broken mutation reads exactly like a guard correctly
detecting nothing — so the harness asserts its own edit landed.)

## Second commit: the VAULT_ROOT ratchet

Editing `heal-journal-guard.py` went STALE against
`scripts/vault-root-read-baseline.txt`, which is by design — that file is a
backlog, and touching a pinned file is meant to force the read to be resolved.
Took the documented exit rather than re-pinning: `# vault-root-ok: <reason>` in
the source where a reviewer sees it, and the row deleted.

The read is genuinely correct, which is why it is exempted rather than rewritten.
`resolve_vault()` serves a **per-account** healer — it repairs `~/.claude`, not a
vault file — so the "resolve per target file first" shape has no target file to
resolve from. The installed commands *are* the per-vault signal and are already
the fallback. No default (`SEV-E-no-default`): unset falls through to that parse
and then to `""`, never a guessed `~/vault`. Set is honored only when it names a
real directory, and `repair_preflight` threads the same value into
`sync-vault-scripts`, so check and repair cannot disagree about the vault.

## Verification

- `bash scripts/ci.sh` → exit **0** (104 integration tests, 338 files
  `py_compile`, shellcheck, utf8, block-protocol, vault-root reads).
- `tests/integration/test_vault_root_read_guard.sh` → ALL TESTS PASSED, fleet
  scan live at 286 files (a 0-file scan is the vacuous-pass mode it fails on).
- `tests/integration/test_vault_script_sync.sh` → passes, including
  `vault resolved from settings.json and synced arg-lessly` — the exact path
  changed in the `.sh`.

**Not verified:** none of this ran on a real Windows machine. The Windows and UNC
forms are proven at the **parse layer**, which is where the bug lives;
`resolve_vault()`'s `is_dir()` half can only be exercised where the path exists.

Closes #335
Closes #370
Closes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)
