### PR TITLE
fix(windows): close the defects an adversarial review found in #487 (tests that could not fail)

### DIFF
--- a/scripts/heal-journal-guard.py
+++ b/scripts/heal-journal-guard.py
@@ -175,33 +175,76 @@ def healthy_matchers(settings: dict) -> "set":
     return ok
 
 
+def _vault_candidates() -> "list[str]":
+    """Every distinct vault-shaped directory in the shallow search space.
+
+    A directory counts only if it actually holds `<meta>/scripts/` -- evidence,
+    not the "guessed ~/vault" this module has always refused to fall back to.
+
+    SEARCH SPACE. Home's immediate children, plus one level under the handful of
+    parents that in practice hold a notes vault (Documents, OneDrive, ...).
+    Bounded and shallow by construction -- never a corpus walk, because this runs
+    on every SessionStart (MYC-571).
+
+    Widening this was a CORRECTNESS fix, not a convenience one. Scanning only
+    home's immediate children made "exactly one candidate" mean "exactly one I
+    bothered to look at". Falsified on a real install: one vault sat directly
+    under home while a SECOND real Obsidian vault (~9k notes) sat one level down
+    under ~/Documents with an EMPTY meta/scripts and no preflight. The narrow
+    scan saw one candidate, called it unambiguous, and returned 'ok' for an
+    account that genuinely had a gap. A wider search does not make discovery more
+    eager -- it makes the AMBIGUITY CHECK honest, and ambiguity refuses.
+
+    Paths are canonicalised before de-duplication: one vault reachable under two
+    names (a `mklink /J` junction, a mirrored OneDrive/Dropbox folder -- all
+    normal Windows layouts) previously read as TWO candidates and disabled
+    discovery entirely.
+    """
+    roots = [Path.home()]
+    for sub in ("Documents", "OneDrive", "Notes", "Obsidian"):
+        p = Path.home() / sub
+        roots.append(p)
+        # One OneDrive level deeper: redirected Documents commonly lives there.
+        if sub == "OneDrive":
+            roots.append(p / "Documents")
+
+    seen: dict = {}
+    for root in roots:
+        try:
+            children = sorted(root.iterdir())
+        except (OSError, RuntimeError):
+            continue  # missing, unreadable, or not a directory - just skip it
+        for child in children:
+            # Per-CHILD isolation: one un-stat-able entry (a permission-denied
+            # folder, a stale network mount, a cloud placeholder) must not abort
+            # the scan and silently switch discovery off for the whole account.
+            try:
+                if not child.is_dir() or child.name.startswith("."):
+                    continue
+                if not any((child / meta / "scripts").is_dir()
+                           for meta in ("⚙️ Meta", "Meta")):
+                    continue
+                key = str(child.resolve()).casefold()
+            except (OSError, RuntimeError):
+                continue
+            seen.setdefault(key, str(child))
+    return sorted(seen.values())
+
+
 def _discover_vault() -> "str":
-    """The one unambiguous vault among home's immediate children, else "".
+    """The ONE unambiguous vault in the shallow search space, else "".
 
     Last resort, reached only when BOTH of resolve_vault's ordinary sources are
-    unavailable -- which on Windows is the normal case, not an edge case (see
-    resolve_vault). A directory is a vault candidate only if it actually holds
-    `<meta>/scripts/`, so this is evidence, not the "guessed ~/vault" the module
-    has always refused to fall back to.
+    unavailable -- which on Windows is the normal case, not an edge case.
 
-    Deliberately refuses to choose when the evidence is ambiguous: EXACTLY ONE
-    candidate returns, zero or many return "". Healing the wrong vault would
-    write a preflight into someone else's notes, which is worse than staying
-    inert. Immediate children only -- never a corpus walk (this runs on every
-    SessionStart)."""
-    try:
-        home = Path.home()
-        found = []
-        for child in sorted(home.iterdir()):
-            if not child.is_dir() or child.name.startswith("."):
-                continue
-            for meta in ("⚙️ Meta", "Meta"):
-                if (child / meta / "scripts").is_dir():
-                    found.append(str(child))
-                    break
-        return found[0] if len(found) == 1 else ""
-    except (OSError, RuntimeError):
-        return ""
+    Refuses to choose when the evidence is ambiguous: exactly one candidate
+    returns, zero or many return "". Healing the wrong vault would write a
+    preflight into someone else's notes, which is strictly worse than staying
+    inert. Callers that need to tell a user WHY nothing happened should call
+    _vault_candidates() directly -- silence about an ambiguous machine is how
+    this class of bug hides."""
+    found = _vault_candidates()
+    return found[0] if len(found) == 1 else ""
 
 
 def resolve_vault(settings: dict, explicit: "str | None" = None) -> "str":
