### PR TITLE
fix(block-raw-vault-git): a newline separates statements, so a cd after one is no longer invisible

### DIFF
--- a/hooks/block-raw-vault-git.py
+++ b/hooks/block-raw-vault-git.py
@@ -87,14 +87,33 @@ def _vault_git_dir_for(target: str) -> str | None:
 
 
 def _effective_cwd(command: str, initial: str) -> str:
-    """Resolve cwd after any leading `cd <path>` commands in the command string."""
+    """Resolve cwd after any `cd <path>` in the command string.
+
+    A NEWLINE separates statements exactly like `;` does. Splitting only on
+    `&&`/`||`/`;` left a newline-separated script as ONE chunk, and the
+    `re.match` below anchors at the chunk start -- so a `cd` was seen only
+    when it was the very first token of the whole command. Any statement
+    before it (`set -e`, an echo, a var assignment) made the `cd` invisible
+    and this hook resolved the HARNESS cwd instead. That disabled the guard
+    outright: from an unrelated repo, `set -e` + `cd <vault>` + a raw
+    `git add` reached the vault with no mutex.
+
+    A `cd` whose target is not an existing directory is IGNORED rather than
+    applied. `_targets_vault_repo` fails OPEN when it cannot resolve a repo,
+    so honouring a bogus path (a `cd` quoted inside a heredoc body or an echo)
+    would silently turn a blocked vault op into an allowed one -- the newline
+    split makes such lines reachable, so this clause is load-bearing, not
+    defensive dressing.
+    """
     cwd = os.path.expanduser(initial) if initial else ""
-    for chunk in re.split(r"\s*(?:&&|\|\||;)\s*", command):
+    for chunk in re.split(r"\s*(?:&&|\|\||;|\n)\s*", command):
         chunk = chunk.strip()
         m = re.match(r"cd\s+(?:\"([^\"]+)\"|'([^']+)'|(\S+))", chunk)
         if m:
             new_path = os.path.expanduser(next(g for g in m.groups() if g is not None))
-            cwd = new_path if os.path.isabs(new_path) else os.path.normpath(os.path.join(cwd, new_path))
+            cand = new_path if os.path.isabs(new_path) else os.path.normpath(os.path.join(cwd, new_path))
+            if os.path.isdir(cand):
+                cwd = cand
     return cwd
 
 

--- a/hooks/block-raw-vault-git.py
+++ b/hooks/block-raw-vault-git.py
@@ -176,7 +176,7 @@ def _targets_vault_repo(cwd: str) -> bool:
     try:
         out = subprocess.run(
             ["git", "-C", cwd, "rev-parse", "--git-common-dir"],
-            capture_output=True, text=True, timeout=5,
+            capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=5,
         )
     except Exception:
         return False
@@ -213,7 +213,7 @@ def _git_dir_is_vault(git_dir: str) -> bool:
     try:
         out = subprocess.run(
             ["git", "--git-dir", git_dir, "rev-parse", "--git-common-dir"],
-            capture_output=True, text=True, timeout=5,
+            capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=5,
             cwd=git_dir if os.path.isdir(git_dir) else None,
         )
         if out.returncode == 0 and out.stdout.strip():

