### PR TITLE
fix(tests): the HOME-sandbox guard was silently inert on macOS bash 3.2

### DIFF
--- a/hooks/rotate-logs.sh
+++ b/hooks/rotate-logs.sh
@@ -23,8 +23,19 @@ MAX_BYTES="${MAX_BYTES:-512000}"
 KEEP="${KEEP:-30}"
 
 # Auto-collect all .log files in LOG_DIR, or override by setting LOGS explicitly.
+#
+# NUL-delimited read loop, not `mapfile`: this script's shebang is /bin/bash,
+# which on macOS is bash 3.2, where `mapfile` does not exist. It used to be one,
+# and the builtin's absence (under `set +e`, and with `exit 0` at the bottom)
+# left LOGS empty on every Mac -- so this hook ran at every SessionStart, rotated
+# nothing, and reported success. Logs grew without bound and nothing said so.
+# See scripts/PORTABILITY.md section 4; enforced by
+# tests/integration/test_bash32_portability.sh.
 if [ ${#LOGS[@]:-0} -eq 0 ]; then
-  mapfile -t LOGS < <(find "$LOG_DIR" -maxdepth 1 -name "*.log" 2>/dev/null)
+  LOGS=()
+  while IFS= read -r -d '' f; do
+    LOGS+=("$f")
+  done < <(find "$LOG_DIR" -maxdepth 1 -name "*.log" -print0 2>/dev/null)
 fi
 
 rotate() {

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -313,6 +313,15 @@ INTEGRATION_TESTS=(
   # every tool call. This static half runs on Linux CI, where the runtime
   # tripwire below cannot see the bug because HOME works there.
   test_home_sandbox_hermeticity
+  # bash-3.2 portability (2026-08-15): the guard above built its offender list
+  # with `mapfile`, a bash-4 builtin macOS /bin/bash does not have. Under
+  # `set -u` without `-e` that is non-fatal, so its primary check evaluated
+  # NOTHING on every Mac while the file still printed PASS and exited 0; the
+  # same defect left hooks/rotate-logs.sh rotating no logs at all. Neither
+  # existing gate can see the class: the bash32-syntax job is `-n` only and all
+  # of these PARSE on 3.2 (they fail at run time), and shellcheck has no
+  # bash-version model. Static, so it gives the same verdict on any runner.
+  test_bash32_portability
   # Root cause of the same incident: the runner path baked into settings.json
   # came from Path(__file__), so installing from a throwaway worktree wired ~95
   # hooks to a path that vanished with it. Pins the resolution to the INSTALLED

--- a/tests/integration/test_bash32_portability.sh
+++ b/tests/integration/test_bash32_portability.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# Static guard: no tracked *.sh may use a bash-4-only feature.
+#
+# THE BUG THIS LOCKS OUT
+#
+# macOS ships bash 3.2.57 (2007) as /bin/bash and that is the ONLY bash on an
+# unmodified Mac. scripts/PORTABILITY.md section 4 has banned bash-4 features
+# since it was written. Nothing enforced it, and on 2026-08-15
+# tests/integration/test_home_sandbox_hermeticity.sh was found building its
+# offender list with `mapfile`. Under /bin/bash the builtin does not exist; the
+# script ran `set -uo pipefail` without `-e`, so the failure was NOT fatal. The
+# array stayed unset, its `${#...[@]}` test errored to stderr, and the check
+# that was the file's entire purpose -- "every HOME site pairs with a
+# USERPROFILE" -- never evaluated. The run still printed PASS=6 FAIL=0 and
+# exited 0. The static half of the Windows HOME-sandbox gate had been dead on
+# every Mac since it shipped, reporting success the whole time.
+#
+# WHY THE TWO GATES THAT ALREADY EXIST CANNOT CATCH THIS -- both verified, not
+# assumed, before this file was written:
+#
+#   * The `bash32-syntax` job in .github/workflows/lint.yml runs a real
+#     /bin/bash 3.2 on macos-latest, but only `-n` (parse). All four constructs
+#     below PARSE cleanly on 3.2 and fail at RUN time: mapfile/readarray exit
+#     127 "command not found", `declare -A` exits 2 "invalid option", `${v^^}`
+#     exits 1 "bad substitution". `bash -n` is green on every one.
+#   * `scripts/shellcheck.sh` has no bash-version model at all: shellcheck
+#     -S style exits 0 on a file using both `mapfile` and `declare -A`.
+#
+# So the property is unreachable from either runner, and CI on ubuntu (bash 5)
+# is green by construction for the whole class. A STATIC scan is the answer
+# precisely because it asks about the CODE, not about the interpreter that
+# happens to be running: it gives the same verdict on any runner.
+#
+# SCOPE -- what this deliberately does NOT check, so the coverage is not
+# silently narrower than the name suggests:
+#   * `|&` and `&>>` (also bash 4+) are NOT scanned. Several .sh here embed
+#     Python heredocs whose regexes contain those exact byte pairs
+#     (e.g. re.split(r"\|\||&&|[|;&]", cmd)), and flagging them would be noise
+#     that trains people to bypass the gate. They have never appeared as real
+#     shell here.
+#   * `"${arr[@]}"` on an empty array under `set -u` (PORTABILITY.md section 4)
+#     is a runtime property, not a lexical one, and cannot be decided by a scan.
+#
+# Stdlib bash + python3 only. Exit 0 = pass.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT" || exit 1
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS + 1)); echo "PASS  $1"; }
+bad() { FAIL=$((FAIL + 1)); echo "FAIL  $1 :: $2"; }
+
+# Every check must report exactly once; asserted at the bottom. This file runs
+# `set -u` without `-e` on purpose (each check should report, not stop the run),
+# which is exactly the condition that let the original bug hide. Bump when
+# adding a check.
+EXPECTED_CHECKS=8
+
+# Files allowed to use a banned construct, each with a reason. Format:
+# "<path>  <reason>". Empty is the healthy state -- a row here is a debt, not a
+# preference, and the fix is almost always the portable idiom in
+# scripts/PORTABILITY.md section 4. Silence is the only banned state: a file
+# that needs an exception gets a row, never a quiet carve-out in the scanner.
+read -r -d '' BASH32_EXEMPT <<'EOF' || true
+EOF
+
+run_scan() {  # run_scan <extra-file-to-scan-instead-of-the-repo-or-empty>
+  python3 - "$1" <<'PY'
+import os, re, subprocess, sys
+
+extra = sys.argv[1] if len(sys.argv) > 1 and sys.argv[1] else None
+
+EXEMPT = set()
+for line in os.environ.get("BASH32_EXEMPT", "").splitlines():
+    line = line.strip()
+    if line:
+        EXEMPT.add(line.split()[0])
+
+# The bash-4-only constructs banned by scripts/PORTABILITY.md section 4. Each
+# carries the portable replacement, because a gate that only says "no" gets
+# worked around.
+BANNED = [
+    (re.compile(r'\b(?:mapfile|readarray)\b'),
+     "mapfile/readarray are bash 4+ (readarray -d is 4.4+); macOS /bin/bash has neither. "
+     "Use a read loop: arr=(); while IFS= read -r x || [ -n \"$x\" ]; do arr+=(\"$x\"); done < <(...)"),
+    (re.compile(r'\b(?:declare|local|typeset)\s+-[A-Za-z]*A[A-Za-z]*\b'),
+     "associative arrays (declare -A) are bash 4+. Use parallel indexed arrays, or a "
+     "python3/awk helper."),
+    (re.compile(r'\$\{[A-Za-z_][A-Za-z0-9_]*(?:\[[^]]*\])?(?:\^\^|,,|\^|,)'),
+     "${v^^} / ${v,,} case conversion is bash 4+. Use tr '[:lower:]' '[:upper:]'."),
+]
+
+# Strip comments so the RULE can be discussed in the files it governs. Without
+# this the guard flags scripts/shellcheck.sh and the hermeticity test, both of
+# which name `mapfile` in a comment explaining why they avoid it -- and a guard
+# whose first act is to flag the documentation of its own rule gets disabled.
+# Heuristic, deliberately: a '#' is a comment start when it is outside single
+# and double quotes and begins the line or follows whitespace.
+def strip_comment(line):
+    sq = dq = 0
+    i = 0
+    while i < len(line):
+        c = line[i]
+        if c == "\\":
+            i += 2
+            continue
+        if c == "'" and dq % 2 == 0:
+            sq += 1
+        elif c == '"' and sq % 2 == 0:
+            dq += 1
+        elif c == "#" and sq % 2 == 0 and dq % 2 == 0 and (i == 0 or line[i - 1] in " \t"):
+            return line[:i]
+        i += 1
+    return line
+
+def tracked(*patterns):
+    out = subprocess.run(["git", "ls-files", "-z", "--"] + list(patterns),
+                         capture_output=True, text=True).stdout
+    return [p for p in out.split("\0") if p]
+
+files = [extra] if extra else tracked("*.sh")
+
+# This file spells out every pattern it hunts for, in prose and in regex, and
+# its controls are deliberate offenders. Scanning itself would be self-indicting.
+SELF = "tests/integration/test_bash32_portability.sh"
+
+offenders, files_checked = [], 0
+for f in files:
+    if not extra and (f == SELF or f in EXEMPT):
+        continue
+    try:
+        lines = open(f, encoding="utf-8", errors="replace").read().splitlines()
+    except OSError:
+        continue
+    files_checked += 1
+    for i, raw in enumerate(lines):
+        line = strip_comment(raw)
+        if not line.strip():
+            continue
+        for rx, fix in BANNED:
+            if rx.search(line):
+                offenders.append(f"{f}:{i+1}: {line.strip()[:80]}  ->  {fix}")
+                break
+
+print(f"FILES={files_checked}")
+for o in offenders:
+    print(f"OFFENDER={o}")
+PY
+}
+
+# bash-3.2-safe array fill: no mapfile (this file, of all files, must obey its
+# own rule). The `|| [ -n "$line" ]` tail keeps the final record when command
+# substitution has stripped the trailing newline.
+collect_offenders() {  # collect_offenders <run_scan-output>
+  OFFENDERS=()
+  local line
+  while IFS= read -r line || [ -n "$line" ]; do
+    [ -n "$line" ] && OFFENDERS+=("$line")
+  done < <(printf '%s' "$1" | sed -n 's/^OFFENDER=//p')
+}
+
+export BASH32_EXEMPT
+
+echo "=== 1. no tracked *.sh uses a bash-4-only feature ==="
+OUT="$(run_scan "")"
+FILES="$(printf '%s' "$OUT" | sed -n 's/^FILES=//p')"
+collect_offenders "$OUT"
+
+# A scan that reaches zero files reports "no offenders" in exactly the same
+# words as a clean repo. Assert it actually looked.
+if [ "${FILES:-0}" -lt 20 ]; then
+  bad "detector reached the repo" "scanned ${FILES:-0} *.sh — this repo tracks ~80; the pattern or the git ls-files call has rotted"
+else
+  ok "scanned $FILES tracked *.sh"
+fi
+
+if [ "${#OFFENDERS[@]}" -eq 0 ]; then
+  ok "every tracked *.sh is bash-3.2 clean"
+else
+  printf '      %s\n' "${OFFENDERS[@]}" >&2
+  bad "bash-4-only feature" "${#OFFENDERS[@]} site(s) use a construct macOS /bin/bash (3.2) cannot run. Each line above names its portable replacement; see scripts/PORTABILITY.md section 4"
+fi
+
+echo "=== 2. POSITIVE CONTROLS: each banned construct is actually detected ==="
+CTL="$(mktemp -d)"
+trap 'rm -rf "$CTL"' EXIT
+
+# One control per pattern, not one for the set. A single control proves the
+# SEARCH runs; it says nothing about the other patterns' VOCABULARY, and a
+# rotted regex reads as "the repo is clean".
+control() {  # control <label> <fixture-basename> <expected-count> <body>
+  printf '%s\n' "$4" > "$CTL/$2"
+  local n
+  n="$(run_scan "$CTL/$2" | grep -c '^OFFENDER=')"
+  if [ "$n" -eq "$3" ]; then
+    ok "$1"
+  else
+    bad "control: $1" "expected $3 offending site(s), got $n"
+  fi
+}
+
+control "mapfile is caught"      "m.sh"  1 'mapfile -t A < <(echo x)'
+control "readarray is caught"    "r.sh"  1 'readarray -t A < <(echo x)'
+control "declare -A is caught"   "d.sh"  1 'declare -A MAP'
+control "\${v^^} is caught"      "c.sh"  1 'echo "${name^^}"'
+
+echo "=== 3. NEGATIVE CONTROLS: the detector does not bite what it should not ==="
+
+# The portable idioms PORTABILITY.md tells people to use must stay clean, or the
+# gate punishes the fix it recommends.
+control "the portable read-loop idiom is not flagged" "clean.sh" 0 'files=()
+while IFS= read -r -d "" f; do files+=("$f"); done < <(git ls-files -z)
+upper="$(printf "%s" "$name" | tr "[:lower:]" "[:upper:]")"
+if [ "${#files[@]}" -eq 0 ]; then echo none; fi'
+
+# The false-positive class that would otherwise flag scripts/shellcheck.sh and
+# the hermeticity guard on their own explanatory comments.
+control "a comment naming the banned construct is not flagged" "cmt.sh" 0 '# Built bash-3.2-safe: no mapfile / readarray, no declare -A, no ${v^^}.
+echo ok   # mapfile would go here on bash 4'
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+# Fail loud when a check did not EVALUATE. `set -u` without `-e` means a check
+# killed mid-run prints to stderr and simply never reports, and the surviving
+# checks render a clean PASS=N FAIL=0 indistinguishable from real success. That
+# is the shape of the bug this whole file exists to prevent; it must not be the
+# shape of this file's own failure.
+if [ "$((PASS + FAIL))" -ne "$EXPECTED_CHECKS" ]; then
+  echo "FAIL  check-count invariant :: only $((PASS + FAIL)) of $EXPECTED_CHECKS checks reported — one did not evaluate. Read stderr above. This is NOT a pass." >&2
+  exit 1
+fi
+[ "$FAIL" -eq 0 ] || exit 1
+echo "PASS: every tracked *.sh runs on macOS /bin/bash 3.2 (scripts/PORTABILITY.md section 4)"

--- a/tests/integration/test_home_sandbox_hermeticity.sh
+++ b/tests/integration/test_home_sandbox_hermeticity.sh
@@ -28,6 +28,18 @@
 #      means it read and wrote the developer's REAL health database.
 #   3. Its own negative control only proved the detector fired, never that a
 #      correctly-paired site was left alone.
+#   4. It built the offender list with `mapfile`, a bash-4 builtin. macOS ships
+#      bash 3.2 (2007) as /bin/bash, where that builtin does not exist -- and
+#      because this file runs `set -uo pipefail` WITHOUT `-e`, the failure was
+#      non-fatal. OFFENDERS stayed unset, the `${#OFFENDERS[@]}` test errored to
+#      stderr, check 1 -- this file's entire reason to exist -- never evaluated,
+#      and the run still printed PASS=6 FAIL=0 and exited 0. Linux CI (bash 4+)
+#      is blind to it by construction: a gate cannot catch a defect its own
+#      runner is incapable of expressing. Fixed three ways below: a portable
+#      read loop, a control proving that loop actually POPULATES, and a
+#      check-count invariant that fails loud when any check silently skips.
+#      The repo-wide half is tests/integration/test_bash32_portability.sh,
+#      which enforces scripts/PORTABILITY.md section 4 over every tracked *.sh.
 #
 # The companion runtime tripwire in scripts/ci.sh watches the real ~/.claude for
 # actual writes. This static half catches the mistake at author time on Linux CI,
@@ -44,6 +56,11 @@ cd "$REPO_ROOT" || exit 1
 PASS=0; FAIL=0
 ok()  { PASS=$((PASS + 1)); echo "PASS  $1"; }
 bad() { FAIL=$((FAIL + 1)); echo "FAIL  $1 :: $2"; }
+
+# Every check below must report exactly once. Asserted at the bottom, because
+# `set -u` without `-e` lets a check that cannot EVALUATE disappear silently
+# instead of failing (see item 4 in the header). Bump this when adding a check.
+EXPECTED_CHECKS=8
 
 # Tests that assign HOME but are deliberately NOT converted. Each needs a reason.
 # Rule: the test must not reach the installer/merge path or any other writer of
@@ -166,13 +183,31 @@ for o in offenders:
 PY
 }
 