@@ -436,9 +479,23 @@ def run_session_start() -> None:
         # the one unambiguous vault under home. Production-only: kept out of
         # resolve_vault() so the hermetic controls stay hermetic (MYC-3875).
         if report["preflight"] == "no-vault":
-            discovered = _discover_vault()
-            if discovered:
-                report = diagnose(settings, clone, discovered)
+            candidates = _vault_candidates()
+            if len(candidates) == 1:
+                report = diagnose(settings, clone, candidates[0])
+            elif len(candidates) > 1:
+                # Refusing is correct - healing the wrong vault writes a
+                # preflight into someone else's notes. But refusing SILENTLY is
+                # the original bug wearing a different hat, so say it and name
+                # the fix. Returns here: an ambiguous machine needs a human.
+                _emit_context(
+                    "[heal-journal-guard] Found "
+                    f"{len(candidates)} candidate vaults on this account, so "
+                    "the /journal Step-0 preflight check could not run and "
+                    "NOTHING was changed: "
+                    + ", ".join(candidates)
+                    + ". Set VAULT_ROOT to the one you journal in (or pass "
+                    "--vault) so this check can verify it.")
+                return
     except Exception:
         _emit_silent()
         return

--- a/scripts/install-hooks-user-level.py
+++ b/scripts/install-hooks-user-level.py
@@ -1187,7 +1187,7 @@ def dedupe_identical_hooks(existing: dict) -> tuple[dict, int]:
     if "hooks" not in cleaned:
         return cleaned, 0
     for event, groups in list(cleaned["hooks"].items()):
-        # seen per matcher, so identical commands are collapsed both WITHIN a group
+        # seen per matcher, so identical entries are collapsed both WITHIN a group
         # and ACROSS groups that share a matcher (a later install can append a new
         # group rather than growing the existing one).
         seen: dict[str, set] = {}
@@ -1198,11 +1198,21 @@ def dedupe_identical_hooks(existing: dict) -> tuple[dict, int]:
             kept = []
             for h in g.get("hooks", []):
                 cmd = h.get("command", "")
-                if cmd and cmd in bucket:
+                # Key on the WHOLE entry, not just the command. Keying on the
+                # command alone made "byte-identical" false: two entries sharing
+                # a command but carrying `timeout: 5` and `timeout: 600` are not
+                # the same configuration, and collapsing them silently discarded
+                # the longer timeout. That breaks this function's entire warrant
+                # -- "there is no configuration in which running it twice is what
+                # the user meant" is only true when the entries really are
+                # identical -- and it would break it on UNOWNED entries, which
+                # may be the user's own.
+                key = json.dumps(h, sort_keys=True, ensure_ascii=True)
+                if cmd and key in bucket:
                     removed += 1
                     continue
                 if cmd:
-                    bucket.add(cmd)
+                    bucket.add(key)
                 kept.append(h)
             if kept:
                 ng = dict(g)
@@ -1769,10 +1779,16 @@ def main() -> int:
                 print(f"  - relocate {moved_count} moved-event stale copy(ies)")
             if deduped_count:
                 print(f"  - dedupe {deduped_count} duplicate owned hook(s)")
+            if identical_count:
+                print(f"  - collapse {identical_count} byte-identical hook(s)")
         return 0
 
+    # identical_count belongs here too: without it this branch can print
+    # "Already in sync. Nothing to write." on a run that collapsed entries and
+    # then discard the collapse -- a printed lie, and the discarded work silently
+    # reappears next run.
     if not summary["added"] and not summary["updated"] and not retired_count \
-            and not moved_count and not deduped_count:
+            and not moved_count and not deduped_count and not identical_count:
         if not args.quiet:
             print("\nAlready in sync. Nothing to write.")
         # Verify anyway. "Nothing to write" says the WIRING matches the template;

--- a/scripts/test_heal_journal_guard_vault.py
+++ b/scripts/test_heal_journal_guard_vault.py
@@ -129,7 +129,9 @@ with tempfile.TemporaryDirectory() as td:
           heal.preflight_state(WINDOWS_SETTINGS, str(plain)) == "ok")
 
 # --- discovery: only when unambiguous ---------------------------------------
