### PR TITLE
fix: unblock main (self-comparing negative control) + attribute the real-home tripwire causally

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -621,11 +621,100 @@ print("    tripwire quiet-control: fingerprint still excludes append-only "
       "logs, lock dirs, runtime-state dotfiles and per-session scratch")
 PY
 }
+# ---- The tripwire watches a DECOY home, not the shared one ------------------
+#
+# WHY THE PER-TEST CHECK MOVED OFF THE REAL ~/.claude (2026-08-15)
+#
+# Everything above is about WHAT to watch. This is about WHOSE home, and it is
+# the half that kept failing. Fingerprinting the real ~/.claude before and after
+# each test and blaming the test that was running is attribution by WALL CLOCK,
+# not by causation. The real ~/.claude is shared ground: on a developer machine
+# the operator's own tooling writes to it continuously and asynchronously, so
+# whichever test happens to be executing when that lands is named as the
+# culprit. Three such failures were captured inside 30 minutes, each naming a
+# DIFFERENT innocent test:
+#
+#   blamed test_offmain_strand_guard   a launchd agent (StartInterval 900)
+#                                      re-derived settings.json
+#   blamed test_vault_safety_guards    a skill auto-sync ran the installer,
+#                                      which rewrote settings.json + a .bak-*
+#   blamed test_vault_root_read_guard  __pycache__/*.pyc rewritten by hooks
+#                                      firing in a concurrent session
+#
+# The third is the tell: settings.json content hash, mtime, baks count AND file
+# count were all IDENTICAL before and after — only tree= moved. No test did
+# anything. The comment block above already documents this exact shape twice
+# ("reddened test_bootstrap_dry_run — a test that touches neither file"), and
+# each time the answer was to widen the exclusions. That approach cannot finish:
+# the loudest remaining writers rewrite settings.json ITSELF, which is the one
+# file this gate exists to watch and can never exclude.
+#
+# So stop watching a resource other processes write. Point HOME and USERPROFILE
+# at a throwaway decoy for the duration of each test, and fingerprint THAT. The
+# decoy is private to one test, so nothing else on the machine can move it and a
+# mismatch is CAUSAL — no timing, no sleeps, no re-runs, no denylist.
+#
+# This also upgrades the gate from detection to PREVENTION. Previously a test
+# that escaped its sandbox really did corrupt the developer's live config and
+# the gate told you afterwards. Now that write lands in a tmpdir that is deleted
+# seconds later, and the gate still names the test.
+#
+# Coverage is unchanged: the same real_home_fingerprint() runs, with the same
+# watched trees, globs and exclusions, so real_home_quiet_control and
+# test_home_fingerprint_noise.sh keep asserting exactly what they always did.
+# Only Path.home() resolves somewhere safe.
+#
+# Verified before switching, against the whole suite: every test still passes
+# under a decoy home; ZERO change their assertion count (so nothing starts
+# passing vacuously because the deployed install is absent); and no test writes
+# any WATCHED path of the decoy — the only ~/.claude writes at all are three
+# tests creating empty dirs under projects/, which is already excluded.
+# (Measured at 106 tests, then re-swept at 111 once the suite grew; the sole
+# failure in the re-sweep was the pre-existing red the parent commit fixes.)
+#
+# The real home is still measured once around the whole suite, but ADVISORY:
+# with tests unable to reach it through "~", a change there is ambient by
+# construction, and failing on it is the bug this section fixes.
+_SANDBOX_LIB="$SCRIPT_DIR/../tests/integration/lib/sandbox_home.sh"
+if [ ! -f "$_SANDBOX_LIB" ]; then
+  # Fail loud. Without it there is no decoy, and every check below would compare
+  # an untouched empty dir against itself and pass vacuously.
+  echo "::error::missing $_SANDBOX_LIB — the integration tripwire cannot sandbox HOME without it, and would pass vacuously"
+  exit 1
+fi
+# shellcheck source=tests/integration/lib/sandbox_home.sh
+. "$_SANDBOX_LIB"
+
+# Fingerprint a decoy home with the real function. The subshell keeps the
+# sandbox exports from leaking into the gate itself.
+decoy_fingerprint() { ( sandbox_home "$1" >/dev/null; real_home_fingerprint ); }
+
+# BITE control for the decoy tripwire. The quiet control above proves the
+# fingerprint stays silent at rest; this proves it still SPEAKS. It runs a
+# synthetic test through the SAME run_sandboxed wrapper the real tests use, so
+# it exercises the wrapper too — a wrapper that failed to redirect HOME would
+# make every check below compare an empty decoy against itself and pass.
+decoy_tripwire_bite_control() {
+  local d before after
+  d="$(mktemp -d)"
+  before="$(decoy_fingerprint "$d")"
+  run_sandboxed "$d" bash -c 'mkdir -p "$HOME/.claude/hooks" && printf "print(1)\n" > "$HOME/.claude/hooks/escaped.py"'
+  after="$(decoy_fingerprint "$d")"
+  rm -rf "$d"
+  if [ "$before" = "$after" ]; then
+    echo "::error::decoy tripwire BITE control FAILED — a synthetic test wrote \$HOME/.claude/hooks/escaped.py and the tripwire did not see it. Every per-test check below is inert; a green run proves nothing."
+    return 1
+  fi
+  echo "    tripwire bite control: a test writing \$HOME/.claude/hooks/ is still caught"
+  return 0
+}
+
 _home_before_suite="$(real_home_fingerprint)"
 
 echo "==> (b) Shell integration: ${#INTEGRATION_TESTS[@]} tests"