+# Fills the global OFFENDERS array from a run_scan output blob.
+#
+# bash-3.2-safe by construction: no `mapfile` (bash 4+, absent from macOS
+# /bin/bash), no `readarray -d` (4.4+). See scripts/PORTABILITY.md section 4.
+# The `|| [ -n "$line" ]` tail is not decoration -- command substitution strips
+# the trailing newline, so the final record arrives unterminated and a bare
+# `read` would return non-zero and drop it.
+#
+# OFFENDERS is reset here rather than at the call site so `set -u` can never see
+# it unset, whatever happens inside the loop.
+collect_offenders() {  # collect_offenders <run_scan-output>
+  OFFENDERS=()
+  local line
+  while IFS= read -r line || [ -n "$line" ]; do
+    [ -n "$line" ] && OFFENDERS+=("$line")
+  done < <(printf '%s' "$1" | sed -n 's/^OFFENDER=//p')
+}
+
 export SANDBOX_EXEMPT
 
 echo "=== 1. every HOME site pairs with a USERPROFILE (shell + python suites) ==="
 OUT="$(run_scan "")"
 FILES="$(printf '%s' "$OUT" | sed -n 's/^FILES=//p')"
 SITES="$(printf '%s' "$OUT" | sed -n 's/^SITES=//p')"
