### PR TITLE
fix(install): hold the routing table to the chain, and stop diagnose prescribing the wrong repair

### DIFF
--- a/scripts/check-phase-chain.py
+++ b/scripts/check-phase-chain.py
@@ -93,12 +93,28 @@ def main() -> int:
         default=None,
         help="directory holding phase-*.md (default: <repo>/phases)",
     )
+    ap.add_argument(
+        "--skill-md",
+        default=None,
+        help="SKILL.md to cross-check the routing-table order against "
+             "(default: the sibling of --phases-dir; 'none' to skip)",
+    )
     args = ap.parse_args()
 
     if args.phases_dir:
         phases_dir = Path(args.phases_dir)
     else:
         phases_dir = Path(__file__).resolve().parent.parent / "phases"
+
+    if args.skill_md == "none":
+        skill_md = None
+    elif args.skill_md:
+        skill_md = Path(args.skill_md)
+    else:
+        # Default: the SKILL.md beside the phases dir. Absent (a bare temp
+        # fixture) means "nothing to cross-check", not a failure.
+        candidate = phases_dir.parent / "SKILL.md"
+        skill_md = candidate if candidate.is_file() else None
 
     if not phases_dir.is_dir():
         return cannot_check(f"phases directory not found: {phases_dir}")
@@ -203,6 +219,47 @@ def main() -> int:
                 "these phase files are never reached by walking the chain from "
                 f"{heads[0]}: {', '.join(unreached)}. A phase nothing points to "
                 "never runs for anybody."
+            )
+
+    # ---- 7: the chain must agree with SKILL.md's routing table --------------
+    # Two sources of truth for the same order is the drift this repo already
+    # learned about on close phases (#400/#415): each file stays internally
+    # consistent while they disagree with each other, and nothing errors. The
+    # footers now DRIVE execution, so a table that disagrees is documentation
+    # that lies -- and a reordered footer would pass every check above.
+    if len(heads) == 1 and not violations and skill_md is not None:
+        if not skill_md.is_file():
+            return cannot_check(f"SKILL.md not found at {skill_md}")
+        try:
+            skill_text = skill_md.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            return cannot_check(f"cannot read {skill_md}: {exc}")
+
+        # Document order, de-duplicated (23.5 and 24 re-cite the final file).
+        table: list[str] = []
+        for m in re.finditer(r"phases/(phase-[A-Za-z0-9._-]+\.md)", skill_text):
+            name = m.group(1)
+            if name not in table:
+                table.append(name)
+
+        walked = []
+        cur = heads[0]
+        while cur is not None:
+            walked.append(cur)
+            cur = nxt.get(cur)
+
+        if not table:
+            violations.append(
+                f"{skill_md.name} names no phase files at all; the routing table "
+                f"cannot be cross-checked against the chain."
+            )
+        elif table != walked:
+            violations.append(
+                "the phase chain and the SKILL.md routing table disagree about "
+                "order.\n         chain: " + " -> ".join(walked) +
+                "\n         table: " + " -> ".join(table) +
+                "\n         The footers drive execution, so the table is the one "
+                "describing something that no longer happens."
             )
 
     if violations:

--- a/skills/diagnose/SKILL.md
+++ b/skills/diagnose/SKILL.md
@@ -81,7 +81,7 @@ Most "Claude is broken" reports trace to one of:
 |---|---|---|---|
 | 1 | CLAUDE.md present + has Vault Map | Re-run /setup-brain Phase 4 | Add the Vault Map section by hand |
 | 2 | ⚙️ Meta/ + scripts/ + rules/ present | Re-run /setup-brain Phase 3 | Create the missing subfolder |
-| 3 | ai-brain-starter + daily-journal skills installed | Re-run bootstrap | Install the missing skill from its phase |
+| 3 | ai-brain-starter + daily-journal skills installed | Re-run bootstrap | **A missing `daily-journal` is usually a STALLED INSTALL, not a missing skill.** That skill is built in Phase 10a, so its absence means setup stopped before Phase 10 and every later phase never ran. Do not tell them to install one skill — that leaves the rest of the install missing. Point them at `docs/RESUME_INSTALL.md` and offer to resume. Only treat it as a genuinely missing skill if the vault also shows Phase 18+ artifacts (`⚙️ Meta/journal-index.json`), which would mean the install DID get past 10 |
 | 4 | Hooks registered + graph-context-hook parses | Phase 5 wires hooks; bash -n the script | - |
 | 5 | journal-index.json valid + fresh | Delete and rebuild via build-journal-index.py | Re-run /weekly to refresh |
 | 6 | git, python3 (jq optional) on PATH | brew install / winget install | Optional tools missing |
@@ -102,6 +102,7 @@ Most "Claude is broken" reports trace to one of:
 - User says "the journal entries aren't showing up in /weekly"
 - User says "I just did a git pull and something feels off"
 - User says "my friend installed it but it's broken"
