### PR TITLE
fix(tests): sandbox HOME in the off-main strand guard test

### DIFF
--- a/tests/integration/test_offmain_strand_guard.sh
+++ b/tests/integration/test_offmain_strand_guard.sh
@@ -10,9 +10,66 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 GUARD="${1:-$HERE/../../git-hooks/guard-session-artifacts-on-default-branch.sh}"
 [ -f "$GUARD" ] || { echo "guard not found: $GUARD"; exit 2; }
 
+# WHY THIS TEST SANDBOXES HOME
+#
+# Every case below runs `git init` and `git commit` in a throwaway repo. A
+# throwaway repo is not a hermetic one: git still reads the developer's own
+# global configuration, and two keys in it reach straight into this test.
+#
+#   core.hooksPath      Commonly set globally (it is on the maintainer's
+#                       machine, pointing at ~/.claude/git-hooks). Every
+#                       `git commit` below then EXECUTES the operator's real
+#                       global pre-commit/post-commit hooks - arbitrary local
+#                       code, run eight times per suite run, inside a test that
+#                       is only supposed to exercise the guard passed as $1.
+#   init.defaultBranch  Feeds the very fallback the guard under test resolves
+#                       (guard line: `git config --get init.defaultBranch`).
+#                       On a machine with `defaultBranch = master` the
+#                       "default-branch + artifact -> ALLOW" case FAILS against
+#                       a completely correct guard, because the guard computes
+#                       _def=master while the case is on main. Verified by
+#                       running this file under that config: 1 FAILED.
+#
+# So the assertions were a function of the machine, not of the guard. HOME alone
+# does not sandbox ~ on Windows - see lib/sandbox_home.sh.
+# shellcheck source=tests/integration/lib/sandbox_home.sh
+. "$HERE/lib/sandbox_home.sh"
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+sandbox_home "$SANDBOX"
+# HOME closes ~/.gitconfig and (with XDG_CONFIG_HOME unset) ~/.config/git/config
+# too. These close the two routes it does not: an exported XDG_CONFIG_HOME, and
+# the system-level gitconfig. Same defect, remaining spellings.
+export XDG_CONFIG_HOME="$SANDBOX/.config"
+export GIT_CONFIG_NOSYSTEM=1
+
 fails=0
 pass(){ echo "PASS: $1"; }
 fail(){ echo "FAIL: $1"; fails=$((fails+1)); }
+
+# Negative control for the sandbox itself. If it ever silently stops taking
+# effect, every case below quietly goes back to executing the operator's real
+# global git hooks and resolving their real init.defaultBranch - and the cases
+# would still pass on a machine where those happen to be benign. This is the
+# only thing that would say so.
+hermetic_check(){
+  local d; d="$(mktemp -d)"
+  (
+    cd "$d" || exit 99
+    git init -q -b main
+    echo "core.hooksPath=$(git config --get core.hooksPath 2>/dev/null || true)"
+    echo "init.defaultBranch=$(git config --get init.defaultBranch 2>/dev/null || true)"
+  ) > "$d/out" 2>&1
+  local leaked
+  leaked="$(grep -E '^(core\.hooksPath|init\.defaultBranch)=.+' "$d/out" || true)"
+  if [ -z "$leaked" ]; then
+    pass "sandbox holds (no real global git config reaches the cases)"
+  else
+    fail "sandbox leaked real git config: $(printf '%s' "$leaked" | tr '\n' ' ')"
+  fi
+  rm -rf "$d"
+}
+hermetic_check
 
 # name, branch, stage-path, bypass(0/1), expect_exit, extra-pattern(optional)
 run_case(){


### PR DESCRIPTION
## What this fixes

`tests/integration/test_offmain_strand_guard.sh` creates eight throwaway repos and runs `git init` / `git commit` in each. A throwaway repo is not a hermetic one: git still reads the developer's global configuration, and two keys in it reached into the test.

**`core.hooksPath`** — when set globally, every `git commit` in those temp repos executes the operator's own global pre-commit/post-commit hooks. Measured on a developer machine:

```
$ cd "$(mktemp -d)" && git init -q -b main && git rev-parse --git-path hooks
/Users/<user>/.claude/git-hooks
```

So arbitrary local hook code ran once per case, inside a test that exists only to exercise the guard passed as `$1`.

**`init.defaultBranch`** — feeds the exact fallback the guard under test resolves (`git config --get init.defaultBranch`, guard line 35). Under a perfectly legal global `defaultBranch = master`, the `default-branch + artifact -> ALLOW` case FAILS against a completely correct guard, because the guard computes `_def=master` while the case is on `main`.

Verified both directions against a fixture home with `defaultBranch = master` and a global `pre-commit` that announces itself:

| | global hook executions | verdict |
|---|---|---|
| before | ran the operator's global hook | `1 FAILED` |
| after | 0 | `ALL PASS (0 failures)` |

## The fix

Sources `tests/integration/lib/sandbox_home.sh` and calls `sandbox_home`, which sets `HOME` **and** `USERPROFILE` together (`HOME` alone does not redirect `~` on Windows — that is the MYC-3536 class this helper exists for). `XDG_CONFIG_HOME` and `GIT_CONFIG_NOSYSTEM` close the two remaining routes by which machine git config reaches the test.

Adds a hermeticity self-check as the first case. Without it, a sandbox that silently stops taking effect leaves no signal at all — the cases would still pass on any machine whose global config happens to be benign. That is the same silent-no-op class the suite guards against elsewhere.

## Verification

- 15 consecutive runs: zero failures, zero change to the real `~/.claude` fingerprint
- `scripts/shellcheck.sh` (canonical gate): clean
- `tests/integration/test_home_sandbox_hermeticity.sh`: still passes
- `ci-test`: GREEN, marker `e96c68d1.ok`

## What this does NOT fix

This was investigated because a `ci-test` run reported `ALL PASS (0 failures)` and then `::error::test_offmain_strand_guard wrote into the real ~/.claude`. **That attribution was false, and this PR does not stop it.**

The runtime tripwire in `scripts/ci.sh` fingerprints `~/.claude` before and after each test and blames whichever test was executing. On a developer machine other things write there concurrently. Three occurrences were captured today, naming three different tests:

| time | test blamed | actual writer |
|---|---|---|
| 15:52:59 | `test_offmain_strand_guard` | launchd `com.adelaida.settings-hooks-assemble` (`StartInterval` 900; exactly 2 intervals after the prior write at 15:22:58) |
| 16:18:41 | `test_vault_safety_guards` | skill auto-sync running `install-hooks-user-level.py` (`.bak-*-abs`) |
| 16:23:41 | `test_vault_root_read_guard` | `__pycache__/*.pyc` rewritten by hooks firing in a concurrent session |

The third is the clearest: `settings.json` hash, mtime, `baks` count and file count were all **identical** before and after; only the tree size+mtime hash moved.

`test_offmain_strand_guard.sh` cannot be the writer. The only `~/.claude` code it can reach is the five scripts under `~/.claude/git-hooks/` (via `core.hooksPath`), and none of them references `settings.json`. Everything else it runs is git inside a `mktemp -d`.

This is the failure mode `scripts/ci.sh` already documents for `state/` and dotfiles ("the gate therefore failed on a DIFFERENT test every run, naming whichever test happened to be executing"). `.pyc`, `hooks.d/*.json` and installer `.bak-*` are the remaining spellings. Filed separately rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