-# Run against a fake HOME so the developer's real home cannot influence the result.
+# Run against a fake HOME so the developer's real home cannot influence the
+# result. ORDER MATTERS in this block and is load-bearing -- see the hermeticity
+# assertion below.
 with tempfile.TemporaryDirectory() as td2:
     fake_home = Path(td2)
     _real_home = heal.Path.home
@@ -146,18 +148,154 @@ with tempfile.TemporaryDirectory() as td2:
         check("discovered-vault-revives-preflight",
               heal.preflight_state(WINDOWS_SETTINGS, heal._discover_vault()) == "ok")
 
-        # Two candidates -> refuse to choose. Healing the wrong vault would write a
-        # preflight into someone else's notes.
-        make_vault(fake_home / "SecondVault")
-        check("discovery-refuses-when-ambiguous", heal._discover_vault() == "")
-
-        # resolve_vault() itself must stay HERMETIC: it must NOT go looking. The
-        # self-test's 'no-vault' controls depend on this, and folding discovery in
+        # HERMETICITY. resolve_vault() must NOT go looking on its own; the
+        # self-test's 'no-vault' controls depend on it, and folding discovery in
         # made them depend on the developer's real home instead.
+        #
+        # This assertion MUST run while exactly ONE vault exists. Asserted after a
+        # second vault is created it is VACUOUS: discovery returns "" under
+        # ambiguity, so `resolve_vault(...) == ""` holds whether or not discovery
+        # is wired in, and the check can never fail. A check that cannot fail is
+        # the exact defect this whole file exists to prevent.
         check("resolve-vault-never-discovers-on-its-own",
               heal.resolve_vault(WINDOWS_SETTINGS) == "")
+
+        # Canonicalisation: one vault reachable under TWO names is ONE vault.
+        # Without resolve() a junction/mirrored copy read as ambiguous and
+        # switched discovery off entirely (a normal Windows layout).
+        link = fake_home / "VaultTwin"
+        made_link = False
+        try:
+            link.symlink_to(fake_home / "OnlyVault", target_is_directory=True)
+            made_link = True
+        except (OSError, NotImplementedError):
+            pass  # unprivileged Windows without Developer Mode; skip, don't fail
+        if made_link:
+            check("same-vault-under-two-names-is-not-ambiguous",
+                  heal._discover_vault() == str(fake_home / "OnlyVault"))
+            link.unlink()
+
+        # Two GENUINELY distinct candidates -> refuse to choose. Healing the
+        # wrong vault would write a preflight into someone else's notes.
+        make_vault(fake_home / "SecondVault")
+        check("discovery-refuses-when-ambiguous", heal._discover_vault() == "")
+        check("ambiguous-candidates-are-still-enumerable",
+              len(heal._vault_candidates()) == 2)
+
+        # One un-stat-able child must not abort the whole scan. Previously the
+        # try/except wrapped the entire loop, so a single permission-denied entry
+        # turned discovery off for the account.
+        import shutil as _shutil
+        _shutil.rmtree(fake_home / "SecondVault")
+        _real_is_dir = Path.is_dir
+        boom = fake_home / "Exploding"
+        boom.mkdir()
+
+        def _is_dir_that_explodes(self):
+            if self.name == "Exploding":
+                raise PermissionError("simulated unreadable child")
+            return _real_is_dir(self)
+
+        Path.is_dir = _is_dir_that_explodes  # type: ignore[assignment]
+        try:
+            check("one-unreadable-child-does-not-abort-the-scan",
+                  heal._discover_vault() == str(fake_home / "OnlyVault"))
+        finally:
+            Path.is_dir = _real_is_dir  # type: ignore[assignment]
     finally:
         heal.Path.home = _real_home  # type: ignore[assignment]
