### PR TITLE
fix(ci): the tripwire names the path it failed on, instead of two digests (MYC-3721)

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -539,9 +539,26 @@ for pattern in WATCH_GLOBS:
             continue
         seen.append(f"{os.path.basename(match)}:{st.st_size}:{st.st_mtime!r}")
 
-parts.append("tree=" + hashlib.sha256("\n".join(seen).encode()).hexdigest()[:16])
-parts.append("files=%d" % len(seen))
-print(" ".join(parts))
+# MANIFEST mode names the paths the digest only summarises (MYC-3721 work item
+# 1: "print WHAT changed, not just that something did"). Same walk, same trees,
+# same exclusions -- deliberately one function, because a second implementation
+# would drift from the digest it exists to explain, and would then name paths
+# the gate never actually compared.
+#
+# Emitted as one sortable line per watched entry so callers can diff two
+# manifests and print only what moved. The three settings.json components are
+# spelled out rather than hashed together, so a content rewrite, a pure mtime
+# touch and a stray .bak-* are told apart on sight.
+if os.environ.get("FINGERPRINT_MANIFEST"):
+    print("settings.json content=%s" % parts[0])
+    for extra in parts[1:]:
+        print("settings.json %s" % extra)
+    for line in seen:
+        print(line)
+else:
+    parts.append("tree=" + hashlib.sha256("\n".join(seen).encode()).hexdigest()[:16])
+    parts.append("files=%d" % len(seen))
+    print(" ".join(parts))
 PY
 }
 
@@ -689,6 +706,45 @@ fi
 # sandbox exports from leaking into the gate itself.
 decoy_fingerprint() { ( sandbox_home "$1" >/dev/null; real_home_fingerprint ); }
 
+# The same two walks in MANIFEST mode, naming paths instead of digesting them.
+# Both run only on a mismatch, so they cost nothing at rest.
+decoy_manifest()     { ( sandbox_home "$1" >/dev/null; FINGERPRINT_MANIFEST=1 real_home_fingerprint ); }
+real_home_manifest() { FINGERPRINT_MANIFEST=1 real_home_fingerprint; }
+
+# Print only the manifest lines that differ, capped so a large drift cannot bury
+# the failure it is explaining.
+_manifest_delta() {
+  local before="$1" after="$2" delta n
+  # diff exits 1 whenever the two differ, which is the only case this is called
+  # in; set -e must not read that as an error.
+  delta="$(diff <(printf '%s\n' "$before") <(printf '%s\n' "$after") || true)"
+  delta="$(printf '%s\n' "$delta" | sed -n -e 's/^> /      + /p' -e 's/^< /      - /p')"
+  [ -n "$delta" ] || { echo "      (no path-level delta — the change was in a component the manifest folds, e.g. settings.json mtime)"; return 0; }
+  n="$(printf '%s\n' "$delta" | wc -l | tr -d ' ')"
+  # `sed -n 1,20p`, never `head -20`: head closes the pipe at line 20, printf
+  # takes SIGPIPE, and under this script's `set -o pipefail` that aborts the
+  # whole gate. On the ADVISORY path that would kill a run over ambient churn —
+  # precisely the misattribution this section exists to prevent. sed reads to
+  # EOF, so it cannot SIGPIPE.
+  printf '%s\n' "$delta" | sed -n '1,20p'
+  [ "$n" -gt 20 ] && echo "      ... and $((n - 20)) more"
+  return 0
+}
+
+# Name the exact paths a test wrote into its decoy.
+#
+# The decoy's "before" state is RECONSTRUCTED rather than guessed: sandbox_home
+# only creates an empty <dir>/.claude, so a freshly-made decoy is byte-identical
+# to how this one started. Manifest lines are relative to ~/.claude (never the
+# tmpdir path) and an absent tree emits a bare "name:ABSENT" carrying no mtime,
+# so the two are directly comparable. That makes this a real diff, not a guess.
+decoy_written_paths() {
+  local fresh
+  fresh="$(mktemp -d)"
+  _manifest_delta "$(decoy_manifest "$fresh")" "$(decoy_manifest "$1")"
+  rm -rf "$fresh"
+}
+
 # BITE control for the decoy tripwire. The quiet control above proves the
 # fingerprint stays silent at rest; this proves it still SPEAKS. It runs a
 # synthetic test through the SAME run_sandboxed wrapper the real tests use, so
