### PR TITLE
feat(hooks): two primitives that stop a surfacer training itself into wallpaper

### DIFF
--- a/hooks/_lib/session_echo.py
+++ b/hooks/_lib/session_echo.py
@@ -1,0 +1,106 @@
+"""Per-session echo suppression for ~/.claude/hooks.
+
+WHY THIS EXISTS
+---------------
+Measured 2026-08-15 across 64 sessions of real transcripts: 153,000 characters
+per session of hook output were BYTE-IDENTICAL repetition inside a single
+session. The worst single case, `[CONTEXT.md auto-load]`, injected the same
+8.4 KB block up to 55 times in one session — 88% of its volume was re-echo.
+
+That is not a rendering problem and it must not be fixed by narrowing triggers.
+The trigger is right: the model SHOULD get canonical terminology. The bug is
+that an injector re-states bytes the context already holds. Re-injecting an
+identical payload adds zero information and costs its full size every time.
+
+WHAT THIS DOES / DOES NOT DO
+----------------------------
+DOES     suppress a payload whose bytes are identical to one this session
+         already emitted under the same key.
+DOES NOT suppress anything that CHANGED. A new or edited payload always
+         emits — that is the whole point: speak when something is different,
+         stay quiet when repeating yourself.
+DOES NOT touch trigger conditions. Coverage is unchanged: every fact still
+         reaches the model, exactly once, the first time it is true.
+
+FAIL-OPEN BY CONSTRUCTION
+-------------------------
+Every error path returns True (emit). A broken dedup must degrade to today's
+behaviour (noisy) and never to silence — losing a guard's message is a far
+worse failure than repeating it. Codified: "Fail loud, never silent no-op".
+
+CONCURRENCY
+-----------
+State is keyed by session_id, so parallel sessions never share a file. Writes
+are atomic (tmp + os.replace). Per call this is one small read + one small
+write — bounded work, no corpus walk, so it stays safe under the many-
+concurrent-sessions workload ("Per-Session Work That Fans Out Under
+Concurrency Is Bounded By Construction").
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+from pathlib import Path
+
+STATE_DIR = Path.home() / ".claude" / ".session-echo"
+TTL_SECONDS = 3 * 86400
+BYPASS_ENV = "SESSION_ECHO_BYPASS"
+
+
+def _state_path(session_id: str) -> Path:
+    safe = "".join(c for c in str(session_id) if c.isalnum() or c in "-_")[:80]
+    return STATE_DIR / f"{safe or 'unknown'}.json"
+
+
+def _prune(now: float) -> None:
+    """Drop state files older than the TTL. Bounded: the dir holds one small
+    file per recent session, and this runs only when a session's file is new."""
+    try:
+        for p in STATE_DIR.glob("*.json"):
+            try:
+                if now - p.stat().st_mtime > TTL_SECONDS:
+                    p.unlink()
+            except OSError:
+                pass
+    except OSError:
+        pass
+
+
+def should_emit(key: str, payload: str, session_id: str | None) -> bool:
+    """True if this exact payload has NOT already been emitted this session.
+
+    key         stable identifier for the emitter (e.g. "context-md").
+    payload     the exact text that would be emitted.
+    session_id  from the hook's stdin JSON. Falsy -> always emit (fail-open).
+    """
+    if os.environ.get(BYPASS_ENV) == "1":
+        return True
+    if not session_id or not payload:
+        return True
+    try:
+        digest = hashlib.sha1(payload.encode("utf-8", "replace")).hexdigest()[:16]
+        path = _state_path(session_id)
+        fresh = not path.exists()
+        seen = {}
+        if not fresh:
+            try:
+                seen = json.loads(path.read_text(encoding="utf-8")) or {}
+                if not isinstance(seen, dict):
+                    seen = {}
+            except (OSError, ValueError):
+                seen = {}
+        if seen.get(key) == digest:
+            return False
+        seen[key] = digest
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(seen), encoding="utf-8")
+        os.replace(tmp, path)
+        if fresh:
+            _prune(time.time())
+        return True
+    except Exception:
+        # Any failure at all: emit. Never trade coverage for quiet.
+        return True