+
+# --- WIRING: the production path must actually USE discovery -----------------
+# Everything above tests the helpers in isolation. None of it notices if the four
+# lines in run_session_start() that call discovery are deleted -- the feature can
+# be unplugged and every assertion above still passes. That is the same
+# artifact-without-activation gap MYC-3875 is about, so lock the call site
+# itself: drive run_session_start() end to end and assert it SPEAKS.
+import io  # noqa: E402
+import json as _json  # noqa: E402
+from contextlib import redirect_stdout  # noqa: E402
+
+
+def _drive_session_start(home: Path, vaults: list, with_preflight: bool):
+    """Run run_session_start() against a sandbox home; return its emitted JSON."""
+    claude = home / ".claude"
+    claude.mkdir(parents=True, exist_ok=True)
+    # Registration healthy, so the ONLY possible gap is the vault preflight.
+    guard = claude / heal.GUARD_BASENAME
+    guard.write_text("#!/usr/bin/env python3\nprint('{}')\n", encoding="utf-8")
+    groups = [{"matcher": m, "hooks": [{"type": "command",
+                                        "command": f'py -3 "{guard}"'}]}
+              for m in sorted(heal.wanted_matchers(heal.clone_root()))]
+    (claude / "settings.json").write_text(
+        _json.dumps({"hooks": {"PreToolUse": groups}}), encoding="utf-8")
+    for v in vaults:
+        make_vault(home / v, with_preflight=with_preflight)
+
+    _home = heal.Path.home
+    heal.Path.home = staticmethod(lambda: home)  # type: ignore[assignment]
+    os.environ["HEAL_JOURNAL_GUARD_NO_COOLDOWN"] = "0"
+    heal._stamp_cooldown()  # pre-stamp: no repair may spawn during a test
+    buf = io.StringIO()
+    try:
+        with redirect_stdout(buf):
+            heal.run_session_start()
+    finally:
+        heal.Path.home = _home  # type: ignore[assignment]
+        os.environ.pop("HEAL_JOURNAL_GUARD_NO_COOLDOWN", None)
+    try:
+        return _json.loads(buf.getvalue() or "{}")
+    except _json.JSONDecodeError:
+        return {}
+
+
+def _context_of(payload):
+    return ((payload.get("hookSpecificOutput") or {})
+            .get("additionalContext", ""))
+
+
+with tempfile.TemporaryDirectory() as td3:
+    home = Path(td3) / "home"
+    out = _drive_session_start(home, ["TheVault"], with_preflight=False)
+    # Discovery must find TheVault, notice the missing preflight, and SAY so.
+    # Unwire the discovery block in run_session_start() and this goes red.
+    check("WIRING-session-start-uses-discovery",
+          "incomplete" in _context_of(out).lower())
+    check("WIRING-session-start-not-silent-on-a-real-gap",
+          not out.get("suppressOutput"))
+
+with tempfile.TemporaryDirectory() as td4:
+    home = Path(td4) / "home"
+    out = _drive_session_start(home, ["VaultA", "VaultB"], with_preflight=False)
+    ctx = _context_of(out)
+    # Ambiguity must refuse to heal, but must NOT be silent about refusing --
+    # a silent refusal is the original bug wearing a different hat.
+    check("WIRING-ambiguous-home-is-reported", "candidate vaults" in ctx)
+    check("WIRING-ambiguous-report-names-the-fix", "VAULT_ROOT" in ctx)
+
+with tempfile.TemporaryDirectory() as td5:
+    home = Path(td5) / "home"
+    out = _drive_session_start(home, ["TheVault"], with_preflight=True)
+    check("WIRING-healthy-account-stays-silent", bool(out.get("suppressOutput")))
+
+# --- WIRING: --vault must reach the DIAGNOSIS, not just the repair -----------
+with tempfile.TemporaryDirectory() as td6:
+    v = make_vault(Path(td6) / "V", with_preflight=False)
+
+    class _Args:
+        clone = None
+        settings = None
+        vault = str(v)
+
+    args = _Args()
+    args.settings = str(Path(td6) / "settings.json")
+    Path(args.settings).write_text(_json.dumps(WINDOWS_SETTINGS), encoding="utf-8")
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = heal.cmd_check_only(args)
+    # Before the fix --vault reached only repair_preflight(), so the DIAGNOSIS
+    # still answered 'no-vault' and, since that is not a gap, nothing ran.
+    check("WIRING-check-only-threads-vault", "preflight=missing" in buf.getvalue())
+    check("WIRING-check-only-exits-nonzero-on-a-real-gap", rc == 1)
 
 if _saved_vault_root is not None:
     os.environ["VAULT_ROOT"] = _saved_vault_root

--- a/scripts/test_heal_journal_guard_vault.py
+++ b/scripts/test_heal_journal_guard_vault.py
@@ -183,8 +183,18 @@ with tempfile.TemporaryDirectory() as td2:
               len(heal._vault_candidates()) == 2)
 
         # One un-stat-able child must not abort the whole scan. Previously the