@@ -710,6 +766,11 @@ decoy_tripwire_bite_control() {
 }
 
 _home_before_suite="$(real_home_fingerprint)"
+# One extra walk, once, so the advisory below can name paths instead of printing
+# two opaque digests. An advisory nobody can act on becomes background noise,
+# and this one is the ONLY remaining detector for a test that writes by absolute
+# path — the single escape a decoy home cannot intercept.
+_home_before_suite_manifest="$(real_home_manifest)"
 
 echo "==> (b) Shell integration: ${#INTEGRATION_TESTS[@]} tests"
 echo "    tripwire: each test runs against a throwaway decoy home (settings.json, installed skill, deployed hooks; state/ only its SessionStart snapshot)"
@@ -729,7 +790,10 @@ for t in "${INTEGRATION_TESTS[@]}"; do
   run_sandboxed "$_decoy" bash "$script"
   _home_after="$(decoy_fingerprint "$_decoy")"
   if [ "$_home_before" != "$_home_after" ]; then
-    echo "::error::$t wrote into ~/.claude — the suite must sandbox HOME *and* USERPROFILE (source tests/integration/lib/sandbox_home.sh and use sandbox_home/run_sandboxed). It was already running under a decoy home, so the developer's real config is intact and this is the test's own write. before=[$_home_before] after=[$_home_after]"
+    echo "::error::$t wrote into ~/.claude — the suite must sandbox HOME *and* USERPROFILE (source tests/integration/lib/sandbox_home.sh and use sandbox_home/run_sandboxed). It was already running under a decoy home, so the developer's real config is intact and this is the test's own write."
+    echo "::error::  it wrote these paths (relative to ~/.claude):"
+    decoy_written_paths "$_decoy"
+    echo "      digests: before=[$_home_before] after=[$_home_after]"
     rm -rf "$_decoy"
     exit 1
   fi
@@ -742,7 +806,9 @@ done
 # the one escape a decoy cannot intercept.
 _home_after_suite="$(real_home_fingerprint)"
 if [ "$_home_before_suite" != "$_home_after_suite" ]; then
-  echo "    note: the real $(dirname "$REAL_SETTINGS") changed while the suite ran. The tests ran against a decoy home, so this is an out-of-band writer on this machine (a settings assembler on a timer, a skill auto-sync running the installer, __pycache__ churn from a concurrent session), not the suite. Not failing the gate on it — that misattribution is what this section exists to prevent. before=[$_home_before_suite] after=[$_home_after_suite]"
+  echo "    note: the real $(dirname "$REAL_SETTINGS") changed while the suite ran. The tests ran against a decoy home, so this is an out-of-band writer on this machine (a settings assembler on a timer, a skill auto-sync running the installer, __pycache__ churn from a concurrent session), not the suite. Not failing the gate on it — that misattribution is what this section exists to prevent."
+  echo "    what moved (read it: an entry under skills/ai-brain-starter/ or a settings.json content= change is NOT ordinary churn, and would mean a test wrote by ABSOLUTE path, which a decoy home cannot intercept):"
+  _manifest_delta "$_home_before_suite_manifest" "$(real_home_manifest)"
 fi
 
 # ---- (c) Shell static analysis gate ----------------------------------------

--- a/tests/integration/test_home_fingerprint_noise.sh
+++ b/tests/integration/test_home_fingerprint_noise.sh
@@ -80,5 +80,35 @@ touch "$FAKE/.claude/settings.json.bak-20260101"
 if [ "$(fp)" != "$BASE" ]; then ok "catches a new installer .bak-* (write-then-rollback)"; else no "MISSED a new .bak-*"; fi
 
 echo