-echo "    real-home tripwire watching: $(dirname "$REAL_SETTINGS") (settings.json, installed skill, deployed hooks; state/ only its SessionStart snapshot)"
+echo "    tripwire: each test runs against a throwaway decoy home (settings.json, installed skill, deployed hooks; state/ only its SessionStart snapshot)"
 real_home_quiet_control || exit 1
+decoy_tripwire_bite_control || exit 1
 for t in "${INTEGRATION_TESTS[@]}"; do
   script="tests/integration/$t.sh"
   if [ ! -f "$script" ]; then
@@ -633,20 +722,27 @@ for t in "${INTEGRATION_TESTS[@]}"; do
     exit 1
   fi
   echo "--- $t"
-  _home_before="$(real_home_fingerprint)"
-  bash "$script"
-  _home_after="$(real_home_fingerprint)"
+  _decoy="$(mktemp -d)"
+  _home_before="$(decoy_fingerprint "$_decoy")"
+  # NOT inside an `if`: set -e must still abort the gate when a test fails.
+  # Wrapping this in a condition would silently disable that.
+  run_sandboxed "$_decoy" bash "$script"
+  _home_after="$(decoy_fingerprint "$_decoy")"
   if [ "$_home_before" != "$_home_after" ]; then
-    echo "::error::$t wrote into the real $(dirname "$REAL_SETTINGS") — the suite must sandbox HOME *and* USERPROFILE (source tests/integration/lib/sandbox_home.sh and use sandbox_home/run_sandboxed). before=[$_home_before] after=[$_home_after]"
+    echo "::error::$t wrote into ~/.claude — the suite must sandbox HOME *and* USERPROFILE (source tests/integration/lib/sandbox_home.sh and use sandbox_home/run_sandboxed). It was already running under a decoy home, so the developer's real config is intact and this is the test's own write. before=[$_home_before] after=[$_home_after]"
+    rm -rf "$_decoy"
     exit 1
   fi
+  rm -rf "$_decoy"
 done
-# Belt and braces: catches a test that restores the file itself but leaves the
-# suite as a whole having moved it (e.g. mtime churn across several tests).
+# The real home, measured once around the whole suite. ADVISORY on purpose: the
+# tests just ran against a decoy, so they could not reach this through "~", and
+# anything that moved here came from outside the suite. Reported rather than
+# swallowed, because silence would hide a test that writes by ABSOLUTE path —
+# the one escape a decoy cannot intercept.
 _home_after_suite="$(real_home_fingerprint)"
 if [ "$_home_before_suite" != "$_home_after_suite" ]; then