-mapfile -t OFFENDERS < <(printf '%s' "$OUT" | sed -n 's/^OFFENDER=//p')
+collect_offenders "$OUT"
 
 if [ "${FILES:-0}" -eq 0 ] || [ "${SITES:-0}" -eq 0 ]; then
   bad "detector matched something" "scanned $FILES file(s) / $SITES site(s) — the pattern must have rotted"
@@ -254,7 +289,34 @@ else
   bad "helper control" "a helper call site was flagged"
 fi
 
+# (e) the PLUMBING control. Controls (a)-(d) count OFFENDER= lines with `grep -c`
+# and so exercise the detector only. They stayed green through the whole macOS
+# outage described in header item 4, because the thing that was broken was the
+# step BETWEEN the detector and the verdict: filling the OFFENDERS array. This
+# runs a deliberately unpaired fixture through the exact code path check 1 uses,
+# and asserts the array is populated -- so the array-building idiom can never
+# again fail silently while the file reports PASS.
+cat > "$CTL/unpaired.sh" <<'EOF'
+#!/usr/bin/env bash
+export HOME="$LEAKY"
+EOF
+collect_offenders "$(run_scan "$CTL/unpaired.sh")"
+if [ "${#OFFENDERS[@]}" -eq 1 ] && case "${OFFENDERS[0]}" in *unpaired.sh:2:*) true ;; *) false ;; esac; then
+  ok "an unpaired HOME site reaches the verdict through the OFFENDERS array"
+else
+  bad "offender-plumbing control" "collect_offenders returned ${#OFFENDERS[@]} entry(ies) for a fixture with exactly 1 unpaired HOME site — the array-building step between the detector and the verdict is broken, which is precisely the failure that made check 1 evaluate nothing while the file still printed PASS"
+fi
+
 echo
 echo "PASS=$PASS FAIL=$FAIL"
