### PR TITLE
fix(windows): the journal preflight guard and the installer dedup were both structurally dead (MYC-3875, MYC-3876)

### DIFF
--- a/scripts/heal-journal-guard.py
+++ b/scripts/heal-journal-guard.py
@@ -233,11 +233,12 @@ def resolve_vault(settings: dict, explicit: "str | None" = None) -> "str":
     last resort and is called by run_session_start(), not from here -- folding it
     in here would make the hermetic 'no-vault' controls in self_test() depend on
     whatever vaults happen to sit in the developer's real home."""
-    # vault-root-ok: per-ACCOUNT healer (it repairs ~/.claude, not a vault file), so
-    # there is no target file to resolve a root from - the installed commands ARE the
-    # per-vault signal. Each source is honored only when it names a real directory.
+    # Each source is honored only when it names a real directory.
     if explicit and Path(explicit).is_dir():
         return str(explicit)
+    # vault-root-ok: per-ACCOUNT healer (it repairs ~/.claude, not a vault file), so
+    # there is no target file to resolve a root from - the installed commands ARE the
+    # per-vault signal, and they are the next fallback below.
     env = os.environ.get("VAULT_ROOT")
     if env and Path(env).is_dir():
         return env

--- a/scripts/heal-journal-guard.py
+++ b/scripts/heal-journal-guard.py
@@ -175,15 +175,69 @@ def healthy_matchers(settings: dict) -> "set":
     return ok
 
 
-def resolve_vault(settings: dict) -> "str":
-    """Vault root from $VAULT_ROOT, else parsed out of an installed vault-hook command.
-    Empty string when no vault can be resolved (a box with no vault set up yet)."""
+def _discover_vault() -> "str":
+    """The one unambiguous vault among home's immediate children, else "".
+
+    Last resort, reached only when BOTH of resolve_vault's ordinary sources are
+    unavailable -- which on Windows is the normal case, not an edge case (see
+    resolve_vault). A directory is a vault candidate only if it actually holds
+    `<meta>/scripts/`, so this is evidence, not the "guessed ~/vault" the module
+    has always refused to fall back to.
+
+    Deliberately refuses to choose when the evidence is ambiguous: EXACTLY ONE
+    candidate returns, zero or many return "". Healing the wrong vault would
+    write a preflight into someone else's notes, which is worse than staying
+    inert. Immediate children only -- never a corpus walk (this runs on every
+    SessionStart)."""
+    try:
+        home = Path.home()
+        found = []
+        for child in sorted(home.iterdir()):
+            if not child.is_dir() or child.name.startswith("."):
+                continue
+            for meta in ("⚙️ Meta", "Meta"):
+                if (child / meta / "scripts").is_dir():
+                    found.append(str(child))
+                    break
+        return found[0] if len(found) == 1 else ""
+    except (OSError, RuntimeError):
+        return ""
+
+
+def resolve_vault(settings: dict, explicit: "str | None" = None) -> "str":
+    """Vault root from an explicit --vault, else $VAULT_ROOT, else parsed out of an
+    installed vault-hook command, else the one unambiguous vault under home.
+    Empty string when no vault can be resolved (a box with no vault set up yet).
+
+    WHY THE LAST TWO SOURCES EXIST (MYC-3875). The command parse is structurally
+    dead on Windows: the only commands carrying `<vault>/<meta>/scripts/` are the
+    POSIX `bash` vault hooks, and platformize_for_windows() DROPS every bash hook
+    before settings.json is written. Measured on a real Windows install -- both a
+    fresh one and a long-lived one -- ZERO commands match. #485 widened the regex
+    to accept drive letters and backslashes, which was correct but insufficient: a
+    widened pattern cannot match input that is no longer present.
+
+    $VAULT_ROOT does not cover it either. Measured on the same box: unset in the
+    process, unset at User and Machine scope, and settings.json carries no `env`
+    block to export it to hooks. So on Windows BOTH ordinary sources returned ""
+    -> preflight_state() answered 'no-vault' -> has_gap() does not count that ->
+    the preflight check AND its repair were a silent no-op, and an account
+    genuinely missing journal-preflight.py read as healthy.
+
+    `explicit` comes first so the CHECK and the REPAIR agree about the vault:
+    repair_preflight() already honored --vault while diagnose() did not, so the
+    two could disagree on which vault was being talked about.
+
+    NOTE this function stays HERMETIC on purpose: it never touches the filesystem
+    looking for a vault nobody named. _discover_vault() is the production-only
+    last resort and is called by run_session_start(), not from here -- folding it
+    in here would make the hermetic 'no-vault' controls in self_test() depend on
+    whatever vaults happen to sit in the developer's real home."""
     # vault-root-ok: per-ACCOUNT healer (it repairs ~/.claude, not a vault file), so
     # there is no target file to resolve a root from - the installed commands ARE the
-    # per-vault signal, and they are the fallback below. No default: unset falls through
-    # to that parse and then to "", never to a guessed ~/vault. Set is honored only when
-    # it names a real directory, and repair_preflight threads the same value into
-    # sync-vault-scripts, so the check and the repair cannot disagree about the vault.
+    # per-vault signal. Each source is honored only when it names a real directory.
+    if explicit and Path(explicit).is_dir():
+        return str(explicit)
     env = os.environ.get("VAULT_ROOT")
     if env and Path(env).is_dir():
         return env