-  echo "::error::the integration suite wrote into the real $(dirname "$REAL_SETTINGS"). before=[$_home_before_suite] after=[$_home_after_suite]"
-  exit 1
+  echo "    note: the real $(dirname "$REAL_SETTINGS") changed while the suite ran. The tests ran against a decoy home, so this is an out-of-band writer on this machine (a settings assembler on a timer, a skill auto-sync running the installer, __pycache__ churn from a concurrent session), not the suite. Not failing the gate on it — that misattribution is what this section exists to prevent. before=[$_home_before_suite] after=[$_home_after_suite]"
 fi
 
 # ---- (c) Shell static analysis gate ----------------------------------------

--- a/tests/fixtures/bootstrap-prefix-27d5243-parent.sh.txt
+++ b/tests/fixtures/bootstrap-prefix-27d5243-parent.sh.txt
@@ -1,0 +1,70 @@
+# FROZEN FIXTURE - do not edit, do not 'update' to match bootstrap.sh.
+#
+# The prereq-install slice of bootstrap.sh as it stood at commit 27d5243^,
+# the last commit BEFORE the user-space Node/Python fallback (MYC-3895,
+# #502) existed. It is the 'before' picture for the negative control in
+# tests/integration/test_bootstrap_userspace_fallback.sh: run through the
+# same build_harness(), this source must still FAIL (err() twice, no node),
+# which is what proves check 4 exercises real logic instead of a tautology.
+#
+# It is a snapshot of history, so it is correct forever and must never be
+# refreshed. Extracted with that test's own extract_fn/awk anchors so it
+# stays byte-faithful to what the harness would have read from git.
+
+log()  { printf "  \033[36m·\033[0m %s\n" "$*"; }
+ok()   { printf "  \033[32m✓\033[0m %s\n" "$*"; }
+warn() { printf "  \033[33m!\033[0m %s\n" "$*"; }
+err()  { printf "  \033[31m✗\033[0m %s\n" "$*"; FAILED+=("$*"); }
+hdr()  { printf "\n\033[1m%s\033[0m\n" "$*"; }
+dry()  { printf "  \033[35m[dry-run]\033[0m %s\n" "$*"; }
+is_mac()   { [[ "$(uname -s)" == "Darwin" ]]; }
+is_linux() { [[ "$(uname -s)" == "Linux" ]]; }
+have() { command -v "$1" >/dev/null 2>&1; }
+GAPS_FILE="$HOME/.claude/.ai-brain-starter-install-gaps.jsonl"
+note_gap() {
+  mkdir -p "$HOME/.claude" 2>/dev/null || true
+  printf '{"ts":"%s","component":"%s","repair":"%s"}\n' \
+    "$(date +%Y-%m-%dT%H:%M:%S)" "$1" "$2" >> "$GAPS_FILE" 2>/dev/null || true
+  log "$(t "$1 will finish setting up during the interview — nothing for you to do." \
+           "$1 se termina de configurar durante la entrevista — no tenés que hacer nada.")"
+}
+if ! python3 -c "import sys; assert sys.version_info >= (3,10)" 2>/dev/null; then
+  if [[ "$CORPORATE_PROFILE" == "1" ]]; then
+    warn "$(t "Corporate profile: Python 3.10+ not found — NOT auto-installing (user-space, no sudo)." \
+              "Perfil corporativo: no se encontró Python 3.10+ — NO se instala automáticamente (espacio de usuario, sin sudo).")"
+    warn "$(t "Provision Python via your IT-approved channel, then re-run. Some steps that need python3 will be skipped." \
+              "Instalá Python por tu canal aprobado de IT y volvé a correr. Algunos pasos que necesitan python3 se omitirán.")"
+  elif [[ $DRY_RUN -eq 1 ]]; then
+    dry "would: install Python 3.12 (brew on Mac; apt/dnf/pacman on Linux)"
+  else
+    hdr "Installing Python 3.12"
+    if is_mac; then
+      brew install python@3.12 || err "python install failed"
+    else
+      sudo apt-get update -qq && sudo apt-get install -y python3 python3-pip python3-venv 2>/dev/null \
+        || sudo dnf install -y python3 python3-pip 2>/dev/null \
+        || sudo pacman -S --noconfirm python python-pip 2>/dev/null \
+        || err "python install failed (couldn't find apt/dnf/pacman)"
+    fi
+  fi
+fi
+if ! have node; then
+  if [[ "$CORPORATE_PROFILE" == "1" ]]; then
+    warn "$(t "Corporate profile: Node.js not found — NOT auto-installing (user-space, no sudo)." \
+              "Perfil corporativo: no se encontró Node.js — NO se instala automáticamente (espacio de usuario, sin sudo).")"
+    warn "$(t "Provision Node.js via your IT-approved channel, then re-run. Some steps that need node will be skipped." \
+              "Instalá Node.js por tu canal aprobado de IT y volvé a correr. Algunos pasos que necesitan node se omitirán.")"
+  elif [[ $DRY_RUN -eq 1 ]]; then
+    dry "would: install Node.js (brew on Mac; apt/dnf/pacman on Linux)"
+  else
+    hdr "Installing Node.js"
+    if is_mac; then
+      brew install node || err "node install failed"
+    else
+      sudo apt-get install -y nodejs npm 2>/dev/null \
+        || sudo dnf install -y nodejs npm 2>/dev/null \
+        || sudo pacman -S --noconfirm nodejs npm 2>/dev/null \
+        || err "node install failed"
+    fi
+  fi
+fi

