### PR TITLE
fix(windows): the SessionStart boundedness audit resolved nothing on Windows (MYC-3879)

### DIFF
--- a/scripts/audit-sessionstart-boundedness.py
+++ b/scripts/audit-sessionstart-boundedness.py
@@ -58,8 +58,11 @@ Modes:
   --selftest        Positive + negative controls: a corpus walk with no guards
                     BITES; one stamping AFTER the walk BITES; one with all three
                     guards PASSES; one carrying the exemption annotation PASSES; a
-                    no-walk hook PASSES; a shell walk with no timeout BITES. Exit 1
-                    on any wrong verdict.
+                    no-walk hook PASSES; a shell walk with no timeout BITES. Plus
+                    resolver controls: the Windows launcher-shim command form
+                    resolves to the TARGET hook (not to hook_runner.py), and an
+                    unresolvable command still resolves to None (skipped, never
+                    counted bounded). Exit 1 on any wrong verdict.
   --json            machine-readable output (with --all).
 
 Stdlib only. Reads are bounded (1 MB cap, binary skip) - cloud-safe-walk
@@ -380,24 +383,91 @@ def sessionstart_commands(settings_path: Path) -> list[str]:
     return out
 
 
+# Every script path a command names, quoted or bare, in command order. THREE path
+# forms have to parse, because the Windows leg of the installer
+# (install-hooks-user-level.py) rewrites every hook command into a launcher shim:
+#
+#   POSIX bare      python3 ~/.claude/hooks/x.py 2>/dev/null || echo '{...}'
+#   POSIX guarded   [ -f ~/.claude/hooks/x.sh ] && bash ~/.claude/hooks/x.sh
+#   Windows shim    py -3 "C:\...\scripts\hook_runner.py" --fallback silent "C:\...\hooks\x.py"
+#
+# The pre-fix matcher required a literal `python`/`python3`/`bash`/`sh`/`zsh`
+# token, OR a forward slash inside the quotes, OR a `~`/`/` first character. The
+# Windows form has none of the three (`py -3` is the launcher, paths are
+# backslashed drive letters), so resolve_command_path() returned None for it and
+# the EFFECTIVE-set audit evaluated essentially nothing on every Windows install:
+# measured on a real box, 19 of 25 wired SessionStart commands resolved to
+# nothing. Same silent-no-op class as issues #370/#375/#485 (MYC-3879).
+#
+# Kept structurally parallel to _GUARD_PATH_RE in scripts/heal-journal-guard.py:
+# quoted alternatives first (a Windows home MAY contain a space), bare last (an
+# unquoted path ends at whitespace or a shell operator). Roots accepted: `~`,
+# POSIX `/`, a UNC `\\share`, a drive letter. Over-matching stays harmless — the
+# caller still stats the path — but a BARE path may only start where a token can,
+# else `./hooks/x.py` would match at its inner `/` and a cwd-relative command
+# would resolve to a bogus absolute `/hooks/x.py`.
+_SCRIPT_TOKEN_RE = re.compile(
+    r"\"([^\"\n]+\.(?:py|sh|bash))\""
+    r"|'([^'\n]+\.(?:py|sh|bash))'"
+    r"|(?<![^\s'\"|&;(=])((?:~|/|\\\\|[A-Za-z]:[\\/])[^\s'\"|&;]*\.(?:py|sh|bash))"
+)
+_RUNNER_SHIM_RE = re.compile(r"(?:^|[\\/])hook_runner\.py$", re.IGNORECASE)
+_DRIVE_ABS_RE = re.compile(r"^[A-Za-z]:[\\/]")
+
+
+def _script_tokens(cmd: str) -> list[str]:
+    """Script-looking paths in `cmd`, in command order."""
+    return [next(g for g in m.groups() if g) for m in _SCRIPT_TOKEN_RE.finditer(cmd)]
+
+
+def _absolute_or_none(raw: str) -> Path | None:
+    """Expand `~` and accept a path that is absolute in EITHER flavour.
+
+    Path.is_absolute() is flavour-BOUND: on Windows `/a/b` is not absolute (no
+    drive) and on POSIX `C:\\a\\b` is not absolute (no root). Leaning on it alone
+    would make this verdict depend on which OS runs the auditor; judging the
+    string keeps resolution platform-independent and unit-testable from POSIX CI.
+    A path that does not exist on THIS host is still counted unresolved by the
+    caller, which stats it.
+
+    Anything relative / cwd-dependent stays None: reported as unresolved, NEVER
+    silently treated as bounded."""
+    p = raw.strip()
+    if p.startswith("~"):
+        p = str(Path.home()) + p[1:]
+    if _DRIVE_ABS_RE.match(p) or p.startswith(("/", "\\\\")):
+        return Path(p)
+    return Path(p) if Path(p).is_absolute() else None
+
+
 def resolve_command_path(cmd: str) -> Path | None:
     """Best-effort resolve the script a SessionStart command runs, to an ABSOLUTE
-    path. Handles `python3 ~/.claude/hooks/x.py --flag`, quoted paths, and a
-    leading `[ -f X ] && ...` guard. Returns None when no path is found OR it is
-    not absolute after expanduser — a relative/cwd-dependent command is reported
-    as unresolved, NEVER silently treated as bounded."""
-    for rx in (r"(?:python3?|bash|sh|zsh)\s+(?:-\w+\s+)*['\"]([^'\"]+\.(?:py|sh|bash))['\"]",
-               r"(?:python3?|bash|sh|zsh)\s+(?:-\w+\s+)*([^\s'\"]+\.(?:py|sh|bash))",
-               r"['\"]([^'\"]*?/[^'\"]+\.(?:py|sh|bash))['\"]",
-               r"([~/][^\s'\"]*\.(?:py|sh|bash))"):
-        m = re.search(rx, cmd)
-        if m:
-            p = m.group(1)
-            if p.startswith("~"):
-                p = str(Path.home()) + p[1:]
-            pp = Path(p)
-            return pp if pp.is_absolute() else None
-    return None
+    path. Handles `python3 ~/.claude/hooks/x.py --flag`, quoted paths, a leading
+    `[ -f X ] && ...` guard, Windows drive-letter paths, and the Windows launcher
+    shim. Returns None when no path is found OR it is not absolute after
+    expanduser — a relative/cwd-dependent command is reported as unresolved,
+    NEVER silently treated as bounded.
+
+    hook_runner.py is a LAUNCHER, not a hook: on Windows every command reads
+    `py -3 "<abs>/scripts/hook_runner.py" --fallback silent "<abs>/hooks/x.py"`,
+    and the shim only re-execs the target with the payload on stdin. So a command
+    that goes through the shim resolves to its TARGET — the first script path
+    AFTER the shim, matching hook_runner's own argv handling
+    (`[--fallback MODE] <target> [extra...]`). Resolving to the shim instead
+    would be WORSE than not resolving at all: the launcher is walk-free and
+    identical for all 19 hooks, so the audit would read one trivially-clean file
+    19 times and report a clean fleet having never opened a hook. That is not
+    hypothetical — the installer's launcher is `python`/`python3` where `py` is
+    absent, and the pre-fix matcher DID resolve that form, straight to the shim."""
+    toks = _script_tokens(cmd)
+    if not toks:
+        return None
+    shim = next((i for i, t in enumerate(toks) if _RUNNER_SHIM_RE.search(t)), None)
+    if shim is not None:
+        target = next((t for t in toks[shim + 1:] if not _RUNNER_SHIM_RE.search(t)), None)
+        if target:  # no target at all -> the shim IS what runs; fall through
+            return _absolute_or_none(target)
+    return _absolute_or_none(toks[0])
 
 
 def cmd_settings(settings_path: Path, porcelain: bool) -> int:
@@ -525,6 +595,86 @@ _FX_SH_MAXDEPTH2 = """#!/usr/bin/env bash
 find ~/x -maxdepth 2 -name '.draft' -type f   # depth-bounded, not the corpus-walk freeze class
 """
 
+# ---- resolver fixtures (the Windows launcher-shim form, MYC-3879) -------------
+# EXACTLY the shape install-hooks-user-level.py emits on Windows:
+#     " ".join([*launcher, f'"{runner}"', "--fallback", fb, f'"{target}"'])
+# Hermetic absolute paths — never this machine's home — so the controls assert the
+# same thing on Windows and in POSIX CI. The win-* cases all resolve to None on
+# the pre-fix matcher: they are the negative control for that bug.
+_RX_RUNNER = r"C:\Users\dev\.claude\skills\ai-brain-starter\scripts\hook_runner.py"
+_RX_TARGET = r"C:\Users\dev\.claude\skills\ai-brain-starter\hooks\session-start-context.py"
+_RX_TARGET_SPACED = r"C:\Users\dev user\.claude\skills\ai-brain-starter\hooks\inject-instinct-context.py"
+_FX_WIN_SHIM = f'py -3 "{_RX_RUNNER}" --fallback silent "{_RX_TARGET}"'
+_FX_WIN_SHIM_SPACED = f'py -3 "{_RX_RUNNER}" --fallback allow "{_RX_TARGET_SPACED}"'
+_FX_WIN_SHIM_PY3 = f'python3 "{_RX_RUNNER}" --fallback silent "{_RX_TARGET}"'
+_FX_POSIX_CHAIN = ("python3 ~/.claude/skills/ai-brain-starter/hooks/surface-backup-status.py "
+                   "2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'")
+_FX_POSIX_GUARD = ("[ -f ~/.claude/hooks/check-claude-code-version.sh ] && "
+                   "bash ~/.claude/hooks/check-claude-code-version.sh || true")
+
+
+def _selftest_resolver() -> list[str]:
+    """Controls for resolve_command_path(). Returns failure lines (empty == pass).
+
+    Every case is an EQUALITY assertion, so a resolver that resolves NOTHING
+    cannot pass one by accident — the shape this guards against is precisely the
+    MYC-3879 bug, where 19 of 25 wired Windows commands silently resolved to None
+    and the effective-set audit evaluated an empty fleet while still printing OK."""
+    fails: list[str] = []
+
+    # --- premise guards: fixtures that rot into proving nothing must fail LOUD --
+    if _RX_RUNNER == _RX_TARGET or not _RX_RUNNER.endswith("hook_runner.py"):
+        fails.append("premise: the shim fixtures must name hook_runner.py AND a "
+                     "DIFFERENT target, else 'resolves to the target' is vacuous")
+    for lbl, fx, tgt in (("silent", _FX_WIN_SHIM, _RX_TARGET),
+                         ("allow+space", _FX_WIN_SHIM_SPACED, _RX_TARGET_SPACED),
+                         ("python3-launcher", _FX_WIN_SHIM_PY3, _RX_TARGET)):
+        if not (_RX_RUNNER in fx and tgt in fx and fx.index(_RX_RUNNER) < fx.index(tgt)):
+            fails.append(f"premise[{lbl}]: fixture must carry the launcher BEFORE a "
+                         f"different target: {fx!r}")
+        if "--fallback" not in fx or '"' not in fx:
+            fails.append(f"premise[{lbl}]: fixture is not the installer's quoted "
+                         f"`--fallback` launcher form: {fx!r}")
+    # Parity with the EMITTER. These fixtures only mean something while the Windows
+    # installer still wraps hooks in hook_runner.py with --fallback; if it stops,
+    # the shim rule above is stale and this must fail rather than keep asserting a
+    # shape nobody writes. An ABSENT installer is a standalone deployed copy of
+    # this script — the structural guards above still hold, so that is not a fail.
+    installer = Path(__file__).resolve().parent / "install-hooks-user-level.py"
+    if installer.exists():
+        isrc = _read_bounded(installer)
+        if not ("hook_runner" in isrc and "--fallback" in isrc):
+            fails.append("premise: install-hooks-user-level.py no longer emits the "
+                         "hook_runner `--fallback` launcher form — the shim rule in "
+                         "resolve_command_path() is stale")
+
+    home = str(Path.home())
+    cases = [
+        # Windows: must resolve to the TARGET hook, never to the launcher shim.
+        ("win shim -> target, not launcher", _FX_WIN_SHIM, Path(_RX_TARGET)),
+        ("win shim, space in home", _FX_WIN_SHIM_SPACED, Path(_RX_TARGET_SPACED)),
+        ("win shim, python3 launcher", _FX_WIN_SHIM_PY3, Path(_RX_TARGET)),
+        ("win bare drive-letter path", r"py -3 C:\Users\dev\.claude\hooks\x.py",
+         Path(r"C:\Users\dev\.claude\hooks\x.py")),
+        ("win shim, no target -> the shim", f'py -3 "{_RX_RUNNER}"', Path(_RX_RUNNER)),
+        # POSIX forms that already worked: regression controls.
+        ("posix tilde + fallback chain", _FX_POSIX_CHAIN,
+         Path(home + "/.claude/skills/ai-brain-starter/hooks/surface-backup-status.py")),
+        ("posix [ -f ] && guard form", _FX_POSIX_GUARD,
+         Path(home + "/.claude/hooks/check-claude-code-version.sh")),
+        ("posix absolute path", "python3 /Users/d/.claude/hooks/x.py",
+         Path("/Users/d/.claude/hooks/x.py")),
+        # Unresolvable stays unresolvable — reported as SKIPPED, never as bounded.
+        ("relative -> unresolved", "python3 hooks/x.py", None),
+        ("dot-relative -> unresolved", "python3 ./hooks/x.py", None),
+        ("no script named -> unresolved", "echo hello", None),
+    ]
+    for label, cmd, want in cases:
+        got = resolve_command_path(cmd)
+        if got != want:
+            fails.append(f"resolve[{label}]: wanted {want!r}, got {got!r}  cmd={cmd!r}")
+    return fails
+
 
 def cmd_selftest() -> int:
     cases = [
@@ -547,13 +697,16 @@ def cmd_selftest() -> int:
             fails.append(f"{label}: wanted {'BITE' if want_bite else 'PASS'}, "
                          f"got {'BITE' if bites else 'PASS'} (walks={v['walks']}, "
                          f"missing={v['missing']}, exempt={v['exempt']})")
+    fails += _selftest_resolver()
     if fails:
         print("SELFTEST FAIL:")
         for f in fails:
             print("  - " + f)
         return 1
     print("SELFTEST PASS: detector bites unguarded + stamp-after corpus walks, "
-          "passes 3-guard / exempt / no-walk hooks (py + sh).")
+          "passes 3-guard / exempt / no-walk hooks (py + sh); resolver reaches the "
+          "TARGET hook through the Windows launcher shim and still skips "
+          "unresolvable commands.")
     return 0
 
 

--- a/scripts/audit-sessionstart-boundedness.py
+++ b/scripts/audit-sessionstart-boundedness.py
@@ -265,9 +265,24 @@ def evaluate(src: str, lang: str = "py") -> dict:
 
 
 # ---- SessionStart set resolution ----------------------------------------------
+# hook_runner.py is the Windows installer's launcher shim, never a hook itself —
+# see resolve_command_path() for the full why. Both resolvers in this file have to
+# skip it, or a platformized hooks.json resolves EVERY entry to the launcher.
+_RUNNER_SHIM_RE = re.compile(r"(?:^|[\\/])hook_runner\.py$", re.IGNORECASE)
+
+
 def _basename(cmd: str) -> str | None:
-    m = re.search(r"([\w.\-]+\.(?:py|sh|bash))", cmd)
-    return m.group(1) if m else None
+    """The hook script's basename — the launcher's, only when it launches nothing.
+
+    --all reads a hooks.json, which ships in POSIX form, so the shim skip is
+    latent there today. It is still wrong to leave: pointed at a platformized
+    file, EVERY entry would resolve to hook_runner.py, none would be found under
+    --hooks-dir, and the gate would report an empty fleet and exit 0 — the silent
+    pass this whole script exists to prevent."""
+    names = re.findall(r"([\w.\-]+\.(?:py|sh|bash))", cmd)
+    if not names:
+        return None
+    return next((n for n in names if not _RUNNER_SHIM_RE.search(n)), names[0])
 
 
 def sessionstart_basenames(hooks_json: Path) -> list[str]:
@@ -411,8 +426,7 @@ _SCRIPT_TOKEN_RE = re.compile(
     r"|'([^'\n]+\.(?:py|sh|bash))'"
     r"|(?<![^\s'\"|&;(=])((?:~|/|\\\\|[A-Za-z]:[\\/])[^\s'\"|&;]*\.(?:py|sh|bash))"
 )
-_RUNNER_SHIM_RE = re.compile(r"(?:^|[\\/])hook_runner\.py$", re.IGNORECASE)
-_DRIVE_ABS_RE = re.compile(r"^[A-Za-z]:[\\/]")
+_DRIVE_ABS_RE = re.compile(r"^[A-Za-z]:[\\/]")  # _RUNNER_SHIM_RE: see _basename above
 
 
 def _script_tokens(cmd: str) -> list[str]:
@@ -673,6 +687,17 @@ def _selftest_resolver() -> list[str]:
         got = resolve_command_path(cmd)
         if got != want:
             fails.append(f"resolve[{label}]: wanted {want!r}, got {got!r}  cmd={cmd!r}")
+
+    # _basename() is the OTHER resolver (--all): it must skip the shim too, or a
+    # platformized hooks.json resolves every entry to the launcher and --all
+    # audits an empty fleet.
+    for label, cmd, want in (("win shim", _FX_WIN_SHIM, "session-start-context.py"),
+                             ("posix chain", _FX_POSIX_CHAIN, "surface-backup-status.py"),
+                             ("shim only", f'py -3 "{_RX_RUNNER}"', "hook_runner.py"),
+                             ("no script", "echo hello", None)):
+        got = _basename(cmd)
+        if got != want:
+            fails.append(f"basename[{label}]: wanted {want!r}, got {got!r}")
     return fails
 
 

--- a/tests/integration/test_sessionstart_boundedness.sh
+++ b/tests/integration/test_sessionstart_boundedness.sh
@@ -161,6 +161,51 @@ else
   bad "fail-loud on missing settings.json" "expected exit 2"
 fi
 
+echo "=== 6. WINDOWS launcher-shim command form is audited end-to-end (MYC-3879) ==="
+# On Windows the installer wires EVERY hook through a launcher shim:
+#   py -3 "<abs>/scripts/hook_runner.py" --fallback silent "<abs>/<hook>.py"
+# The pre-fix resolver matched no part of that shape, so the effective-set audit
+# skipped 19 of 25 wired commands on a real box and still printed OK. Worse, where
+# `py` is absent the installer falls back to a `python`/`python3` launcher, which
+# the old matcher DID resolve -- to the LAUNCHER. hook_runner.py is walk-free, so
+# an unguarded corpus walker behind it read as a clean hook. Both legs below.
+RUNNER="$REPO_ROOT/scripts/hook_runner.py"
+cat > "$EFF/settings_win_bad.json" <<JSON
+{"hooks": {"SessionStart": [{"hooks": [
+  {"type": "command", "command": "py -3 \"$RUNNER\" --fallback silent \"$EFF/evil-eff.py\""}
+]}]}}
+JSON
+cat > "$EFF/settings_win_py3.json" <<JSON
+{"hooks": {"SessionStart": [{"hooks": [
+  {"type": "command", "command": "python3 \"$RUNNER\" --fallback silent \"$EFF/evil-eff.py\""}
+]}]}}
+JSON
+cat > "$EFF/settings_win_ok.json" <<JSON
+{"hooks": {"SessionStart": [{"hooks": [
+  {"type": "command", "command": "py -3 \"$RUNNER\" --fallback silent \"$EFF/good-eff.py\""}
+]}]}}
+JSON
+# The walker is BEHIND the shim. Resolving to the shim (or to nothing) yields
+# OK:*; only resolving to the TARGET can produce UNGUARDED. One assertion, both
+# failure modes.
+for leg in win_bad win_py3; do
+  if python3 "$AUDIT" --settings "$EFF/settings_$leg.json" --porcelain 2>/dev/null \
+     | grep -q '^UNGUARDED:1:evil-eff.py'; then
+    ok "shim form ($leg): unguarded walker behind the launcher is CAUGHT"
+  else
+    bad "shim form ($leg) caught" \
+      "audit resolved the launcher or nothing, not the target hook (MYC-3879 regression)"
+  fi
+done
+# ...and a bounded hook behind the shim resolves and passes, with 0 unresolved:
+# a resolver that skipped the whole form would report OK:0:0:1 here.
+if python3 "$AUDIT" --settings "$EFF/settings_win_ok.json" --porcelain 2>/dev/null \
+   | grep -q '^OK:1:0:0'; then
+  ok "shim form: bounded hook resolves (0 unresolved)"
+else
+  bad "shim form resolves" "expected OK:1:0:0 (a skipped shim form would be OK:0:0:1)"
+fi
+
 echo
 echo "=== summary: $PASS passed, $FAIL failed ==="
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## What does this PR do?

Makes `scripts/audit-sessionstart-boundedness.py` able to resolve the hook-command form the Windows installer actually writes, so the effective-set audit (`--settings`) stops evaluating an essentially empty fleet on every Windows install.

## The bug

`resolve_command_path()` had four regexes. None matched the shape `install-hooks-user-level.py` emits on Windows:

```
py -3 "C:\...\scripts\hook_runner.py" --fallback silent "C:\...\hooks\<hook>.py"
```

Two required a literal `python`/`python3`/`bash`/`sh`/`zsh` token (`py -3` is the Windows launcher), one required a forward slash inside the quotes, one required a `~` or `/` first character — Windows paths are backslashed drive letters.

Measured on a real Windows install (read-only against the live `~/.claude/settings.json`): **19 of 25 wired SessionStart commands resolved to nothing**, and 14 unique hooks were never opened — including both that do a recursive walk. The audit still printed `OK`.

There is a worse leg. Where `py` is absent the installer falls back to a `python`/`python3` launcher, and the old matcher **did** resolve that — straight to `hook_runner.py`. The launcher is walk-free and identical for all 19 hooks, so the audit would read one trivially-clean file 19 times and report a clean fleet having never opened a hook. Silently wrong beats silently skipped.

Same structurally-dead-guard class as #370 / #375 / #485 and MYC-3875/3876. Sibling of #501 (MYC-3880), which cites this idiom — note this file itself was still unfixed upstream while #501 referenced it.

## The fix

- Four regexes → one ordered path tokenizer, structurally parallel to `_GUARD_PATH_RE` in `scripts/heal-journal-guard.py`: quoted alternatives first (a Windows home may contain a space), bare last, rooted at `~`, POSIX `/`, a UNC `\\share`, or a drive letter.
- A bare path may only start where a token can, so `./hooks/x.py` no longer matches at its inner `/` and resolve to a bogus absolute `/hooks/x.py`. Relative commands stay unresolved, never counted bounded.
- A command through the shim resolves to its **target** — the first script path after the shim, matching `hook_runner`'s own argv handling (`[--fallback MODE] <target> [extra...]`), so it stays correct if a hook ever takes arguments.
- Absoluteness is judged on the string, not `Path.is_absolute()`, which is flavour-bound (`/a/b` is not absolute on Windows, `C:\a\b` is not on POSIX) and would otherwise make the verdict depend on which OS runs the auditor — and make these controls unassertable from POSIX CI.
- Second commit closes the same blindness in `_basename()`, the resolver `--all` uses. Latent today (`hooks.json` ships POSIX), but pointed at a platformized file every entry would resolve to the launcher, none would be found under `--hooks-dir`, and the gate would report an empty fleet and exit 0 — the silent pass this script exists to prevent.

## Verification

- `--settings` against the live Windows `settings.json`: `19 of 25 unresolved` → **`OK:19:1:0`, zero unresolved**. All 20 unique hooks now read *and* evaluated; the walk detector is genuinely exercised on the newly visible set (`worktree-footprint-signal.py`, os.walk with all three guards; `surface-orphan-worktree-snapshots.py`, declared-bounded). No unguarded corpus walker was hiding among them.
- Old-vs-new resolver sweep over **all 61 commands across 7 events** in `hooks.json`: zero behaviour change.
- `--selftest` gains 15 resolver + 4 basename controls (all three shim shapes incl. a spaced home and a `python3` launcher, bare drive-letter, POSIX regression controls, three unresolvable-stays-skipped). Every case is an equality assertion, so a resolver that resolves *nothing* cannot pass one by accident — which is precisely this bug. Fixtures are premise-guarded, and each guard was verified to bite by degrading the fixture and the resolver in turn.
- `test_sessionstart_boundedness.sh` gains section 6: an unguarded walker wired **behind** the shim must trip `UNGUARDED:1:evil-eff.py`. Resolving to the launcher (walk-free) or to nothing both yield `OK:*`, so one assertion covers both failure modes. Both launcher legs (`py -3` and `python3`) are covered.
- `py_compile`, `check-utf8-stdout`, `check-utf8-subprocess`, `check-hook-negative-control`, `check-hook-activation --selftest` all clean; `shellcheck` clean and `bash -n` parses the edited test.

The integration suite was not executed locally (it rewrites the developer's live `settings.json`). Section 6's heredocs, quoting and grep pipeline were run verbatim in bash against dual-resolvable paths — 3/3 pass — and the assertions were proven to bite against the pre-fix resolver, which reports `OK:0:0:1`.

## Which file(s) changed?

- [x] Other: `scripts/audit-sessionstart-boundedness.py`, `tests/integration/test_sessionstart_boundedness.sh`

## Is this a breaking change?

- [x] No — a stricter audit only. On POSIX, resolution is byte-identical (proven by the 61-command sweep). On Windows the audit starts evaluating hooks it previously skipped, so an install with a genuinely unguarded SessionStart corpus walker will now fail the gate — which is the point.

## Did you update `docs/CHANGELOG.md`?

- [x] Not needed (bug fix, consistent with #498 / #499 / #501)

## Checklist

- [x] No personal data, vault paths, or API keys included
- [x] The pattern is universal (works for any user, not just one setup)
- [x] SKILL.md changes don't break the existing phase flow (n/a)
- [x] Tested manually (see Verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
