### PR TITLE
fix(bootstrap): use a Python the machine already has instead of installing a redundant one

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -118,6 +118,34 @@ set -euo pipefail
 
 REPO_URL="https://github.com/mycelium-hq/ai-brain-starter.git"
 SKILL_DIR="$HOME/.claude/skills/ai-brain-starter"
+
+# === Python interpreter ===
+# `python3` is only ever the FIRST match on PATH, and on macOS that is
+# /usr/bin/python3 (3.9) whenever Homebrew sits later in PATH. The version
+# check further down used to test that one name and, finding it too old,
+# install Python 3.12 -- which fixes nothing on that machine, because
+# installing a formula cannot change what `python3` resolves to while /usr/bin
+# still comes first. The result was a redundant install, after which every
+# python3 call below still ran 3.9.
+#
+# So resolve an interpreter once, here, before anything uses one, and use it
+# everywhere below. AI_BRAIN_PYTHON names one directly, for a prefix no search
+# would guess (pyenv, conda).
+PY="python3"
+pick_python() {
+  local candidate resolved
+  for candidate in "${AI_BRAIN_PYTHON:-}" python3 python3.14 python3.13 python3.12 python3.11 python3.10; do
+    [[ -n "$candidate" ]] || continue
+    resolved="$(command -v "$candidate" 2>/dev/null || true)"
+    [[ -n "$resolved" ]] || continue
+    if "$resolved" -c 'import sys; sys.exit(0 if sys.version_info[:2] >= (3,10) else 1)' >/dev/null 2>&1; then
+      PY="$resolved"
+      return 0
+    fi
+  done
+  return 1
+}
+pick_python || true
 DRY_RUN=0
 # Corporate / hardened install profile (surfaced by an enterprise security
 # review). When 1, the installer: skips ALL third-party plugin marketplaces,
@@ -220,7 +248,7 @@ for arg in "$@"; do
         for a in "$@"; do
           [[ "$a" == "--install-hooks-user-level" ]] || forward_args+=("$a")
         done
-        exec python3 "$INSTALLER" "${forward_args[@]}"
+        exec "$PY" "$INSTALLER" "${forward_args[@]}"
       else
         echo "ERROR: install-hooks-user-level.py not found." >&2
         exit 2
@@ -632,7 +660,7 @@ if [[ "$UNINSTALL" == "1" ]]; then
 
   if [[ -f "$HOME/.claude/.mcp.json" ]]; then
     backup_file "$HOME/.claude/.mcp.json"
-    python3 - <<'PY' || warn "MCP cleanup failed"
+    "$PY" - <<'PY' || warn "MCP cleanup failed"
 import json, os
 p = os.path.expanduser("~/.claude/.mcp.json")
 m = json.load(open(p))
@@ -645,7 +673,7 @@ PY
 
   if [[ -f "$HOME/.claude/settings.json" ]]; then
     backup_file "$HOME/.claude/settings.json"
-    python3 - <<'PY' || warn "settings cleanup failed"
+    "$PY" - <<'PY' || warn "settings cleanup failed"
 import json, os
 p = os.path.expanduser("~/.claude/settings.json")
 s = json.load(open(p))
