### PR TITLE
fix(version-hook): stop the update banner reading one release stale

### DIFF
--- a/hooks/check-claude-code-version.sh
+++ b/hooks/check-claude-code-version.sh
@@ -28,7 +28,13 @@ fi
 # --------------------------------------------------------------------------
 
 CACHE_FILE="$HOME/.claude/.claude-code-version-check"
-CACHE_TTL_SEC=$((24 * 60 * 60))   # 24 hours
+# 6h, not 24h. Claude Code ships ~daily, so a 24h cache made this banner
+# SYSTEMATICALLY one release stale: every reading was up to a full release train
+# behind by the time anyone saw it. Measured stale-by-one on three consecutive
+# upstream delta audits. The cache exists to avoid hammering the API; one version
+# check every 6h costs nothing and keeps the reading current. The root cause was
+# the TTL, NOT a releases-feed-vs-npm lag (both feeds verified in agreement).
+CACHE_TTL_SEC=$((6 * 60 * 60))    # 6 hours
 WARN_VERSION_GAP=3                # warn loudly if behind by N or more patch versions
 DIFF_BULLET_LIMIT=8               # max bullets to surface from the changelog diff
 
@@ -37,7 +43,15 @@ if [[ -f "$CACHE_FILE" ]]; then
   last=$(stat -f %m "$CACHE_FILE" 2>/dev/null || stat -c %Y "$CACHE_FILE" 2>/dev/null || echo 0)
   age=$(( now - last ))
   if (( age < CACHE_TTL_SEC )); then
+    # DATE the snapshot. A cached reading is byte-identical in shape to a live
+    # one, so replaying it bare lets a stale version number read as current --
+    # the reader has no way to tell. Stamp the age whenever it is old enough to
+    # matter, so a stale answer announces itself instead of impersonating a
+    # fresh one.
     cat "$CACHE_FILE"
+    if [[ -s "$CACHE_FILE" ]] && (( age >= 3600 )); then
+      printf '[claude-code-version] (reading is %dh old; upstream ships ~daily, so the real head may already be newer)\n' "$(( age / 3600 ))"
+    fi
     exit 0
   fi
 fi


### PR DESCRIPTION
## What

The Claude Code update banner cached its reading for 24h while upstream ships roughly daily, so the version it showed was systematically about one release behind. A cached reading is byte-identical in shape to a live one, so it read as current every time.

Measured stale-by-one on three consecutive upstream delta audits.

## Changes

1. **Cache TTL 24h to 6h.** The cache exists to avoid hammering the API; one version check every 6h costs nothing and keeps the reading current.
2. **Date the snapshot.** The replay path now stamps the reading's age once it is at least an hour old, so a stale answer announces itself instead of impersonating a fresh one.

The empty-cache case means "up to date" and stays silent, so no phantom age line appears when there is nothing to report.

## Root-cause discipline

The obvious explanation was a releases-feed-vs-npm lag. That was **measured and rejected**: both feeds were verified in agreement before the fix. The root cause was the TTL alone.

## Verification

- `bash -n` syntax check
- 3h-old cache renders the age line, cached body preserved
- 10min-old cache stays silent
- aged **empty** cache stays silent, no phantom age line
- Full canonical gate green (`ci-test`): py_compile 347 files + 111 integration tests + 18 scripts + 15 hook unit suites + shellcheck + hook block-protocol + home-hook deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
