### PR TITLE
fix(windows): the snapshot guard's own remediation line was unrunnable on Windows (MYC-3880)

### DIFF
--- a/hooks/sessionstart-hook-snapshot-guard.py
+++ b/hooks/sessionstart-hook-snapshot-guard.py
@@ -65,6 +65,7 @@ Behavior:
 from __future__ import annotations
 
 import json
+import os
 import re
 import sys
 from pathlib import Path, PureWindowsPath
@@ -375,6 +376,25 @@ def _self_test() -> int:
         fails.append("snapshot: a v2 snapshot must re-baseline, never re-normalize -- "
                      "its collapsed Windows entry matches no current identity")
 
+    # -- the remediation line must be runnable on the platform that PRINTS it ---
+    # A warning whose one prescribed action cannot be run is a warning that trains
+    # people to ignore it -- the same cry-wolf failure this guard's de-noising
+    # exists to prevent.
+    hint = _refresh_hint()
+    if "~" in hint:
+        fails.append(f"refresh hint: carries an unexpanded `~` (PowerShell does not "
+                     f"expand it in an argument): {hint!r}")
+    if str(Path(__file__).resolve()) not in hint:
+        fails.append(f"refresh hint: must name THIS copy's absolute path: {hint!r}")
+    if hint.startswith(('"', "'")):
+        fails.append(f"refresh hint: a quoted FIRST token is a string literal in "
+                     f"PowerShell, so the launcher must stay bare: {hint!r}")
+    if not hint.endswith(" --refresh"):
+        fails.append(f"refresh hint: does not actually pass --refresh: {hint!r}")
+    if (hint.split()[0] == "py") != (os.name == "nt"):
+        fails.append(f"refresh hint: launcher does not match this platform "
+                     f"(os.name={os.name!r}): {hint!r}")
+
     if fails:
         print("SELF-TEST FAIL:")
         for f in fails:
@@ -385,6 +405,26 @@ def _self_test() -> int:
           f"identities), POSIX de-noise forms still collapse, keys are untruncated, and "
           f"a pre-v{SNAPSHOT_V} snapshot re-baselines instead of crying wolf.")
     return 0
+
+
+def _refresh_hint() -> str:
+    """The remediation command, in a form the LOCAL shell actually parses.
+
+    This line was hardcoded as `python3 ~/.claude/hooks/<this>.py --refresh`, which
+    is unrunnable on Windows three ways over: there is no `python3` on PATH (the
+    installer probes `py -3` first for exactly that reason), PowerShell does not
+    expand `~` in an argument, and the hook is installed under
+    ~/.claude/skills/ai-brain-starter/hooks/, not ~/.claude/hooks/. So the single
+    action this warning asks for could not be performed on the platform where the
+    guard was ALSO silently broken (MYC-3880) -- and now that the guard is actually
+    wired, that is the first thing a Windows user sees when it fires.
+
+    The launcher stays BARE and only the path is quoted: a quoted first token is a
+    string literal in PowerShell, the same rule scripts/hook_runner.py documents.
+    __file__ rather than a literal path, so it names wherever this copy really is."""
+    script = Path(__file__).resolve()
+    launcher = "py -3" if os.name == "nt" else "python3"
+    return f'{launcher} "{script}" --refresh'
 
 
 def main() -> int:
@@ -410,7 +450,7 @@ def main() -> int:
         print(f"[sessionstart-hook-guard] WARNING: {len(missing)} SessionStart hook(s) missing since last snapshot:")
         for ident in sorted(missing):
             print(f"  - {_label(ident)}")
-        print("[sessionstart-hook-guard] If intentional: `python3 ~/.claude/hooks/sessionstart-hook-snapshot-guard.py --refresh`. If not: re-add the missing hook(s).")
+        print(f"[sessionstart-hook-guard] If intentional: `{_refresh_hint()}`. If not: re-add the missing hook(s).")
         # Do NOT update snapshot - leave it so the warning persists until reconciled.
         return 0
 

--- a/tests/integration/test_sessionstart_hook_snapshot_guard.sh
+++ b/tests/integration/test_sessionstart_hook_snapshot_guard.sh
@@ -265,6 +265,38 @@ run_guard "$H6"
 assert_warns "post-migration drop still warns"
 assert_has   "post-migration warning names the hook" "heal-journal-guard.py"
 