--- a/hooks/test_block_raw_vault_git_cd.py
+++ b/hooks/test_block_raw_vault_git_cd.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Negative controls for block-raw-vault-git.py's `cd` resolution.
+
+THE NEGATIVE CONTROL IS THE POINT. Every "BLOCKS" leg below builds a REAL git
+repository for the vault and a REAL second repository standing in for an
+unrelated checkout, then asserts the hook refuses. A hook that returned 0
+unconditionally would pass only the ALLOW legs and fail every BLOCK leg.
+
+The regression these legs pin down:
+
+  `_effective_cwd` split statements on `&&`/`||`/`;` but NOT on a newline, and
+  its `cd` regex anchors at the chunk start. A newline-separated script was
+  therefore ONE chunk, so a `cd` was recognised only when it was the very first
+  token of the whole command. Any statement before it -- `set -e`, an echo, a
+  variable assignment -- made the `cd` invisible, and the hook resolved the
+  HARNESS cwd instead of the directory the command actually runs in.
+
+  That disabled the guard outright: from an unrelated repo, `set -e` then a
+  `cd` into the vault then a raw staging command reached the vault with no
+  mutex, which is the index race this hook exists to prevent.
+
+  The second clause is equally load-bearing. `_targets_vault_repo` fails OPEN
+  when it cannot resolve a repo, so once newlines split statements, a bogus
+  `cd /nonexistent` line quoted inside a heredoc body becomes reachable and
+  would redirect the cwd -- turning a blocked vault op into an allowed one.
+  Splitting on newlines WITHOUT ignoring unresolvable `cd` targets is a net
+  regression, so leg 6 fails if that clause is ever dropped.
+
+Legs:
+   1. BLOCKS a raw mutating op when cwd IS the vault        <- positive control
+   2. BLOCKS when `set -e` precedes the cd                  <- the regression
+   3. BLOCKS when an echo precedes the cd
+   4. BLOCKS when a variable assignment precedes the cd
+   5. BLOCKS when the cd is the first line                  <- worked before too
+   6. BLOCKS despite a bogus `cd` inside a heredoc body     <- fail-open guard
+   7. BLOCKS via the `&&` form                              <- no regression
+   8. ALLOWS an unrelated repo reached by a newline cd      <- no false positive
+   9. ALLOWS an unrelated repo reached after `set -e`       <- the false positive
+  10. ALLOWS read-only ops in the vault
+
+Stdlib only. Exit 0 = all pass.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+HOOK = os.path.join(os.path.dirname(os.path.abspath(__file__)), "block-raw-vault-git.py")
+MUTATE = "git add -A"
+
+
+def _init_repo(path: str) -> None:
+    os.makedirs(path, exist_ok=True)
+    subprocess.run(["git", "init", "-q", path], check=True, capture_output=True, text=True)
+
+
+def _blocked(cmd: str, cwd: str, vault: str) -> bool:
+    env = dict(os.environ, VAULT_ROOT=vault)
+    env.pop("GIT_VAULT_BYPASS", None)
+    p = subprocess.run(
+        [sys.executable, HOOK],
+        input=json.dumps({"tool_name": "Bash",
+                          "tool_input": {"command": cmd},
+                          "cwd": cwd}),
+        capture_output=True, text=True, env=env,
+    )
+    return p.returncode != 0 or "BLOCKED" in (p.stdout + p.stderr)
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        vault = os.path.realpath(os.path.join(tmp, "vault"))
+        other = os.path.realpath(os.path.join(tmp, "other-repo"))
+        _init_repo(vault)
+        _init_repo(other)
+
+        cases = [
+            ("raw mutating op, cwd IS the vault", MUTATE, vault, True),
+            ("`set -e` precedes the cd", f"set -e\ncd {vault}\n{MUTATE}", other, True),
+            ("an echo precedes the cd", f"echo hi\ncd {vault}\n{MUTATE}", other, True),
+            ("a variable assignment precedes the cd", f"X=1\ncd {vault}\n{MUTATE}", other, True),
+            ("the cd is the first line", f"cd {vault}\n{MUTATE}", other, True),
+            ("a bogus cd inside a heredoc must not unblock",
+             f"cd {vault}\ncat <<XX\ncd /definitely/not/a/real/dir\nXX\n{MUTATE}", other, True),
+            ("the && form still blocks", f"cd {vault} && {MUTATE}", other, True),
+            ("unrelated repo reached by a newline cd", f"cd {other}\ngit add file.txt", vault, False),
+            ("unrelated repo reached after `set -e`", f"set -e\ncd {other}\ngit add file.txt", vault, False),
+            ("read-only op in the vault", "git status", vault, False),
+        ]
+
+        failed = 0
+        for label, cmd, cwd, must_block in cases:
+            got = _blocked(cmd, cwd, vault)
+            ok = got == must_block
+            failed += not ok
+            print(f"{'PASS' if ok else 'FAIL':5} "
+                  f"expected={'BLOCK' if must_block else 'ALLOW':5} "
+                  f"got={'BLOCK' if got else 'ALLOW':5}  {label}")
+
+        print("\nALL PASS" if not failed else f"\n{failed} FAILING")
+        return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/test_block_raw_vault_git_cd.py
+++ b/hooks/test_block_raw_vault_git_cd.py
@@ -55,7 +55,9 @@ MUTATE = "git add -A"
 
 def _init_repo(path: str) -> None:
     os.makedirs(path, exist_ok=True)
-    subprocess.run(["git", "init", "-q", path], check=True, capture_output=True, text=True)
+    subprocess.run(["git", "init", "-q", path], check=True,
+                   capture_output=True, text=True,
+                   encoding="utf-8", errors="replace")
 
 
 def _blocked(cmd: str, cwd: str, vault: str) -> bool:
@@ -66,7 +68,7 @@ def _blocked(cmd: str, cwd: str, vault: str) -> bool:
         input=json.dumps({"tool_name": "Bash",
                           "tool_input": {"command": cmd},
                           "cwd": cwd}),