--- a/tests/integration/test_bootstrap_userspace_fallback.sh
+++ b/tests/integration/test_bootstrap_userspace_fallback.sh
@@ -248,25 +248,88 @@ grep -qF '.local/python/bin' "$POST_HOME/.bashrc" || fail "4: python's user-spac
 
 # ── 5. NEGATIVE CONTROL: the identical harness against the PRE-FIX source
 # must fail the way the bug actually failed (err() called, node absent) —
-# proving check 4 exercises real logic, not a tautology. Requires origin/main
-# fetched already (true in CI and any normal dev checkout); skips loudly,
-# never silently, if it truly cannot be resolved. ──
-PREFIX_SRC="$TMP/bootstrap-prefix.sh"
-if git -C "$REPO_ROOT" show origin/main:bootstrap.sh > "$PREFIX_SRC" 2>/dev/null && [ -s "$PREFIX_SRC" ]; then
-  PRE_HOME="$TMP/pre-home"; mkdir -p "$PRE_HOME"
-  PRE_HARNESS="$TMP/pre-harness.sh"
-  build_harness "$PREFIX_SRC" "$PRE_HARNESS" "$PRE_HOME"
-  PRE_OUT="$(PATH="$POST_STUB:/usr/bin:/bin" bash "$PRE_HARNESS" 2>&1)" || true
-  echo "$PRE_OUT" | grep -q 'RESULT_FAILED_COUNT=2' \
-    || fail "5 (negative control): the pre-fix source was expected to call err() exactly twice (python + node) with brew absent + no sudo, so this harness would have caught the original bug. Output:
-$PRE_OUT"
-  echo "$PRE_OUT" | grep -q 'RESULT_NODE=NONE' \
-    || fail "5 (negative control): the pre-fix source was expected to leave node completely absent. Output:
-$PRE_OUT"
-  echo "PASS: negative control confirmed against pre-fix bootstrap.sh (origin/main) — RESULT_FAILED_COUNT=2, RESULT_NODE=NONE"
-else
-  echo "SKIP: 5 (negative control) — origin/main not resolvable here (no network / shallow clone); check 4 still ran for real"
+# proving check 4 exercises real logic, not a tautology.
+#
+# THE "BEFORE" SOURCE IS A FROZEN FIXTURE, NEVER A MOVING REF.
+#
+# This check used to read it with `git show origin/main:bootstrap.sh`. That was
+# true exactly once: while the fix sat on a feature branch and origin/main still
+# held the pre-fix code. The moment #502 merged, origin/main:bootstrap.sh BECAME
+# the fixed code, so the control ran the fix against itself, observed success
+# where it demands failure, and went red — on main, on every commit after it, for
+# four commits, blocking every push and every merge in the repo.
+#
+# The shape is worth naming, because it is invisible in review: a control whose
+# "before" is a moving ref is GUARANTEED to pass in the PR that introduces it and
+# GUARANTEED to fail forever once that PR lands. It cannot be caught by running
+# it; it can only be caught by reading it, or by the identity assertion below.
+#
+# A pinned SHA would fix the mutability but not the reachability: the `ci` job's
+# checkout takes no fetch-depth, so it is shallow, and an old SHA is simply not
+# in the object store there. Hence a vendored fixture — a snapshot of history,
+# correct forever, immune to ref movement, history rewrites and clone depth.
+#
+# That same shallowness is why this survived four commits, and it is the
+# strongest argument for the fixture. `origin/main` does not resolve in the
+# shallow `ci` job either, so on every PR the old code took its `else` branch,
+# printed "SKIP: 5 (negative control) — origin/main not resolvable here", and
+# reported PASS. The control had therefore NEVER run in a gating context since
+# it was written: green on every PR, red only on push-to-main, where origin/main
+# finally resolves and it compares the fix against itself. A required check that
+# can only fail AFTER the merge blocks nothing. That SKIP branch is gone for
+# exactly this reason — an unresolvable "before" source now fails loud, because
+# a control that cannot run must not report success.
+#
+# The fixture also makes PR and main SYMMETRIC: a vendored file resolves the
+# same way in a shallow checkout and a full one, so this control now runs where
+# it can still stop something.
+#
+# The fixture is named .sh.txt, not .sh, deliberately: it is frozen DATA, never
+# executed, and scripts/shellcheck.sh lints every tracked *.sh. A historical
+# snapshot must not be edited to satisfy a linter.
+PREFIX_SRC="$REPO_ROOT/tests/fixtures/bootstrap-prefix-27d5243-parent.sh.txt"
+if [ ! -s "$PREFIX_SRC" ]; then
+  fail "5 (negative control): the frozen pre-fix fixture is missing or empty at $PREFIX_SRC. Without a 'before' source this control cannot run, and a control that cannot run must not report success."
 fi