+echo "=== scenario 11: a POSIX -> Windows rewire is NOT a disappearance ==="
+# Running install-hooks-user-level.py on Windows platformizes EVERY wired command
+# in one shot. So the two wirings of one hook must yield the SAME identity, or that
+# single upgrade reads as the whole fleet vanishing at once -- the fleet-wide false
+# alarm scenario 10 guards against for v2 snapshots, reached by a different route
+# and on an install whose snapshot is already current.
+#
+# _self_test() pins this parity per command string; this pins it end to end, across
+# settings.json -> identities -> snapshot diff, which is where an integration-level
+# regression (in _current_identities or extract_sessionstart_commands) would land
+# without touching _script_identity at all.
+H7="$(newhome)"
+# literal ~ is the raw settings.json command text under test, not a path to expand
+# shellcheck disable=SC2088
+write_settings "$H7" \
+  'python3 ~/.claude/hooks/session-start-context.py 2>/dev/null || echo "{}"' \
+  'python3 ~/.claude/hooks/lint-claude-settings.py'
+run_guard "$H7"
+assert_rc     "posix baseline exits 0" 0
+assert_silent "posix baseline is silent"
+write_settings "$H7" \
+  "$(win_cmd session-start-context.py)" \
+  "$(win_cmd lint-claude-settings.py)"
+run_guard "$H7"
+assert_rc     "rewire run exits 0" 0
+assert_silent "platformizing the SAME hooks -> no false missing"
+# ...and the snapshot must still hold ONE identity per hook, not one per wiring.
+SF7="$(state_file "$H7")"
+python3 -c "import json;d=json.load(open('$SF7'));assert sorted(d['identities'])==['lint-claude-settings.py','session-start-context.py'],d" 2>/dev/null \
+  && ok "rewire leaves one identity per hook" \
+  || bad "rewire leaves one identity per hook" "$(cat "$SF7" 2>/dev/null)"
+
 echo ""
 echo "=== SUMMARY: $PASS passed, $FAIL failed ==="
 [ "$FAIL" = 0 ]


### PR DESCRIPTION
﻿## What does this PR do?

Makes the SessionStart snapshot guard's own remediation line runnable on Windows. Follow-up to #501.

## The problem

#501 fixed the guard's identity collapse **and wired the hook for the first time** — so the warning it emits is now reachable. That warning ends with:

```
If intentional: `python3 ~/.claude/hooks/sessionstart-hook-snapshot-guard.py --refresh`
```

On Windows that command fails three ways over:

- **no `python3` on PATH** — `install-hooks-user-level.py` probes `py -3` first for exactly this reason;
- **PowerShell does not expand `~`** in an argument, so the path never resolves;
- **the hook installs under `~/.claude/skills/ai-brain-starter/hooks/`**, not `~/.claude/hooks/`, so even the POSIX form names the wrong file.

The single action this warning prescribes was un-performable on the platform where the guard was also silently broken. A warning whose one prescribed action cannot be run is a warning that trains people to ignore it — the same cry-wolf failure the guard's de-noising exists to prevent.

## The fix

`_refresh_hint()` emits a form the local shell actually parses:

```
py -3 "C:\Users\<you>\.claude\skills\ai-brain-starter\hooks\sessionstart-hook-snapshot-guard.py" --refresh
```

- `py -3` on Windows, `python3` elsewhere.
- Launcher **bare**, only the path quoted — a quoted first token is a string literal in PowerShell, the rule `scripts/hook_runner.py` documents.
- Path from `__file__`, so it names wherever this copy really lives rather than a literal that is wrong on every Windows install.

## Verification

Self-test gains five controls on the emitted string: no unexpanded `~`, names this copy's absolute path, first token unquoted, actually passes `--refresh`, and the launcher matches `os.name`. **Verified to bite** — restoring the old literal fails three of the five:

```
- refresh hint: carries an unexpanded `~` (PowerShell does not expand it in an argument)
- refresh hint: must name THIS copy's absolute path
- refresh hint: launcher does not match this platform (os.name='nt')
```

`--self-test` PASS; `py_compile`, `check-utf8-stdout`, `check-utf8-subprocess`, `check-hook-negative-control`, `check-hook-activation --selftest` all clean. No other file in the repo referenced the old command form, and `test_sessionstart_hook_snapshot_guard.sh` does not assert the hint text, so it is unaffected.

## Which file(s) changed?

- [x] Other: `hooks/sessionstart-hook-snapshot-guard.py`

## Is this a breaking change?

- [x] No — the only behaviour change is the printed text. Identity, snapshot and `--refresh` paths are untouched.

## Did you update `docs/CHANGELOG.md`?

- [x] Not needed (bug fix, consistent with #498 / #499 / #501)

## Checklist

- [x] No personal data, vault paths, or API keys included
- [x] The pattern is universal (works for any user, not just one setup)
- [x] SKILL.md changes don't break the existing phase flow (n/a)
- [x] Tested manually (see Verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Added: scenario 11 — POSIX → Windows rewire is not a disappearance

Running `install-hooks-user-level.py` on Windows platformizes **every** wired command in one shot, so the two wirings of one hook must produce the same identity — otherwise that single upgrade reads as the entire fleet vanishing at once.

`_self_test()` already pins this parity per command string. Scenario 11 pins it **end to end** — `settings.json` → `_current_identities()` → snapshot diff — which is where an integration-level regression lands: a change in `_current_identities()` or `extract_sessionstart_commands()` breaks it without touching `_script_identity()`, and every unit control still passes.

It is also a distinct route to the failure scenario 10 covers. Scenario 10 is a **stale v2 snapshot** on upgrade; this is an install whose snapshot is already current and whose hooks are merely rewired — no version change involved.

**Verified to bite** — against the pre-fix identity function the same scenario prints:

```
WARNING: 2 SessionStart hook(s) missing since last snapshot:
  - lint-claude-settings.py
  - session-start-context.py
```

Reuses the existing `win_cmd` / `write_settings` / `run_guard` helpers so fixtures stay hermetic. Assertions replicated verbatim in bash against dual-resolvable paths (5/5); `bash -n` parses, `shellcheck` clean. Adds `tests/integration/test_sessionstart_hook_snapshot_guard.sh` to the changed files.