+# Fail loud when a check did not EVALUATE. Without this, a check killed mid-run
+# (missing builtin, unset var — `set -u`, no `-e`) prints to stderr and simply
+# never reports, and the surviving checks render a clean PASS=N FAIL=0 that is
+# indistinguishable from real success. A guard that cannot run its own spec must
+# fail, not no-op.
+if [ "$((PASS + FAIL))" -ne "$EXPECTED_CHECKS" ]; then
+  echo "FAIL  check-count invariant :: only $((PASS + FAIL)) of $EXPECTED_CHECKS checks reported — one did not evaluate. Read stderr above for the cause; a bash-4-only builtin under macOS /bin/bash (3.2) is the known one. This is NOT a pass." >&2
+  exit 1
+fi
 [ "$FAIL" -eq 0 ] || exit 1
 echo "PASS: HOME sandboxing is hermetic on Windows as well as POSIX (MYC-3536)"


### PR DESCRIPTION
## The bug

`tests/integration/test_home_sandbox_hermeticity.sh` built its offender list with `mapfile`, a bash-4 builtin. macOS ships bash 3.2.57 as `/bin/bash`, where it does not exist, and the file runs `set -uo pipefail` **without** `-e`, so the failure was not fatal:

```
tests/integration/test_home_sandbox_hermeticity.sh: line 175: mapfile: command not found
PASS  scanned 20 HOME site(s) across 19 file(s)
tests/integration/test_home_sandbox_hermeticity.sh: line 183: OFFENDERS: unbound variable
...
PASS=6 FAIL=0
```
exit 0.

