### PR TITLE
fix(vault-root): a Spanish CLAUDE.md never declared its own vault, so it wrote into someone else's

### DIFF
--- a/docs/SESSION_CLOSE.md
+++ b/docs/SESSION_CLOSE.md
@@ -66,6 +66,37 @@ cascadeTelemetry: false              # opt in to anonymized cascade-fire / compl
 ---
 ```
 
+## Which vault does the cascade write to?
+
+Session artifacts go to the **nearest folder that declares it owns a close cascade**, walking up from the working directory. If none does, resolution falls back to `$VAULT_ROOT`, then to the working directory itself.
+
+That fallback matters more than it looks. `VAULT_ROOT` is usually set once, globally. So a folder that does *not* declare itself gets its session notes filed into whatever other vault `VAULT_ROOT` names — the cascade runs, the paths look normal, and one project's notes land in another project's vault. If the resolved root is not the folder you are working in, the injected block now says so explicitly.
+
+A folder declares itself in either of two ways.
+
+**A heading in its `CLAUDE.md`** (zero-config, and what `/setup-brain` writes for you). Matched case-insensitively in the same three languages as the closing signals, and it must also have a `Meta` (or `⚙️ Meta`) directory:
+
+| Language | Headings that declare a root |
+|---|---|
+| English | `## Session End`, `## Session Close` |
+| Spanish | `## Cierre de sesión`, `## Fin de sesión` (accent optional) |
+| Portuguese | `## Fim de sessão`, `## Encerramento` |
+
+Session-adjacent headings like `## Session Protocol` deliberately do **not** count — a vault can discuss sessions without owning a cascade.
+
+**A declarative marker** (prose-independent, survives translation and rewording). Either:
+
+- an empty `.session-close-root` file in the folder, or
+- `sessionCloseRoot: true` in the frontmatter of its `CLAUDE.md`.
+
+The marker wins over the heading, and unlike the heading it does not require a `Meta` directory — an explicit declaration is an instruction, so the cascade honors it and then tells you plainly if there is nowhere to write yet.
+
+To make an existing folder own its cascade:
+
+```bash
+mkdir -p "Meta/Sessions" "Meta/Decisions" && touch .session-close-root
+```
+
 ## Closing signals (what gets matched)
 
 Three confidence levels:

--- a/hooks/_lib/vault_root.py
+++ b/hooks/_lib/vault_root.py
@@ -63,12 +63,40 @@ __all__ = [
     "vault_root_for",
 ]
 
