### PR TITLE
fix(vault-backup): report where the passphrase actually lives

### DIFF
--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -68,10 +68,44 @@ If your vault holds journals, health data, or client/CRM notes, add `--encrypt`:
 bash ~/.claude/skills/ai-brain-starter/scripts/vault-backup.sh setup --encrypt
 ```
 
-It encrypts each archive with AES-256 (via `gpg`, or `openssl` as a fallback) and
-stores the passphrase in your **OS keychain** (macOS Keychain / libsecret /
-Windows DPAPI), never in plaintext on disk. The daily run reads it from there
-with no prompt.
+It encrypts each archive with AES-256 and stores the passphrase in your **OS
+keychain** (macOS Keychain / libsecret / Windows DPAPI). The daily run reads it
+from there with no prompt.
+
+**The crypto dependency differs by platform, and `--encrypt` fails loudly rather
+than silently shipping an unencrypted archive:**
+
+| Platform | Needs | If missing |
+|---|---|---|
+| macOS | `openssl` (ships with the OS) or `gpg` | n/a in practice |
+| Linux | `gpg` or `openssl` | error, nothing is written |
+| Windows | **`gpg` (Gpg4win), on `PATH`** — there is **no** `openssl` fallback | `-Encrypt` exits with an error |
+
+Windows, encrypted:
+
+```powershell
+pwsh ~/.claude/skills/ai-brain-starter/scripts/vault-backup.ps1 setup -Encrypt
+```
+
+### Where the passphrase actually lands
+
+On a machine with **no OS keychain**, the passphrase falls back to a `chmod 600`
+file at `~/.claude/.vault-backup-pass-<slug>` and setup prints a `WARN` saying so.
+This is weaker than a keychain: anyone who can read your home directory can
+decrypt the backups. It is a deliberate fallback, not a failure, but you should
+know which one you got.
+
+Because that warning is a one-shot you can scroll past, `status` reports the
+store on every run:
+
+```
+Encrypted:   True    Keep: 7
+Passphrase:  OS keychain (keychain)
+```
+
+If instead you see a `WARN` block naming a `chmod-600 file`, install a keychain
+(macOS has one built in; on Linux install `libsecret` / `secret-tool`) and re-run
+`setup`.
 
 ---
 
@@ -135,6 +169,11 @@ You do not have to remember any of this. Two surfaces keep it visible:
   ```bash
   bash ~/.claude/skills/ai-brain-starter/scripts/vault-backup.sh schedule
   ```
+
+  **`schedule` is POSIX-only** (launchd / cron). `vault-backup.ps1` has no
+  `schedule` command and will exit with `unknown command`. On Windows the repair
+  path is re-running `setup`, which self-heals the Scheduled Task as described
+  above.
 
   This exists because a self-heal that only fires inside `setup` misses exactly
   the population that has a dead schedule — those installs never re-run setup.

--- a/scripts/vault-backup.ps1
+++ b/scripts/vault-backup.ps1
@@ -351,6 +351,22 @@ function Cmd-Status {
     $reach = if (Test-Path -LiteralPath $e.dest) { "(reachable)" } else { "(UNREACHABLE)" }
     Say "Destination: $($e.dest) $reach"
     Say "Encrypted:   $($e.encrypt)    Keep: $($e.keep)"
+    # Parity with vault-backup.sh: report WHERE the passphrase lives, not just
+    # that encryption is on. "Encrypted: True" alone does not tell the user
+    # whether the key is protected by the OS.
+    # Explicit rather than truthiness: ConvertFrom-Json normally yields a real
+    # bool, but any non-empty STRING is truthy in PowerShell, so a conf carrying
+    # "False" would print this line on an unencrypted vault.
+    $encOn = ($e.encrypt -is [bool] -and $e.encrypt) -or
+             ("$($e.encrypt)".Trim().ToLower() -in @("true", "1", "yes"))
+    if ($encOn) {
+      switch ($e.store_kind) {
+        "dpapi" { Say "Passphrase:  OS-protected (DPAPI, current user)" }
+        ""      { Warn "Passphrase:  unknown (no store_kind recorded) - re-run setup to repair" }
+        $null   { Warn "Passphrase:  unknown (no store_kind recorded) - re-run setup to repair" }
+        default { Say "Passphrase:  $($e.store_kind)" }
+      }
+    }
     $n = (Get-ChildItem -LiteralPath $e.dest -Filter "$Stem-*" -File -ErrorAction SilentlyContinue).Count
     Say "Snapshots:   $n in destination"
     Say "Last run:    $(if ($e.last) { $e.last } else { 'never' })"

--- a/scripts/vault-backup.sh
+++ b/scripts/vault-backup.sh
@@ -22,9 +22,11 @@
 #           one that never re-runs setup. (MYC-3528)
 #
 # Provider-agnostic: the destination is any folder path you give it. Encryption
-# (--encrypt) is optional and uses gpg (or openssl) with the passphrase stored
-# in your OS keychain, never in plaintext. Pure POSIX-ish bash + python3 for the
-# small JSON bits (python3 is already a hard dependency of this repo).
+# (--encrypt) is optional and uses gpg (or openssl), with the passphrase stored
+# in your OS keychain when one is available. With NO keychain it falls back to a
+# 0600 file (loudly, and `status` keeps reporting which of the two you have).
+# Pure POSIX-ish bash + python3 for the small JSON bits (python3 is already a
+# hard dependency of this repo).
 #
 # Usage:
 #   bash vault-backup.sh setup  [--vault PATH] [--dest DIR] [--encrypt] [--keep N] [--schedule daily|none]
@@ -451,7 +453,7 @@ cmd_schedule() {
 }
 
 cmd_status() {
-  local vault=""
+  local vault="" enc_on=0
   while [ $# -gt 0 ]; do case "$1" in --vault) vault="$2"; shift 2;; *) shift;; esac; done
   vault="$(resolve_vault "$vault")"
   say "${B}Vault:${N} $vault"
@@ -462,6 +464,31 @@ cmd_status() {
   else
     say "${B}Destination:${N} $dest $([ -d "$dest" ] && echo "(reachable)" || echo "${R}(UNREACHABLE)${N}")"
     say "${B}Encrypted:${N}   $(conf_get "$vault" encrypt)    ${B}Keep:${N} $(conf_get "$vault" keep)"
+    # Where the passphrase lives is part of the security posture, not a setup
+    # detail. "Encrypted: true" on its own reads as safe even when the key fell
+    # back to a file on the same disk as the backup. The setup-time warning is a
+    # one-shot the user scrolls past; status is the surface they come back to, so
+    # report the store kind every time and mark the fallback as weaker.
+    # conf_get renders the JSON bool through python, so this reads "True", not
+    # "true". Match every plausible spelling: a strict compare here fails open
+    # (the line silently never prints) and looks exactly like a healthy status.
+    case "$(conf_get "$vault" encrypt)" in true|True|TRUE|1|yes) enc_on=1;; *) enc_on=0;; esac
+    if [ "$enc_on" = 1 ]; then
+      local skind; skind="$(conf_get "$vault" store_kind)"
+      case "$skind" in
+        keychain|secret-tool|dpapi)
+          say "${B}Passphrase:${N}  OS keychain ($skind)" ;;
+        file:*)
+          warn "Passphrase:  ${skind#file:}"
+          warn "             chmod-600 file, NOT an OS keychain. Weaker: anyone who can"
+          warn "             read your home dir can decrypt the backups. Install a keychain"
+          warn "             (macOS: built in; Linux: libsecret/secret-tool) and re-run setup." ;;
+        "")
+          warn "Passphrase:  unknown (no store_kind recorded) - re-run setup to repair" ;;
+        *)
+          say "${B}Passphrase:${N}  $skind" ;;
+      esac
+    fi
     local last lastv n
     last="$(conf_get "$vault" last)"; lastv="$(conf_get "$vault" last_verify)"
     n="$(ls -1 "$dest"/$ARCHIVE_STEM-* 2>/dev/null | wc -l | tr -d ' ')"


### PR DESCRIPTION
## The problem

`docs/BACKUP.md` promised a security property the code does not always provide:

> stores the passphrase in your **OS keychain** ... **never in plaintext on disk**

The code has a deliberate fallback. With no keychain tool available, `store_passphrase()` writes the passphrase to a `chmod 600` file next to the vault and warns. The fallback is reasonable. Documenting it as impossible is not, because a reader trusts the stronger claim and never checks.

Worse, `status` hid which one you got. It printed `Encrypted: True` and nothing about the key, so the weaker outcome was undiscoverable once the one-shot setup warning scrolled past. `store_kind` was already recorded in the conf and already used for decryption. It was simply never surfaced.

That is the "vacuous success reads as real success" shape: the reassuring half is displayed, the qualifying half is dropped.

## What changed

**`status` now reports the store on every run**, and marks the fallback as weaker with the remediation:

```
Encrypted:   True    Keep: 7
Passphrase:  OS keychain (keychain)
```

```
Encrypted:   True    Keep: 7
WARN Passphrase:  /path/.vault-backup-pass-<slug>
WARN              chmod-600 file, NOT an OS keychain. Weaker: anyone who can
WARN              read your home dir can decrypt the backups. Install a keychain
WARN              (macOS: built in; Linux: libsecret/secret-tool) and re-run setup.
```

**Two platform claims corrected that would strand Windows users:**

- `--encrypt` on Windows requires **gpg (Gpg4win)** and has **no** `openssl` fallback, so `-Encrypt` hard-fails on a stock box. BACKUP.md described the POSIX dependency chain as if it were cross-platform and showed no Windows encrypted command. Now a per-platform table plus the real command.
- `schedule` is **POSIX-only**. `vault-backup.ps1` dispatches `setup|run|verify|status`, so a Windows user following the documented repair path gets `unknown command`. Documented, with the real Windows path (re-run `setup`, which self-heals the Scheduled Task).

The same false claim in the script header (what `--help` prints) is fixed. `vault-backup.ps1` gains the matching `Passphrase` line for parity.

## Two bugs the verification caught in my own diff

Worth recording, because both would have shipped looking healthy:

1. **The guard shipped inert.** `conf_get` renders the JSON bool through python, so the value reads `True`, and my strict `= "true"` compare silently never fired. Status output looked completely normal. Caught by exercising the branch instead of trusting the diff; now matched spelling-tolerantly.
2. **PowerShell truthiness.** `if ($e.encrypt)` is true for *any* non-empty string, so a conf carrying `"False"` would print the line on an unencrypted vault. Now an explicit bool/string check. Proven across `$true/$false/"True"/"False"/""`.

## Verification

- `test-vault-backup-roundtrip.sh` — 15/15 PASS, before and after.
- `ci-test` (canonical, not a subset) — GREEN: py_compile 343 files + 105 integration tests + 17 scripts + 15 hook suites + shellcheck.
- `bash -n` and the PowerShell parser on both scripts.
- Three-state control on `status`: OS keychain, forced file fallback, and unencrypted (line correctly absent).

No behavior change to what gets backed up, encrypted, or restored. Output and docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