-        capture_output=True, text=True, env=env,
+        capture_output=True, text=True, encoding="utf-8", errors="replace", env=env,
     )
     return p.returncode != 0 or "BLOCKED" in (p.stdout + p.stderr)
 

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -995,6 +995,14 @@ PY_DIRECT=(
   # platform-only import, because a Linux runner structurally cannot observe a
   # Windows-only import crash.
   hooks/test_hook_smoke.py
+  # block-raw-vault-git resolved a `cd` only when it was the first token of the
+  # whole command, because it split statements on && || ; but not on a NEWLINE.
+  # `set -e` on line 1 was enough to make the cd invisible, so the hook read the
+  # harness cwd and allowed raw git straight into the vault. The control also
+  # pins the fail-open half: _targets_vault_repo allows when it cannot resolve a
+  # repo, so honouring an unresolvable `cd` (now reachable, since newlines split)
+  # would turn a blocked op into an allowed one.
+  hooks/test_block_raw_vault_git_cd.py
 )
 dormant_py=()
 while IFS= read -r -d '' f; do

--- a/scripts/utf8-subprocess-baseline.txt
+++ b/scripts/utf8-subprocess-baseline.txt
@@ -4,7 +4,6 @@
 # Fix by adding: encoding="utf-8", errors="replace"
 e2f343536da6ef508c45d335a9d2fbe9977f40aaa152f5c86913ddeb82f9c531 hooks/_lib/git_locks.py
 987aca2ae82229a42d29a8c89fed690e9de7e6fad4182dea564bc92557a81922 hooks/auto-capture-public-ships.py
-03d0966a13e6d14e1257d2b115894ac52bc350d3b955ec2ca1c7c9266107de51 hooks/block-raw-vault-git.py
 851421a1c5ac1daa0fae7effa71f06e08330cd4ec9edd9909b6fea8626ad0140 hooks/block-vault-git-fullwalk.py
 9cbf3bb52c04fd00a41852d12baf7640f9212db9b5a34aaac2247ee6abb4312f hooks/check-py-import-precommit.py
 25d963d25e1e2e6844a35133bbad1d0aad8d03de424e29d4a406a67cb1d4c1cb hooks/check-rule-conflicts-on-write.py


### PR DESCRIPTION
## What

`_effective_cwd` split statements on `&&` `||` `;` but **not on a newline**, and its `cd` regex anchors at the chunk start. A newline-separated script was therefore ONE chunk, so a `cd` was recognised only when it was the very first token of the whole command.

Any statement before it -- `set -e`, an echo, a variable assignment -- made the `cd` invisible, and the hook resolved the **harness cwd** instead of the directory the command actually runs in.

That disabled the guard outright. From an unrelated repo:

```
set -e
cd <vault>
git add -A
```

reached the vault with no mutex: the 60K-file `index.lock` race this hook exists to prevent. Found when the mirror-image false positive blocked a legitimate commit in a separate repo.

## Fix

Two parts, both load-bearing:

1. a newline joins the separator alternation
2. a `cd` whose target is not an existing directory is **ignored**

Part 2 is not defensive dressing. `_targets_vault_repo` fails **open** when it cannot resolve a repo, so once newlines split statements, a `cd /nonexistent` line quoted inside a heredoc body becomes reachable and would redirect the cwd -- turning a blocked vault op into an allowed one. **Part 1 without part 2 is a net regression**, which is why leg 6 of the new control pins it.

## Control

`hooks/test_block_raw_vault_git_cd.py` builds real git repos in a tempdir and runs against the hook in place, so `_lib.vault_root` resolves.

| | pre-fix | post-fix |
|---|---|---|
| positive control (raw op, no `cd`) | BLOCK | BLOCK |
| `set -e` before the cd | **ALLOW** | BLOCK |
| echo before the cd | **ALLOW** | BLOCK |
| var assignment before the cd | **ALLOW** | BLOCK |
| cd on the first line | BLOCK | BLOCK |
| bogus cd in a heredoc | BLOCK | BLOCK |
| `&&` form | BLOCK | BLOCK |
| unrelated repo after `set -e` | **BLOCK** (false positive) | ALLOW |

4 legs fail pre-fix, 10/10 pass after. The positive control passes in both directions, so a hook that blanket-allowed would not sneak through.

## Gates run locally

- `check-hook-activation.py` + `--selftest` -- OK
- `check-hook-negative-control.py` + `--selftest` -- OK (4/4)
- `test_hook_smoke.py` -- 91 hooks OK
- personal-data scrub -- clean, 19 gated + 16 markdown patterns each proven against a planted specimen

Same fix applied to the private deployed copy and its canonical source.

Generated with [Claude Code](https://claude.com/claude-code)