-# Matches "## Session End", "## Session end", "# Session Close", etc. Deliberately
-# does NOT match "Session Protocol" or other session-adjacent headings — a vault
-# can discuss sessions without declaring itself the owner of a close cascade for
-# THIS purpose, and headings like that are exactly how the default/fallback
-# vault stays reachable only through the fallback path, never a false walk-up win.
-_SESSION_HEADING_RE = re.compile(r"^#+\s*Session\s+(?:End|Close)\b", re.IGNORECASE | re.MULTILINE)
+# Matches a heading that declares THIS folder owns a session-close cascade, in
+# the same three languages the close-signal packs already ship (en/es/pt). The
+# detector used to be English-only while the rest of the cascade was trilingual,
+# so a Spanish- or Portuguese-authored CLAUDE.md silently failed to declare
+# itself and — for an operator with a global VAULT_ROOT exported — resolved to
+# the WRONG vault with no signal. That is the LatAm multi-client delivery shape
+# (one operator, several client brains on one machine), so it is the default
+# case there, not an edge case. MYC-2457.
+#
+# Deliberately does NOT match "Session Protocol" or other session-adjacent
+# headings — a vault can discuss sessions without owning a close cascade for
+# THIS purpose, and such headings are exactly how the default/fallback vault
+# stays reachable only through the fallback path, never a false walk-up win.
+#
+# Accent-less spellings (sesion, sessao) are accepted because people type them.
+_SESSION_HEADING_RE = re.compile(
+    r"^#+\s*(?:"
+    r"Session\s+(?:End|Close)"                      # en
+    r"|(?:Cierre|Fin)\s+de\s+sesi[oó]n"             # es
+    r"|Fim\s+de\s+sess[aã]o"                        # pt
+    r"|Encerramento(?:\s+d[eao]\s+sess[aã]o)?"      # pt
+    r")\b",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+# Prose-independent opt-in. A heading is translation-, rename- and reword-proof
+# only up to the next time someone edits it; these two are not. Either form
+# declares the folder a session-close root:
+#   - a `.session-close-root` sentinel file beside CLAUDE.md, or
+#   - `sessionCloseRoot: true` in CLAUDE.md's frontmatter.
+_SESSION_ROOT_SENTINEL = ".session-close-root"
+_SESSION_ROOT_KEY_RE = re.compile(
+    r"^\s*sessionCloseRoot\s*:\s*(?:true|yes)\s*$", re.IGNORECASE | re.MULTILINE
+)
 
 # Defensive bound on the walk-up, independent of the $HOME/filesystem-root
 # stop conditions below — cheap insurance against an unexpected filesystem
@@ -116,19 +144,56 @@ def _has_meta_dir(candidate: Path) -> bool:
         return False
 
 
+def _frontmatter(text: str) -> str:
+    """The leading `---` fenced block, or "" when the file has none.
+
+    Scoped on purpose: `sessionCloseRoot: true` quoted in prose further down a
+    CLAUDE.md (documenting the feature, say) must not declare the folder a root.
+    """
+    if not text.startswith("---"):
+        return ""
+    end = text.find("\n---", 3)
+    return text[:end] if end != -1 else ""
+
+
+def _declares_session_root_explicitly(candidate: Path) -> bool:
+    """True iff `candidate` carries the prose-independent opt-in marker.
+
+    Unlike the heading path this does NOT require a Meta dir. An explicit
+    declaration is an instruction, not a hint: honoring it and then failing
+    loudly about the missing Meta dir (see detect-closing-signal's
+    unscaffolded-vault notice) tells the operator exactly what to fix. Falling
+    back to some other vault because the folder is half-built is the silent
+    cross-vault write this whole resolver exists to prevent.
+    """
+    if (candidate / _SESSION_ROOT_SENTINEL).is_file():
+        return True
+    claude_md = candidate / "CLAUDE.md"
+    if not claude_md.is_file():
+        return False
+    try:
+        text = claude_md.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    return bool(_SESSION_ROOT_KEY_RE.search(_frontmatter(text)))
+
+
 def _declares_own_session_close_cascade(candidate: Path) -> bool:
     """True iff `candidate` is a self-contained vault for session-close purposes.
 
-    Both signals required:
-      - a CLAUDE.md documenting its OWN "Session End"/"Session Close" cascade
-        (heading match, case-insensitive), AND
-      - an existing Meta folder to write into.
-    Either alone is too weak: a CLAUDE.md can mention sessions without owning
-    a cascade for this purpose (a default vault's own CLAUDE.md may use a
-    different heading — e.g. "Session Protocol" — precisely so it keeps
-    reaching itself through the fallback, not a walk-up match); a Meta
+    Precedence (MYC-2457):
+      1. The explicit marker wins outright — see _declares_session_root_explicitly.
+      2. Otherwise the zero-config heading path, which needs BOTH signals:
+         a CLAUDE.md whose heading declares its OWN close cascade (en/es/pt,
+         case-insensitive), AND an existing Meta folder to write into.
+    Either heading signal alone is too weak: a CLAUDE.md can mention sessions
+    without owning a cascade for this purpose (a default vault's own CLAUDE.md
+    may use a different heading — e.g. "Session Protocol" — precisely so it
+    keeps reaching itself through the fallback, not a walk-up match); a Meta
     folder can exist without any CLAUDE.md ever declaring it canonical.
     """
+    if _declares_session_root_explicitly(candidate):
+        return True
     claude_md = candidate / "CLAUDE.md"
     if not claude_md.is_file():
         return False

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -169,6 +169,7 @@ INTEGRATION_TESTS=(
   test_detect_closing_signal_worktree
   test_detect_closing_signal_repo_aware_vault
   test_detect_closing_signal_unscaffolded_vault
+  test_detect_closing_signal_trilingual_vault_root
   test_detect_closing_signal_goal_clear
   test_close_phase_numbering_aligned
   test_phase_chain_contract

--- a/tests/integration/test_detect_closing_signal_trilingual_vault_root.sh
+++ b/tests/integration/test_detect_closing_signal_trilingual_vault_root.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Test: session-close vault-root detection must work in every language the
+# close cascade already supports, and must offer a prose-independent opt-in.
+#
+# Bug (MYC-2457): the "does this folder own its own close cascade" check matched
+# an ENGLISH-ONLY heading (`^#+\s*Session\s+(?:End|Close)\b`) while the rest of
+# the cascade shipped trilingual en/es/pt closing-signal packs. A Spanish- or
+# Portuguese-authored CLAUDE.md therefore never declared itself, so
+# find_repo_vault_root() returned None and resolution fell back to the global
+# VAULT_ROOT. For an operator running several client brains on one machine with
+# a global VAULT_ROOT exported — the LatAm consultant delivery shape — a
+# non-English vault silently wrote its session artifacts into the WRONG vault.
+# Silent, and it looks exactly like a healthy close.
+#
+# A heading is also only translation-proof until someone rewords it, so this
+# adds a declarative marker that does not depend on prose at all.
+#
+# Assertions:
+#   1. Spanish heading ("## Cierre de sesión") resolves to ITSELF under a
+#      competing global VAULT_ROOT.  <- the reported bug
+#   2. Portuguese heading ("## Fim de sessão") likewise.
+#   3. Accent-less spellings ("Cierre de sesion") likewise — people type them.
+#   4. `.session-close-root` sentinel file declares the root with NO heading at
+#      all, in any language, however worded.
+#   5. `sessionCloseRoot: true` in CLAUDE.md frontmatter does the same.
+#   6. NEGATIVE CONTROL — English behavior byte-unchanged: an English-heading
+#      vault still resolves to itself.
+#   7. NEGATIVE CONTROL — FALLBACK PRESERVED: "## Session Protocol" (the
+#      default vault's own real heading) must still NOT declare a root, or
+#      every default vault would start false-winning the walk-up.
+#   8. NEGATIVE CONTROL — a Spanish heading about something else
+#      ("## Cierre de trimestre") must NOT declare a root.
+#
+# Controls 6-8 carry the weight: widening a regex is easy, and a widened regex
+# that matches everything would pass 1-5 while silently breaking the fallback
+# that keeps unrelated folders resolving to the operator's default vault.
+#
+# Self-contained: tmpdir fake vaults, HOME sandboxed. Exit 0 = pass.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=tests/integration/lib/sandbox_home.sh
+. "$REPO_ROOT/tests/integration/lib/sandbox_home.sh"
+HOOK="$REPO_ROOT/hooks/detect-closing-signal.py"
+if [ ! -f "$HOOK" ]; then
+  echo "ERROR: $HOOK not found" >&2
+  exit 1
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+sandbox_home "$TMP/home"
+
+DEFAULT="$TMP/default"
+mkdir -p "$DEFAULT/⚙️ Meta"
+printf '# Default vault\n\n## Session Protocol\n\nnot a close-cascade heading\n' > "$DEFAULT/CLAUDE.md"
+
+fails=0
+
+# Build a candidate vault: $1=name, $2=CLAUDE.md body ("" for none), $3=sentinel?(yes/no)
+mkvault() {
+  local d="$TMP/$1"
+  mkdir -p "$d/⚙️ Meta"
+  [ -n "$2" ] && printf '%s\n' "$2" > "$d/CLAUDE.md"
+  [ "${3:-no}" = "yes" ] && : > "$d/.session-close-root"
+  echo "$d"
+}
+
+# Which vault root does the hook resolve to for a close fired inside $1?
+resolved() {
+  printf '{"prompt":"ok bye","session_id":"t","cwd":"%s"}' "$1" \
+   | VAULT_ROOT="$DEFAULT" python3 "$HOOK" \
+   | python3 -c 'import json,sys,re
+c=json.load(sys.stdin).get("hookSpecificOutput",{}).get("additionalContext","")
+m=re.search(r"^  Vault root:\s+(.*)$", c, re.M)
+print(m.group(1).strip() if m else "")'
+}
+
+expect() { # $1=label $2=dir $3=self|default
+  local got want
+  got="$(resolved "$2")"
+  if [ "$3" = "self" ]; then want="$2"; else want="$DEFAULT"; fi
+  if [ "$got" != "$want" ]; then
+    echo "FAIL: $1 — resolved to '$got', expected '$want'" >&2
+    fails=$((fails + 1))
+  fi
+}
+
+# 1-3. Non-English headings must declare the folder its own root.
+expect "es heading"          "$(mkvault es      '# Bóveda
+
+## Cierre de sesión
+
+cascada aquí')"                        self
+expect "pt heading"          "$(mkvault pt      '# Cofre
+
+## Fim de sessão
+
+cascata aqui')"                        self
+expect "es heading no accent" "$(mkvault esna   '# Boveda
+
+## Cierre de sesion
+
+cascada aqui')"                        self
+
+# 4-5. Declarative markers, prose-independent.
+expect "sentinel file, no heading at all" "$(mkvault sentinel '# Anything
+
+## Notas sueltas
+
+no close heading here' yes)"           self
+expect "frontmatter key" "$(mkvault fm '---
+title: Client brain
+sessionCloseRoot: true
+---
+
+# Whatever
+
+## Notas')"                            self
+
+# 6. NEGATIVE CONTROL — English unchanged.
+expect "en heading (unchanged)" "$(mkvault en '# Vault
+
+## Session End
+
+cascade here')"                        self
+
+# 7. NEGATIVE CONTROL — fallback preserved for a session-adjacent heading.
+expect "Session Protocol still falls back" "$(mkvault proto '# Vault
+
+## Session Protocol
+
+not a close cascade')"                 default
+
+# 8. NEGATIVE CONTROL — unrelated Spanish heading must not win.
+expect "es unrelated heading falls back" "$(mkvault esother '# Bóveda
+
+## Cierre de trimestre
+
+reporte financiero')"                  default
+
+if [ "$fails" -gt 0 ]; then
+  echo "FAILED: $fails assertion(s)" >&2
+  exit 1
+fi
+echo "PASS: vault-root detection is trilingual (en/es/pt) + declarative, fallback preserved"


### PR DESCRIPTION
## The bug

The cascade decides *"does this folder own its session-close cascade"* by matching a heading in `CLAUDE.md`. That regex was English-only:

```python
r"^#+\s*Session\s+(?:End|Close)\b"
```

Meanwhile the rest of the cascade has shipped **trilingual en/es/pt** closing-signal packs for months. So a Spanish- or Portuguese-authored `CLAUDE.md` never declared itself, `find_repo_vault_root()` returned `None`, resolution fell back to the global `VAULT_ROOT`, and the folder's session artifacts were filed into a **different vault**. No error, and the injected paths read completely normal.

This is not an edge case for the delivery shape the substrate serves — one operator, several client brains on one machine, Spanish `CLAUDE.md`. There it is the *default* case.

## Two changes

**1. Trilingual headings**, matching the languages the closing-signal packs already support:

| Language | Declares a root |
|---|---|
| English | `## Session End`, `## Session Close` |
| Spanish | `## Cierre de sesión`, `## Fin de sesión` (accent optional) |
| Portuguese | `## Fim de sessão`, `## Encerramento` |

Session-adjacent headings still deliberately do **not** match, so a default vault using `## Session Protocol` keeps reaching itself through the fallback instead of false-winning a walk-up.

**2. A prose-independent opt-in**, because a heading is only translation-proof until someone rewords it. Either a `.session-close-root` sentinel file, or `sessionCloseRoot: true` in `CLAUDE.md` frontmatter.

The marker wins over the heading. Unlike the heading it does **not** require a `Meta` dir: an explicit declaration is an instruction, so the cascade honors it and then fails loudly about the missing `Meta` dir (#534) rather than silently resolving elsewhere. Frontmatter parsing is scoped to the leading fence, so documenting the key in prose does not accidentally declare a root.

All three close hooks already share `_lib/vault_root.py`, so this covers `detect-closing-signal`, `verify-session-close-cascade` and `verify-discoverability-on-close` in one place.

## On the negative controls

Widening a regex is easy, and a regex that matched everything would pass every new case while quietly breaking the fallback that keeps unrelated folders resolving to the operator's default vault. So 3 of the test's 8 cases are controls: `## Session Protocol` must still fall back, `## Cierre de trimestre` must still fall back, and English must be unchanged. A 21-case unit corpus covers the regex directly, including 9 false-positive candidates.

## Verification

- New integration test fails **5 assertions** against the old resolver, passes after; the 3 controls pass both before and after, which is the point of them.
- Registered in `INTEGRATION_TESTS` so the orphan-test guard is satisfied.
- Personal-data scrub: exit 0.
- Documented in `docs/SESSION_CLOSE.md` — which vault the cascade writes to was not written down anywhere before.

**One pre-existing gate failure, not from this diff:** `hooks/test_unpushed_drift_surface.py` fails locally. Verified by stashing this entire diff and re-running — identical failure, so it is environmental. Its "NO hub state present" case leaks the real machine's `~/dev` state into an assertion that expects none, so it passes or fails depending on the operator's unpushed branches. Filed separately.

## Ticket

Implements MYC-2457 in full. The branch name deliberately omits the issue ID so the merge does not auto-close it — the ticket gets moved by hand after the predicate is verified against merged `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