+# The assertion that would have caught the origin/main bug on day one: if the
+# "before" and "after" sources are the same bytes, this control is comparing the
+# fix to itself and proves nothing, whatever its other assertions then say.
+if [ "$(cksum < "$PREFIX_SRC")" = "$(cksum < "$BOOTSTRAP")" ]; then
+  fail "5 (negative control): the pre-fix fixture is byte-identical to $BOOTSTRAP, so this control is comparing the fix against itself and cannot fail. Restore a genuine pre-fix snapshot."
+fi
+# The byte check alone is nearly inert, because the fixture is a ~70-line
+# EXTRACT and bootstrap.sh is the whole 2000+ line script: those two can never
+# be byte-equal in the intended design, so that check only catches someone
+# literally copying bootstrap.sh over the fixture.
+#
+# The likelier regression is subtler and the byte check is blind to it: a future
+# maintainer sees a fixture that looks stale next to bootstrap.sh and
+# "refreshes" it by re-running the extraction against CURRENT source. That
+# produces a ~70-line extract of POST-fix code, which is not byte-equal to
+# anything, so the check above stays silent — and check 5 then fails on
+# RESULT_FAILED_COUNT with a message pointing at bootstrap.sh, sending the next
+# person to debug the wrong file. This repo has already paid for a
+# wrong-repair-pointer once (6ac8364).
+#
+# So assert PROVENANCE, not merely difference. What makes this fixture pre-fix
+# is precisely that the user-space installers did not exist yet; the setup loop
+# above already proves all four DO exist in $BOOTSTRAP, so this binds the pair.
+for _fn in install_node_userspace install_python_userspace user_space_platform fetch_tarball; do
+  if grep -q "$_fn" "$PREFIX_SRC"; then
+    fail "5 (negative control): the pre-fix fixture references ${_fn}, which did not exist until the fix (27d5243). It was probably regenerated from post-fix source. It must stay a frozen snapshot of 27d5243^, never a re-extraction from HEAD."
+  fi
+done
+PRE_HOME="$TMP/pre-home"; mkdir -p "$PRE_HOME"
+PRE_HARNESS="$TMP/pre-harness.sh"
+build_harness "$PREFIX_SRC" "$PRE_HARNESS" "$PRE_HOME"
+PRE_OUT="$(PATH="$POST_STUB:/usr/bin:/bin" bash "$PRE_HARNESS" 2>&1)" || true
+echo "$PRE_OUT" | grep -q 'RESULT_FAILED_COUNT=2' \
+  || fail "5 (negative control): the pre-fix source was expected to call err() exactly twice (python + node) with brew absent + no sudo, so this harness would have caught the original bug. Output:
+$PRE_OUT"
+echo "$PRE_OUT" | grep -q 'RESULT_NODE=NONE' \
+  || fail "5 (negative control): the pre-fix source was expected to leave node completely absent. Output:
+$PRE_OUT"
+echo "PASS: negative control confirmed against the frozen pre-fix fixture (27d5243^) — RESULT_FAILED_COUNT=2, RESULT_NODE=NONE"
 
 # ── 6. Linux wiring: both sections gate on is_linux && have_sudo, and fall
 # back to the same install_*_userspace() functions on that branch ──


