### PR TITLE
fix(close-cascade): a folder with no Meta/ ended the session in total silence

### DIFF
--- a/hooks/detect-closing-signal.py
+++ b/hooks/detect-closing-signal.py
@@ -78,15 +78,17 @@ from datetime import datetime
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 try:
-    from _lib.vault_root import resolve_vault_root  # noqa: E402
+    from _lib.vault_root import collapse_worktree, resolve_vault_root  # noqa: E402
 except Exception:  # fail-open: if the lib cannot load, behave as before
-    def resolve_vault_root(cwd: Path, env_vault_root: str | None) -> Path:  # type: ignore
-        text = str(Path(env_vault_root) if env_vault_root else cwd)
-        norm = text.replace("\\", "/")  # marker must match Windows paths too
+    def collapse_worktree(path: Path) -> Path:  # type: ignore
+        norm = str(path).replace("\\", "/")  # marker must match Windows paths too
         marker = "/.claude/worktrees/"
         if marker in norm:
             return Path(norm.split(marker, 1)[0])
-        return Path(text)
+        return Path(path)
+
+    def resolve_vault_root(cwd: Path, env_vault_root: str | None) -> Path:  # type: ignore
+        return collapse_worktree(Path(env_vault_root) if env_vault_root else cwd)
 
 
 def log_debug(msg: str) -> None:
@@ -685,6 +687,89 @@ def write_marker(
     return marker
 
 
+def path_contains(parent: Path, child: Path) -> bool:
+    """True iff `child` is `parent` or sits underneath it.
+
+    Deliberately string/parts based rather than Path.is_relative_to (3.9+) or
+    os.path.commonpath (raises on mixed drives): a hook must not crash on an
+    exotic path, and a False here only costs an advisory line.
+    """
+    try:
+        pp = os.path.normcase(os.path.abspath(str(parent))).replace("\\", "/")
+        cp = os.path.normcase(os.path.abspath(str(child))).replace("\\", "/")
+    except (OSError, ValueError):
+        return False
+    if pp == cp:
+        return True
+    return cp.startswith(pp.rstrip("/") + "/")
+
+
+def offsite_vault_warning(vault_root: Path, cwd: Path) -> str:
+    """Advisory line when the cascade will write OUTSIDE the working folder.
+
+    resolve_vault_root falls back to $VAULT_ROOT (then cwd) when the current
+    folder does not declare its own cascade. That fallback is intended, but it
+    is silent: with a global VAULT_ROOT configured, a session in an unrelated
+    folder pre-builds its session file inside that other vault, and the model
+    is told a "Vault root:" that reads perfectly normal. Naming the mismatch is
+    what lets the model stop before it files one project's work in another's.
+
+    Returns "" when the resolution is in-scope (the common case).
+    """
+    base = collapse_worktree(cwd)
+    if path_contains(vault_root, base):
+        return ""
+    return (
+        "\n  ⚠ HETEROTOPIC RESOLUTION — the vault root above is NOT this session's\n"
+        f"    working folder ({base}).\n"
+        "    This folder does not declare its own cascade, so resolution fell back\n"
+        "    to $VAULT_ROOT. Every artifact below will be written into the OTHER\n"
+        "    vault. Before writing anything: confirm with the user that this\n"
+        "    session's notes belong there. If they do not, STOP and offer to\n"
+        "    scaffold this folder (Meta/ + a `## Session End` section in its own\n"
+        "    CLAUDE.md) so it owns its cascade — do not silently cross vaults."
+    )
+
+
+def build_unscaffolded_vault_notice(
+    matched: str,
+    confidence: str,
+    vault_root: Path,
+    meta_dir: Path,
+    reason: str,
+) -> str:
+    """Fail LOUD when the resolved vault has nowhere to write.
+
+    Previously this path logged to stderr behind CLOSING_SIGNAL_DEBUG and
+    emitted a passthrough: the user said "bye", the cascade did nothing, and
+    nothing anywhere said why. A silent no-op and a healthy close are
+    indistinguishable from the outside, which is the failure mode this
+    codebase treats as the worst one.
+    """
+    return (
+        f"SESSION CLOSE detected (signal: {matched!r}, confidence: {confidence}) — "
+        f"but the cascade CANNOT RUN here, so NOTHING has been written.\n\n"
+        f"  Resolved vault root: {vault_root}\n"
+        f"  Expected Meta dir:   {meta_dir}\n"
+        f"  Reason:              {reason}\n\n"
+        f"This folder is not scaffolded as a vault, so there is no Sessions/ or\n"
+        f"Decisions/ directory to write session artifacts into.\n\n"
+        f"TELL THE USER THIS PLAINLY in your closing message — do not report a\n"
+        f"normal close, and do not invent somewhere else to write. Then offer\n"
+        f"the fix:\n"
+        f"  1. Make this folder own its cascade — create {meta_dir}/Sessions/ and\n"
+        f"     {meta_dir}/Decisions/, AND add a `## Session End` (or\n"
+        f"     `## Session Close`) section to a CLAUDE.md at {vault_root}.\n"
+        f"     BOTH are required: the Meta dir alone gives the cascade somewhere\n"
+        f"     to write, but only the CLAUDE.md heading makes this folder resolve\n"
+        f"     to ITSELF instead of falling back to $VAULT_ROOT.\n"
+        f"  2. Or, if these notes belong to an existing vault, point VAULT_ROOT\n"
+        f"     at it for this project.\n\n"
+        f"Still give the user a normal verbal wrap-up. Just do not claim the\n"
+        f"cascade ran."
+    )
+
+
 def build_injected_context(
     confidence: str,
     matched: str,
@@ -700,6 +785,7 @@ def build_injected_context(
     is_trivial: bool,
     is_ambiguous: bool,
     goal_condition: str | None = None,
+    offsite_warning: str = "",
 ) -> str:
     """Compose the system block injected into the model's context.
 
@@ -729,7 +815,7 @@ def build_injected_context(
             + _full_cascade_block(
                 timestamp_human, timestamp_file, worktree, vault_root,
                 meta_dir, session_file, decisions_dir, captures_file,
-                pending_outcomes,
+                pending_outcomes, offsite_warning=offsite_warning,
             )
         )
 
@@ -740,6 +826,7 @@ def build_injected_context(
             timestamp_human, timestamp_file, worktree, vault_root,
             meta_dir, session_file, decisions_dir, captures_file,
             pending_outcomes, goal_condition,
+            offsite_warning=offsite_warning,
         )
     )
 
@@ -792,6 +879,7 @@ def _full_cascade_block(
     captures_file: Path,
     pending_outcomes: list[str],
     goal_condition: str | None = None,
+    offsite_warning: str = "",
 ) -> str:
     """The reusable cascade-instruction block."""
     pending = ", ".join(pending_outcomes) if pending_outcomes else "(none)"
@@ -840,7 +928,7 @@ Then walk Phases 0b -> 1 -> 2 -> 2b -> 3 below."""
 
   Timestamp:        {timestamp_human}
   Worktree:         {worktree}
-  Vault root:       {vault_root}
+  Vault root:       {vault_root}{offsite_warning}
   Session file:     {session_file}  (already pre-built with frontmatter + headers; fill in the body)
   Decisions dir:    {decisions_dir}  (write per-decision files here, slug-named)
   Captures file:    {captures_file}
@@ -1073,8 +1161,15 @@ def main() -> int:
         meta_dir = find_meta_dir(vault_root)
         ok, reason = verify_meta_dir(meta_dir)
         if not ok:
-            log_debug(f"meta_dir verification failed, skipping cascade: {reason}")
-            emit_passthrough()
+            # Fail LOUD. Skipping the WRITE is right (a phantom meta_dir would
+            # swallow the model's writes); skipping in SILENCE is not — the user
+            # signalled close and would otherwise get a clean-looking goodbye
+            # with no cascade behind it, indistinguishable from a healthy one.
+            log_debug(f"meta_dir verification failed, cascade cannot run: {reason}")
+            emit_context(build_unscaffolded_vault_notice(
+                matched=matched or "", confidence=confidence,
+                vault_root=vault_root, meta_dir=meta_dir, reason=reason,
+            ))
             return 0
         sessions_dir = meta_dir / "Sessions"
         decisions_dir = meta_dir / "Decisions"
@@ -1134,6 +1229,7 @@ def main() -> int:
             is_trivial=is_trivial,
             is_ambiguous=is_ambiguous,
             goal_condition=active_session_goal(transcript_path),
+            offsite_warning=offsite_vault_warning(vault_root, cwd),
         )
         emit_context(context)
         log_debug(f"injected context for {confidence} signal in {int((time.time() - start) * 1000)}ms")

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -168,6 +168,7 @@ INTEGRATION_TESTS=(
   test_verify_real_hooksjson_healthy_install
   test_detect_closing_signal_worktree
   test_detect_closing_signal_repo_aware_vault
+  test_detect_closing_signal_unscaffolded_vault
   test_detect_closing_signal_goal_clear
   test_close_phase_numbering_aligned
   test_phase_chain_contract

--- a/tests/integration/test_detect_closing_signal_unscaffolded_vault.sh
+++ b/tests/integration/test_detect_closing_signal_unscaffolded_vault.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Test: detect-closing-signal.py must never end a session in SILENCE, and must
+# say so when the cascade will write into a DIFFERENT vault than the one the
+# session is working in.
+#
+# Two bug classes, both in the SILENT-NO-OP family:
+#
+#  (1) UNSCAFFOLDED VAULT — when the resolved vault root has no Meta dir,
+#      verify_meta_dir() correctly refuses to emit paths (a phantom meta_dir
+#      would swallow the model's writes). But it refused by calling log_debug()
+#      — gated behind CLOSING_SIGNAL_DEBUG=1 — and then emit_passthrough().
+#      With debug off (every real session), the user said "bye", the cascade
+#      did nothing, and NOTHING anywhere said why. A silent no-op and a healthy
+#      close are indistinguishable from the outside. Reported 2026-08-18 by a
+#      student whose client folder closed "fine" for weeks writing nothing.
+#
+#  (2) HETEROTOPIC RESOLUTION — VAULT_ROOT is normally set once, globally, in
+#      settings.json. A session in a folder that does NOT declare its own
+#      cascade therefore resolves to that OTHER vault and pre-builds its
+#      session file there. The emitted block printed a "Vault root:" that read
+#      perfectly normal, so one project's session notes land in another
+#      project's vault with no signal. The RESOLUTION is intended and is left
+#      unchanged (see test_detect_closing_signal_repo_aware_vault.sh assertion
+#      4, which pins that fallback); only the silence is fixed.
+#
+# Assertions:
+#   1. No Meta dir + no VAULT_ROOT: emits a visible CANNOT-RUN notice naming
+#      the reason and the remediation — NOT a bare passthrough.
+#   2. That notice does not claim the cascade ran.
+#   3. Offsite resolution (bare cwd, VAULT_ROOT elsewhere): cascade emits AND
+#      carries the heterotopic warning.
+#   4. NEGATIVE CONTROL — a folder declaring its own cascade (Meta/ + a
+#      "## Session End" CLAUDE.md): cascade emits with NO warning.
+#   5. NEGATIVE CONTROL — cwd IS the configured vault root: no warning.
+#   6. NEGATIVE CONTROL — a worktree inside a self-declaring vault: no warning
+#      (the collapse must happen before the comparison, or every worktree
+#      close would cry wolf).
+#
+# Negative controls 4-6 exist because a warning that always fires is worth
+# nothing: the first draft of this fix raised NameError on collapse_worktree,
+# which the hook's catch-all turned into a passthrough — every case looked
+# "quiet and fine" and only the negative controls exposed it.
+#
+# Self-contained: tmpdir fake vaults, HOME sandboxed. Exit 0 = pass.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=tests/integration/lib/sandbox_home.sh
+. "$REPO_ROOT/tests/integration/lib/sandbox_home.sh"
+HOOK="$REPO_ROOT/hooks/detect-closing-signal.py"
+if [ ! -f "$HOOK" ]; then
+  echo "ERROR: $HOOK not found" >&2
+  exit 1
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+sandbox_home "$TMP/home"
+
+mkdir -p "$TMP/bare"
+mkdir -p "$TMP/default/⚙️ Meta"
+mkdir -p "$TMP/own/Meta" "$TMP/own/.claude/worktrees/slug"
+printf '# Own\n\n## Session End\n\nits own cascade\n' > "$TMP/own/CLAUDE.md"
+
+fails=0
+
+# Emit the hook's additionalContext ("" when it passed through).
+ctx() { # $1 = cwd, $2 = VAULT_ROOT ("" to unset)
+  local cwd="$1" vr="${2:-}"
+  local payload
+  payload="$(printf '{"prompt":"ok bye","session_id":"t","cwd":"%s"}' "$cwd")"
+  if [ -z "$vr" ]; then
+    printf '%s' "$payload" | env -u VAULT_ROOT python3 "$HOOK"
+  else
+    printf '%s' "$payload" | VAULT_ROOT="$vr" python3 "$HOOK"
+  fi | python3 -c 'import json,sys; print(json.load(sys.stdin).get("hookSpecificOutput",{}).get("additionalContext",""))'
+}
+
+check() { # $1=label $2=haystack $3=needle $4=expect(yes|no)
+  local got="no"
+  case "$2" in *"$3"*) got="yes";; esac
+  if [ "$got" != "$4" ]; then
+    echo "FAIL: $1 — expected '$3' present=$4, got present=$got" >&2
+    fails=$((fails + 1))
+  fi
+}
+
+# 1 + 2. Unscaffolded, no VAULT_ROOT — must be loud, must not claim success.
+out="$(ctx "$TMP/bare" "")"
+if [ -z "$out" ]; then
+  echo "FAIL: unscaffolded vault produced a silent passthrough (the bug)" >&2
+  fails=$((fails + 1))
+fi
+check "unscaffolded notice"     "$out" "cascade CANNOT RUN here" yes
+check "notice names remediation" "$out" "## Session End"          yes
+check "notice does not run cascade" "$out" "PHASE 0b"             no
+
+# 3. Offsite resolution must warn.
+out="$(ctx "$TMP/bare" "$TMP/default")"
+check "offsite cascade emitted" "$out" "PHASE 0b"                yes
+check "offsite warns"           "$out" "HETEROTOPIC RESOLUTION"  yes
+
+# 4. Negative control: folder owns its cascade.
+out="$(ctx "$TMP/own" "$TMP/default")"
+check "own-vault cascade emitted" "$out" "PHASE 0b"               yes
+check "own-vault does NOT warn"   "$out" "HETEROTOPIC RESOLUTION" no
+
+# 5. Negative control: cwd is the vault root itself.
+out="$(ctx "$TMP/default" "$TMP/default")"
+check "vault-root cwd does NOT warn" "$out" "HETEROTOPIC RESOLUTION" no
+
+# 6. Negative control: worktree inside a self-declaring vault.
+out="$(ctx "$TMP/own/.claude/worktrees/slug" "$TMP/default")"
+check "worktree does NOT warn" "$out" "HETEROTOPIC RESOLUTION" no
+
+if [ "$fails" -gt 0 ]; then
+  echo "FAILED: $fails assertion(s)" >&2
+  exit 1
+fi
+echo "PASS: close cascade fails loud on an unscaffolded vault, and flags offsite resolution"


### PR DESCRIPTION
## The report

From the field: a student set up a client folder, used it for weeks, and the session close "worked" every time. It was writing nothing. Their diagnosis was that the cascade lives in ai-brain-starter and needs a `Meta/` scaffold plus a `## Session End` heading in `CLAUDE.md`, and that without them the hook "fails silently."

Half right, and the half that was wrong matters. Measured against `origin/main` with a repro, there are **two** distinct failure modes, and which one you hit depends entirely on whether `VAULT_ROOT` is set.

## Bug 1 — silent close (no `VAULT_ROOT`)

`verify_meta_dir()` is correct to refuse when the resolved vault root has no `Meta` dir; a phantom path would swallow the model's writes. But it refused through `log_debug()`, gated behind `CLOSING_SIGNAL_DEBUG=1`, then `emit_passthrough()`. With debug off — every real session — the user says "bye" and gets a clean-looking goodbye with no cascade behind it. **A silent no-op and a healthy close were indistinguishable from the outside.**

## Bug 2 — cross-vault write (`VAULT_ROOT` set, the common case)

`VAULT_ROOT` is normally set once, globally, in `settings.json`. A folder that does not declare its own cascade resolves to *that other vault* and pre-builds its session file there. Repro, with `cwd` in the unscaffolded folder:

```
Vault root:   .../fakevault
Session file: .../fakevault/⚙️ Meta/Sessions/2026-08-18T10-58-main.md
```

The working folder got nothing. Note the third repro scenario: **the working folder had its own `Meta/` dir and the write still went to the other vault** — because `_declares_own_session_close_cascade` requires the `CLAUDE.md` heading *too*. So scaffolding `Meta/` alone does not bring the cascade home, which is the part the field diagnosis got backwards.

The resolution itself is intended (`test_detect_closing_signal_repo_aware_vault.sh` assertion 4 pins that fallback) and is **unchanged here**. Only the silence is fixed.

## The fix

- Bug 1: emit a visible CANNOT-RUN notice naming the resolved path, the reason, and the two-part remediation, and instruct the model not to report a normal close.
- Bug 2: an advisory line on the `Vault root:` row when the resolved root does not contain the worktree-collapsed `cwd`.
- Imports `collapse_worktree` from `_lib.vault_root`, using the file's existing fallback-shim pattern.

## On the negative controls

The first draft raised `NameError` on `collapse_worktree`, which the hook's catch-all turned into a passthrough — so every scenario looked quiet and fine, including the ones that were supposed to warn. Only the negative controls caught it. That is why 3 of the new test's 6 assertions are cases that must **not** warn (self-declaring vault, `cwd` is the vault root, worktree inside a vault). A warning that always fires is worth nothing.

## Verification

- New test fails **4 assertions** against the pre-fix hook, passes after.
- Canonical gate `scripts/ci.sh`: **EXIT=0** — 353 py_compile, 113 integration tests (incl. this one, confirmed executed by name in the log), 18 scripts, 16 hooks/tests suites, shellcheck, all secondary gates.
- Registered in `INTEGRATION_TESTS`, so the orphan-test guard is satisfied.
- Personal-data scrub: exit 0, clean.

Not verified: Windows-path behavior beyond the existing normalization, and no live end-to-end close was run in a real unscaffolded folder outside the repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