`OFFENDERS` stayed unset, the `${#OFFENDERS[@]}` test errored to stderr, and check 1 — *"every HOME site pairs with a USERPROFILE"*, the file's entire purpose — never evaluated. The run still reported success.

It looked healthy because the negative controls in section 3 count `OFFENDER=` lines with `grep -c` rather than through the array, so they kept passing. **The static half of the Windows HOME-sandbox gate (MYC-3536) has been dead on every Mac since it shipped.** Latent on Linux CI (bash 4+), which is why nothing surfaced it.

## The fix

- `mapfile` → a bash-3.2 read loop inside a `collect_offenders` helper that resets `OFFENDERS` itself, so `set -u` can never see it unset.
- **New control (e)**: a deliberately unpaired-HOME fixture driven through the exact code path check 1 uses, asserting the array is *populated*. Controls (a)–(d) only ever exercised the detector — that is precisely why they stayed green through the whole outage.
- **Check-count invariant**: a check that cannot *evaluate* now fails loud instead of vanishing into a clean-looking `PASS=N FAIL=0`.

## The class gate

`scripts/PORTABILITY.md` §4 has banned bash-4 features since it was written. Nothing enforced it. New `tests/integration/test_bash32_portability.sh` enforces it across all 188 tracked `*.sh`.