### PR DESCRIPTION
Two commits. The first unblocks `main`, which has been red since #502. The second fixes the tripwire that has been blaming innocent tests. They ship together because **neither can be verified without the other** — see "Why one PR" at the bottom.

---

## 1. `fix(tests)` — the pre-fix negative control read a moving ref

`test_bootstrap_userspace_fallback.sh` check 5 obtained its "before" source with:

```bash
git show origin/main:bootstrap.sh
```

That was true exactly once: while the fix sat on a feature branch and `origin/main` still held the pre-fix code. The moment #502 merged, `origin/main:bootstrap.sh` **became the fixed code**, so the control ran the fix against itself, observed success where it demands failure, and went red.

Verified rather than inferred: `git show origin/main:bootstrap.sh` is byte-identical to the working-tree `bootstrap.sh`. CI shows the identical failure on four consecutive commits — `27d52432`, `61763024`, `ed946553`, `6ac8364b` — and again at `3057966`.

### Why nobody caught it for four commits

This is the part worth keeping. The `ci` job's checkout at `lint.yml:526` sets no `fetch-depth`, so it is **shallow**, and `origin/main` does not resolve there. On every PR the old code took its `else` branch:

```
SKIP: 5 (negative control) — origin/main not resolvable here (no network / shallow clone); check 4 still ran for real
PASS: test_bootstrap_userspace_fallback (6 checks, negative control on the main scenario)
```

`ci gate` is a **required** check and it was green on all of them. So the control had never once run in a gating context since it was written: green on every PR, red only on push-to-main where `origin/main` finally resolves. **A required check that can only fail after the merge blocks nothing.** That `SKIP` branch is the silent-no-op this repo's own rules ban, and it is gone — an unresolvable "before" source now fails loud.

### The fix

A frozen fixture at `tests/fixtures/bootstrap-prefix-27d5243-parent.sh.txt`, extracted from `27d5243^` using the test's own `extract_fn`/awk anchors so it is byte-faithful to what `build_harness` would have read from git. All four fix functions (`install_node_userspace`, `install_python_userspace`, `user_space_platform`, `fetch_tarball`) verified absent there and present post-fix.

