### PR TITLE
fix(journal-guard): resolve Windows paths, and audit the fleet for the class

### DIFF
--- a/hooks/warn-journal-saved-without-context.py
+++ b/hooks/warn-journal-saved-without-context.py
@@ -61,12 +61,30 @@ def _target_today():
     return d.isoformat()
 
 
+def _norm(text):
+    """Backslashes -> forward slashes before ANY path matching.
+
+    On Windows the journal path arrives as `C:\\vault\\Journals\\May 2026\\x.md`,
+    which matches none of the '/'-written patterns here. Without this the gate
+    never opens on Windows: no warning, no error, no signal — a silent fail-open
+    on the platform rather than a visible break. Matching only; nothing here is
+    executed as a path (and Python opens `C:/x/y` fine on Windows)."""
+    return text.replace("\\", "/")
+
+
 def _vault_root(text):
     """Absolute dir before the '<optional emoji >Journals/<Month YYYY>/' segment.
-    Anchored on the absolute path (starts at a real '/'), so a leading shell prefix
-    like `cat > '/vault/.../x.md'` is NOT captured into the root (that was the
-    2026-07-07 Bash-path fail-open bug). Quotes bound the segment on the Bash path."""
-    m = re.search(r"(/[^\n\"']*?)/(?:[^/\n]*\s)?Journals/[A-Z][a-zA-Z]+\s+\d{4}/", text)
+    Anchored on the absolute path (starts at a real '/', or a `C:/` drive root),
+    so a leading shell prefix like `cat > '/vault/.../x.md'` is NOT captured into
+    the root (that was the 2026-07-07 Bash-path fail-open bug). Quotes bound the
+    segment on the Bash path.
+
+    The drive-letter alternative is guarded by `(?<![A-Za-z])` so a URL like
+    `http://host/Journals/May 2026/` cannot have its `p:` read as a drive."""
+    m = re.search(
+        r"((?:(?<![A-Za-z])[A-Za-z]:)?/[^\n\"']*?)/(?:[^/\n]*\s)?"
+        r"Journals/[A-Z][a-zA-Z]+\s+\d{4}/",
+        text)
     return m.group(1) if m else None
 
 
@@ -87,7 +105,7 @@ tool_input = payload.get("tool_input", {}) or {}
 
 blob = ""          # text to scan for path + date + vault root
 if tool_name == "Write":
-    fp = tool_input.get("file_path", "") or ""
+    fp = _norm(tool_input.get("file_path", "") or "")
     if JOURNAL_PATH_RE.search(fp):
         blob = fp + "\n" + (tool_input.get("content", "") or "")
 elif tool_name == "Bash":
@@ -98,10 +116,12 @@ elif tool_name == "Bash":
     if inline_bypass(cmd, "JOURNAL_CONTEXT_BYPASS") or \
        re.search(r"(^|\s)JOURNAL_CONTEXT_BYPASS=1(\s|$)", cmd):
         sys.exit(0)
-    if JOURNAL_PATH_RE.search(cmd) and any(
+    cmd_norm = _norm(cmd)
+    if JOURNAL_PATH_RE.search(cmd_norm) and any(
         m in cmd for m in ("cat >", "cat >>", "tee ", "tee -", " > ", " >> ", "mv ", "cp ", "rsync ")
     ):
-        blob = cmd
+        # Normalized, because _vault_root() below must see forward slashes too.
+        blob = cmd_norm
 
 if not blob:
     sys.exit(0)  # not a journal save

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -339,6 +339,11 @@ INTEGRATION_TESTS=(
   # negative control, because a guard that blocks everything and one that blocks
   # the right thing produce identical PASSes on a block-only suite.
   test_skip_prefix_guard
+  # Journal-context guard vs Windows paths. Its patterns are forward-slash only,
+  # so a `C:\vault\Journals\...` write matched nothing and the gate never opened
+  # — silently, on a whole platform. Two layers must hold (the path gate AND the
+  # vault-root resolve); fixing only the first looks right and still fails open.
+  test_journal_guard_windows_paths
 )
 # ---- Gate-coverage invariant -------------------------------------------------
 # The list above is an explicit allow-list, and allow-lists rot: a new

--- a/tests/integration/test_journal_guard_windows_paths.sh
+++ b/tests/integration/test_journal_guard_windows_paths.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Integration test: warn-journal-saved-without-context.py resolves Windows paths.
+#
+# Every path pattern in that hook is written with forward slashes. On Windows a
+# journal write arrives as `C:\vault\Journals\May 2026\x.md`, which matches none
+# of them, so the gate never opens: no warning, no error, no signal at all. A
+# guard that silently does nothing on a whole platform is worse than an absent
+# one, because the user believes it is running.
+#
+# Two layers have to hold, and a fix to only the first LOOKS correct while still
+# failing open one step later:
+#   1. JOURNAL_PATH_RE must match the path (the gate).
+#   2. _vault_root() must return a usable root, which means accepting a `C:/`
+#      drive root and not only a leading `/`.
+#
+# Asserted against the hook's OWN predicates, so this tests shipped code rather
+# than a reimplementation of it. Every claim carries a control.
+set -euo pipefail
+
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+PY="${PYTHON:-python3}"
+
+"$PY" - "$REPO_ROOT" <<'PYEOF'
+import importlib.util, pathlib, sys
+
+repo = pathlib.Path(sys.argv[1])
+path = repo / "hooks" / "warn-journal-saved-without-context.py"
+spec = importlib.util.spec_from_file_location("journal_guard", path)
+m = importlib.util.module_from_spec(spec)
+sys.modules["journal_guard"] = m
+try:
+    spec.loader.exec_module(m)
+except SystemExit:
+    pass
+
+rx, vault_root, norm = m.JOURNAL_PATH_RE, m._vault_root, m._norm
+failures = 0
+
+def check(label, got, want):
+    global failures
+    if got == want:
+        print(f"PASS  {label}")
+    else:
+        print(f"FAIL  {label} (got {got!r}, want {want!r})")
+        failures += 1
+
+CASES = [
+    ("POSIX file path",      "/Users/me/vault/Journals/May 2026/e.md",              "/Users/me/vault"),
+    ("Windows file path",    r"C:\Users\me\vault\Journals\May 2026\e.md",           "C:/Users/me/vault"),
+    ("POSIX bash heredoc",   "cat > '/Users/me/vault/Journals/May 2026/e.md' <<EOF", "/Users/me/vault"),
+    ("Windows bash heredoc", r"cat > 'C:\Users\me\vault\Journals\May 2026\e.md' <<EOF", "C:/Users/me/vault"),
+    ("emoji vault folder",   "/Users/me/v/📓 Journals/May 2026/e.md",                "/Users/me/v"),
+]
+for label, raw, want_root in CASES:
+    t = norm(raw)
+    check(f"{label}: gate opens", bool(rx.search(t)), True)
+    check(f"{label}: vault root resolves", vault_root(t), want_root)
+
+# --- controls: things that must NOT change ----------------------------------
+check("CONTROL: non-journal path does not open the gate",
+      bool(rx.search(norm("/Users/me/vault/Notes/x.md"))), False)
+check("CONTROL: Windows non-journal path does not open the gate",
+      bool(rx.search(norm(r"C:\Users\me\vault\Notes\x.md"))), False)
+# A URL's `p:` must never be read as a drive letter. Behaviour here is
+# unchanged from before the drive-letter alternative was added.
+check("CONTROL: a URL is not parsed as a drive root",
+      vault_root(norm("see http://host/x/Journals/May 2026/e.md")), "//host/x")
+
+print()
+if failures:
+    print(f"FAILED ({failures})")
+    sys.exit(1)
+print("ALL PASS (13 assertions, controls included)")
+PYEOF


### PR DESCRIPTION
Sweeping the sibling of the bug fixed in #496, plus the fleet audit that found it.

## The sibling

`warn-journal-saved-without-context.py` had the identical defect and is **registered on every install**. Proven against the hook's own predicate, not a reimplementation of it:

```
JOURNAL_PATH_RE.search(posix)   -> True
JOURNAL_PATH_RE.search(windows) -> False    # the gate never opens
```

**Two layers had to be fixed**, and repairing only the first would have looked correct while still failing open one step later:

1. The path gate (`JOURNAL_PATH_RE`) never matched a backslash path.
2. `_vault_root()` anchored on a leading `/`, so even a normalized `C:/vault/…` returned `None` and the hook failed open anyway.

Both fixed: normalize backslashes before matching, and accept a `C:/` drive root. The drive-letter alternative is guarded with `(?<![A-Za-z])` so a URL's `p:` in `http://` can never be read as a drive — that control returns `//host/x`, byte-identical to the pre-change behaviour.

New test asserts **both** layers across POSIX, Windows, bash-heredoc and emoji-folder shapes, plus three controls (13 assertions), wired into `INTEGRATION_TESTS`.

## The fleet audit

An AST scan of all 108 hooks for path patterns that match a POSIX path and miss its Windows twin found **7, five of them registered**.

The first scan found only **one**. It was a regex over the source, and it truncated at embedded quotes — so this very hook's `[^/\"']` pattern was mangled and silently skipped. The scan only became trustworthy after a positive control: running it against the known-buggy pre-fix hook from #495 and confirming it flags it. A zero result from an unproven instrument is not evidence.

| Hook | Registered | Status |
|---|---|---|
| `warn-journal-saved-without-context.py` | yes | **fixed here**, behaviour proven |
| `block-populated-public-skill.py` | yes | pattern-level only; did not fire on *either* shape in testing, so exposure is **unconfirmed, not clean** |
| `context-budget-measure.py` | yes | pattern-level only; fired on both shapes |
| `verify-session-close-cascade.py` | yes | pattern-level only |
| `warn-stale-dev-checkout.py` | yes | pattern-level only |
| `check-rule-conflicts-on-write.py` | no | pattern-level only |
| `hookify-auto-commit.py` | no | pattern-level only |

Behaviour is proven **only** for the hook fixed here. The other six are reported at pattern level; each needs its own trigger payload to confirm, which is a separate pass rather than a blanket normalization that could change semantics in a hook where `/` matching is intentional.

## Verification

- `test_journal_guard_windows_paths.sh` — 13/13, controls included.
- `ci-test` canonical — GREEN, **107** integration tests, marker written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
