### PR TITLE
fix(install): make the entry point work with no git, no brew, no admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,13 +86,15 @@ Read the four problems the team version solves: [`for-teams/why-teams-are-differ
 >
 > ```bash
 > # macOS / Linux
-> git clone https://github.com/mycelium-hq/ai-brain-starter ~/.claude/skills/ai-brain-starter 2>/dev/null || true
-> bash ~/.claude/skills/ai-brain-starter/bootstrap.sh
+> D=~/.claude/skills/ai-brain-starter
+> [ -f "$D/bootstrap.sh" ] || { T=$(mktemp -d) && curl -fsSL https://github.com/mycelium-hq/ai-brain-starter/archive/refs/heads/main.tar.gz | tar xz -C "$T" --strip-components=1 && [ -f "$T/bootstrap.sh" ] && mkdir -p "$D" && cp -R "$T"/. "$D"/ && rm -rf "$T"; }
+> bash "$D/bootstrap.sh"
 > ```
 > ```powershell
 > # Windows — run in PowerShell, not bash
-> if (-not (Test-Path "$env:USERPROFILE\.claude\skills\ai-brain-starter")) { git clone https://github.com/mycelium-hq/ai-brain-starter "$env:USERPROFILE\.claude\skills\ai-brain-starter" }
-> powershell -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\.claude\skills\ai-brain-starter\bootstrap.ps1"
+> $D="$env:USERPROFILE\.claude\skills\ai-brain-starter"
+> if (-not (Test-Path "$D\bootstrap.ps1")) { $t="$env:TEMP\abs-$(Get-Random)"; $z="$t.zip"; Invoke-WebRequest "https://github.com/mycelium-hq/ai-brain-starter/archive/refs/heads/main.zip" -OutFile $z -UseBasicParsing; Expand-Archive $z $t -Force; if (Test-Path "$t\ai-brain-starter-main\bootstrap.ps1") { New-Item -ItemType Directory -Force -Path $D | Out-Null; Copy-Item "$t\ai-brain-starter-main\*" $D -Recurse -Force }; Remove-Item $z,$t -Recurse -Force -ErrorAction SilentlyContinue }
+> powershell -NoProfile -ExecutionPolicy Bypass -File "$D\bootstrap.ps1"
 > ```
 >
 > **Two approvals are expected, and both are normal — pre-frame them, never treat either as a blocker.** (1) Claude Code may ask the user to approve running the install command itself; tell them to approve it so you can continue. (2) Partway through, Claude Code shows its built-in trust prompt for the third-party tools; tell them it's coming and that approving is the expected step. If a command is declined or a stricter permission mode blocks it, ask the user to approve it (or to allow the command) and continue. Do **not** fall back to a menu, and do **not** substitute the `/plugin`-only install as a shortcut — that adds the plugin's skills but skips the system tools, MCP wiring, and vault setup, so it is not the full install. Every change is backed up and reversible (`bash bootstrap.sh --uninstall`). The detailed sections below are reference for a curious human, not a checklist you must clear before running. Full step-by-step (post-install interview, handling failures) is in the assistant guide at the end of this section.
@@ -194,13 +196,15 @@ When the prompt appears, approving it is the normal choice. And if you ever want
 >
 > 1. Clone the public repo onto the user's machine, then run its installer from that local copy. On macOS or Linux:
 >    ```bash
->    git clone https://github.com/mycelium-hq/ai-brain-starter ~/.claude/skills/ai-brain-starter 2>/dev/null || true
->    bash ~/.claude/skills/ai-brain-starter/bootstrap.sh
+>    D=~/.claude/skills/ai-brain-starter
+>    [ -f "$D/bootstrap.sh" ] || { T=$(mktemp -d) && curl -fsSL https://github.com/mycelium-hq/ai-brain-starter/archive/refs/heads/main.tar.gz | tar xz -C "$T" --strip-components=1 && [ -f "$T/bootstrap.sh" ] && mkdir -p "$D" && cp -R "$T"/. "$D"/ && rm -rf "$T"; }
+>    bash "$D/bootstrap.sh"
 >    ```
 >    On Windows, use the PowerShell installer instead:
 >    ```powershell
->    if (-not (Test-Path "$env:USERPROFILE\.claude\skills\ai-brain-starter")) { git clone https://github.com/mycelium-hq/ai-brain-starter "$env:USERPROFILE\.claude\skills\ai-brain-starter" }
->    powershell -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\.claude\skills\ai-brain-starter\bootstrap.ps1"
+>    $D="$env:USERPROFILE\.claude\skills\ai-brain-starter"
+>    if (-not (Test-Path "$D\bootstrap.ps1")) { $t="$env:TEMP\abs-$(Get-Random)"; $z="$t.zip"; Invoke-WebRequest "https://github.com/mycelium-hq/ai-brain-starter/archive/refs/heads/main.zip" -OutFile $z -UseBasicParsing; Expand-Archive $z $t -Force; if (Test-Path "$t\ai-brain-starter-main\bootstrap.ps1") { New-Item -ItemType Directory -Force -Path $D | Out-Null; Copy-Item "$t\ai-brain-starter-main\*" $D -Recurse -Force }; Remove-Item $z,$t -Recurse -Force -ErrorAction SilentlyContinue }
+>    powershell -NoProfile -ExecutionPolicy Bypass -File "$D\bootstrap.ps1"
 >    ```
 >    This is a normal `git clone` of a public repo followed by running a local script — you can do it with your own tools, and the user does not need to open a terminal. The installer is idempotent: safe on a fresh machine and safe to re-run; if the repo is already cloned, the install proceeds and reconciles the existing copy.
 > 2. While the installer runs (a few minutes), tell the user what is happening in plain, calm language. It prints its own progress lines, so you need not repeat each one. If the user wants the full list of what gets installed, it is in the "what gets installed" section above and in [`SECURITY.md`](SECURITY.md) — point them there rather than improvising warnings.
@@ -232,7 +236,7 @@ Bootstrap is idempotent — re-running after a `git pull` just installs anything
   - **Session-only (no install at all):** `claude --plugin-url https://github.com/mycelium-hq/ai-brain-starter/releases/latest/download/ai-brain-starter.zip`
 
   The full install above remains the recommended path for the complete substrate (vault setup, MCP wiring, hooks, lifecycle).
-- **Chat-native install not working?** Open Terminal (`Cmd+Space` → "terminal" → Enter), paste `git clone https://github.com/mycelium-hq/ai-brain-starter ~/.claude/skills/ai-brain-starter && bash ~/.claude/skills/ai-brain-starter/bootstrap.sh`, press Enter. Then open Claude Code and paste "set up my AI Brain Starter." This is the deterministic fallback if Claude gets confused by the URL.
+- **Chat-native install not working?** Open Terminal (`Cmd+Space` → "terminal" → Enter), paste `D=~/.claude/skills/ai-brain-starter; T=$(mktemp -d); curl -fsSL https://github.com/mycelium-hq/ai-brain-starter/archive/refs/heads/main.tar.gz | tar xz -C "$T" --strip-components=1 && [ -f "$T/bootstrap.sh" ] && mkdir -p "$D" && cp -R "$T"/. "$D"/ && rm -rf "$T"; bash "$D/bootstrap.sh"`, press Enter. Then open Claude Code and paste "set up my AI Brain Starter." This is the deterministic fallback if Claude gets confused by the URL.
 
 </details>
 
@@ -244,13 +248,15 @@ Bootstrap is idempotent — re-running after a `git pull` just installs anything
 >
 > ```bash
 > # macOS / Linux
-> git clone https://github.com/mycelium-hq/ai-brain-starter ~/.claude/skills/ai-brain-starter 2>/dev/null || true
-> bash ~/.claude/skills/ai-brain-starter/bootstrap.sh
+> D=~/.claude/skills/ai-brain-starter
+> [ -f "$D/bootstrap.sh" ] || { T=$(mktemp -d) && curl -fsSL https://github.com/mycelium-hq/ai-brain-starter/archive/refs/heads/main.tar.gz | tar xz -C "$T" --strip-components=1 && [ -f "$T/bootstrap.sh" ] && mkdir -p "$D" && cp -R "$T"/. "$D"/ && rm -rf "$T"; }
+> bash "$D/bootstrap.sh"
 > ```
 > ```powershell
 > # Windows — corré en PowerShell, no en bash
-> if (-not (Test-Path "$env:USERPROFILE\.claude\skills\ai-brain-starter")) { git clone https://github.com/mycelium-hq/ai-brain-starter "$env:USERPROFILE\.claude\skills\ai-brain-starter" }
-> powershell -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\.claude\skills\ai-brain-starter\bootstrap.ps1"
+> $D="$env:USERPROFILE\.claude\skills\ai-brain-starter"
+> if (-not (Test-Path "$D\bootstrap.ps1")) { $t="$env:TEMP\abs-$(Get-Random)"; $z="$t.zip"; Invoke-WebRequest "https://github.com/mycelium-hq/ai-brain-starter/archive/refs/heads/main.zip" -OutFile $z -UseBasicParsing; Expand-Archive $z $t -Force; if (Test-Path "$t\ai-brain-starter-main\bootstrap.ps1") { New-Item -ItemType Directory -Force -Path $D | Out-Null; Copy-Item "$t\ai-brain-starter-main\*" $D -Recurse -Force }; Remove-Item $z,$t -Recurse -Force -ErrorAction SilentlyContinue }
+> powershell -NoProfile -ExecutionPolicy Bypass -File "$D\bootstrap.ps1"
 > ```
 >
 > **Vas a cruzarte con dos aprobaciones, y las dos son normales — anticipálas, nunca las trates como un bloqueo.** (1) Claude Code puede pedirle a la persona que apruebe correr el comando de instalación; decile que lo apruebe para que puedas seguir. (2) En algún momento, Claude Code muestra su aviso de confianza para las herramientas de terceros; avisale que viene y que aprobarlo es el paso esperado. Si el comando se rechaza o un modo de permisos más estricto lo bloquea, pedile a la persona que lo apruebe (o que permita el comando) y seguí. **No** caigas en un menú, y **no** uses la instalación sólo-`/plugin` como atajo: agrega las skills del plugin pero se saltea las herramientas de sistema, el cableado de MCP y el setup del vault, así que no es la instalación completa. Cada cambio queda respaldado y es reversible (`bash bootstrap.sh --uninstall`). Las secciones de abajo son referencia para quien tiene curiosidad, no una lista de control que tengas que pasar antes de correr.
@@ -300,7 +306,7 @@ El bootstrap es idempotente — al re-correrlo después de un `git pull` instala
 
 - **¿Querés registrarte vía web antes de instalar Claude Code?** Usá el formulario en [myceliumai.co/es/install](https://myceliumai.co/es/install) (English: [myceliumai.co/install](https://myceliumai.co/install)). Te manda por email un comando de un pegado.
 - **¿Ya usás Claude Code y sólo querés probar las skills contra un vault existente** (sin instalación completa, sin setup de Obsidian)? Cargá el plugin sólo para la sesión actual: `claude --plugin-url https://github.com/mycelium-hq/ai-brain-starter/releases/latest/download/ai-brain-starter.zip`. La instalación completa de arriba sigue siendo la ruta recomendada.
-- **¿La instalación chat-native no funciona?** Abrí Terminal (`Cmd+Espacio` → "terminal" → Enter), pegá `git clone https://github.com/mycelium-hq/ai-brain-starter ~/.claude/skills/ai-brain-starter && bash ~/.claude/skills/ai-brain-starter/bootstrap.sh`, presioná Enter. Después abrí Claude Code y pegá "configurá mi AI Brain Starter." Este es el fallback determinista si Claude se confunde con el URL.
+- **¿La instalación chat-native no funciona?** Abrí Terminal (`Cmd+Espacio` → "terminal" → Enter), pegá `D=~/.claude/skills/ai-brain-starter; T=$(mktemp -d); curl -fsSL https://github.com/mycelium-hq/ai-brain-starter/archive/refs/heads/main.tar.gz | tar xz -C "$T" --strip-components=1 && [ -f "$T/bootstrap.sh" ] && mkdir -p "$D" && cp -R "$T"/. "$D"/ && rm -rf "$T"; bash "$D/bootstrap.sh"`, presioná Enter. Después abrí Claude Code y pegá "configurá mi AI Brain Starter." Este es el fallback determinista si Claude se confunde con el URL.
 
 </details>
 

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -782,6 +782,48 @@ if (Have graphify) { Ok "graphify" } else { Err "graphify install failed" }
 #   - Stashes local uncommitted changes before pulling
 #   - Detects DIVERGENT history (your fork has commits not on origin/main)
 #     and refuses to pull, so your fork is never silently overwritten
+# Adopt-ArchiveInstall DIR REPOURL - turn a directory that holds this repo's
+# files but no .git (the archive entry path, for a machine with no git) into a
+# real clone, so the self-update path below works on every later run. Returns
+# $true on success. A $false is NON-FATAL to the caller: archive content is
+# complete and functional, and only auto-update depends on this.
+#
+# NEVER destroys local edits. A bare `reset --hard` would silently discard a
+# hand-patched archive install, so the tree is staged and diffed against
+# origin/main first; anything that differs is copied aside under the same
+# .bak-<stamp> convention this installer already uses for Node.
+function Adopt-ArchiveInstall {
+    param([string]$Dir, [string]$RepoUrl)
+    # git writes progress/notices to stderr, which PowerShell 5.1 turns into a
+    # terminating error under Stop even with 2>$null. Same guard the self-update
+    # section below uses; $LASTEXITCODE checks are unaffected.
+    $eapAdopt = $ErrorActionPreference
+    $ErrorActionPreference = "SilentlyContinue"
+    Push-Location $Dir
+    try {
+        Remove-Item -LiteralPath "$Dir\.adopt-backup-path" -Force -ErrorAction SilentlyContinue
+        git init -q 2>$null;                       if ($LASTEXITCODE -ne 0) { return $false }
+        git remote remove origin 2>$null | Out-Null
+        git remote add origin $RepoUrl 2>$null;    if ($LASTEXITCODE -ne 0) { return $false }
+        git fetch --quiet origin main 2>$null;     if ($LASTEXITCODE -ne 0) { return $false }
+        git add -A 2>$null | Out-Null
+        git diff --cached --quiet origin/main 2>$null
+        if ($LASTEXITCODE -ne 0) {
+            $shelved = "$Dir.bak-$(Get-Date -Format 'yyyy-MM-dd-HHmm')"
+            Copy-Item -LiteralPath $Dir -Destination $shelved -Recurse -Force
+            if (-not (Test-Path -LiteralPath $shelved)) { return $false }
+            Set-Content -LiteralPath "$Dir\.adopt-backup-path" -Value $shelved
+        }
+        git reset --hard --quiet origin/main 2>$null; if ($LASTEXITCODE -ne 0) { return $false }
+        git branch -q -M main 2>$null | Out-Null
+        git branch -q --set-upstream-to=origin/main main 2>$null | Out-Null
+        return $true
+    } finally {
+        Pop-Location
+        $ErrorActionPreference = $eapAdopt
+    }
+}
+
 Hdr "Installing the ai-brain-starter skill"
 New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.claude\skills" | Out-Null
 if (Test-Path "$SkillDir\.git") {
@@ -847,6 +889,32 @@ if (Test-Path "$SkillDir\.git") {
     }
     Pop-Location
     $ErrorActionPreference = $eapSelfUpdate
+} elseif (Test-Path "$SkillDir\bootstrap.ps1") {
+    # The directory holds this repo's files but has no .git: the entry command
+    # fetched a zip because git was unavailable. `git clone` into a non-empty
+    # directory FAILS, and that failure used to land in the red actionable list -
+    # trading a missing-git block for a scary-looking one. Adopt instead.
+    if (-not (Have git)) {
+        Warn (T "Installed from an archive, and git isn't available yet - automatic updates stay off until git is installed." `
+                "Instalado desde un archivo, y git todavia no esta disponible - las actualizaciones automaticas quedan apagadas hasta instalar git.")
+        $script:Skipped += "ai-brain-starter clone (archive install, git unavailable)"
+    }
+    elseif ($DryRun) { Dry "would: adopt $SkillDir as a git clone of $RepoUrl" }
+    elseif (Adopt-ArchiveInstall -Dir $SkillDir -RepoUrl $RepoUrl) {
+        if (Test-Path "$SkillDir\.adopt-backup-path") {
+            Warn (T "Local changes were found in the archive install. A copy is at:" `
+                    "Se encontraron cambios locales en la instalacion por archivo. Hay una copia en:")
+            Warn ("  " + (Get-Content -LiteralPath "$SkillDir\.adopt-backup-path" -ErrorAction SilentlyContinue))
+        }
+        $script:Installed += "ai-brain-starter clone (adopted from archive install)"
+    }
+    else {
+        # Non-fatal: the archive content is complete and functional. Only
+        # auto-update needs the git wiring, so this is a Warn, never an Err.
+        Warn (T "Couldn't reconnect the archive install to the repository - automatic updates stay off. Everything else works." `
+                "No se pudo reconectar la instalacion por archivo al repositorio - las actualizaciones automaticas quedan apagadas. Todo lo demas funciona.")
+        $script:Skipped += "ai-brain-starter clone (archive install, adopt failed)"
+    }
 } else {
     if ($DryRun) { Dry "would: git clone $RepoUrl -> $SkillDir" }
     elseif (-not (Run-Native { git clone --quiet $RepoUrl $SkillDir })) { Err "ai-brain-starter clone failed (git exit $LASTEXITCODE)" }

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -990,6 +990,97 @@ elif is_mac && ! have brew; then
 fi
 
 # ───────────────────────────────────────────────────────────────────────────────
+# git
+# The entry command fetches this repo and every later update runs `git pull`, so
+# git is a prerequisite — and until now it was the one prerequisite bootstrap
+# never installed. Corporate laptops block the CLI installers that provide it
+# (2026-08-12 cohort install session: "Git and Node.js CLI installs require
+# administrator rights"), and none of the no-admin recovery below could help,
+# because the fetch
+# that lands THIS script ran first and needed git. The entry command now falls
+# back to an archive, so we can arrive here without git; install it for the
+# update path.
+#
+# PRESENCE IS NOT CAPABILITY on macOS. With the Command Line Tools absent,
+# /usr/bin/git exists and is on PATH, so `have git` returns true — but running it
+# raises the CLT install dialog and exits non-zero. Probe by EXECUTION, bounded,
+# so a stub that opens a GUI cannot hang a non-interactive install.
+# ───────────────────────────────────────────────────────────────────────────────
+
+have_working_git() {
+  have git || return 1
+  run_with_timeout 15 git --version >/dev/null 2>&1
+}
+
+# adopt_archive_install DIR REPO_URL — turn a directory that holds this repo's
+# files but no .git (the archive entry path) into a real clone, so the update
+# path works on every later run. Returns non-zero on any failure; the caller
+# treats that as non-fatal, because archive content is complete and functional
+# and only auto-update depends on this.
+#
+# NEVER destroys local edits: a bare `reset --hard` would silently discard a
+# hand-patched archive install, so the tree is staged and diffed against
+# origin/main first, and anything that differs is copied aside under the same
+# .bak-<stamp> convention the rest of this installer uses. Writes the backup
+# path to .adopt-backup-path so the caller can surface it.
+adopt_archive_install() {
+  local dir="$1" repo_url="$2" shelved
+  cd "$dir" || return 1
+  rm -f "$dir/.adopt-backup-path" 2>/dev/null || true
+  git init -q || return 1
+  git remote remove origin 2>/dev/null || true
+  git remote add origin "$repo_url" || return 1
+  git fetch --quiet origin main || return 1
+  git add -A 2>/dev/null || true
+  if ! git diff --cached --quiet origin/main 2>/dev/null; then
+    shelved="$dir.bak-$(date +%Y-%m-%d-%H%M)"
+    cp -R "$dir" "$shelved" || return 1
+    printf '%s\n' "$shelved" > "$dir/.adopt-backup-path" 2>/dev/null || true
+  fi
+  git reset --hard --quiet origin/main || return 1
+  git branch -q -M main 2>/dev/null || true
+  git branch -q --set-upstream-to=origin/main main 2>/dev/null || true
+  return 0
+}
+
+if ! have_working_git; then
+  if [[ "$CORPORATE_PROFILE" == "1" ]]; then
+    warn "$(t "Corporate profile: git not found — NOT auto-installing (user-space, no sudo)." \
+              "Perfil corporativo: no se encontró git — NO se instala automáticamente (espacio de usuario, sin sudo).")"
+    warn "$(t "The exact request for IT: install Git (macOS: Xcode Command Line Tools; Linux: the distro's git package)." \
+              "El pedido exacto para IT: instalar Git (macOS: Xcode Command Line Tools; Linux: el paquete git de la distro).")"
+  elif [[ $DRY_RUN -eq 1 ]]; then
+    dry "would: install git (brew on Mac; apt/dnf/pacman on Linux)"
+  elif is_mac; then
+    hdr "$(t "Installing git" "Instalando git")"
+    if have brew; then
+      quiet_retry brew install git || note_gap "git" "brew install git"
+    else
+      # No brew and no working git. Apple's only supported route is the Command
+      # Line Tools, which open a GUI dialog and want an admin password, neither
+      # answerable from here. Do NOT fire `xcode-select --install` blindly: an
+      # unexplained dialog is exactly what strands a non-technical installer.
+      # Name the click, then keep going — thanks to the archive entry path the
+      # rest of the install does not need git, only auto-update does.
+      warn "$(t "git isn't available yet, and installing it needs one click only you can make." \
+                "git todavía no está disponible, y instalarlo necesita un clic que sólo podés hacer vos.")"
+      warn "$(t "  In Terminal run:  xcode-select --install   then click Install in the window that appears." \
+                "  En Terminal corré:  xcode-select --install   y hacé clic en Instalar en la ventana que aparece.")"
+      warn "$(t "  Everything else continues now — only automatic updates wait on it." \
+                "  Todo lo demás sigue ahora — sólo las actualizaciones automáticas dependen de eso.")"
+      note_gap "git" "xcode-select --install"
+    fi
+  else
+    hdr "$(t "Installing git" "Instalando git")"
+    sudo apt-get install -y git 2>/dev/null \
+      || sudo dnf install -y git 2>/dev/null \
+      || sudo pacman -S --noconfirm git 2>/dev/null \
+      || note_gap "git" "install git with your distribution's package manager"
+  fi
+fi
+have_working_git && ok "git $(git --version 2>/dev/null | awk '{print $3}')"
+
+# ───────────────────────────────────────────────────────────────────────────────
 # Python 3.10+
 # ───────────────────────────────────────────────────────────────────────────────
 
@@ -1296,6 +1387,37 @@ if [[ -d "$SKILL_DIR/.git" ]]; then
   fi
 
   cd - >/dev/null
+elif [[ -f "$SKILL_DIR/bootstrap.sh" ]]; then
+  # The directory holds this repo's files but has no .git: the entry command
+  # fetched an archive because git was unavailable at the time. `git clone` into
+  # a non-empty directory FAILS, and that failure used to land in the red
+  # actionable list — trading a missing-git block for a scary-looking one. Adopt
+  # the directory as a real clone instead, which restores the update path above
+  # for every later run.
+  if ! have_working_git; then
+    warn "$(t "Installed from an archive, and git isn't available yet — automatic updates stay off until git is installed." \
+              "Instalado desde un archivo, y git todavía no está disponible — las actualizaciones automáticas quedan apagadas hasta instalar git.")"
+    SKIPPED+=("ai-brain-starter clone (archive install, git unavailable)")
+  elif [[ $DRY_RUN -eq 1 ]]; then
+    dry "would: adopt $SKILL_DIR as a git clone of $REPO_URL"
+  else
+    log "$(t "Installed from an archive — reconnecting it to the repository so updates work." \
+             "Instalado desde un archivo — reconectándolo al repositorio para que las actualizaciones funcionen.")"
+    if ( adopt_archive_install "$SKILL_DIR" "$REPO_URL" ); then
+      if [[ -f "$SKILL_DIR/.adopt-backup-path" ]]; then
+        warn "$(t "Local changes were found in the archive install. A copy is at:" \
+                  "Se encontraron cambios locales en la instalación por archivo. Hay una copia en:")"
+        warn "  $(cat "$SKILL_DIR/.adopt-backup-path" 2>/dev/null)"
+      fi
+      INSTALLED+=("ai-brain-starter clone (adopted from archive install)")
+    else
+      # Non-fatal: the archive content is complete and fully functional. Only
+      # auto-update needs the git wiring, so this is a warn, never a red ✗.
+      warn "$(t "Couldn't reconnect the archive install to the repository — automatic updates stay off. Everything else works." \
+                "No se pudo reconectar la instalación por archivo al repositorio — las actualizaciones automáticas quedan apagadas. Todo lo demás funciona.")"
+      note_gap "ai-brain-starter clone" "rm -rf $SKILL_DIR && git clone $REPO_URL $SKILL_DIR"
+    fi
+  fi
 else
   do_cmd "clone ai-brain-starter to $SKILL_DIR" git clone --quiet "$REPO_URL" "$SKILL_DIR" || err "ai-brain-starter clone failed"
   INSTALLED+=("ai-brain-starter clone")

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -193,6 +193,7 @@ INTEGRATION_TESTS=(
   test_windows_platformize
   test_memory_routing_guard
   test_bootstrap_omits_vault_hooks
+  test_bootstrap_archive_entry
   test_bootstrap_brew_terminal_step
   test_bootstrap_optional_packs_soft_fail
   test_bootstrap_corporate_profile

--- a/tests/integration/test_bootstrap_archive_entry.sh
+++ b/tests/integration/test_bootstrap_archive_entry.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Test the zero-prerequisite entry path: bootstrap.sh must survive being run
+# from a directory that holds this repo's files but has no .git.
+#
+# Bug (MYC-3895, 2026-08-12 cohort install session): the install's FIRST
+# command was `git clone`, and git was the one prerequisite neither bootstrap
+# installed. Corporate laptops block the CLI installers that provide it — the
+# session transcript records it verbatim: "Git and Node.js CLI installs require
+# administrator rights." Five participants ended the session still blocked. Every
+# no-admin recovery path further down bootstrap.sh was unreachable, because the
+# fetch that lands bootstrap.sh itself ran first and needed git.
+#
+# Fix: the entry command falls back to a tarball/zip (curl+tar, Invoke-WebRequest
+# +Expand-Archive) which need no git, no brew and no admin. That means bootstrap
+# can now start in a directory with no .git, where a plain `git clone` FAILS
+# (non-empty target) and used to land in the red actionable-failures list —
+# trading a missing-git block for a scary-looking one. adopt_archive_install()
+# converts that directory into a real clone so auto-update keeps working.
+#
+# Covered here:
+#   1. bootstrap.sh is syntactically valid (bash -n).
+#   2. have_working_git probes by EXECUTION, not presence — macOS ships a
+#      /usr/bin/git stub with the Command Line Tools absent, so `command -v git`
+#      succeeds on a machine where git cannot clone anything.
+#   3. adopt_archive_install turns a clean archive dir into a real clone tracking
+#      origin/main, and leaves NO backup behind.
+#   4. Negative control for 3: an archive dir with a local edit is NOT silently
+#      reset — a .bak-<stamp> copy is made and its path recorded.
+#   5. adopt_archive_install RETURNS NON-ZERO when it cannot reach the remote, so
+#      the caller's non-fatal warn path is real rather than assumed.
+#   6. Ordering: the archive-adopt branch comes BEFORE the bare `git clone` else
+#      branch, so a non-empty directory can never reach the failing clone.
+#
+# Self-contained; no network; never writes outside its tmpdir.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BOOTSTRAP="$REPO_ROOT/bootstrap.sh"
+[ -f "$BOOTSTRAP" ] || { echo "ERROR: $BOOTSTRAP not found" >&2; exit 1; }
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# ── 1. syntax ──
+bash -n "$BOOTSTRAP" || fail "1: bootstrap.sh has a syntax error"
+
+# ── 2. capability probe, not presence probe ──
+# Presence-only would be `have git` alone. The whole point is that macOS's git
+# stub passes that check and then fails to clone, so the probe MUST execute git.
+PROBE_BODY="$(awk '/^have_working_git\(\) \{/,/^\}/' "$BOOTSTRAP")"
+[ -n "$PROBE_BODY" ] || fail "2: have_working_git() not found in bootstrap.sh"
+printf '%s' "$PROBE_BODY" | grep -q 'git --version' \
+  || fail "2: have_working_git must EXECUTE git (git --version), not just check presence"
+printf '%s' "$PROBE_BODY" | grep -q 'run_with_timeout' \
+  || fail "2: have_working_git must bound the probe — a CLT stub can open a GUI and hang"
+
+# Behavioral: a git that exists on PATH but exits non-zero (the stub) must read
+# as ABSENT. This is the exact macOS failure, reproduced portably.
+STUBDIR="$TMP/stubbin"; mkdir -p "$STUBDIR"
+cat > "$STUBDIR/git" <<'STUB'
+#!/usr/bin/env bash
+echo "xcode-select: note: No developer tools were found." >&2
+exit 1
+STUB
+chmod +x "$STUBDIR/git"
+PROBE_HARNESS="$TMP/probe.sh"
+{
+  echo 'have() { command -v "$1" >/dev/null 2>&1; }'
+  awk '/^run_with_timeout\(\) \{/,/^\}/' "$BOOTSTRAP"
+  echo "$PROBE_BODY"
+  echo 'if have_working_git; then echo WORKING; else echo ABSENT; fi'
+} > "$PROBE_HARNESS"
+
+STUB_RESULT="$(PATH="$STUBDIR:$PATH" bash "$PROBE_HARNESS")"
+[ "$STUB_RESULT" = "ABSENT" ] \
+  || fail "2: a git stub that exits non-zero must read as ABSENT, got '$STUB_RESULT'"
+# Negative control: the same probe must say WORKING with a real git, or the
+# assertion above would pass for the wrong reason (e.g. a broken harness).
+REAL_RESULT="$(bash "$PROBE_HARNESS")"
+[ "$REAL_RESULT" = "WORKING" ] \
+  || fail "2 (negative control): a real git must read as WORKING, got '$REAL_RESULT'"
+
+# ── shared fixture: a local "origin" so no test below touches the network ──
+export GIT_CONFIG_NOSYSTEM=1
+export HOME="$TMP/fakehome"; mkdir -p "$HOME"
+git config --global user.email "ci@example.invalid"
+git config --global user.name  "CI"
+git config --global init.defaultBranch main
+
+ORIGIN="$TMP/origin.git"
+SEED="$TMP/seed"
+git init -q --bare -b main "$ORIGIN"
+git init -q -b main "$SEED"
+mkdir -p "$SEED"
+printf '#!/usr/bin/env bash\necho hi\n' > "$SEED/bootstrap.sh"
+printf 'upstream content\n' > "$SEED/README.md"
+git -C "$SEED" add -A
+git -C "$SEED" commit -qm "seed"
+git -C "$SEED" remote add origin "$ORIGIN"
+git -C "$SEED" push -q origin main
+
+ADOPT_FN="$(awk '/^adopt_archive_install\(\) \{/,/^\}/' "$BOOTSTRAP")"
+[ -n "$ADOPT_FN" ] || fail "3: adopt_archive_install() not found in bootstrap.sh"
+
+run_adopt() { # run_adopt DIR REPO_URL -> prints exit code
+  local d="$1" u="$2" h="$TMP/adopt.sh"
+  { echo "$ADOPT_FN"; echo 'adopt_archive_install "$1" "$2"; echo "RC=$?"'; } > "$h"
+  ( bash "$h" "$d" "$u" 2>/dev/null || true )
+}
+
+# ── 3. clean archive dir adopts cleanly ──
+CLEAN="$TMP/clean"
+mkdir -p "$CLEAN"
+cp "$SEED/bootstrap.sh" "$SEED/README.md" "$CLEAN/"      # archive extract: files, no .git
+[ -d "$CLEAN/.git" ] && fail "3: fixture invalid — archive dir must start with no .git"
+
+OUT="$(run_adopt "$CLEAN" "$ORIGIN")"
+echo "$OUT" | grep -q 'RC=0' || fail "3: adopt of a clean archive dir failed ($OUT)"
+[ -d "$CLEAN/.git" ] || fail "3: adopt did not create a real clone (.git missing)"
+[ "$(git -C "$CLEAN" rev-parse HEAD)" = "$(git -C "$ORIGIN" rev-parse main)" ] \
+  || fail "3: adopted clone is not at origin/main"
+[ "$(git -C "$CLEAN" rev-parse --abbrev-ref HEAD)" = "main" ] \
+  || fail "3: adopted clone is not on branch main (auto-update pulls main)"
+git -C "$CLEAN" rev-parse --abbrev-ref '@{u}' >/dev/null 2>&1 \
+  || fail "3: adopted clone has no upstream — git pull would fail on the next run"
+compgen -G "$CLEAN.bak-*" >/dev/null \
+  && fail "3: a clean archive dir must NOT produce a backup copy"
+[ -f "$CLEAN/.adopt-backup-path" ] \
+  && fail "3: a clean archive dir must not record a backup path"
+
+# ── 4. NEGATIVE CONTROL: local edits are preserved, never silently reset ──
+DIRTY="$TMP/dirty"
+mkdir -p "$DIRTY"
+cp "$SEED/bootstrap.sh" "$DIRTY/"
+printf 'MY LOCAL PATCH\n' > "$DIRTY/README.md"        # differs from upstream
+printf 'my own file\n'   > "$DIRTY/my-notes.txt"      # untracked-upstream addition
+
+OUT="$(run_adopt "$DIRTY" "$ORIGIN")"
+echo "$OUT" | grep -q 'RC=0' || fail "4: adopt of a modified archive dir failed ($OUT)"
+[ -f "$DIRTY/.adopt-backup-path" ] \
+  || fail "4: modified archive dir must record a backup path"
+SHELVED="$(cat "$DIRTY/.adopt-backup-path")"
+[ -d "$SHELVED" ] || fail "4: recorded backup path '$SHELVED' does not exist"
+grep -q 'MY LOCAL PATCH' "$SHELVED/README.md" \
+  || fail "4: the user's local edit was not preserved in the backup"
+grep -q 'my own file' "$SHELVED/my-notes.txt" \
+  || fail "4: the user's added file was not preserved in the backup"
+grep -q 'upstream content' "$DIRTY/README.md" \
+  || fail "4: the adopted tree should now match origin/main"
+
+# ── 5. unreachable remote returns non-zero (the caller's warn path is real) ──
+BROKEN="$TMP/broken"
+mkdir -p "$BROKEN"
+cp "$SEED/bootstrap.sh" "$BROKEN/"
+OUT="$(run_adopt "$BROKEN" "$TMP/does-not-exist.git")"
+echo "$OUT" | grep -q 'RC=0' \
+  && fail "5: adopt must return non-zero when the remote is unreachable"
+
+# ── 6. ordering: archive-adopt branch precedes the bare `git clone` ──
+# `|| true` is load-bearing: under `set -e`, a grep that matches nothing makes
+# the assignment itself non-zero and kills the script BEFORE the check below can
+# report why. That turns "the adopt branch is gone" — the exact regression this
+# check exists to catch — into a silent non-zero exit with no message.
+ADOPT_LINE="$( { grep -n 'elif \[\[ -f "\$SKILL_DIR/bootstrap.sh" \]\]' "$BOOTSTRAP" || true; } | head -1 | cut -d: -f1)"
+CLONE_LINE="$( { grep -n 'clone ai-brain-starter to \$SKILL_DIR' "$BOOTSTRAP" || true; } | head -1 | cut -d: -f1)"
+[ -n "$ADOPT_LINE" ] || fail "6: the archive-adopt branch is missing"
+[ -n "$CLONE_LINE" ] || fail "6: the bare clone branch is missing"
+[ "$ADOPT_LINE" -lt "$CLONE_LINE" ] \
+  || fail "6: a non-empty dir reaches 'git clone' (line $CLONE_LINE) before adopt (line $ADOPT_LINE) — the clone fails on a non-empty target and lands in the red FAILED list"
+
+echo "PASS: test_bootstrap_archive_entry (6 checks, 2 negative controls)"

--- a/tests/integration/test_bootstrap_archive_entry.sh
+++ b/tests/integration/test_bootstrap_archive_entry.sh
@@ -36,6 +36,9 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# HOME alone does not sandbox ~ on Windows — see lib/sandbox_home.sh.
+# shellcheck source=tests/integration/lib/sandbox_home.sh
+. "$REPO_ROOT/tests/integration/lib/sandbox_home.sh"
 BOOTSTRAP="$REPO_ROOT/bootstrap.sh"
 [ -f "$BOOTSTRAP" ] || { echo "ERROR: $BOOTSTRAP not found" >&2; exit 1; }
 
@@ -85,7 +88,10 @@ REAL_RESULT="$(bash "$PROBE_HARNESS")"
 
 # ── shared fixture: a local "origin" so no test below touches the network ──
 export GIT_CONFIG_NOSYSTEM=1
-export HOME="$TMP/fakehome"; mkdir -p "$HOME"
+# sandbox_home sets HOME *and* USERPROFILE (and neutralises HOMEDRIVE/HOMEPATH),
+# so the `git config --global` writes below cannot reach the real ~/.gitconfig
+# on Windows, where ntpath.expanduser ignores HOME entirely.
+sandbox_home "$TMP"
 git config --global user.email "ci@example.invalid"
 git config --global user.name  "CI"
 git config --global init.defaultBranch main


### PR DESCRIPTION
Closes part of MYC-3895.

## The bug

The install's first command was `git clone`, and **git was the one prerequisite neither bootstrap installed** — while `bootstrap.ps1` calls `git clone` itself.

* On a corporate laptop that blocks CLI installers, the install could not start.
* On a virgin Mac, `/usr/bin/git` is a stub that raises the Xcode Command Line Tools dialog: a GUI an agent cannot click, wanting an admin password.

Because the fetch that lands `bootstrap.sh` ran first and needed git, **every no-admin recovery path already in the installer was unreachable** — including the user-space Node ZIP install that has been there all along. From a 2026-08-12 cohort install session: *"Git and Node.js CLI installs require administrator rights."* Five participants ended that session still blocked.

## The change

**Entry needs nothing.** `curl` + `tar` (macOS/Linux) and `Invoke-WebRequest` + `Expand-Archive` (PowerShell 5.1) ship preinstalled everywhere. The command never invokes git at all, so the Xcode dialog cannot fire. Staged through a temp directory and moved into place only once `bootstrap` is proven present, so a dropped connection cannot leave a half-extracted tree whose truncated `bootstrap.sh` still executes. Existing installs are untouched.

**Adopt.** Bootstrap can now start in a directory holding the repo's files but no `.git`, where `git clone` fails on a non-empty target and used to land in the red actionable-failures list — trading a missing-git block for a scary-looking one. `adopt_archive_install()` / `Adopt-ArchiveInstall` convert it into a real clone so auto-update keeps working. Local edits are never silently reset: the tree is staged and diffed against `origin/main` first, and anything differing is copied aside under the existing `.bak-<stamp>` convention. Failure is non-fatal — archive content is complete, and only auto-update depends on the wiring.

**git (macOS/Linux).** Installed for the update path, probing by **execution** rather than presence, because the macOS stub passes `command -v git` on a machine where git cannot clone anything. When git needs a click only the user can make, the click is named and the install continues instead of firing an unexplained dialog.

## Verification

| Check | Result |
| --- | --- |
| New entry, git genuinely unreachable (`env -i`, sanitized PATH) | exit 0, full repo |
| Old entry, same environment | `git: command not found`, exit 127, nothing installed |
| Failed fetch (404) | no directory left behind |
| Re-run over an existing install | no clobber |
| PowerShell adopt: clean / dirty / unreachable remote | `True` / `True` + patch preserved / `False` |

`tests/integration/test_bootstrap_archive_entry.sh` — 6 checks, 2 negative controls, registered in the `ci.sh` integration allow-list. All three source mutations (presence-only probe, no-backup reset, adopt branch removed) were confirmed to turn it red.

## Deliberately NOT in this PR

The Windows **PortableGit** no-admin install. GitHub's Windows runners ship git preinstalled, so that path would execute only on the locked-down machines it exists to rescue and **never once in CI or local test**. It ships separately with a CI leg that forces the fallback. Windows is unblocked regardless: the zip entry needs no git, and git's absence now costs only auto-update.

Also still open on MYC-3895: macOS/Linux user-space Node + Python fallback (Windows already has it), and the preflight doctor with the IT-permission packet.