A pinned SHA was rejected deliberately: it fixes mutability but not reachability, since an old SHA is not in the shallow `ci` job's object store. A vendored file resolves identically in a shallow checkout and a full one, so **PR and main are now symmetric** and this control finally runs where it can still stop something.

Two new guards, both bite-tested:

| guard | catches |
|---|---|
| byte-identity (`cksum`) | someone copying `bootstrap.sh` over the fixture |
| provenance (no reference to the four post-fix functions) | someone "refreshing" the stale-looking fixture by re-extracting from HEAD |

The provenance guard matters because the byte check alone is nearly inert — a ~70-line extract can never equal a 2000-line script, so it only catches the crude case. A post-fix re-extraction is byte-equal to nothing and would have slipped through, failing later with a message pointing at `bootstrap.sh` instead of the fixture. This repo has already paid for a wrong-repair-pointer once (`6ac8364`).

Class swept: the other `origin/main` reads (`update-check.sh`, `update-check.ps1`, a docstring in `check-hookify-template-capabilities.py`) all deliberately want *current* upstream state. This was the only instance.

---

## 2. `fix(ci)` — attribute the real-home tripwire causally

The tripwire fingerprinted the real `~/.claude` around each test and failed naming the test that was running. That is attribution by **wall clock**, not causation. The real `~/.claude` is shared ground: the operator's own tooling writes to it asynchronously, so whichever test is executing gets named. Five occurrences were captured, each naming a **different innocent test**:

| blamed | actual writer |
|---|---|
| `test_offmain_strand_guard` | launchd agent (`StartInterval` 900) re-derived settings.json |
| `test_vault_safety_guards` | skill auto-sync ran the installer (`.bak-*-abs`) |
| `test_vault_root_read_guard` | `__pycache__/*.pyc` from a concurrent session |
| `test_relocate_vault` | ambient settings.json rewrite |
| `test_renderer_crash_guard` | ambient settings.json rewrite |

The third is the tell: settings hash, mtime, `baks` and file count were **all identical** — only `tree=` moved.

`ci.sh` already documented this shape twice and each time answered by widening exclusions. That cannot finish: the loudest writers rewrite `settings.json` itself, the one file the gate can never exclude.

So each test now runs with `HOME`/`USERPROFILE` pointed at a throwaway decoy, and the fingerprint is taken of **that**. The decoy is private to one test, so a mismatch is causal — no timing, no sleeps, no re-runs, no denylist. It also upgrades the gate from detection to **prevention**: an escaping write now lands in a tmpdir deleted seconds later, and the gate still names the test.

Coverage is unchanged — same `real_home_fingerprint()`, same trees, globs and exclusions, so `real_home_quiet_control` and `test_home_fingerprint_noise.sh` keep asserting what they always did. Only `Path.home()` resolves somewhere safe. The real home is still measured once around the suite, but **advisory**, since a change there is now ambient by construction; it is reported rather than swallowed so an absolute-path write still surfaces.

Adds a **bite control** beside the existing quiet control. The quiet control proved the fingerprint stays silent at rest; nothing proved it still speaks. It runs a synthetic escape through the same `run_sandboxed` wrapper the real tests use, so a wrapper that failed to redirect HOME is caught rather than making every check compare an empty decoy against itself.

Measured before switching: every test passes under a decoy home, **zero** change their assertion count (nothing starts passing vacuously), and no test writes a watched decoy path.

---

## Why one PR

These are separate concerns and I would rather have shipped them separately. They cannot be: no green local gate is reachable without both in the tree. The bootstrap control fails **deterministically**, so a tripwire-only branch is red; the tripwire false-fires **probabilistically** on ambient churn, so a bootstrap-only branch could not get a green marker in five attempts. With both applied: `ci-test` GREEN, 111 integration tests, marker `fadbbb4c.ok`.

The commits are separable and individually revertable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