@@ -698,7 +726,7 @@ if [[ "${EMAIL_GATE_BYPASS:-0}" != "1" && $DRY_RUN -eq 0 && ! -f "$EMAIL_MARKER"
     esac
     log "$(t "Minting install token for $EMAIL via $INSTALL_API_BASE..." \
             "Generando token de instalación para $EMAIL en $INSTALL_API_BASE...")"
-    QM_PAYLOAD="$(EMAIL="$EMAIL" NAME="$NAME" QM_LANG="$QM_LANG" QM_OS="$QM_OS" python3 <<'PY'
+    QM_PAYLOAD="$(EMAIL="$EMAIL" NAME="$NAME" QM_LANG="$QM_LANG" QM_OS="$QM_OS" "$PY" <<'PY'
 import json, os
 print(json.dumps({
   "email": os.environ.get("EMAIL",""),
@@ -714,7 +742,7 @@ PY
       -H "content-type: application/json" \
       -d "$QM_PAYLOAD" 2>/dev/null)"
     set -e
-    QM_TOKEN="$(printf '%s' "${QM_RESP:-}" | python3 -c '
+    QM_TOKEN="$(printf '%s' "${QM_RESP:-}" | "$PY" -c '
 import json, sys
 try:
     d = json.load(sys.stdin)
@@ -953,7 +981,7 @@ hdr "Cleaning up deprecated tools"
 # into every session. The built-in memory system covers all use cases safely.
 SETTINGS="$HOME/.claude/settings.json"
 _claude_mem_present=0
-if [[ -f "$SETTINGS" ]] && python3 -c "
+if [[ -f "$SETTINGS" ]] && "$PY" -c "
 import json, sys
 try:
     s = json.load(open('$SETTINGS'))
@@ -970,7 +998,7 @@ if [[ $_claude_mem_present -eq 1 ]]; then
     dry "would remove claude-mem from settings.json (marketplace + plugin entry)"
   else
     backup_file "$SETTINGS"
-    python3 - <<'PY'
+    "$PY" - <<'PY'
 import json, os
 p = os.path.expanduser("~/.claude/settings.json")
 s = json.load(open(p))
@@ -1180,7 +1208,7 @@ have_working_git && ok "git $(git --version 2>/dev/null | awk '{print $3}')"
 # Python 3.10+
 # ───────────────────────────────────────────────────────────────────────────────
 
-if ! python3 -c "import sys; assert sys.version_info >= (3,10)" 2>/dev/null; then
+if ! "$PY" -c "import sys; assert sys.version_info >= (3,10)" 2>/dev/null; then
   if [[ $DRY_RUN -eq 1 ]]; then
     dry "would: install Python 3.12 (brew on Mac; apt/dnf/pacman on Linux; user-space tarball with neither)"
   elif { is_mac && have brew; } || { is_linux && have_sudo; }; then
@@ -1202,7 +1230,11 @@ if ! python3 -c "import sys; assert sys.version_info >= (3,10)" 2>/dev/null; the
     install_python_userspace || note_gap "python3" "install Python 3.10+ yourself, then re-run"
   fi
 fi
-have python3 && ok "python3 $(python3 --version | awk '{print $2}')"
+# A newly installed interpreter lands under a versioned name, in a prefix
+# that may not come first in PATH either, so re-resolve instead of assuming
+# `python3` changed meaning.
+pick_python || true
+have "$PY" && ok "python3 $("$PY" --version 2>/dev/null | awk '{print $2}')"
 
 # ───────────────────────────────────────────────────────────────────────────────
 # Node.js + npm
@@ -1270,7 +1302,7 @@ elif ! have pipx; then
   if is_mac; then
     brew install pipx && pipx ensurepath || err "pipx install failed"
   else
-    python3 -m pip install --user pipx && python3 -m pipx ensurepath || err "pipx install failed"
+    "$PY" -m pip install --user pipx && "$PY" -m pipx ensurepath || err "pipx install failed"
   fi
 fi
 # pipx installs console scripts into ~/.local/bin, and `pipx ensurepath` only
@@ -1392,7 +1424,7 @@ elif ! have graphify; then
   # the fallback when pipx itself misbehaves; both land in ~/.local/bin,
   # which is already exported above.
   quiet_retry pipx install graphifyy \
-    || quiet_retry python3 -m pip install --user graphifyy \
+    || quiet_retry "$PY" -m pip install --user graphifyy \
     || true
   hash -r 2>/dev/null || true
   if have graphify; then
@@ -1905,7 +1937,7 @@ backup_file "$HOME/.claude/.mcp.json"
 if [[ $DRY_RUN -eq 1 ]]; then
   dry "would register granola + chatprd MCPs in ~/.claude/.mcp.json (existing entries preserved)"
 else
-  python3 - <<'PY' || err "MCP registration failed"
+  "$PY" - <<'PY' || err "MCP registration failed"
 import json, os
 p = os.path.expanduser("~/.claude/.mcp.json")
 try:
@@ -1945,7 +1977,7 @@ if [[ $DRY_RUN -eq 1 ]]; then
   [[ "$CORPORATE_PROFILE" == "1" ]] && \
     dry "would ENFORCE telemetry-off + pin env in settings.json: DISABLE_TELEMETRY, DISABLE_ERROR_REPORTING, DISABLE_FEEDBACK_COMMAND, CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC, DISABLE_AUTOUPDATER, MYCELIUM_NO_PING"
 else
-  python3 - <<'PY' || err "settings.json plugin registration failed"
+  "$PY" - <<'PY' || err "settings.json plugin registration failed"
 import json, os
 p = os.path.expanduser("~/.claude/settings.json")
 corporate = os.environ.get("CORPORATE_PROFILE") == "1"
@@ -2141,7 +2173,7 @@ if [[ -f "$USER_HOOK_INSTALLER" ]] && [[ "$DRY_RUN" -eq 0 ]]; then
   # not present on the local fork, the runtime swallows the failure silently
   # via `2>/dev/null || echo '{"continue":true}'`. Verifying at install time
   # surfaces the gap loudly so it can actually be fixed.
-  python3 "$USER_HOOK_INSTALLER" --quiet --fail-on-missing 2>&1 | tee -a "$BOOTSTRAP_LOG"
+  "$PY" "$USER_HOOK_INSTALLER" --quiet --fail-on-missing 2>&1 | tee -a "$BOOTSTRAP_LOG"
   rc=${PIPESTATUS[0]}
   if [[ "$rc" -eq 0 ]]; then
     ok "User-level hooks installed (~/.claude/settings.json)"
@@ -2175,7 +2207,7 @@ if [[ -f "$EMAIL_MARKER" && $DRY_RUN -eq 0 ]]; then
     if [[ -f "$SIG_FILE" ]] && have python3; then
       HMAC_SECRET="$(head -1 "$SIG_FILE" 2>/dev/null | tr -d '[:space:]')"
       if [[ -n "$HMAC_SECRET" ]]; then
-        SIG="$(python3 -c 'import hmac,hashlib,sys; t,s=sys.argv[1:3]; print(hmac.new(s.encode(),t.encode(),hashlib.sha256).hexdigest())' "$RECORDED_TOKEN" "$HMAC_SECRET" 2>/dev/null || true)"
+        SIG="$("$PY" -c 'import hmac,hashlib,sys; t,s=sys.argv[1:3]; print(hmac.new(s.encode(),t.encode(),hashlib.sha256).hexdigest())' "$RECORDED_TOKEN" "$HMAC_SECRET" 2>/dev/null || true)"
       fi
     fi
     if [[ -n "$SIG" ]]; then

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -201,6 +201,7 @@ INTEGRATION_TESTS=(
   test_bootstrap_optional_packs_soft_fail
   test_bootstrap_corporate_profile
   test_bootstrap_userspace_fallback
+  test_bootstrap_python_discovery
   test_preflight_git_and_it_request
   test_remediate_runaway_procs
   test_scan_prior_single_instance

--- a/tests/integration/test_bootstrap_python_discovery.sh
+++ b/tests/integration/test_bootstrap_python_discovery.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Test bootstrap.sh's Python interpreter discovery.
+#
+# Bug (2026-08-18 cohort feedback): bootstrap.sh tested one name -- `python3` --
+# and, finding it older than 3.10, installed Python 3.12. On macOS `python3` is
+# /usr/bin/python3 (3.9) whenever Homebrew sits later in PATH, so the machine
+# got a redundant install that could not help: installing a formula does not
+# change what `python3` resolves to while /usr/bin still comes first, so every
+# python3 call in the rest of the script kept running 3.9. Machines that already
+# had a perfectly good python3.14 went through the whole detour.
+#
+# pick_python() resolves an interpreter ONCE, up front, preferring `python3` when
+# it already qualifies (so nothing changes for anyone bootstrap already worked
+# for) and otherwise walking the version-suffixed names newest-first.
+#
+# Covered here:
+#   1. pick_python() exists and is extractable from the real bootstrap.sh.
+#   2. THE REPORTED CASE: python3 too old, python3.12 present -> the versioned
+#      one is chosen. Paired with a NEGATIVE CONTROL asserting the ambient
+#      python3 in that same sandbox really does fail the >=3.10 test, so this
+#      cannot pass because the fixture forgot to model the bug.
+#   3. python3 already new enough -> it is kept, and a newer sibling does NOT
+#      displace it. This is the "changes nothing for existing installs" claim.
+#   4. Newest-first ordering among several qualifying versioned names.
+#   5. Nothing new enough -> pick_python reports failure rather than silently
+#      selecting a too-old interpreter.
+#   6. AI_BRAIN_PYTHON names an interpreter no search would find.
+#   7. Every executed python3 call in bootstrap.sh routes through "$PY" -- a
+#      structural check, because one missed call site silently runs 3.9 again.
+#
+# pick_python is extracted from the real bootstrap.sh (never reimplemented), so
+# this cannot drift from the shipped source -- same technique as
+# test_bootstrap_userspace_fallback.sh.
+#
+# PATH is sealed to the stub directory alone, so the runner's own interpreters
+# cannot decide any outcome. That matters: /usr/bin/python3 is 3.9 on macOS but
+# 3.12 on the Ubuntu CI runner, and a leaky PATH would make check 5 pass locally
+# and fail in CI (exactly the trap documented in the userspace-fallback test).
+# Stubs use #!/bin/sh, not `env bash`, because `env` needs a PATH to find bash.
+#
+# Self-contained; no network; never writes outside its own temp dir.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=tests/integration/lib/sandbox_home.sh
+. "$REPO_ROOT/tests/integration/lib/sandbox_home.sh"
+BOOTSTRAP="$REPO_ROOT/bootstrap.sh"
+[ -f "$BOOTSTRAP" ] || { echo "ERROR: $BOOTSTRAP not found" >&2; exit 1; }
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+TMP="$(mktemp -d)"
+sandbox_home "$TMP/realhome-guard"
+trap 'rm -rf "$TMP"' EXIT
+
+# Absolute bash, captured BEFORE any PATH sealing below.
+BASH_BIN="$(command -v bash)"
+
+# ── 1. pick_python() is present in the shipped script ──
+PICK_SRC="$(awk '/^pick_python\(\)[ ]*\{/,/^}$/' "$BOOTSTRAP")"
+[ -n "$PICK_SRC" ] || fail "1: pick_python() not found in bootstrap.sh"
+
+# mk_py DIR NAME VERSION — a stand-in interpreter answering the two questions
+# pick_python asks: the >=3.10 probe (-c), and --version.
+mk_py() {
+  local path="$1/$2" minor="${3#3.}"
+  cat > "$path" <<STUB
+#!/bin/sh
+if [ "\$1" = "-c" ]; then
+  [ "$minor" -ge 10 ] && exit 0
+  exit 1
+fi
+echo "Python $3"
+STUB
+  chmod +x "$path"
+}
+
+# run_pick DIR [AI_BRAIN_PYTHON] -> prints "PY=<resolved>" and, on failure,
+# "PICK_FAILED". PATH is the stub dir ONLY.
+run_pick() {
+  local dir="$1" override="${2:-}" harness="$TMP/pick-harness.sh"
+  {
+    echo 'set -uo pipefail'
+    echo 'PY="python3"'
+    printf '%s\n' "$PICK_SRC"
+    echo 'pick_python || echo "PICK_FAILED"'
+    echo 'echo "PY=$PY"'
+  } > "$harness"
+  env -i PATH="$dir" AI_BRAIN_PYTHON="$override" "$BASH_BIN" "$harness" 2>&1
+}
+
+# ── 2. THE REPORTED CASE: too-old python3, good python3.12 alongside ──
+D2="$TMP/case2"; mkdir -p "$D2"
+mk_py "$D2" python3 3.9
+mk_py "$D2" python3.12 3.12
+
+# Negative control FIRST: the sandbox must really reproduce the bug, or check 2
+# would be asserting against a fixture that was never broken.
+if env -i PATH="$D2" "$D2/python3" -c 'x' >/dev/null 2>&1; then
+  fail "2 (negative control): the stub python3 passes the >=3.10 probe, so this sandbox does not model the reported bug at all"
+fi
+
+OUT2="$(run_pick "$D2")"
+case "$OUT2" in
+  *PICK_FAILED*) fail "2: pick_python found nothing, but python3.12 was right there. Output: $OUT2" ;;
+esac
+case "$OUT2" in
+  *"PY=$D2/python3.12"*) : ;;
+  *) fail "2: expected python3.12 to be chosen, got: $OUT2" ;;
+esac
+
+# ── 3. a qualifying python3 is KEPT (no change for existing installs) ──
+D3="$TMP/case3"; mkdir -p "$D3"
+mk_py "$D3" python3 3.12
+mk_py "$D3" python3.14 3.14
+OUT3="$(run_pick "$D3")"
+case "$OUT3" in
+  *"PY=$D3/python3"*) : ;;
+  *) fail "3: a working python3 must be kept rather than displaced by a newer sibling, got: $OUT3" ;;
+esac
+case "$OUT3" in
+  *python3.14*) fail "3: python3.14 displaced a perfectly good python3 — that is a behaviour change for installs that already worked. Got: $OUT3" ;;
+esac
+
+# ── 4. newest-first among versioned names ──
+D4="$TMP/case4"; mkdir -p "$D4"
+mk_py "$D4" python3 3.9
+mk_py "$D4" python3.10 3.10
+mk_py "$D4" python3.11 3.11
+mk_py "$D4" python3.13 3.13
+OUT4="$(run_pick "$D4")"
+case "$OUT4" in
+  *"PY=$D4/python3.13"*) : ;;
+  *) fail "4: expected the newest qualifying interpreter (3.13), got: $OUT4" ;;
+esac
+
+# ── 5. nothing new enough -> reports failure, does not select a too-old one ──
+D5="$TMP/case5"; mkdir -p "$D5"
+mk_py "$D5" python3 3.9
+mk_py "$D5" python3.8 3.8
+OUT5="$(run_pick "$D5")"
+case "$OUT5" in
+  *PICK_FAILED*) : ;;
+  *) fail "5: pick_python must report failure when nothing reaches 3.10, so the caller still installs one. Got: $OUT5" ;;
+esac
+
+# ── 6. AI_BRAIN_PYTHON reaches a prefix no search would guess ──
+D6="$TMP/case6"; mkdir -p "$D6"
+mk_py "$D6" python3 3.9
+D6_ELSEWHERE="$TMP/case6-prefix"; mkdir -p "$D6_ELSEWHERE"
+mk_py "$D6_ELSEWHERE" python3 3.12
+OUT6="$(run_pick "$D6" "$D6_ELSEWHERE/python3")"
+case "$OUT6" in
+  *"PY=$D6_ELSEWHERE/python3"*) : ;;
+  *) fail "6: AI_BRAIN_PYTHON was ignored, got: $OUT6" ;;
+esac
+
+# ── 7. every executed python3 call routes through "$PY" ──
+# One missed call site runs 3.9 again on exactly the machines this fixes, and
+# nothing would say so. Comments, the candidate list inside pick_python, apt/dnf
+# PACKAGE names, and user-facing recovery text are all legitimately still
+# "python3", so strip those before looking.
+STRAY="$(grep -nE '(^|[^A-Za-z_#"])python3 ' "$BOOTSTRAP" \
+  | grep -vE '^[0-9]+:[[:space:]]*#' \
+  | grep -vE 'for candidate in' \
+  | grep -vE 'apt-get install|dnf install|pacman -S' \
+  | grep -vE '^[0-9]+:[[:space:]]*(err|dry|warn|log|ok) ' \
+  || true)"
+[ -z "$STRAY" ] || fail "7: these python3 invocations still bypass \$PY, so they keep running whatever PATH resolves first:
+$STRAY"
+
+echo "PASS: test_bootstrap_python_discovery (7 checks, 1 negative control)"