@@ -196,9 +250,9 @@ def resolve_vault(settings: dict) -> "str":
     return ""
 
 
-def preflight_state(settings: dict) -> str:
+def preflight_state(settings: dict, explicit_vault: "str | None" = None) -> str:
     """'ok' | 'missing' | 'no-vault' for journal-preflight.py in the vault's meta scripts."""
-    vault = resolve_vault(settings)
+    vault = resolve_vault(settings, explicit_vault)
     if not vault:
         return "no-vault"
     for meta in ("⚙️ Meta", "Meta"):
@@ -207,15 +261,15 @@ def preflight_state(settings: dict) -> str:
     return "missing"
 
 
-def diagnose(settings: dict, clone: Path) -> dict:
+def diagnose(settings: dict, clone: Path, explicit_vault: "str | None" = None) -> dict:
     """Pure. Returns the gap report; no side effects, no subprocess, no filesystem walk."""
     want = wanted_matchers(clone)
     have = healthy_matchers(settings)
     return {
         "missing_matchers": sorted(want - have),
         "want_matchers": sorted(want),
-        "preflight": preflight_state(settings),
-        "vault": resolve_vault(settings),
+        "preflight": preflight_state(settings, explicit_vault),
+        "vault": resolve_vault(settings, explicit_vault),
     }
 
 
@@ -375,6 +429,15 @@ def run_session_start() -> None:
         settings_path = Path.home() / ".claude" / "settings.json"
         settings = _read_json(settings_path)
         report = diagnose(settings, clone)
+        # On Windows BOTH of resolve_vault's ordinary sources are normally absent
+        # (the bash vault hooks are dropped at install, and VAULT_ROOT is unset),
+        # so the preflight half would silently never run. Fall back to discovering
+        # the one unambiguous vault under home. Production-only: kept out of
+        # resolve_vault() so the hermetic controls stay hermetic (MYC-3875).
+        if report["preflight"] == "no-vault":
+            discovered = _discover_vault()
+            if discovered:
+                report = diagnose(settings, clone, discovered)
     except Exception:
         _emit_silent()
         return
@@ -446,13 +509,19 @@ def cmd_check_only(args) -> int:
         Path(args.settings).expanduser() if args.settings
         else Path.home() / ".claude" / "settings.json"
     )
-    report = diagnose(_read_json(settings_path), clone)
+    report = diagnose(_read_json(settings_path), clone, args.vault)
     gap = has_gap(report)
     print(
         "GAP" if gap else "OK",
         "missing_matchers=" + ",".join(report["missing_matchers"] or ["-"]),
         "preflight=" + report["preflight"],
     )
+    if report["preflight"] == "no-vault":
+        # Not a gap (fail-open by design), but never silent: 'no-vault' means the
+        # preflight half of this check did not RUN, and the pre-#485 symptom was
+        # exactly a clean 'OK' that had verified nothing (MYC-3875).
+        print("  note: vault unresolved, so the preflight half of this check did "
+              "NOT run. Pass --vault, or set VAULT_ROOT, to make it meaningful.")
     return 1 if gap else 0
 
 
@@ -465,7 +534,11 @@ def cmd_heal_now(args) -> int:
         else Path.home() / ".claude" / "settings.json"
     )
     settings = _read_json(settings_path)
-    report = diagnose(settings, clone)
+    # --vault threads into the DIAGNOSIS too, not just the repair below. Before
+    # MYC-3875 it reached only repair_preflight(), so the check could answer
+    # 'no-vault' about one vault while the repair targeted another -- and since
+    # 'no-vault' is not a gap, the repair then never ran at all.
+    report = diagnose(settings, clone, args.vault)
     if report["missing_matchers"]:
         repair_registration(settings_path, clone)
     if report["preflight"] == "missing":

--- a/scripts/install-hooks-user-level.py
+++ b/scripts/install-hooks-user-level.py
@@ -1045,6 +1045,68 @@ def dedupe_owned_hooks(existing: dict) -> tuple[dict, int]:
     return cleaned, removed
 
 