+- User says "I never got the interview" / "setup said it was done but nothing happened" / "my CLAUDE.md is empty" / "nunca llegué a la entrevista" (a STALLED INSTALL — setup stopped partway and reported success. Do not diagnose it as N separate missing pieces; send them to `docs/RESUME_INSTALL.md` and resume from where the vault says they stopped)
 - User says "Obsidian keeps crashing when I open it" / "Obsidian won't open" (likely a heavy-indexer renderer OOM on a large vault - check 13)
 - User says "my brain feels stale" / "I haven't seen any new Granola/WhatsApp/Slack/Gmail notes in a while" / "<source> stopped showing up" (likely a silently-empty connector - check 14b)
 - User says "Obsidian melted / pegged the CPU after I opened a Claude Desktop session" / "the vault doubled itself" / "there's a `.claude/worktrees` folder full of copies of my vault" (likely a worktree-on-vault checkout - check 17; relaunch PLAIN with the worktree box unchecked)

--- a/tests/integration/test_phase_chain_contract.sh
+++ b/tests/integration/test_phase_chain_contract.sh
@@ -183,8 +183,33 @@ rc="$(run_checker "$TMP/does-not-exist")"
 [ "$rc" = "2" ] && ok "a missing phases dir exits 2 (fail loud)" \
   || fail "missing phases dir should exit 2, got $rc"
 
+# --- 11. NEGATIVE: the chain and SKILL.md's routing table disagree ----------
+# Two sources of truth for one order. The footers drive execution now, so a
+# table that drifts is documentation that lies, and every check above passes.
+mk_chain "$TMP/tabledrift"
+cat > "$TMP/tabledrift/SKILL.md" <<'EOF'
+# Routing table
+| 0 | `phases/phase-00-a.md` |
+| 2 | `phases/phase-02-c.md` |
+| 1 | `phases/phase-01-b.md` |
+EOF
+rc="$(python3 "$CHECKER" --phases-dir "$TMP/tabledrift" --skill-md "$TMP/tabledrift/SKILL.md" >/dev/null 2>&1; echo $?)"
+[ "$rc" = "1" ] && ok "a routing table that disagrees with the chain is rejected" \
+  || fail "chain/table order drift NOT caught (exit $rc)"
+
+# --- 12. POSITIVE: a table that agrees passes -------------------------------
+cat > "$TMP/tabledrift/SKILL.md" <<'EOF'
+# Routing table
+| 0 | `phases/phase-00-a.md` |
+| 1 | `phases/phase-01-b.md` |
+| 2 | `phases/phase-02-c.md` |
+EOF
+rc="$(python3 "$CHECKER" --phases-dir "$TMP/tabledrift" --skill-md "$TMP/tabledrift/SKILL.md" >/dev/null 2>&1; echo $?)"
+[ "$rc" = "0" ] && ok "a routing table that agrees passes (not just always-red)" \
+  || fail "agreeing table wrongly rejected (exit $rc)"
+
 if [ "$failed" -eq 0 ]; then
-  echo "PASS: phase-chain contract holds, and the checker rejects all 7 break modes."
+  echo "PASS: phase-chain contract holds, and the checker rejects all 8 break modes."
   exit 0
 fi
 echo "FAILED" >&2


### PR DESCRIPTION
Two follow-ons to #503, both found by asking what the first fix left open.

## 1. The routing table became a second source of truth

#503 made the phase footers DRIVE execution. That left `SKILL.md`'s routing table describing the same order without anything holding the two together — the exact drift this repo already learned about on close phases (#400/#415), where both files stay internally consistent while disagreeing with each other and nothing errors.

Concretely: **a reordered footer passed every check in #503.** The chain was still valid, so the guard was green while the documented order was wrong.

`check-phase-chain.py` now walks the chain and compares it to the table's document order, printing both sequences on mismatch. It skips when no `SKILL.md` sits beside the phases dir, so a bare temp fixture does not false-fail.

## 2. /diagnose prescribed a repair that does not repair

Check 3 read a missing `daily-journal` skill as a missing **skill**. That skill is built in Phase 10a, so its absence almost always means the install **stopped before Phase 10** and fifteen phases never ran.

The old remedy — *"install the missing skill from its phase"* — fixes one symptom and leaves the rest of the install missing. The user follows the advice, the check goes green, and their brain is still two-thirds unbuilt.

It now names the stall, points at `docs/RESUME_INSTALL.md`, and preserves the genuinely-missing-skill reading only when Phase 18+ artifacts (`journal-index.json`) prove the install got past 10. The "I never got the interview" phrasings (EN + ES) are added to the proactive-trigger list.

**Deliberately not in this PR:** a programmatic stalled-install check inside `diagnose.sh`/`diagnose.ps1`. That needs cross-platform parity and its own test surface, and rushing it is how a Windows-only gap ships. Filed separately on the tracker.

## Verification

| Check | Result |
|---|---|
| `test_phase_chain_contract.sh` | 13/13 |
| ↳ NEGATIVE: swapped table order | rejected (exit 1) |
| ↳ POSITIVE control on same mutation | agreeing table passes — the check is not always-red |
| `check-utf8-stdout.py` / `check-utf8-subprocess.py` | exit 0 |
| `check-phase-python.py`, `py_compile` | exit 0 |
| `scripts/shellcheck.sh` (-S warning, 193 files) | clean |
| personal-data + key scrub | 0 hits |

🤖 Generated with [Claude Code](https://claude.com/claude-code)