--- a/tests/integration/test_bootstrap_userspace_fallback.sh
+++ b/tests/integration/test_bootstrap_userspace_fallback.sh
@@ -181,7 +181,17 @@ build_harness() {
     done
     echo 'DRY_RUN=0'
     echo 'CORPORATE_PROFILE=0'   # inert on the post-fix code; required under set -u on the pre-fix code
-    awk '/^if ! python3 -c "import sys; assert sys.version_info >= \(3,10\)" 2>\/dev\/null; then$/,/^fi$/' "$src"
+    # The section resolves its interpreter through $PY, which is set at the top
+    # of bootstrap.sh -- far outside the range extracted here. Seed it, and pull
+    # in the picker the section re-runs after an install. extract_fn yields
+    # nothing on the pre-fix source, which never mentions either; harmless there.
+    echo 'PY="python3"'
+    extract_fn pick_python "$src"
+    # Anchored on the version assertion rather than on the interpreter token, so
+    # the SAME builder still extracts the section from the pre-fix source (which
+    # spells it `python3`) and the post-fix one (which spells it `"$PY"`). That
+    # dual match is what keeps check 5's negative control honest.
+    awk '/^if ! .* -c "import sys; assert sys.version_info >= \(3,10\)" 2>\/dev\/null; then$/,/^fi$/' "$src"
     echo 'have python3 && ok "python3 $(python3 --version | awk "{print \$2}")"'
     awk '/^if ! have node; then$/,/^fi$/' "$src"
     echo 'have node && ok "node $(node --version)"'
@@ -335,7 +345,8 @@ echo "PASS: negative control confirmed against the frozen pre-fix fixture (27d52
 # back to the same install_*_userspace() functions on that branch ──
 grep -q 'is_linux && have_sudo' "$BOOTSTRAP" \
   || fail "6: no section gates its Linux admin path on 'is_linux && have_sudo'"
-PY_BLOCK="$(awk '/^if ! python3 -c "import sys; assert sys.version_info >= \(3,10\)" 2>\/dev\/null; then$/,/^fi$/' "$BOOTSTRAP")"
+# Interpreter-token-agnostic, for the same reason as build_harness above.
+PY_BLOCK="$(awk '/^if ! .* -c "import sys; assert sys.version_info >= \(3,10\)" 2>\/dev\/null; then$/,/^fi$/' "$BOOTSTRAP")"
 NODE_BLOCK="$(awk '/^if ! have node; then$/,/^fi$/' "$BOOTSTRAP")"
 printf '%s' "$PY_BLOCK"   | grep -q 'is_linux && have_sudo' || fail "6: the Python section does not gate on is_linux && have_sudo"
 printf '%s' "$NODE_BLOCK" | grep -q 'is_linux && have_sudo' || fail "6: the Node section does not gate on is_linux && have_sudo"


### PR DESCRIPTION
Reported alongside the google-workspace-mcp installer bug (adelaidasofia/google-workspace-mcp#59), same root cause on a second surface.

## What was wrong

`bootstrap.sh` tested one name — `python3` — and, finding it older than 3.10,
installed Python 3.12. On macOS `python3` is `/usr/bin/python3` (3.9) whenever
Homebrew sits later in PATH, so a machine that already had a working
`python3.14` went through the whole detour.

The worse half: the remediation could not work on that machine either.
Installing a formula does not change what `python3` resolves to while
`/usr/bin` still comes first, so all ~15 `python3` calls in the rest of the
script kept running 3.9 afterwards. The gate looked like it was protecting
them and was not — a redundant install, followed by exactly the state it was
meant to prevent.

Seven of those call sites run *before* the version check, so they were never
covered by it at all.

## What changed

`pick_python()` resolves an interpreter once, before anything uses one, and
every executed call site routes through `"$PY"`.

- `python3` is still tried first, so **nothing changes for anyone bootstrap
  already worked for**. Otherwise it walks `python3.14` down to `python3.10`.
- `AI_BRAIN_PYTHON=/path/to/python3` names one directly, for a prefix no
  search would guess (pyenv, conda).
- The picker runs **again after an install lands**. That is the half that
  makes the install branch actually take effect: a fresh interpreter arrives
  under a versioned name, in a prefix that may not come first in PATH either.

## Tests

`test_bootstrap_python_discovery` (new, registered in `scripts/ci.sh` so it
cannot ship dormant) covers the reported case, newest-first ordering, the
"a working python3 is kept" claim, failure when nothing reaches 3.10, the
override, and a structural check that no executed call site still bypasses
`$PY` — one missed site silently runs 3.9 again on exactly the machines this
fixes.

PATH is sealed to the stub directory, because `/usr/bin/python3` is 3.9 on
macOS and 3.12 on the Ubuntu runner; a leaky PATH would make it pass locally
and fail in CI, which is the trap already documented in
`test_bootstrap_userspace_fallback`. It carries a negative control asserting
the fixture really reproduces the bug, and it fails against the pre-fix script.

`test_bootstrap_userspace_fallback` extracted that section by an awk anchor on
the literal `if ! python3 -c ...` line, and the *same* builder has to keep
extracting it from the pre-fix source for its own negative control. The anchor
now matches on the version assertion rather than the interpreter token, and the
harness seeds `$PY` and pulls in `pick_python`. Its negative control still
passes against the frozen pre-fix fixture.

## Deliberately not done

`bootstrap.ps1` has the same single-name shape (`python`, with no `py -3.x`
launcher fallback). It is left alone here: PowerShell cannot be exercised on
the machine this was written on, and shipping an unverified change to the
installer every Windows user runs is the wrong trade. Worth its own pass on a
Windows box.
