### PR TITLE
fix(hooks): a warn reaches the model, it does not also print at the operator

### DIFF
--- a/hooks/warn-chained-state-command-truncated.py
+++ b/hooks/warn-chained-state-command-truncated.py
@@ -151,7 +151,6 @@ def main() -> None:
                     "permissionDecision": "allow",
                     "permissionDecisionReason": cmsg,
                 },
-                "systemMessage": cmsg,
             }))
             sys.exit(0)
 
@@ -190,7 +189,6 @@ def main() -> None:
                 "permissionDecision": "allow",
                 "permissionDecisionReason": vmsg,
             },
-            "systemMessage": vmsg,
         }))
         sys.exit(0)
 
@@ -221,7 +219,6 @@ def main() -> None:
             "permissionDecision": "allow",
             "permissionDecisionReason": msg,
         },
-        "systemMessage": msg,
     }))
     sys.exit(0)
 


### PR DESCRIPTION
`warn-chained-state-command-truncated` emitted the same string twice per fire:

- `permissionDecisionReason` — reaches the **model**, which is the entire point of a warn-tier nudge
- `systemMessage` — reaches only the **operator's transcript**

Three payloads, all `permissionDecision: "allow"`. This removes the second copy.

## Why

A guard exists to change what the agent does next. Printing it at the human is not delivery, it is interruption. In practice an ordinary Bash call rendered a 600-char advisory into the session as `PreToolUse:Bash says: ...`, repeated line by line.

Same principle already applied to the hookify rule engine: **a block is visible, a warn is not.**

## Scope held tight

- Only payloads that already carried the *identical variable* to the model were touched.
- Only payloads with no `deny` / `block`. A real refusal stays fully visible.
- `permissionDecisionReason` count unchanged at 3 — the model loses nothing.

## Review-risky area

The transformation keys on "same variable already delivered to the model". If a future payload sends a *different* string to `systemMessage` than to `permissionDecisionReason`, that one is deliberately left alone, because dropping it would lose content rather than a duplicate.

## Verification

Run against the deployed artifact, not just the branch copy — the first pass verified the branch file and wrongly reported silence:

| check | result |
|---|---|
| fires on piped-gate-then-`&&` | yes, 609 chars to model |
| `systemMessage` | 0 chars |
| `stderr` | 0 chars |
| `permissionDecision` | `allow` (still non-blocking) |

`ci-test` GREEN — `py_compile` (353 files) + 113 integration tests + 18 script suites + 16 hook suites + `shellcheck` + block-protocol + utf8 console guard.

Drafted with Claude Code; reviewed before merge.