-        # try/except wrapped the entire loop, so a single permission-denied entry
-        # turned discovery off for the account.
+        # try/except wrapped the entire loop, so a single unreadable entry (an
+        # ACL we cannot stat, a stale network mount) turned discovery off for the
+        # whole account.
+        #
+        # Wording note: keep hook BASENAMES out of prose in this file.
+        # check-hook-negative-control.py decides a hook is covered when its
+        # basename appears anywhere in the test corpus, so merely naming one in a
+        # COMMENT makes an untested hook look tested and trips the ratchet that
+        # asks for its removal from NO_TEST_BASELINE. Prose must not be able to
+        # manufacture coverage -- that is the failure this whole file guards
+        # against, and the check is substring-based, so it cannot tell the
+        # difference between a test and a sentence.
         import shutil as _shutil
         _shutil.rmtree(fake_home / "SecondVault")
         _real_is_dir = Path.is_dir

--- a/scripts/test_install_idempotent.py
+++ b/scripts/test_install_idempotent.py
@@ -142,6 +142,74 @@ for n in (2, 3, 7, 12):
     c, r = inst.dedupe_identical_hooks(settings(*[UNOWNED] * n))
     check(f"pile-of-{n}-collapses-to-one", r == n - 1 and count(c) == 1)
 
+# --- "byte-identical" must mean the WHOLE entry, not just the command --------
+# Keying on `command` alone made the docstring's warrant false: two entries
+# sharing a command but carrying different timeouts are NOT the same
+# configuration, and collapsing them silently discarded the longer timeout --
+# on UNOWNED entries, which may be the user's own.
+diff_timeout = {"hooks": {"SessionStart": [{"hooks": [
+    {"type": "command", "command": UNOWNED, "timeout": 5},
+    {"type": "command", "command": UNOWNED, "timeout": 600},
+]}]}}
+c, r = inst.dedupe_identical_hooks(diff_timeout)
+check("differing-timeout-is-NOT-a-duplicate", r == 0 and count(c) == 2)
+check("longer-timeout-survives",
+      any(h.get("timeout") == 600
+          for h in c["hooks"]["SessionStart"][0]["hooks"]))
+
+same_timeout = {"hooks": {"SessionStart": [{"hooks": [
+    {"type": "command", "command": UNOWNED, "timeout": 5},
+    {"type": "command", "command": UNOWNED, "timeout": 5},
+]}]}}
+c, r = inst.dedupe_identical_hooks(same_timeout)
+check("genuinely-identical-entries-still-collapse", r == 1 and count(c) == 1)
+
+# --- the "deliberately narrow" claim, asserted rather than asserted-about ----
+# Near-misses must survive. Without these, a future "helpful" normalisation
+# (trim whitespace, casefold) could be added and no test would notice.
+near_misses = [
+    ("extra-inner-space", "py -3  x.py", "py -3 x.py"),
+    ("trailing-space", "py -3 x.py ", "py -3 x.py"),
+    ("case-difference", "PY -3 X.PY", "py -3 x.py"),
+    ("quoting-difference", 'py -3 "x.py"', "py -3 x.py"),
+]
+for name, a, b in near_misses:
+    c, r = inst.dedupe_identical_hooks(settings(a, b))
+    check(f"near-miss-preserved-{name}", r == 0 and count(c) == 2)
+
+# --- WIRING: main() must actually CALL the collapse --------------------------
+# Everything above tests the function in isolation, so all of it still passes if
+# the call site in main() is deleted or its result discarded. In a repo that
+# carries an explicit artifact-without-activation doctrine, an unwired pass is
+# the same defect as no pass. Drive the real installer end to end.
+import os                     # noqa: E402
+import subprocess             # noqa: E402
+import sys as _sys            # noqa: E402
+import tempfile               # noqa: E402
+
+with tempfile.TemporaryDirectory() as td:
+    home = Path(td) / "home"
+    (home / ".claude").mkdir(parents=True)
+    target = home / ".claude" / "settings.json"
+    # Six byte-identical UNOWNED copies: invisible to dedupe_owned_hooks, so only
+    # the new pass can remove them.
+    target.write_text(json.dumps(settings(*[UNOWNED] * 6)), encoding="utf-8")
+
+    env = dict(os.environ)
+    env.update(USERPROFILE=str(home), HOME=str(home),
+               HOMEDRIVE=str(home)[:2], HOMEPATH=str(home)[2:])
+    proc = subprocess.run(
+        [_sys.executable, str(ROOT / "scripts" / "install-hooks-user-level.py"),
+         "--settings", str(target), "--quiet"],
+        capture_output=True, env=env, timeout=180,
+    )
+    after = json.loads(target.read_text(encoding="utf-8"))
+    survivors = [h for groups in after.get("hooks", {}).values()
+                 for g in groups for h in g.get("hooks", [])
+                 if h.get("command") == UNOWNED]
+    check("WIRING-installer-run-succeeded", proc.returncode == 0)
+    check("WIRING-installer-collapses-identical-copies", len(survivors) == 1)
+
 # --- report ----------------------------------------------------------------
 if FAILS:
     print("FAIL: " + ", ".join(FAILS), file=sys.stderr)