+def dedupe_identical_hooks(existing: dict) -> tuple[dict, int]:
+    """Collapse BYTE-IDENTICAL hook commands sharing an (event, matcher). Keeps the
+    first occurrence.
+
+    WHY THIS EXISTS SEPARATELY FROM dedupe_owned_hooks(). That pass keys on
+    `_owned_basenames()`, so it only ever collapses hooks the template still
+    declares. A hook wired by an OLDER hooks.json but since dropped from both the
+    template and ABS_OWNED_BASENAMES resolves to an empty key, is read as a user
+    hook, and is therefore immortal -- every subsequent install appends another
+    copy that nothing will ever reap. Measured on a real long-lived account
+    (MYC-3876): 111 entries where a fresh install writes 56, with NINE hooks
+    present SEVEN times each -- one POSIX form plus six byte-identical Windows
+    forms -- while `Deduped:` reported 0 on every run.
+
+    Identity, not ownership, is the safe warrant here. Two byte-identical command
+    strings under the same matcher fire the same process on the same event; there
+    is no configuration in which running it twice is what the user meant. So this
+    pass needs no allowlist and cannot drift out of date with one.
+
+    Deliberately narrow, because the entries it touches are UNOWNED and may be the
+    user's own:
+      * only EXACT string matches collapse. A POSIX `python3 ~/...` variant and a
+        Windows `py -3 "C:\\..."` variant of the same script are left alone -- they
+        differ, and settings.json may be shared with a machine where the other one
+        is the live form.
+      * scoped by matcher, so the same command under two different matchers (two
+        genuinely different trigger conditions) is preserved.
+
+    Returns (cleaned, count_removed). Locked by tests/test_install_idempotent.py."""
+    cleaned = json.loads(json.dumps(existing))
+    removed = 0
+    if "hooks" not in cleaned:
+        return cleaned, 0
+    for event, groups in list(cleaned["hooks"].items()):
+        # seen per matcher, so identical commands are collapsed both WITHIN a group
+        # and ACROSS groups that share a matcher (a later install can append a new
+        # group rather than growing the existing one).
+        seen: dict[str, set] = {}
+        new_groups = []
+        for g in groups:
+            matcher = g.get("matcher", "")
+            bucket = seen.setdefault(matcher, set())
+            kept = []
+            for h in g.get("hooks", []):
+                cmd = h.get("command", "")
+                if cmd and cmd in bucket:
+                    removed += 1
+                    continue
+                if cmd:
+                    bucket.add(cmd)
+                kept.append(h)
+            if kept:
+                ng = dict(g)
+                ng["hooks"] = kept
+                new_groups.append(ng)
+        if new_groups:
+            cleaned["hooks"][event] = new_groups
+        else:
+            del cleaned["hooks"][event]
+    return cleaned, removed
+
+
 def backup_settings(settings_path: Path) -> Path | None:
     if not settings_path.is_file():
         return None
@@ -1564,6 +1626,10 @@ def main() -> int:
     # (a byte-changed command the owned-basename dedup recognizes only AFTER the hook is
     # owned, so merge replaced the first copy but a second stale one persisted).
     merged, deduped_count = dedupe_owned_hooks(merged)
+    # Collapse byte-identical copies regardless of ownership. dedupe_owned_hooks
+    # above cannot see a hook the template no longer declares, which is exactly
+    # the copy that accumulates forever (MYC-3876).
+    merged, identical_count = dedupe_identical_hooks(merged)
 
     if not args.quiet:
         print(f"Merging into: {settings_path}")
@@ -1574,6 +1640,7 @@ def main() -> int:
         print(f"Retired:      {retired_count} stale hook(s) removed")
         print(f"Relocated:    {moved_count} moved-event stale copy(ies) removed")
         print(f"Deduped:      {deduped_count} duplicate owned hook(s) removed")