Neither existing gate can express the class — verified, not assumed:

| gate | why it is blind |
|---|---|
| `bash32-syntax` job | runs real bash 3.2, but `bash -n` only. All four constructs **parse** on 3.2 and fail at **run** time (exit 127 / 2 / 1). |
| `scripts/shellcheck.sh` | no bash-version model at all: `shellcheck -S style` exits 0 on a file using both `mapfile` and `declare -A`. |

Static by design, so its verdict does not depend on the interpreter that happens to run it. Ships a **positive control per pattern** (a rotted regex otherwise reads as "the repo is clean"), plus negative controls that the recommended portable idioms and comments *naming* the banned construct are not flagged.

## Second live instance, found by the new gate

`hooks/rotate-logs.sh:27` — a `#!/bin/bash` SessionStart hook, so always bash 3.2 on a Mac. `LOGS` was never populated; with `set +e` and `exit 0` the hook rotated nothing and reported success every time.

Verified before/after: a 600 KB log over the 512 KB threshold stayed 600 KB with zero archives. It is now gzipped and truncated, while an under-threshold log is correctly left alone. Fixed with a NUL-delimited read loop so the gate lands green.

## Trap worth knowing

`git grep -E '\bmapfile\b'` returns **zero** on macOS — git's ERE engine does not implement `\b` as a word boundary, so the pattern silently matches nothing. `git grep -P` and plain `grep -E` both find it. My own first sweep came back falsely clean this way and missed `rotate-logs.sh`; the gate caught it. That is why this ships as a gate and not a one-time grep.

## Verification

- Full `bash scripts/ci.sh` green — **107 integration tests**, up from 106. `All gates passed`.
- Both suites **8/8 under `/bin/bash` 3.2.57**; `bash -n` clean on 3.2; `shellcheck -S warning` clean.
- **Two mutants killed:**
  - an unpaired-HOME fixture in a real scanned file makes check 1 go red and exit 1 (it named `test_zz_mutant_unpaired_home.sh:3`);
  - re-introducing `mapfile` now trips the check-count invariant and exits 1, instead of the previous silent `PASS=6 FAIL=0` / exit 0.

## Scope

No unrelated changes. All four files are the same defect class: the fix, the gate that prevents recurrence, the instance that gate found, and the one-line `INTEGRATION_TESTS` entry the repo's own gate-coverage invariant requires for any new `tests/integration/test_*.sh`. The `scripts/ci.sh` edit is confined to the array block and was coordinated with a concurrent session working in `real_home_fingerprint()` / the tripwire loop — disjoint regions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
