### PR TITLE
fix(close-cascade): a hook crash after "bye" was still a silent close

### DIFF
--- a/hooks/detect-closing-signal.py
+++ b/hooks/detect-closing-signal.py
@@ -731,6 +731,36 @@ def offsite_vault_warning(vault_root: Path, cwd: Path) -> str:
     )
 
 
+def build_crashed_after_signal_notice(matched: str, err: str) -> str:
+    """Fail LOUD when the hook dies AFTER deciding the user is closing.
+
+    The catch-all below exists so a hook bug never blocks the user, and that is
+    right. But it returned a passthrough, and a passthrough after a matched
+    close signal is indistinguishable from a healthy close: the user says
+    "bye", the cascade never runs, and nothing anywhere says why. That is the
+    same defect #534 fixed for the KNOWN refusal, left open for the UNKNOWN
+    one — and it is not theoretical. A NameError introduced while writing #534
+    took exactly this path, and every scenario looked quiet and fine until a
+    negative control caught it.
+
+    Only fires once a signal has matched. No signal means the hook has no
+    business speaking, and the passthrough stays.
+    """
+    return (
+        f"SESSION CLOSE detected (signal: {matched!r}) — but the close hook "
+        f"CRASHED before it could emit the cascade, so NOTHING has been "
+        f"written.\n\n"
+        f"  Error: {err}\n\n"
+        f"This is a bug in the hook itself, not in the vault. TELL THE USER "
+        f"PLAINLY that the automatic close did not run — do not report a "
+        f"normal close.\n\n"
+        f"Then close the session MANUALLY: write the session file, decisions "
+        f"and captures by hand per the vault's own close rule, and report the "
+        f"error above so it can be fixed. Re-running with "
+        f"CLOSING_SIGNAL_DEBUG=1 prints the full trace."
+    )
+
+
 def build_unscaffolded_vault_notice(
     matched: str,
     confidence: str,
@@ -1073,6 +1103,7 @@ narration.{_goal_clear_block(goal_condition)}"""
 
 def main() -> int:
     start = time.time()
+    signal_seen: dict[str, str | None] = {"matched": None}
     try:
         hook_input = read_hook_input()
         prompt = (hook_input.get("prompt") or "").strip()
@@ -1143,6 +1174,9 @@ def main() -> int:
         confidence, matched = classify_signal(
             prompt, packs, custom, suppress, custom_only
         )
+        # Visible to the catch-all below: once a signal matches, going silent
+        # on an unexpected error is itself a failure the user must see.
+        signal_seen["matched"] = matched
 
         # Hybrid: ambiguous matches OR no match get a Haiku second look
         if confidence in (None, "ambiguous"):
@@ -1236,6 +1270,15 @@ def main() -> int:
         return 0
     except Exception as e:  # never block the user on hook errors
         log_debug(f"unexpected error: {e!r}")
+        # Never block — but never go SILENT once a close signal has matched.
+        if signal_seen["matched"] is not None:
+            try:
+                emit_context(build_crashed_after_signal_notice(
+                    signal_seen["matched"], f"{type(e).__name__}: {e}"
+                ))
+                return 0
+            except Exception:  # notice itself failed — fall through, still never block
+                log_debug("failed to emit crash notice")
         emit_passthrough()
         return 0
 

--- a/hooks/test_close_catchall_not_silent.py
+++ b/hooks/test_close_catchall_not_silent.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""The close hook must never go SILENT after a close signal has matched.
+
+detect-closing-signal wraps main() in a catch-all so a hook bug can never block
+the user. Correct. But it returned a PASSTHROUGH, and a passthrough after a
+matched close signal is byte-indistinguishable from a healthy close: the user
+says "bye", the cascade never runs, and nothing anywhere says why.
+
+That is the same defect #534 fixed for the KNOWN refusal (no Meta dir), left
+open for the UNKNOWN one. It is not theoretical — a NameError introduced while
+writing #534 took exactly this path, and every scenario read "quiet and fine"
+until a negative control caught it. A refactor bug in any branch downstream of
+the signal match silently disables the whole close cascade, permanently, with
+no signal on any surface.
+
+Assertions:
+  1. A crash AFTER the signal matches emits a visible notice, not a passthrough.
+  2. That notice names the error, so the bug is diagnosable from the transcript.
+  3. It instructs the model not to report a normal close.
+  4. NEGATIVE CONTROL — a crash with NO signal matched still passes through
+     silently. A hook that has not decided the user is closing has no business
+     speaking, and a notice there would fire on every unrelated prompt.
+  5. NEGATIVE CONTROL — the happy path is untouched: a normal close on a
+     healthy vault still emits the cascade, not the crash notice.
+
+Control 4 is the one that matters: "always emit something" would pass 1-3 and
+turn every hook error on every prompt into user-visible noise.
+"""
+import io
+import json
+import os
+import sys
+import tempfile
+from contextlib import redirect_stdout
+from pathlib import Path
+
+HOOKS = Path(__file__).resolve().parent
+sys.path.insert(0, str(HOOKS))
+
+import importlib.util
+
+spec = importlib.util.spec_from_file_location(
+    "detect_closing_signal", HOOKS / "detect-closing-signal.py"
+)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+failures = []
+
+
+def run(prompt, cwd, vault_root, boom=None):
+    """Run main() with stdin stubbed; optionally make a post-signal step raise."""
+    payload = json.dumps({"prompt": prompt, "session_id": "t", "cwd": str(cwd)})
+    original_stdin, original_find = sys.stdin, mod.find_meta_dir
+    # vault-root-ok: saving the caller's value to RESTORE it after the stub,
+    # not resolving a vault root. The hook under test does its own resolution
+    # through _lib/vault_root.py; this only keeps the test from leaking env.
+    original_vr = os.environ.get("VAULT_ROOT")
+    try:
+        sys.stdin = io.StringIO(payload)
+        os.environ["VAULT_ROOT"] = str(vault_root)
+        if boom:
+            def explode(*_a, **_k):
+                raise boom
+            mod.find_meta_dir = explode
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            mod.main()
+        return buf.getvalue()
+    finally:
+        sys.stdin = original_stdin
+        mod.find_meta_dir = original_find
+        if original_vr is None:
+            os.environ.pop("VAULT_ROOT", None)
+        else:
+            os.environ["VAULT_ROOT"] = original_vr
+
+
+def context_of(out):
+    try:
+        return json.loads(out).get("hookSpecificOutput", {}).get("additionalContext", "")
+    except (json.JSONDecodeError, AttributeError):
+        return ""
+
+
+with tempfile.TemporaryDirectory() as tmp:
+    tmp = Path(tmp)
+    vault = tmp / "vault"
+    (vault / "⚙️ Meta").mkdir(parents=True)
+
+    # 1-3. Crash after the signal matched -> loud, diagnosable, non-normal.
+    out = run("ok bye", vault, vault, boom=NameError("name 'collapse_worktree' is not defined"))
+    ctx = context_of(out)
+    if not ctx:
+        failures.append("crash after a matched signal produced a SILENT passthrough (the bug)")
+    if "CRASHED before it could emit the cascade" not in ctx:
+        failures.append("crash notice missing its headline")
+    if "collapse_worktree" not in ctx:
+        failures.append("crash notice does not name the error, so the bug is not diagnosable")
+    if "do not report a normal close" not in ctx:
+        failures.append("crash notice does not tell the model to stop reporting a normal close")
+
+    # 4. NEGATIVE CONTROL — no signal matched: stay silent.
+    out = run("what is the weather", vault, vault, boom=RuntimeError("kaboom"))
+    if context_of(out):
+        failures.append(
+            "crash with NO close signal emitted a notice — every unrelated prompt "
+            "would become user-visible noise"
+        )
+
+    # 5. NEGATIVE CONTROL — happy path unchanged.
+    out = run("ok bye", vault, vault)
+    ctx = context_of(out)
+    if "CRASHED" in ctx:
+        failures.append("healthy close wrongly reported a crash")
+    if "SESSION CLOSE detected" not in ctx:
+        failures.append("healthy close no longer emits the cascade")
+
+if failures:
+    print("FAILED — close catch-all silence guard:")
+    for f in failures:
+        print(f"  ✗ {f}")
+    sys.exit(1)
+print("OK - the close hook fails loud on a post-signal crash, stays quiet otherwise")

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -996,6 +996,7 @@ PY_DIRECT=(
   # platform-only import, because a Linux runner structurally cannot observe a
   # Windows-only import crash.
   hooks/test_hook_smoke.py
+  hooks/test_close_catchall_not_silent.py
   # block-raw-vault-git resolved a `cd` only when it was the first token of the
   # whole command, because it split statements on && || ; but not on a NEWLINE.
   # `set -e` on line 1 was enough to make the cd invisible, so the hook read the


### PR DESCRIPTION
Completes #534. That PR made the **known** refusal loud — no `Meta` dir, so the cascade says so instead of doing nothing quietly. It left the **unknown** one open.

## The gap

`main()` is wrapped in a catch-all so a hook bug can never block the user. That is right. But it returned a passthrough:

```python
except Exception as e:  # never block the user on hook errors
    log_debug(f"unexpected error: {e!r}")
    emit_passthrough()
```

`log_debug` is gated behind `CLOSING_SIGNAL_DEBUG=1`. So in every real session, a passthrough after a **matched close signal** is byte-indistinguishable from a healthy close: the user says "bye", the cascade never runs, nothing anywhere says why.

Not theoretical. A `NameError` introduced while writing #534 took exactly this path — every scenario read "quiet and fine" until a negative control caught it. Any refactor bug in any branch downstream of the signal match silently disables the entire close cascade, permanently, for everyone.

`hooks/test_hook_smoke.py` structurally cannot catch this: it runs every hook on a *minimal payload*, which never carries a close phrase, so the whole post-signal path is unexercised.

## The change

Once a signal has matched, the catch-all emits a notice naming the error and telling the model to close manually rather than report a normal close. Emitting the notice is itself wrapped, so a failure there still falls through to the passthrough — *never block the user* stays true.

## The assertion that carries the weight

It stays **silent when no signal matched**. A hook that has not decided the user is closing has no business speaking, and a notice there would turn every hook error on every unrelated prompt into user-visible noise.

That is assertion 4 of the new test, and it is the important one: a naive "always emit something" would pass assertions 1-3 and be considerably worse than the bug. Assertion 5 pins the happy path unchanged.

## Verification

- New test fails **4 assertions** against the old catch-all, passes after; both negative controls hold in each direction.
- Registered in `PY_DIRECT` so the dormancy invariant is satisfied.
- Canonical gate `scripts/ci.sh`: **EXIT=0** — 353 py_compile, 113 integration, 18 scripts, 17 hooks/tests suites, all secondary gates. New suite confirmed by name in the log.
- Personal-data scrub: exit 0.

One `os.environ.get("VAULT_ROOT")` in the new test carries a `# vault-root-ok:` annotation — it saves the caller's value to restore it after stubbing rather than resolving a root. The guard was correct to stop it; the annotation states why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