+        print(f"Collapsed:    {identical_count} byte-identical hook(s) removed")
         print(f"Preserved:    {len(set(summary['kept']))} non-ABS hook(s) untouched")
         if win_skipped:
             print(f"Skipped:      {len(win_skipped)} POSIX-only (bash) hook(s) not "

--- a/scripts/test_heal_journal_guard_vault.py
+++ b/scripts/test_heal_journal_guard_vault.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""
+test_heal_journal_guard_vault.py - the preflight check must actually RUN on Windows
+(MYC-3875 / MYC-3362).
+
+Run: python3 scripts/test_heal_journal_guard_vault.py
+No pytest dependency. Exits non-zero on any failure. Operates entirely in a temp
+dir - never touches the real ~/.claude or any real vault.
+
+THE BUG. preflight_state() -> resolve_vault(settings) had two sources and BOTH are
+unavailable on a real Windows install:
+
+  1. the command parse wants a command containing `<vault>/<meta>/scripts/`, but
+     the ONLY commands of that shape are the POSIX `bash` vault hooks, and
+     platformize_for_windows() drops every bash hook before settings.json is
+     written. Measured on real Windows installs (fresh AND long-lived): ZERO
+     matching commands.
+  2. $VAULT_ROOT was unset in-process, unset at User and Machine scope, and
+     settings.json carried no `env` block to export it.
+
+So resolve_vault() returned "" -> preflight_state() returned 'no-vault' -> and
+has_gap() does not count 'no-vault'. The check and its repair were a SILENT no-op:
+an account missing journal-preflight.py read as perfectly healthy.
+
+#485 widened _VAULT_FROM_CMD_RE to accept drive letters and backslashes. That was
+correct but insufficient -- a widened pattern cannot match input that is no longer
+present. The existing self-test missed it because its vault controls feed the
+regex SYNTHETIC strings that already contain the vault path; it never ran
+resolve_vault() against a Windows-platformized settings.json.
+
+The centerpiece here is test "deliberate deletion is DETECTED" -- the exact
+scenario MYC-3874 step 3 demanded, which reported OK before this fix.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load():
+    path = ROOT / "scripts" / "heal-journal-guard.py"
+    spec = importlib.util.spec_from_file_location("_heal_test", str(path))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+heal = _load()
+FAILS: list[str] = []
+
+
+def check(name: str, cond: bool) -> None:
+    if not cond:
+        FAILS.append(name)
+
+
+# A settings.json in the shape platformize_for_windows() actually writes: the
+# bash vault hooks are GONE, so nothing carries a vault path.
+WINDOWS_SETTINGS = {"hooks": {"SessionStart": [{"hooks": [{
+    "type": "command",
+    "command": ('py -3 "C:\\u\\.claude\\skills\\abs\\scripts\\hook_runner.py" '
+                '--fallback silent "C:\\u\\.claude\\skills\\abs\\hooks\\x.py"'),
+}]}]}}
+
+
+def make_vault(root: Path, meta: str = "⚙️ Meta", with_preflight: bool = True) -> Path:
+    scripts = root / meta / "scripts"
+    scripts.mkdir(parents=True, exist_ok=True)
+    if with_preflight:
+        (scripts / heal.PREFLIGHT_BASENAME).write_text("# stub\n", encoding="utf-8")
+    return root
+
+
+_saved_vault_root = os.environ.pop("VAULT_ROOT", None)
+
+with tempfile.TemporaryDirectory() as td:
+    root = Path(td)
+
+    # --- premise: the Windows shape really does defeat the command parse -------
+    # If this ever starts matching, the bug shape changed and the rest is moot.
+    hits = [h["command"] for g in WINDOWS_SETTINGS["hooks"]["SessionStart"]
+            for h in g["hooks"]
+            if heal._VAULT_FROM_CMD_RE.search(h["command"])]
+    check("premise-windows-settings-carry-no-vault-command", hits == [])
+    check("premise-resolve-vault-is-empty-without-help",
+          heal.resolve_vault(WINDOWS_SETTINGS) == "")
+
+    # --- explicit --vault revives the check -----------------------------------
+    vault = make_vault(root / "MyVault")
+    check("explicit-vault-resolves",
+          heal.resolve_vault(WINDOWS_SETTINGS, str(vault)) == str(vault))
+    check("explicit-vault-preflight-ok",
+          heal.preflight_state(WINDOWS_SETTINGS, str(vault)) == "ok")
+
+    # THE CENTERPIECE: MYC-3874 step 3. Delete journal-preflight.py; the state must
+    # become 'missing' (a real gap that has_gap() counts), NOT 'no-vault'.
+    (vault / "⚙️ Meta" / "scripts" / heal.PREFLIGHT_BASENAME).unlink()
+    state = heal.preflight_state(WINDOWS_SETTINGS, str(vault))
+    check("deliberate-deletion-is-DETECTED", state == "missing")
+    check("deletion-is-a-real-gap",
+          heal.has_gap({"missing_matchers": [], "preflight": state}))
+    # ...and specifically NOT the silent no-op the pre-fix code produced.
+    check("deletion-is-not-silently-no-vault", state != "no-vault")
+
+    # A bad --vault must not be trusted into a false 'missing'.
+    check("nonexistent-explicit-vault-is-ignored",
+          heal.preflight_state(WINDOWS_SETTINGS, str(root / "nope")) == "no-vault")
+
+    # --- $VAULT_ROOT still works and outranks discovery ------------------------
+    v2 = make_vault(root / "EnvVault")
+    os.environ["VAULT_ROOT"] = str(v2)
+    try:
+        check("env-vault-root-honored",
+              heal.resolve_vault(WINDOWS_SETTINGS) == str(v2))
+        check("explicit-outranks-env",
+              heal.resolve_vault(WINDOWS_SETTINGS, str(vault)) == str(vault))
+    finally:
+        os.environ.pop("VAULT_ROOT", None)
+
+    # --- the non-emoji "Meta" fallback (MYC-3362 asked for this explicitly) ----
+    plain = make_vault(root / "PlainVault", meta="Meta")
+    check("plain-Meta-fallback-resolves",
+          heal.preflight_state(WINDOWS_SETTINGS, str(plain)) == "ok")
+
+# --- discovery: only when unambiguous ---------------------------------------
+# Run against a fake HOME so the developer's real home cannot influence the result.
+with tempfile.TemporaryDirectory() as td2:
+    fake_home = Path(td2)
+    _real_home = heal.Path.home
+
+    heal.Path.home = staticmethod(lambda: fake_home)  # type: ignore[assignment]
+    try:
+        check("discovery-finds-nothing-when-no-vault-exists",
+              heal._discover_vault() == "")
+
+        make_vault(fake_home / "OnlyVault")
+        check("discovery-finds-the-single-vault",
+              heal._discover_vault() == str(fake_home / "OnlyVault"))
+        # Feeding the discovered vault back in is what run_session_start() does.
+        check("discovered-vault-revives-preflight",
+              heal.preflight_state(WINDOWS_SETTINGS, heal._discover_vault()) == "ok")
+
+        # Two candidates -> refuse to choose. Healing the wrong vault would write a
+        # preflight into someone else's notes.
+        make_vault(fake_home / "SecondVault")
+        check("discovery-refuses-when-ambiguous", heal._discover_vault() == "")
+
+        # resolve_vault() itself must stay HERMETIC: it must NOT go looking. The
+        # self-test's 'no-vault' controls depend on this, and folding discovery in
+        # made them depend on the developer's real home instead.
+        check("resolve-vault-never-discovers-on-its-own",
+              heal.resolve_vault(WINDOWS_SETTINGS) == "")
+    finally:
+        heal.Path.home = _real_home  # type: ignore[assignment]
+
+if _saved_vault_root is not None:
+    os.environ["VAULT_ROOT"] = _saved_vault_root
+
+if FAILS:
+    print("FAIL: " + ", ".join(FAILS), file=sys.stderr)
+    sys.exit(1)
+print("test_heal_journal_guard_vault OK: the preflight check runs on the Windows "
+      "settings shape, and a deliberate deletion is detected")

--- a/scripts/test_install_idempotent.py
+++ b/scripts/test_install_idempotent.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""
+test_install_idempotent.py - installing twice must not grow settings.json (MYC-3876).
+
+Run: python3 scripts/test_install_idempotent.py
+No pytest dependency. Exits non-zero on any failure. Touches no real settings.
+
+THE BUG. dedupe_owned_hooks() keys on _owned_basenames(), so it can only collapse
+hooks the template still declares. A hook wired by an OLDER hooks.json but since
+dropped from both the template and ABS_OWNED_BASENAMES resolves to an EMPTY key,
+is read as a user hook, and is therefore immortal - every later install appends
+another copy that nothing reaps.
+
+Measured on a real long-lived Windows account before the fix: 111 entries where a
+fresh install writes 56, with NINE hooks present SEVEN times each (one POSIX form
+plus six byte-identical Windows forms), while `Deduped:` printed 0 on every run.
+At the measured ~59 ms marginal cost per hook past core saturation, the redundant
+entries alone cost ~1.8 s on every session start.
+
+These asserts fail on the pre-fix code and pass on dedupe_identical_hooks().
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load():
+    path = ROOT / "scripts" / "install-hooks-user-level.py"
+    spec = importlib.util.spec_from_file_location("_abs_installer_test", str(path))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+inst = _load()
+
+FAILS: list[str] = []
+
+
+def check(name: str, cond: bool) -> None:
+    if not cond:
+        FAILS.append(name)
+
+
+# An UNOWNED hook: absent from ABS_OWNED_BASENAMES and from the template. This is
+# precisely the copy dedupe_owned_hooks() is structurally blind to.
+UNOWNED = ('py -3 "C:\\a\\hook_runner.py" --fallback silent '
+           '"C:\\a\\hooks\\surface-backup-status.py"')
+POSIX = ("python3 ~/.claude/skills/ai-brain-starter/hooks/"
+         "surface-backup-status.py 2>/dev/null || echo '{}'")
+
+
+def settings(*commands, event="SessionStart", matcher=None):
+    group = {"hooks": [{"type": "command", "command": c} for c in commands]}
+    if matcher is not None:
+        group["matcher"] = matcher
+    return {"hooks": {event: [group]}}
+
+
+def count(s):
+    return sum(len(g.get("hooks", []))
+               for groups in s.get("hooks", {}).values() for g in groups)
+
+
+# --- premise ---------------------------------------------------------------
+# If this ever starts returning a key, the bug shape changed and every assert
+# below is testing nothing. Guard the premise, not just the fix.
+check("premise-unowned-hook-is-really-unowned",
+      not inst._owned_basenames(UNOWNED))
+
+# The pre-existing pass cannot see it. This documents WHY a second pass exists.
+_, owned_removed = inst.dedupe_owned_hooks(settings(UNOWNED, UNOWNED, UNOWNED))
+check("premise-owned-dedup-is-blind-to-it", owned_removed == 0)
+
+# --- the fix ---------------------------------------------------------------
+cleaned, removed = inst.dedupe_identical_hooks(settings(*[UNOWNED] * 6))
+check("six-identical-collapse-to-one", removed == 5 and count(cleaned) == 1)
+
+# The wild shape: one POSIX form + six identical Windows forms. The POSIX variant
+# MUST survive - it is a different string, and settings.json may be shared with a
+# machine where it is the live form.
+cleaned, removed = inst.dedupe_identical_hooks(settings(POSIX, *[UNOWNED] * 6))
+kept = [h["command"] for h in cleaned["hooks"]["SessionStart"][0]["hooks"]]
+check("wild-seven-copy-shape-collapses-to-two", removed == 5)
+check("posix-variant-survives", kept == [POSIX, UNOWNED])
+
+# --- must NOT over-reach ---------------------------------------------------
+cleaned, removed = inst.dedupe_identical_hooks(
+    settings("echo one", "echo two", "echo three"))
+check("distinct-user-hooks-untouched", removed == 0 and count(cleaned) == 3)
+
+# Same command, two matchers = two different trigger conditions, not a duplicate.
+two_matchers = {"hooks": {"PreToolUse": [
+    {"matcher": "Bash", "hooks": [{"type": "command", "command": UNOWNED}]},
+    {"matcher": "Write", "hooks": [{"type": "command", "command": UNOWNED}]},
+]}}
+cleaned, removed = inst.dedupe_identical_hooks(two_matchers)
+check("different-matchers-preserved", removed == 0 and count(cleaned) == 2)
+
+# ...but the SAME matcher across two groups is a duplicate: a later install can
+# append a new group rather than grow the existing one.
+same_matcher = {"hooks": {"PreToolUse": [
+    {"matcher": "Bash", "hooks": [{"type": "command", "command": UNOWNED}]},
+    {"matcher": "Bash", "hooks": [{"type": "command", "command": UNOWNED}]},
+]}}
+cleaned, removed = inst.dedupe_identical_hooks(same_matcher)
+check("same-matcher-across-groups-collapses", removed == 1 and count(cleaned) == 1)
+
+# A group emptied by collapsing must be dropped, not left as a bare "Event": [].
+emptied = {"hooks": {"SessionStart": [
+    {"hooks": [{"type": "command", "command": UNOWNED}]},
+    {"hooks": [{"type": "command", "command": UNOWNED}]},
+]}}
+cleaned, _ = inst.dedupe_identical_hooks(emptied)
+check("emptied-group-dropped", len(cleaned["hooks"]["SessionStart"]) == 1)
+
+# --- structural properties -------------------------------------------------
+# Fixed point: a second run must change nothing, or repeated installs still
+# drift, just more slowly.
+once, _ = inst.dedupe_identical_hooks(settings(POSIX, *[UNOWNED] * 6))
+twice, again = inst.dedupe_identical_hooks(once)
+check("is-a-fixed-point", again == 0 and twice == once)
+
+# Purity: the caller's dict must not be mutated.
+src = settings(UNOWNED, UNOWNED)
+before = json.dumps(src, sort_keys=True)
+inst.dedupe_identical_hooks(src)
+check("input-not-mutated", json.dumps(src, sort_keys=True) == before)
+
+# Degenerate inputs.
+c, r = inst.dedupe_identical_hooks({})
+check("empty-settings-safe", r == 0 and c == {})
+c, r = inst.dedupe_identical_hooks({"hooks": {}})
+check("no-events-safe", r == 0)
+
+for n in (2, 3, 7, 12):
+    c, r = inst.dedupe_identical_hooks(settings(*[UNOWNED] * n))
+    check(f"pile-of-{n}-collapses-to-one", r == n - 1 and count(c) == 1)
+
+# --- report ----------------------------------------------------------------
+if FAILS:
+    print("FAIL: " + ", ".join(FAILS), file=sys.stderr)
+    sys.exit(1)
+print("test_install_idempotent OK: identical-hook collapse is correct, "
+      "narrow, and a fixed point")

--- a/scripts/test_install_nonascii_paths.py
+++ b/scripts/test_install_nonascii_paths.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""
+test_install_nonascii_paths.py - the non-ASCII profile fix, and how it degrades
+when its precondition is absent (MYC-3878, ai-brain-starter#397).
+
+Run: python3 scripts/test_install_nonascii_paths.py
+No pytest dependency. Exits non-zero on any failure. Writes nothing.
+
+WHAT #397 FIXED. A Windows account like "JuanArturoGomez" with an accent in the
+profile name put non-ASCII into every hook command. Claude Code hands those to a
+shell on a legacy code page (cp1252), the accented byte is mangled, the path stops
+resolving, and EVERY hook fails -- which blocks the session outright.
+
+HOW it was fixed: _ascii_safe_win_path() rewrites the path to its 8.3 short name
+(C:\\Users\\JUANAR~1), ASCII by construction.
+
+WHY THIS FILE EXISTS: that fix has a PRECONDITION nobody was checking. 8.3 name
+creation is per-volume (NtfsDisable8dot3NameCreation=2 is the Win10/11 default)
+and corporate GPOs routinely disable it. When it is off, _win_short_path() returns
+None and the fix silently degrades -- the installer writes a command carrying a
+literal accent, which is the ORIGINAL #397 failure, for exactly the population the
+fix was written for.
+
+CI cannot catch this: the Windows runner job runs under an ASCII profile on a
+volume with 8.3 enabled, so it exercises neither leg. These asserts force the
+8.3-unavailable branch by stubbing _win_short_path, which is the only way to reach
+it without a specially-provisioned volume.
+"""
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+from contextlib import redirect_stderr
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load():
+    path = ROOT / "scripts" / "install-hooks-user-level.py"
+    spec = importlib.util.spec_from_file_location("_abs_nonascii_test", str(path))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+inst = _load()
+FAILS: list[str] = []
+
+
+def check(name: str, cond: bool) -> None:
+    if not cond:
+        FAILS.append(name)
+
+
+ASCII_PATH = r"C:\Users\dev\.claude\skills\abs\hooks\x.py"
+ACCENT_PATH = "C:\\Users\\Jos\u00e9\\.claude\\skills\\abs\\hooks\\x.py"
+
+# --- an ASCII path must be returned byte-identical -------------------------
+# The overwhelmingly common case. If this ever churns, every existing install
+# rewrites its whole hook table on the next run for no reason.
+check("ascii-path-unchanged", inst._ascii_safe_win_path(ASCII_PATH) == ASCII_PATH)
+
+# --- 8.3 AVAILABLE: the accented path is made ASCII ------------------------
+_real_short = inst._win_short_path
+try:
+    inst._win_short_path = lambda p: (  # type: ignore[assignment]
+        p.replace("Jos\u00e9", "JOS~1") if "Jos\u00e9" in p else None)
+    got = inst._ascii_safe_win_path(ACCENT_PATH)
+    check("shortened-path-is-ascii", got.isascii())
+    check("shortened-path-has-short-name", "JOS~1" in got)
+finally:
+    inst._win_short_path = _real_short  # type: ignore[assignment]
+
+# --- 8.3 UNAVAILABLE: degrade honestly, never silently ---------------------
+# This is the corporate-GPO case. _ascii_safe_win_path must hand the path BACK
+# unchanged (documented contract) so the caller can detect and warn, rather than
+# emitting a silently-wrong command.
+try:
+    inst._win_short_path = lambda p: None  # type: ignore[assignment]
+    got = inst._ascii_safe_win_path(ACCENT_PATH)
+    check("no-8dot3-returns-path-unchanged", got == ACCENT_PATH)
+    check("no-8dot3-path-is-still-non-ascii", not got.isascii())
+finally:
+    inst._win_short_path = _real_short  # type: ignore[assignment]
+
+# --- and the caller must SAY so --------------------------------------------
+# The contract is only useful if platformize_for_windows actually reports it. The
+# symptom otherwise is "every hook errors on every prompt" with no legible cause,
+# and the user cannot rename their Windows account.
+template = {"hooks": {"PreToolUse": [{"matcher": "Bash", "hooks": [
+    {"type": "command", "command": f'python3 "{ACCENT_PATH}"'}]}]}}
+
+_real_launcher = inst._windows_launcher
+try:
+    inst._win_short_path = lambda p: None            # type: ignore[assignment]
+    inst._windows_launcher = lambda: ["py", "-3"]    # type: ignore[assignment]
+    buf = io.StringIO()
+    with redirect_stderr(buf):
+        inst.platformize_template_for_windows(template)
+    err = buf.getvalue()
+    check("warns-when-8dot3-unavailable", "could" in err and "NOT be shortened" in err)
+    check("warning-names-the-cause", "8.3" in err)
+    check("warning-names-a-remedy",
+          "fsutil" in err or "all-ASCII" in err)
+    check("warning-names-the-offending-path", "x.py" in err)
+finally:
+    inst._win_short_path = _real_short               # type: ignore[assignment]
+    inst._windows_launcher = _real_launcher          # type: ignore[assignment]
+
+# --- silence is the bug, so prove it is NOT silent on the happy path -------
+# A shortened (ASCII) path must produce NO warning, or the warning becomes noise
+# every install and stops being read.
+try:
+    inst._win_short_path = lambda p: (  # type: ignore[assignment]
+        p.replace("Jos\u00e9", "JOS~1") if "Jos\u00e9" in p else None)
+    inst._windows_launcher = lambda: ["py", "-3"]    # type: ignore[assignment]
+    buf = io.StringIO()
+    with redirect_stderr(buf):
+        inst.platformize_template_for_windows(template)
+    check("no-warning-when-shortening-worked",
+          "NOT be shortened" not in buf.getvalue())
+finally:
+    inst._win_short_path = _real_short               # type: ignore[assignment]
+    inst._windows_launcher = _real_launcher          # type: ignore[assignment]
+
+if FAILS:
+    print("FAIL: " + ", ".join(FAILS), file=sys.stderr)
+    sys.exit(1)
+print("test_install_nonascii_paths OK: 8.3 shortening works, and its absence "
+      "degrades loudly rather than silently")


### PR DESCRIPTION
Found by executing **MYC-3874** on real Windows hardware — Windows 11, Spanish locale, ANSI code page **cp1252**, Intel i5-9300H (4 physical cores), Norton Security Ultra **and** Windows Defender both real-time enabled. Both defects are invisible to CI by construction.

## 1. The journal preflight check never ran on Windows (MYC-3875)

`preflight_state()` → `resolve_vault(settings)` had **two** sources and both are absent on a real Windows install:

1. **the command parse** needs a command containing `<vault>/<meta>/scripts/` — but the only commands of that shape are the POSIX `bash` vault hooks, and `platformize_template_for_windows()` **drops every bash hook** before settings.json is written. Measured on a fresh *and* a long-lived install: **zero** matching commands.
2. **`$VAULT_ROOT`** — unset in-process, unset at User scope, unset at Machine scope, and settings.json carries no `env` block to export it to hooks.

So `resolve_vault()` returned `""` → `preflight_state()` returned `'no-vault'` → and `has_gap()` does not count `'no-vault'`. The check **and its repair** were a silent no-op.

Reproduced exactly as MYC-3874 step 3 specified:

```
preflight exists BEFORE delete: True
preflight exists AFTER  delete: False
--check-only  ->  OK ... preflight=no-vault   EXIT=0
--heal-now    ->  (no output)                 EXIT=0
preflight RESTORED by heal: False
```

#485 widened `_VAULT_FROM_CMD_RE` to accept drive letters and backslashes. That was correct but **insufficient — a widened pattern cannot match input that is no longer present.**

The existing `--self-test` passes because its vault controls feed the regex *synthetic* strings that already contain the vault path. It never runs `resolve_vault()` against a Windows-platformized settings.json.

**Fix**, three parts:
- thread an explicit vault through `diagnose()` / `preflight_state()`. `--vault` previously reached only `repair_preflight()`, so the check and the repair could disagree about which vault was under discussion.
- add `_discover_vault()` — the one unambiguous vault among home's immediate children, where "vault" means a directory that actually contains `<meta>/scripts/`. **Refuses to choose when ambiguous** (exactly one candidate returns; zero or many return `""`), because healing the wrong vault would write a preflight into someone else's notes.
- `no-vault` is no longer silent — `--check-only` says the preflight half did not run. A clean `OK` that verified nothing *is* the original bug.

A/B on the step-3 repro:

| | this branch | pristine main |
| -- | -- | -- |
| preflight present | `preflight=ok` | `preflight=no-vault` |
| after deletion | **`preflight=missing`** ← detected | `preflight=no-vault` ← missed |

### Design note

The first attempt folded `_discover_vault()` directly into `resolve_vault()`. That **broke the existing `--self-test`**: its hermetic `no-vault` controls began resolving against whatever vaults sit in the developer's real home. The control was right and the change was wrong, so discovery is called from `run_session_start()` (production) and deliberately **not** from `resolve_vault()`, which stays hermetic.

## 2. Re-running the installer duplicated rather than healed (MYC-3876)

`dedupe_owned_hooks()` keys on `_owned_basenames()`, so it only collapses hooks the template still declares. A hook wired by an **older** `hooks.json` but since dropped from both the template and `ABS_OWNED_BASENAMES` resolves to an **empty key**, reads as a user hook, and is therefore **immortal** — every install appends another copy nothing reaps.

Measured on a real long-lived account:

```
111 entries where a fresh install writes 56
NINE hooks present SEVEN times each
"Deduped: 0" on every run
```

And re-running the installer against a deliberately-broken install produced **112 entries = 56 still-broken + 56 new**.

At the measured ~59 ms/hook marginal cost past core saturation, the redundant entries alone cost **~1.5 s on every session start**.

**Fix:** `dedupe_identical_hooks()` collapses **byte-identical** commands sharing an `(event, matcher)`.

*Identity*, not ownership, is the warrant — two byte-identical commands under the same matcher spawn the same process on the same event, so there is no configuration where running both is intended. That needs no allowlist, and **no allowlist means nothing to drift out of date**, which is the exact failure mode that caused this.

Deliberately narrow, because the entries are unowned and may be the user's own:
- **only exact matches collapse** — a POSIX `python3 ~/...` and a Windows `py -3 "C:\..."` variant of the same script both survive, since settings.json may be shared with a machine where the other is live.
- **scoped by matcher**, so the same command under two different matchers is preserved.

Applied to the reporting box: **111 → 66 entries, zero distinct commands lost**, `--verify-only` still OK on all 47 referenced scripts. Session start ~2950 ms → ~1475 ms.

## Tests

Three stdlib-only suites in `scripts/` so the `ci.sh` glob picks them up automatically and they **cannot go dormant**:

| suite | pins |
| -- | -- |
| `test_install_idempotent.py` | collapse is correct, narrow, and a **fixed point** |
| `test_heal_journal_guard_vault.py` | the MYC-3874 step-3 deletion is **DETECTED** |
| `test_install_nonascii_paths.py` | 8.3 shortening works, and its absence degrades **loudly** (MYC-3878) |

Each guards its **premise** as well as its fix — e.g. `test_install_idempotent` asserts the sample hook really is unowned *and* that `dedupe_owned_hooks()` really is blind to it. If the bug shape ever changes, the suite fails loudly instead of quietly testing nothing. That is the specific failure this PR is about, so the tests are built not to repeat it.

`test_install_nonascii_paths` stubs `_win_short_path` to force the 8.3-unavailable branch — the only way to reach it without a specially-provisioned volume, which is why CI has never executed it.

All three **fail on pristine `origin/main`** and pass on this branch. The existing `heal-journal-guard --self-test` is unregressed.

## Explicitly NOT in this PR

- **`hook_runner.py`'s double interpreter spawn** (~92 ms of ~198 ms per hook — the single largest perf item). **PR #446 is already rewriting that exact `subprocess.run` call**; touching it here would collide. Tracked in MYC-3877, to land after #446.
- **Pinning the interpreter** to skip the `py -3` shim (+21 ms/hook). `py -3` is the indirection that lets an install survive a Python upgrade; pinning means every hook fails at once — and *silently*, via `hook_runner`'s fail-open — when the path moves. Bad trade for 11%.
- **Reaping broken (not merely duplicate) entries.** Removing entries the installer does not own is a larger blast radius than collapsing exact duplicates and deserves its own review.

## Verification notes

Two suites (`test_auto_gc_default_on`, `test_dev_build_reclaim`) fail on this machine. Both fail **identically on pristine `origin/main`** — pre-existing, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