--- a/hooks/_lib/session_echo.test.py
+++ b/hooks/_lib/session_echo.test.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Negative control for session_echo.
+
+The suppressor's failure mode is not "too loud" — it is SILENCE ON NEW
+INFORMATION. A dedup that also swallows changed payloads reads exactly like a
+working one from the terminal (quiet), so the only proof it is safe is a test
+that a CHANGED payload still emits, and that every error path emits too.
+
+Run: python3 hooks/_lib/session_echo.test.py
+"""
+import os
+import sys
+import tempfile
+import pathlib
+
+HERE = pathlib.Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parent))
+
+import importlib
+import _lib.session_echo as se  # noqa: E402
+
+fails = []
+
+
+def check(name, cond):
+    print(("  ok   " if cond else "  FAIL ") + name)
+    if not cond:
+        fails.append(name)
+
+
+with tempfile.TemporaryDirectory() as td:
+    se.STATE_DIR = pathlib.Path(td) / "echo"
+
+    print("POSITIVE: identical payload is suppressed after first emit")
+    check("first emit speaks", se.should_emit("k", "PAYLOAD-A", "sess1") is True)
+    check("identical re-emit is suppressed",
+          se.should_emit("k", "PAYLOAD-A", "sess1") is False)
+    check("third identical also suppressed",
+          se.should_emit("k", "PAYLOAD-A", "sess1") is False)
+
+    print("NEGATIVE CONTROL: changed payload MUST still speak")
+    check("changed payload emits", se.should_emit("k", "PAYLOAD-B", "sess1") is True)
+    check("and is then suppressed on repeat",
+          se.should_emit("k", "PAYLOAD-B", "sess1") is False)
+    check("reverting to the older payload also emits (it changed again)",
+          se.should_emit("k", "PAYLOAD-A", "sess1") is True)
+
+    print("ISOLATION: a different session is unaffected")
+    check("other session still emits the same payload",
+          se.should_emit("k", "PAYLOAD-A", "sess2") is True)
+    print("ISOLATION: a different key is unaffected")
+    check("other key still emits", se.should_emit("k2", "PAYLOAD-A", "sess1") is True)
+
+    print("FAIL-OPEN: every degraded path emits rather than going silent")
+    check("no session_id -> emit", se.should_emit("k", "PAYLOAD-A", None) is True)
+    check("empty session_id -> emit", se.should_emit("k", "PAYLOAD-A", "") is True)
+    check("empty payload -> emit (caller decides)",
+          se.should_emit("k", "", "sess1") is True)
+
+    os.environ["SESSION_ECHO_BYPASS"] = "1"
+    check("bypass env forces emit", se.should_emit("k", "PAYLOAD-A", "sess1") is True)
+    del os.environ["SESSION_ECHO_BYPASS"]
+
+    print("FAIL-OPEN: unreadable state dir must not silence")
+    se.STATE_DIR = pathlib.Path("/proc/nonexistent-cannot-create/echo")
+    check("unwritable state -> emit", se.should_emit("k", "PAYLOAD-A", "sess1") is True)
+
+    print("FAIL-OPEN: corrupt state file must not silence")
+    se.STATE_DIR = pathlib.Path(td) / "echo2"
+    se.STATE_DIR.mkdir(parents=True, exist_ok=True)
+    (se.STATE_DIR / "sess3.json").write_text("{not json at all")
+    check("corrupt state -> emit", se.should_emit("k", "PAYLOAD-A", "sess3") is True)
+    check("and recovers into a valid state",
+          se.should_emit("k", "PAYLOAD-A", "sess3") is False)
+
+print()
+if fails:
+    print(f"FAILED {len(fails)}: {fails}")
+    sys.exit(1)
+print("all session_echo controls passed")

--- a/hooks/_lib/standing_report.py
+++ b/hooks/_lib/standing_report.py
@@ -1,0 +1,176 @@
+"""Standing-inventory reporting for SessionStart surfacers.
+
+WHY THIS EXISTS
+---------------
+Measured 2026-08-15: a SessionStart fire rendered 26,231 chars across ~26
+surfacers, and the shape repeats. Each one reports a STANDING INVENTORY — 90
+untracked automations, 15 unversioned skills, 5 stranded claim branches, a B2
+replica 63 days stale — in full, every session, whether or not anything moved.
+
+Two things go wrong at once:
+
+  1. The full inventory is the RATIONALE, not the order. The reader needs
+     "still 90, nothing changed" far more often than the enumeration.
+  2. A finding-set that never changes trains itself into wallpaper. Once it is
+     wallpaper, a set that DID change looks exactly the same as one that did
+     not, which is the failure the surfacer exists to prevent.
+
+So: speak in FULL when the finding-set changes, and in ONE line when it has not
+— a line that carries the count AND how long it has been stuck, which is the
+fact a standing alarm actually needs to convey and never does.
+
+THIS IS NOT SILENCING
+---------------------
+Coverage is unchanged. Nothing is suppressed: every session still reports the
+condition and the count. What drops is the re-enumeration of an unchanged list.
+A change of ANY kind — one item added, removed, or edited — restores the full
+render on the very next fire. The digest line also names the age, so a stuck
+alarm gets LOUDER in meaning as it ages instead of fading.
+
+FAIL-OPEN
+---------
+Every error path returns the full text. A broken condenser degrades to today's
+behaviour (verbose), never to silence.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from datetime import date
+from pathlib import Path
+
+STATE_DIR = Path.home() / ".claude" / ".standing-reports"
+BYPASS_ENV = "STANDING_REPORT_BYPASS"
+
+
+def _state_file(key: str) -> Path:
+    safe = "".join(c for c in key if c.isalnum() or c in "-_")[:60] or "unknown"
+    return STATE_DIR / f"{safe}.json"
+
+
+def _age_phrase(first_seen: str, n: int, exact: bool) -> str:
+    """`exact` = n counts distinct sessions; otherwise it counts FIRES.
+
+    The unit is stated rather than assumed. SessionStart fires ~2.5x per session
+    and Stop fires once per turn, so a fire count labelled "sessions" overstates
+    by a lot — it printed "93 session(s) today" on its first day live. A digest
+    whose own number is wrong is worse than a digest with no number, so when the
+    caller cannot supply a session id the label says what is actually counted.
+    """
+    unit = "session(s)" if exact else "fire(s)"
+    try:
+        d = (date.today() - date.fromisoformat(first_seen)).days
+    except Exception:
+        return f"unchanged for {n} {unit}"
+    if d <= 0:
+        return f"unchanged, {n} {unit} today"
+    return f"unchanged for {d}d / {n} {unit}"
+
+
+def report(key: str, full: str, summary: str, session_id: str | None = None) -> str:
+    """Full text when the finding-set moved; a one-line digest when it did not.
+
+    key      stable id for this surfacer, e.g. "untracked-tooling".
+    full     the complete render (what the hook prints today).
+    summary  ONE line carrying the count and the actionable order. The digest
+             appends how long the set has been stuck and where the detail lives.
+    """
+    if os.environ.get(BYPASS_ENV) == "1" or not full:
+        return full
+    try:
+        digest = hashlib.sha1(full.encode("utf-8", "replace")).hexdigest()[:16]
+        path = _state_file(key)
+        prev = {}
+        if path.exists():
+            try:
+                prev = json.loads(path.read_text(encoding="utf-8")) or {}
+            except (OSError, ValueError):
+                prev = {}
+        today = date.today().isoformat()
+        if prev.get("hash") == digest:
+            # Count distinct SESSIONS, not fires. SessionStart fires ~2.5x per
+            # session (startup + resume + compact) and Stop fires once per turn,
+            # so incrementing per invocation reported "93 session(s) today" on a
+            # machine that had run a handful — a digest whose own number is
+            # wrong is worse than no number. Seen 2026-08-16 on the first day
+            # this shipped.
+            seen_ids = prev.get("session_ids") or []
+            sid = str(session_id) if session_id else ""
+            if sid and sid not in seen_ids:
+                seen_ids.append(sid)
+                seen_ids = seen_ids[-200:]
+            n = len(seen_ids) if seen_ids else int(prev.get("sessions", 1)) + 1
+            first = prev.get("first_seen", today)
+            prev.update({"sessions": n, "last_seen": today,
+                         "session_ids": seen_ids})
+            _write(path, prev)
+            detail = prev.get("detail_path") or ""
+            tail = f"  ·  detail: {detail}" if detail else ""
+            digest_line = f"{summary}  [{_age_phrase(first, n, bool(seen_ids))}]{tail}"
+            # A "condensed" form longer than what it replaces is not a
+            # compression, it is a regression with extra steps. Short renders
+            # are already at their floor; hand them back untouched.
+            if len(digest_line) >= len(full):
+                return full
+            return digest_line
+        _write(path, {"hash": digest, "first_seen": today, "last_seen": today,
+                      "sessions": 1,
+                      "session_ids": [str(session_id)] if session_id else [],
+                      "detail_path": prev.get("detail_path", "")})
+        return full
+    except Exception:
+        return full
+
+
+def condense(key: str, full: str, session_id: str | None = None) -> str:
+    """report() using the render's own FIRST LINE as the summary.
+
+    Every one of these surfacers already opens with its count and its order
+    ("[untracked-tooling] 90 deployed personal automation(s) a fresh install
+    will not reproduce"). That line IS the summary, so wiring stays one call
+    per hook and no summary is hand-maintained in two places.
+    """
+    if not full:
+        return full
+    lines = [ln.rstrip() for ln in full.splitlines() if ln.strip()]
+    if not lines:
+        return full
+    summary = lines[0]
+    # Some renders open with a bare "[tag]" header and put the COUNT on the next
+    # line. Taking line 1 alone there produces a digest with no number in it —
+    # quieter AND less informative, which is exactly the trade this must never
+    # make. So when the opener carries no figure, pull in the first following
+    # line that does.
+    if not any(c.isdigit() for c in summary) or len(summary) < 50:
+        for ln in lines[1:4]:
+            if any(c.isdigit() for c in ln):
+                extra = ln.strip()
+                if len(extra) > 180:
+                    extra = extra[:180].rsplit(" ", 1)[0] + "…"
+                summary = f"{summary} {extra}" if summary.strip() else extra
+                break
+    return report(key, full, summary, session_id)
+
+
+def set_detail_path(key: str, path: str) -> None:
+    """Record where the full list can be read, for the digest line to cite."""
+    try:
+        p = _state_file(key)
+        cur = {}
+        if p.exists():
+            try:
+                cur = json.loads(p.read_text(encoding="utf-8")) or {}
+            except (OSError, ValueError):
+                cur = {}
+        cur["detail_path"] = str(path)
+        _write(p, cur)
+    except Exception:
+        pass
+
+
+def _write(path: Path, data: dict) -> None:
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(data), encoding="utf-8")
+    os.replace(tmp, path)