+echo "=== MANIFEST mode: the failure must NAME the path, not just digest it ==="
+# MYC-3721 Done= requires the failure to name the exact path. A digest cannot,
+# so ci.sh re-walks in FINGERPRINT_MANIFEST mode on the failure path. Two things
+# have to hold, and only one of them is obvious.
+mf() { run_sandboxed "$FAKE" env FINGERPRINT_MANIFEST=1 bash -c "source '$FN'; real_home_fingerprint"; }
+
+printf 'print("escaped")\n' > "$FAKE/.claude/hooks/escaped.py"
+if mf | grep -q "hooks/escaped.py"; then
+  ok "manifest names the exact path a test wrote"
+else
+  no "manifest did NOT name hooks/escaped.py — the gate's failure message is decorative"
+fi
+
+# The non-obvious half. The manifest is a SECOND output mode of the same walk;
+# if it ever became a second implementation it could name paths the digest never
+# compared, and the gate would report a path it did not actually fail on. Pin
+# them together: anything the digest excludes must be absent from the manifest.
+if mf | grep -q "cwd-changed.log"; then
+  no "manifest lists cwd-changed.log — it has drifted from the digest's exclusions and would name churn the gate never compares"
+else
+  ok "manifest inherits the digest's exclusions (append-only logs stay out)"
+fi
+
+if mf | grep -q "^settings.json content="; then
+  ok "manifest breaks settings.json into content/mtime/baks (a rewrite is told apart from a bare touch)"
+else
+  no "manifest does not carry the settings.json components"
+fi
+
+echo
 echo "test_home_fingerprint_noise: $PASS passed, $FAIL failed"
 [ "$FAIL" = 0 ] || exit 1


### PR DESCRIPTION
Closes the one Done= clause [#509](https://github.com/mycelium-hq/ai-brain-starter/pull/509) left open on MYC-3721: **"the failure names the exact path."**

#509 fixed attribution properly — each test runs against a throwaway decoy home, so a mismatch is causal instead of wall-clock coincidence. But a trip still printed `before=[...] after=[...]` and nothing else, so every real failure began with an investigation to find out *which* file moved. The ticket calls this work item 1, *"highest value, near-free."*

## What this does

One extra output mode on the **same walk** (`FINGERPRINT_MANIFEST=1`), deliberately **not** a second implementation — a separate walk could drift from the digest and then name paths the gate never actually compared. Used at both call sites, on the failure path only, so the happy path costs nothing.

**Per-test.** The decoy's "before" is *reconstructed*, not guessed: `sandbox_home` only creates an empty `<dir>/.claude`, so a freshly-made decoy is byte-identical to how this one started. Manifest lines are relative to `~/.claude` (never the tmpdir path) and an absent tree emits a bare `name:ABSENT` carrying no mtime, so the two diff exactly. Real diff, not a heuristic.

**Suite.** The real-home advisory now lists what moved. That advisory is the **only** remaining detector for a test writing by absolute path — the one escape a decoy cannot intercept — and an advisory nobody can act on becomes background noise.

Output on a real trip:

```
::error::test_foo wrote into ~/.claude — ...
::error::  it wrote these paths (relative to ~/.claude):
      - settings.json content=ABSENT
      + settings.json content=7610115a...
      + hooks/escaped.py:9:1786856430.08
```

## One bug found in my own diff before it shipped

`printf | head -20` looks harmless. Under this script's `set -o pipefail` it is not: `head` closes the pipe at line 20, `printf` takes SIGPIPE, the pipeline returns 141, and `set -e` aborts the whole gate. On the **advisory** path that would kill a run over ambient churn — reintroducing precisely the misattribution #509 exists to prevent. Switched to `sed -n 1,20p`, which reads to EOF and cannot SIGPIPE. Proven against a 30-path delta.

## Controls, both directions

In `test_home_fingerprint_noise.sh`, matching the file's existing discipline:

- the manifest **names** a path a synthetic test wrote (without this the new failure message is decorative)
- the manifest stays **pinned to the digest's exclusions**, so it cannot drift into naming churn the gate never compares
- `settings.json` is broken into `content`/`mtime`/`baks`, so a rewrite is told apart from a bare touch

## Verification

- `test_home_fingerprint_noise.sh`: **11/11 pass** (8 pre-existing + 3 new)
- End-to-end proof of the failure path under `set -euo pipefail`: names the escaped hook, names the settings rewrite, survives a >20-path delta
- `ci-test`: **GREEN** — 346 py_compile + 111 integration tests + 18 scripts + 15 hook suites + shellcheck + phase-doc python + utf8 + block-protocol + vault-root + home-hook deploy + subprocess decode. `EXIT=0`, marker `3bafbae9.ok`
- shellcheck clean at `-S warning`
- personal-data scrub: clean, positive control passed first

## Not in scope

The decoy home also removes the deployed install from every test's view, so a test that gates on its presence can now pass vacuously. Filed as **MYC-3920** rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