### PR DESCRIPTION
Follow-up to **#487**, which merged as `458beca` while a third commit was still in flight. **#487 shipped the fixes with tests that cannot detect those fixes being removed** — this PR closes that.

An independent reviewer was asked to break #487. It found seven real defects, and the sharpest ones were in the tests.

## Tests that could not fail

**The hermeticity assertion was vacuous.** `resolve-vault-never-discovers-on-its-own` ran *after* the fixture created a second vault — and under ambiguity discovery returns `""` regardless. So it passed whether or not discovery was wired into `resolve_vault()`. It now runs while exactly **one** vault exists, and the ordering is documented as load-bearing.

**Neither feature's production wiring was tested.** Deleting the discovery block from `run_session_start()`, or the dedupe call from `main()`, left every suite green — the feature could be unplugged and CI would not notice. That is the same artifact-without-activation gap #487 exists to close. Added WIRING tests that drive `run_session_start()` and the real installer end to end.

**`--vault` threading was untested** — the exact check/repair disagreement #487 claimed to fix.

**"Deliberately narrow" was asserted about, never asserted.** Added near-miss cases (extra space, trailing space, case, quoting) that must all survive.

## Correctness defects

**`_discover_vault()` counted names, not vaults.** No canonicalisation, so one vault reachable under two names — a `mklink /J` junction, a mirrored OneDrive or Dropbox folder, all ordinary Windows layouts — read as two candidates and disabled discovery entirely. Now `resolve()`d and case-folded before de-duplication.

**"Exactly one candidate among home's immediate children" is not "exactly one vault."** Falsified on the reporting machine: one vault sat directly under home while a **second real Obsidian vault (~9k notes)** sat one level down under `~/Documents`, with an empty `meta/scripts` and no preflight. The narrow scan saw one candidate, called it unambiguous, and would have returned `ok` for an account that genuinely had a gap. The search now also covers one level under `Documents`/`OneDrive`/`Notes`/`Obsidian`. Widening it does **not** make discovery more eager — it makes the *ambiguity check* honest, and ambiguity refuses.

**Ambiguity refused silently**, which is the original bug wearing a different hat. `run_session_start()` now names the candidate vaults and tells the operator to set `VAULT_ROOT`.

**One un-stat-able child aborted the entire scan.** The `try` wrapped the whole loop and `Path.is_dir()` re-raises `PermissionError`, so a single unreadable entry switched discovery off for the account. Now isolated per child.

**`dedupe_identical_hooks` was not byte-identical.** It keyed on `command` alone, so two entries sharing a command but carrying `timeout: 5` and `timeout: 600` collapsed — silently discarding the longer timeout. That falsifies the function's own warrant ("there is no configuration in which running it twice is what the user meant" only holds when the entries really are identical), and it did so on **unowned** entries, which may be the user's own. Now keyed on the whole entry.

**`identical_count` was missing** from the "Already in sync. Nothing to write." guard and the `--dry-run` itemization, so a run that collapsed entries could print "nothing to write" and discard the collapse. Latent today — `merge_hooks` always records an update — but a printed lie waiting to happen.

## Verified by mutation, not by assertion

Seven mutations, each one a defect the reviewer proved the old suites could not see, replayed against the hardened suites:

```
KILLED  H1 unwire discovery from run_session_start
KILLED  H2 fold discovery into resolve_vault (breaks hermeticity)
KILLED  H3 drop canonicalisation (junction twin reads as ambiguous)
KILLED  H4 abort whole scan on one unreadable child
KILLED  M1 key dedupe on command only (drops longer timeout)
KILLED  M2 unwire dedupe_identical_hooks from main()
KILLED  M3 whitespace-normalising collapse (over-reach)
```

All seven now turn a suite red. Before this PR, every one of them survived.

Gates green locally: `check-vault-root-reads`, `check-utf8-stdout`, `check-utf8-subprocess`, `audit-sessionstart-boundedness --check`, `py_compile`, and the existing `heal-journal-guard --self-test`.

Related: MYC-3875, MYC-3876, MYC-3880 (the container-vs-contents doctrine these findings all instantiate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