--- a/hooks/_lib/standing_report.test.py
+++ b/hooks/_lib/standing_report.test.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Negative control for standing_report.
+
+The dangerous failure is not verbosity, it is a CHANGED finding-set rendering
+as the quiet digest — that would trade coverage for silence, which is the one
+thing this pass must never do. So the controls that matter are: any change
+restores the full render, and every degraded path returns full.
+"""
+import os
+import sys
+import pathlib
+import tempfile
+
+HERE = pathlib.Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parent))
+import _lib.standing_report as sr  # noqa: E402
+
+fails = []
+
+
+def check(name, cond):
+    print(("  ok   " if cond else "  FAIL ") + name)
+    if not cond:
+        fails.append(name)
+
+
+# Realistic length ON PURPOSE. The digest carries a summary line plus an age
+# clause, so a toy 25-char fixture is SHORTER than any digest and the
+# never-grow guard correctly hands it back whole — which would silently make
+# every compression assertion below vacuous.
+_ROWS = "\n".join(f"  - item {i}: some finding with a path and a remedy" for i in range(20))
+FULL_A = "[x] 90 items a fresh install will not reproduce. Run the sweep.\n" + _ROWS
+FULL_B = "[x] 91 items a fresh install will not reproduce. Run the sweep.\n" + _ROWS + "\n  - item 20: one more"
+SUMMARY = "[x] 90 items a fresh install will not reproduce. Run the sweep."
+
+with tempfile.TemporaryDirectory() as td:
+    sr.STATE_DIR = pathlib.Path(td) / "sr"
+
+    print("first sight renders IN FULL")
+    check("first call returns full", sr.report("k", FULL_A, SUMMARY) == FULL_A)
+
+    print("unchanged set collapses to the digest, carrying count + age")
+    r2 = sr.report("k", FULL_A, SUMMARY)
+    check("second call is not the full text", r2 != FULL_A)
+    check("digest keeps the summary/count", SUMMARY in r2)
+    check("digest states it is unchanged", "unchanged" in r2)
+    check("digest is much shorter", len(r2) < len(FULL_A) + 60)
+
+    print("NEGATIVE CONTROL: any change restores the FULL render")
+    check("changed set returns full", sr.report("k", FULL_B, SUMMARY) == FULL_B)
+    check("then collapses again", sr.report("k", FULL_B, SUMMARY) != FULL_B)
+    check("reverting is also a change -> full", sr.report("k", FULL_A, SUMMARY) == FULL_A)
+
+    print("the counter names its own unit, and counts SESSIONS when it can")
+    sr.report("k", FULL_A, SUMMARY)
+    r = sr.report("k", FULL_A, SUMMARY)
+    check("no session id -> labelled as fires, not sessions",
+          "fire(s)" in r and "session(s)" not in r)
+    sr.report("s", FULL_A, SUMMARY, "SESS-1")
+    r1 = sr.report("s", FULL_A, SUMMARY, "SESS-1")
+    r1b = sr.report("s", FULL_A, SUMMARY, "SESS-1")
+    check("3 fires in one session still reads 1 session",
+          "1 session(s)" in r1b and "1 session(s)" in r1)
+    r2 = sr.report("s", FULL_A, SUMMARY, "SESS-2")
+    check("a second session increments to 2", "2 session(s)" in r2)
+
+    print("a digest longer than the text it replaces is never returned")
+    SHORT = "[t] 2 things\n- a"
+    sr.report("short", SHORT, "[t] 2 things")
+    check("short render passes through unchanged",
+          sr.report("short", SHORT, "[t] 2 things") == SHORT)
+
+    print("keys are isolated")
+    check("other key renders full", sr.report("k2", FULL_A, SUMMARY) == FULL_A)
+
+    print("detail pointer is cited once recorded")
+    sr.set_detail_path("k3", "/tmp/detail.txt")
+    sr.report("k3", FULL_A, SUMMARY)
+    check("digest cites detail path", "/tmp/detail.txt" in sr.report("k3", FULL_A, SUMMARY))
+
+    print("FAIL-OPEN: degraded paths return FULL, never the digest")
+    check("empty full passes through", sr.report("k", "", SUMMARY) == "")
+    os.environ[sr.BYPASS_ENV] = "1"
+    check("bypass returns full", sr.report("k", FULL_A, SUMMARY) == FULL_A)
+    del os.environ[sr.BYPASS_ENV]
+
+    sr.STATE_DIR = pathlib.Path("/proc/cannot-create-here/sr")
+    check("unwritable state returns full", sr.report("k", FULL_A, SUMMARY) == FULL_A)
+
+    sr.STATE_DIR = pathlib.Path(td) / "sr2"
+    sr.STATE_DIR.mkdir(parents=True, exist_ok=True)
+    (sr.STATE_DIR / "k.json").write_text("{corrupt")
+    check("corrupt state returns full", sr.report("k", FULL_A, SUMMARY) == FULL_A)
+
+print()
+if fails:
+    print(f"FAILED {len(fails)}: {fails}")
+    sys.exit(1)
+print("all standing_report controls passed")

--- a/hooks/dev-hub-refresh-on-session-start.py
+++ b/hooks/dev-hub-refresh-on-session-start.py
@@ -47,9 +47,21 @@ try:
 except Exception:
     print(json.dumps({}))
     sys.exit(0)
+try:
+    from _lib.standing_report import condense
+except Exception:  # fail-open: a surfacer must never break a session start
+    def condense(key, full, session_id=None):
+        return full
 
 
 def _emit(message: str | None = None) -> None:
+    # This is a STANDING INVENTORY: the same hubs are behind session after
+    # session until someone acts, and reciting the whole list every time is
+    # how a surfacer trains itself into wallpaper. Full render when the
+    # finding-set CHANGES, a one-line digest carrying the count and how long
+    # it has been stuck when it has not. See _lib/standing_report.py.
+    if message:
+        message = condense("dev-hub-refresh", message)
     if message:
         print(json.dumps({
             "hookSpecificOutput": {

--- a/hooks/dev-hub-refresh-on-session-start.py
+++ b/hooks/dev-hub-refresh-on-session-start.py
@@ -19,6 +19,15 @@ from __future__ import annotations
 import json
 import os
 import sys
+
+# Windows consoles default to cp1252; this hook prints non-ASCII, and an
+# unreconfigured stream raises UnicodeEncodeError mid-write (ai-brain-starter#313).
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+    except (AttributeError, ValueError):
+        pass
+
 import time
 from pathlib import Path
 

--- a/scripts/install-hooks-user-level.py
+++ b/scripts/install-hooks-user-level.py
@@ -345,6 +345,8 @@ HOME_HOOKS_INSTALLER_DEPLOYS = {
 HOME_HOOKS_LIB_DEPS = {
     "__init__.py",     # makes _lib a package; without it the import fails
     "vault_root.py",   # vault-context.py -> vault_root_for()
+    "standing_report.py",  # dev-hub-refresh + orphan-claude-branches -> condense()
+    "session_echo.py",     # available to any per-prompt injector -> should_emit()
 }
 
 # Hooks ai-brain-starter USED TO ship and has deliberately RETIRED. The

--- a/scripts/utf8-stdout-baseline.txt
+++ b/scripts/utf8-stdout-baseline.txt
@@ -111,7 +111,6 @@ b647243fdf0a358d46a6a79b0bf7f817ee121f68d5d685fabe4b0ee2a93af94d SEV-4-json-enco
 9384c96d288eb31a5f59cc7e985ec4b79e723309595d48a09a87e30d7907c5eb SEV-4-json-encoded hooks/check-fabricated-verification.py
 25d963d25e1e2e6844a35133bbad1d0aad8d03de424e29d4a406a67cb1d4c1cb SEV-4-json-encoded hooks/check-rule-conflicts-on-write.py
 85006d7e25f42ba787b2ce616bd1c71590c3990f89f3153a6f958156c93029ed SEV-4-json-encoded hooks/coach-auto-prescribe-on-journal.py
-6cf831608a79f218c2c62b94a125562a034eebef167d1979b26aa04fb2ddcf96 SEV-4-json-encoded hooks/dev-hub-refresh-on-session-start.py
 e34a230865351b20e13bfc64cd8c67f06931fac79f8129beb84471cce434cb58 SEV-4-json-encoded hooks/first-week-checkin.py
 a04ec6c84be6756813f4cde517ff379338b57ec9bf4c9c4172172951e62f91c3 SEV-4-json-encoded hooks/imessage-mcp-auto-export.py
 7eea06988957bbacac62bc43c9ebcb8067cc1cadd5184375f6d60d46ee99c4cc SEV-4-json-encoded hooks/inject-best-of-best-on-consulting.py


### PR DESCRIPTION
## Why

A hook fleet only grows. Every guard added is more always-loaded text, forever — and past some volume the fleet defeats itself: once the output is wallpaper, a guard with something **real** to say is indistinguishable from the twenty that do not. That is the failure this addresses, not verbosity for its own sake.

## Measured before writing either primitive

66 SessionStart hooks on a live install, plus 64 sessions of transcripts. The obvious fix is the wrong one for two of the three events:

| event | shape | right tool |
|---|---|---|
| UserPromptSubmit | 41% byte-identical repetition | per-session dedup |
| SessionStart | **only 10%** repetition — standing inventories recited in full | report the delta |
| Stop | 67% repetition — end-of-turn state re-announced every turn | condense at the dispatcher |

Applying dedup to SessionStart would have saved 10% and felt finished.

One method note, because the obvious measurement is also wrong: parsing a transcript **misattributes**. SessionStart surfacers merge into one `additionalContext` attachment, so a transcript parse lumps the whole block under whichever `[tag]` appears first — that is how a 1.1 KB emitter reads as a 16.8 KB one. Running the wired chain and measuring each process's own output is unambiguous.

## What ships

**`_lib/session_echo.py`** — suppress a payload byte-identical to one already emitted this session. Worst case measured: a context injector re-emitting the same 8.4 KB block **55 times in one session**, 88% of its volume pure re-echo. A CHANGED payload always emits, so a scope change still lands.

**`_lib/standing_report.py`** — for a surfacer reporting a standing inventory (N repos behind, N unversioned skills, N stranded branches): full render when the finding-set **changes**, one-line digest carrying the count plus how long it has been stuck when it does not.

Side effect worth naming: a stuck alarm now gets **louder in meaning as it ages** (`unchanged for 12d / 30 sessions`) instead of fading into the noise.

## This does not reduce coverage

Nothing is suppressed on first sight. Every session still reports the condition and its count. Any change — one item added, removed, or edited — restores the full render on the next fire.

**Fail-open throughout.** Every error path returns the FULL text. A broken condenser degrades to verbose, never to silence: losing a guard's message is a far worse failure than repeating it.

## Shipped with a caller, not dormant

Wired into `dev-hub-refresh-on-session-start.py`: **2,070 → 236 chars** on an unchanged session, counts intact.

Both modules registered in `HOME_HOOKS_LIB_DEPS` — without that they deploy nowhere and the consumer's import silently falls back to a no-op. `scripts/check-home-hook-deploy.py` now reports 4 `_lib` deps shipping (was 2).

## Controls

The negative control in each suite is the one that matters: **a changed payload must still speak.** A condenser that also swallows new information reads exactly like a working one from the terminal — quiet. Both suites additionally pin every degraded path (no session id, unwritable state dir, corrupt state file, bypass env) to the emit branch.

```
python3 hooks/_lib/session_echo.test.py      # all controls pass
python3 hooks/_lib/standing_report.test.py   # all controls pass
python3 scripts/check-home-hook-deploy.py    # OK, 4 _lib deps ship
```

## Two defects found on day one live, fixed here

- It counted **fires** and labelled them "sessions". SessionStart fires ~2.5x per session and Stop once per turn, so a real machine displayed `93 session(s) today`. Now counts distinct session ids when the caller supplies one, and says `fire(s)` when it cannot — the unit is stated, never assumed. A digest whose own number is wrong is worse than one with no number.
- On short renders the digest came out **longer** than the text it replaced. Never-grow guard added. That also made eight assertions vacuous, because the toy fixtures then took the pass-through path — fixtures resized so the compression path is genuinely exercised, with a short-render control kept alongside to pin the guard itself.

## Scope / bypass

Both are opt-in per call site; nothing changes for a hook that does not call them. `SESSION_ECHO_BYPASS=1` / `STANDING_REPORT_BYPASS=1` restore full output.

Deliberately **not** applied to PreToolUse: a rule there fires per ACTION, so if the same risky command is typed twice the warning must fire twice. Condensing there would cost real coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
