### PR TITLE
fix(privacy): the __SKIP guard was silently inert on Windows

### DIFF
--- a/hooks/block-skip-prefix-in-vault-write.py
+++ b/hooks/block-skip-prefix-in-vault-write.py
@@ -144,11 +144,24 @@ SKIP_LINE_RE = re.compile(r"(?m)^[ \t]*__SKIP(?=[ \t]|$)")
 BASH_REDIRECT_MARKERS = ("cat >", "cat >>", "tee ", "tee -", " > ", " >> ")
 
 
+def _norm(text: str) -> str:
+    """Backslashes -> forward slashes before ANY path matching.
+
+    On Windows a life-record path arrives as `C:\\vault\\Journals\\May 2026\\x.md`.
+    The folder patterns are written with `/`, so without this every Windows write
+    misses every pattern and the guard fails OPEN -- silently, with no error, on
+    a privacy control. Matching only; nothing here is executed as a path.
+    """
+    return text.replace("\\", "/")
+
+
 def _matches_life_record(text: str) -> bool:
+    text = _norm(text)
     return any(rx.search(text) for rx in (_DEFAULT_PATH_RES + _extra_path_res()))
 
 
 def _is_self_ref_exempt(text: str) -> bool:
+    text = _norm(text)
     return any(marker in text for marker in SELF_REF_EXEMPT_MARKERS)
 
 

--- a/tests/integration/test_skip_prefix_guard.sh
+++ b/tests/integration/test_skip_prefix_guard.sh
@@ -141,5 +141,24 @@ assert "SKIP_PREFIX_EXTRA_PATHS extends coverage to a custom path" \
 assert "an unparseable EXTRA_PATHS entry does not crash or disable defaults" \
   "$(run "$(payload Write "$JOURNAL" '__SKIP private')" SKIP_PREFIX_EXTRA_PATHS='Diario/:[unclosed')" 2
 
+# --- 10. Windows-shaped paths ------------------------------------------------
+# A backslash path that misses every forward-slash pattern makes the guard fail
+# OPEN -- silently, no error, on a privacy control. Caught post-merge on #495.
+WIN_JOURNAL='C:\Users\me\vault\Journals\May 2026\x.md'
+WIN_COACHING='C:\vault\Home\Coaching Sessions\x.md'
+
+assert "Windows backslash journal path is BLOCKED (not silently inert)" \
+  "$(run "$(payload Write "$WIN_JOURNAL" 'ok
+__SKIP private')")" 2
+
+assert "Windows backslash coaching path is BLOCKED" \
+  "$(run "$(payload Write "$WIN_COACHING" '__SKIP private')")" 2
+
+assert "NEGATIVE CONTROL: clean Windows-path write is still allowed" \
+  "$(run "$(payload Write "$WIN_JOURNAL" 'nothing private here')")" 0
+
+assert "NEGATIVE CONTROL: Windows path outside a life-record folder is allowed" \
+  "$(run "$(payload Write 'C:\vault\Notes\groceries.md' '__SKIP buy milk')")" 0
+
 echo
 echo "ALL PASS ($pass assertions, negative control on every claim)"


### PR DESCRIPTION
Follow-up to #495, caught by the post-merge evidence check before anyone relied on the guard.

## The defect

Every life-record pattern is written with forward slashes (`Journals/`, `Coaching Sessions/`, `Co-founder Syncs/`). On Windows the path arrives as:

```
C:\Users\me\vault\Journals\May 2026\x.md
```

which matches **none** of them. The guard failed **open** on every Windows write: no block, no error, no signal of any kind.

A privacy control that silently does nothing is worse than no control, because the user believes it is there and speaks accordingly. And this guard is aimed squarely at journals and coaching notes — a large share of the people it exists for are on Windows.

## Proof, before and after

Before:

```
backslash journal path: exit=0   (leaks)
forward-slash control:  exit=2   (blocks)
```

After: both exit 2, and a clean Windows-path write still exits 0.

## The fix

Normalize backslashes to forward slashes before any path matching. Matching only — nothing here is executed as a path.

Four assertions added (24 total), each with its negative control, so the suite fails if the forward-slash assumption ever comes back:

- Windows backslash journal path is BLOCKED
- Windows backslash coaching path is BLOCKED
- clean Windows-path write is still allowed
- Windows path outside a life-record folder is allowed

## How it was found

The `--fallback` wrapper check for Windows (`hook_runner.py` preserves exit 2, verified) prompted the question the wrapper check could *not* answer: the wrapper faithfully forwards a block, but only if the hook decides to block in the first place. Testing the hook against a Windows-**shaped path** rather than the Windows **launcher** is what surfaced it.

Worth noting for other hooks in this fleet that match on path fragments: same assumption, same exposure.

## Verification

- `test_skip_prefix_guard.sh` — 24/24.
- `ci-test` canonical — GREEN, 106 integration tests, marker written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
