### PR TITLE
fix(bootstrap.ps1): use a Python the machine already has, and consult the py launcher (#290)

### DIFF
--- a/.github/workflows/windows-install.yml
+++ b/.github/workflows/windows-install.yml
@@ -88,6 +88,37 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
+      # Which Python does bootstrap pick? (ai-brain-starter#290)
+      # scripts/ci.sh runs this SAME suite on ubuntu under pwsh 7. That proves
+      # the resolver's logic and structurally cannot express the two things
+      # that only exist here: Windows PowerShell 5.1 semantics, and a real `py`
+      # launcher. Neither runner alone is the gate.
+      # Placed before the e2e run below so a resolver regression names itself
+      # instead of surfacing as a confusing failure in the middle of an install.
+      # Costs seconds and shares this job's already-paid runner, rather than
+      # adding a second windows-latest job floor at the 2x multiplier.
+      - name: bootstrap.ps1 Python discovery (Windows PowerShell 5.1)
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          if ($PSVersionTable.PSEdition -ne "Desktop") {
+            Write-Host "::error::Expected Windows PowerShell 5.1 (Desktop edition) for this suite; got $($PSVersionTable.PSEdition) $($PSVersionTable.PSVersion)."
+            exit 1
+          }
+          # Informational only: the suite seals PATH to its own stubs, so the
+          # runner's interpreters decide nothing. Logged so that "is this runner
+          # still representative of a real Windows box?" is answerable from the
+          # run, without turning an image change into a red gate.
+          $realPy = Get-Command py -ErrorAction SilentlyContinue
+          if ($realPy) { Write-Host "runner has a real py launcher at $($realPy.Source)" }
+          else { Write-Host "runner has NO py launcher on PATH (suite is unaffected; it uses sealed stubs)" }
+          powershell -NoProfile -ExecutionPolicy Bypass -File "$env:GITHUB_WORKSPACE\tests\integration\test_bootstrap_ps1_python_discovery.ps1"
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "::error::bootstrap.ps1 Python discovery suite failed (exit $LASTEXITCODE)"
+            exit $LASTEXITCODE
+          }
+          exit 0
+
       # A clean, known Python interpreter. The user-level hook installer is a
       # Python script, so SOME python must be present for the hook-install
       # assertion to mean anything; Bug 2 is a path-ENCODING bug, independent of

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -424,11 +424,133 @@ if (Have winget) {
 }
 
 # ─── Python 3.10+ ─────────────────────────────────────────────────────────────
-$pythonOk = $false
-try {
-    $v = (python --version 2>&1) -replace 'Python ',''
-    if ([version]$v -ge [version]"3.10") { $pythonOk = $true }
-} catch {}
+# Windows offers three separate ways to be wrong about "is Python here?", and
+# testing the single name `python` walked into all three:
+#   1. The Python Launcher (`py -3.12`) is the canonical multi-version resolver
+#      on Windows and was never consulted, so a machine with 3.12 installed but
+#      `python` unset or shadowed read as "no Python at all".
+#   2. Windows ships a `python` STUB in WindowsApps that opens the Microsoft
+#      Store instead of running an interpreter. It IS on PATH, so a presence
+#      check passes; it prints no parseable version, so the [version] cast threw
+#      and $pythonOk stayed $false. Result: install a Python already present.
+#   3. A real but too-old `python` (3.9) can shadow a newer one later in PATH.
+#      Installing 3.12 cannot fix that, because it cannot change what the NAME
+#      `python` resolves to - the same trap fixed on the shell side in #538.
+# So resolve ONE interpreter up front by EXECUTING each candidate and letting
+# Python itself answer the >= 3.10 question, then use that exact interpreter for
+# every call below. Mirrors pick_python() in bootstrap.sh. AI_BRAIN_PYTHON names
+# one directly, for a prefix no search would guess (pyenv-win, conda).
+#
+# ai-brain:pick-python:start
+# Everything between these two markers is extracted VERBATIM and dot-sourced by
+# tests/integration/test_bootstrap_ps1_python_discovery.ps1, so it must stay
+# self-contained: no Log/Warn/T or any other bootstrap-only helper in here.
+$PythonExe             = $null
+$PythonArgs            = @()
+$PythonOverrideIgnored = $false
+
+function Test-PythonCandidate($Exe, $PrefixArgs) {
+    # Executing the candidate is the only honest test. Presence on PATH is not
+    # evidence (the Store alias is present and is not an interpreter), and
+    # parsing --version is not evidence (the alias prints no version at all).
+    # Let the interpreter decide and read the answer off its exit code.
+    if (-not $PrefixArgs) { $PrefixArgs = @() }
+    # EAP is "Stop" for the whole script, and Windows PowerShell 5.1 turns a
+    # native command's STDERR into a terminating NativeCommandError under it -
+    # the crash class that killed this installer once already (Bug 1, see
+    # windows-install.yml). A pyenv/conda shim printing a deprecation warning
+    # would then be REJECTED as "not a Python" and earn the user the redundant
+    # install this whole change exists to prevent. Exit code decides, not
+    # stderr, so neutralise EAP here exactly as Run-Native does.
+    $eapSaved = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    try {
+        # Sentinel, not 0: if the process somehow never runs WITHOUT throwing,
+        # $LASTEXITCODE keeps the sentinel and the candidate is rejected. Seeding
+        # 0 here would make that same silence read as a pass.
+        $global:LASTEXITCODE = 9009
+        & $Exe @PrefixArgs -c 'import sys; sys.exit(0 if sys.version_info[:2] >= (3,10) else 1)' 2>$null | Out-Null
+        return ($LASTEXITCODE -eq 0)
+    } catch {
+        # CommandNotFound, or a file that is not a valid executable image: the
+        # process never ran, so $LASTEXITCODE still holds whatever it held
+        # before this call. Never read it here - the throw IS the answer.
+        return $false
+    } finally {
+        $ErrorActionPreference = $eapSaved
+    }
+}
+
+function Resolve-Python {
+    # Generic names first, so a machine bootstrap already worked on keeps the
+    # interpreter it was already using; then the launcher newest-first.
+    # Candidates are objects, NOT nested arrays: PowerShell flattens
+    # @("py", @()) down to a 1-element array, which would silently drop every
+    # prefix argument and turn `py -3.12` back into a bare `py`.
+    $candidates = @()
+    if ($env:AI_BRAIN_PYTHON) {
+        $candidates += [pscustomobject]@{ Name = $env:AI_BRAIN_PYTHON; Prefix = @(); IsOverride = $true }
+    }
+    foreach ($n in @("python", "python3")) {
+        $candidates += [pscustomobject]@{ Name = $n; Prefix = @(); IsOverride = $false }
+    }
+    foreach ($v in @("3.14", "3.13", "3.12", "3.11", "3.10")) {
+        $candidates += [pscustomobject]@{ Name = "py"; Prefix = @("-$v"); IsOverride = $false }
+    }
+    # Bare `py` last: honours the machine's configured default and catches a
+    # version newer than anything enumerated above.
+    $candidates += [pscustomobject]@{ Name = "py"; Prefix = @(); IsOverride = $false }
+
+    foreach ($c in $candidates) {
+        $prefix = $c.Prefix
+        if (-not $prefix) { $prefix = @() }
+        $found = Get-Command $c.Name -ErrorAction SilentlyContinue
+        if (-not $found) {
+            if ($c.IsOverride) { $script:PythonOverrideIgnored = $true }
+            continue
+        }
+        $exe = $found.Source
+        if (-not $exe) { $exe = $found.Name }
+        if (-not (Test-PythonCandidate $exe $prefix)) {
+            if ($c.IsOverride) { $script:PythonOverrideIgnored = $true }
+            continue
+        }
+        # Collapse `py -3.12` to the interpreter the launcher actually selected,
+        # so every call site downstream is a plain exe. Otherwise one forgotten
+        # prefix argument silently runs the machine's DEFAULT python instead.
+        $real = $null
+        $eapSaved = $ErrorActionPreference
+        $ErrorActionPreference = "Continue"   # same stderr-under-Stop reason as above
+        try {
+            $global:LASTEXITCODE = 9009
+            # Capture in full, THEN take the first line. Piping a native command
+            # straight into `Select-Object -First 1` stops the pipeline early, and
+            # an early-stopped pipeline never updates $LASTEXITCODE - so the check
+            # below read the seeded sentinel and threw away a good answer every
+            # single time. Measured on pwsh 7.5: -First 1 leaves LASTEXITCODE at
+            # 9009, the same call without it leaves 0.
+            $out = & $exe @prefix -c 'import sys; print(sys.executable)' 2>$null
+            if ($LASTEXITCODE -eq 0) { $real = ($out | Select-Object -First 1) }
+        } catch { $real = $null } finally { $ErrorActionPreference = $eapSaved }
+        if ($real) { $real = "$real".Trim() }
+        if ($real -and (Test-Path -LiteralPath $real)) {
+            $script:PythonExe  = $real
+            $script:PythonArgs = @()
+        } else {
+            $script:PythonExe  = $exe
+            $script:PythonArgs = @($prefix)
+        }
+        return $true
+    }
+    return $false
+}
+# ai-brain:pick-python:end
+
+$pythonOk = Resolve-Python
+if ($PythonOverrideIgnored) {
+    Warn (T "AI_BRAIN_PYTHON is set to '$env:AI_BRAIN_PYTHON' but that is not a Python 3.10+ interpreter - ignoring it and searching PATH." `
+            "AI_BRAIN_PYTHON apunta a '$env:AI_BRAIN_PYTHON' pero no es un interprete Python 3.10+ - se ignora y se busca en el PATH.")
+}
 if (-not $pythonOk -and $CorporateProfile) {
     Warn (T "Corporate profile: Python 3.10+ not found - NOT auto-installing (user-space, pinned-version policy)." `
             "Perfil corporativo: no se encontro Python 3.10+ - NO se instala automaticamente (espacio de usuario, version fija).")
@@ -475,7 +597,29 @@ if (-not $pythonOk -and $CorporateProfile) {
     }
     $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
 }
-if (Have python) { Ok "python $(python --version)" } else { Err "python install failed" }
+# The install branch above refreshed $env:Path, so a Python that was invisible a
+# moment ago may be resolvable now. Re-resolve rather than trusting the earlier
+# miss; when nothing was installed this is a handful of cheap Get-Command misses.
+if (-not $pythonOk) { $pythonOk = Resolve-Python }
+if ($PythonExe) {
+    $pyVerRaw = $null
+    # Capture first, select after: see the note in Resolve-Python about
+    # `Select-Object -First 1` short-circuiting a native-command pipeline.
+    $eapSaved = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"   # same stderr-under-Stop reason as in Resolve-Python
+    try { $pyVerOut = & $PythonExe @PythonArgs --version 2>$null } catch { $pyVerOut = $null } finally { $ErrorActionPreference = $eapSaved }
+    $pyVerRaw = $pyVerOut | Select-Object -First 1
+    if ($pyVerRaw) { $pyVer = "$pyVerRaw".Trim() } else { $pyVer = "(version unavailable)" }
+    # Print the resolved PATH, not just the version: "which python is this?" is
+    # the question every report about this area has turned on.
+    Ok "$pyVer  [$PythonExe]"
+} elseif ($CorporateProfile -or $DryRun) {
+    Warn (T "No Python 3.10+ resolved - steps that need python will be skipped." `
+            "No se resolvio Python 3.10+ - los pasos que necesitan python se omitiran.")
+} else {
+    Err (T "No Python 3.10+ available after install (tried python, python3, py -3.14..-3.10)." `
+           "No hay Python 3.10+ disponible despues de instalar (se probo python, python3, py -3.14..-3.10).")
+}
 
 # ─── Node.js ──────────────────────────────────────────────────────────────────
 if (-not (Have node) -and $CorporateProfile) {
@@ -615,13 +759,18 @@ if (Have claude) { Ok (T "Claude Code installed" "Claude Code instalado") }
 
 # ─── pipx ─────────────────────────────────────────────────────────────────────
 if (-not (Have pipx) -and $DryRun) {
-    Dry "would: python -m pip install --user pipx"
+    Dry "would: <resolved-python> -m pip install --user pipx"
+} elseif (-not (Have pipx) -and -not $PythonExe) {
+    # Previously this ran a bare `python`, which under EAP=Stop raised
+    # CommandNotFound and killed the whole bootstrap. Name the cause instead.
+    Err (T "pipx needs Python 3.10+ and none was resolved - skipping pipx." `
+           "pipx necesita Python 3.10+ y no se resolvio ninguno - se omite pipx.")
 } elseif (-not (Have pipx)) {
     Hdr "Installing pipx"
     # Run-Native: pip's routine "scripts not on PATH" stderr warning aborted a
     # real install here under EAP=Stop. Exit code decides success, not stderr.
-    if (-not (Run-Native { python -m pip install --user pipx })) { Err "pip install pipx failed" }
-    [void](Run-Native { python -m pipx ensurepath })
+    if (-not (Run-Native { & $PythonExe @PythonArgs -m pip install --user pipx })) { Err "pip install pipx failed" }
+    [void](Run-Native { & $PythonExe @PythonArgs -m pipx ensurepath })
     $env:Path = "$env:USERPROFILE\.local\bin;$env:Path"
 }
 if (Have pipx) { Ok "pipx" } else { Err "pipx install failed" }
@@ -1044,8 +1193,13 @@ if 'chatprd' not in m['mcpServers']:
     m['mcpServers']['chatprd'] = {'type': 'url', 'url': 'https://app.chatprd.ai/mcp'}
 with open(p, 'w') as f: json.dump(m, f, indent=2)
 "@
-    $pyMcp | python -
-    if ($LASTEXITCODE -eq 0) { Ok "MCPs registered: granola, chatprd (Granola needs an account to use)" } else { Err "MCP registration failed" }
+    if (-not $PythonExe) {
+        Err (T "No Python 3.10+ resolved - skipping MCP registration." `
+               "No se resolvio Python 3.10+ - se omite el registro de MCPs.")
+    } else {
+        $pyMcp | & $PythonExe @PythonArgs -
+        if ($LASTEXITCODE -eq 0) { Ok "MCPs registered: granola, chatprd (Granola needs an account to use)" } else { Err "MCP registration failed" }
+    }
 }
 }  # end corporate-profile MCP gate
 
@@ -1089,8 +1243,13 @@ if corporate:
         env[k] = v
 with open(p, 'w') as f: json.dump(s, f, indent=2)
 "@
-    $pyPlugins | python -
-    if ($LASTEXITCODE -eq 0) { Ok "Marketplace + plugins registered (settings.json backed up)" } else { Err "settings.json plugin registration failed" }
+    if (-not $PythonExe) {
+        Err (T "No Python 3.10+ resolved - skipping marketplace/plugin registration." `
+               "No se resolvio Python 3.10+ - se omite el registro de marketplace/plugins.")
+    } else {
+        $pyPlugins | & $PythonExe @PythonArgs -
+        if ($LASTEXITCODE -eq 0) { Ok "Marketplace + plugins registered (settings.json backed up)" } else { Err "settings.json plugin registration failed" }
+    }
 }
 
 # ─── Verification ────────────────────────────────────────────────────────────
@@ -1176,15 +1335,15 @@ if ((Test-Path $userHookInstaller) -and -not $DryRun) {
     Write-Host ("━━━ " + (T "Installing hooks at user level (so they fire inside worktrees)" `
                               "Instalando hooks a nivel de usuario (para que disparen dentro de worktrees)") + " ━━━") -ForegroundColor Cyan
 
-    # py first: the launcher is always real. A bare `python3`/`python` on PATH
-    # can be the Microsoft Store alias STUB (opens the Store instead of running),
-    # so every candidate is validated by actually executing it.
-    $pythonCmd = $null
-    foreach ($candidate in @("py", "python", "python3")) {
-        $resolved = Get-Command $candidate -ErrorAction SilentlyContinue
-        if (-not $resolved) { continue }
-        & $resolved.Source -c "import sys" 2>$null | Out-Null
-        if ($LASTEXITCODE -eq 0) { $pythonCmd = $resolved.Source; break }
+    # One answer to "which Python" for the whole install: Resolve-Python already
+    # walked python/python3/py -3.x, executed each candidate, and enforced
+    # >= 3.10. This block used to repeat a weaker version of that search (no
+    # version floor), so it could pick a 3.9 the rest of the script had rejected.
+    $pythonCmd = $PythonExe
+    if ($PythonArgs -and $PythonArgs.Count) {
+        $pyCmdDisplay = "$PythonExe $($PythonArgs -join ' ')"
+    } else {
+        $pyCmdDisplay = "$PythonExe"
     }
 
     if (-not $pythonCmd) {
@@ -1197,7 +1356,7 @@ if ((Test-Path $userHookInstaller) -and -not $DryRun) {
         try {
             # --fail-on-missing (parity with bootstrap.sh): verifies every wired
             # hook script exists on disk and escalates divergent-fork strands.
-            & $pythonCmd $userHookInstaller --quiet --fail-on-missing
+            & $pythonCmd @PythonArgs $userHookInstaller --quiet --fail-on-missing
             if ($LASTEXITCODE -eq 0) {
                 Write-Host ("  OK " + (T "User-level hooks installed (~/.claude/settings.json)" `
                                           "Hooks a nivel de usuario instalados (~/.claude/settings.json)")) -ForegroundColor Green
@@ -1206,8 +1365,8 @@ if ((Test-Path $userHookInstaller) -and -not $DryRun) {
                                          "La instalación de hooks a nivel de usuario FALLÓ (exit $LASTEXITCODE).")) -ForegroundColor Red
                 Write-Host ("  X " + (T "The meeting trigger + 6 other UserPromptSubmit hooks will not fire." `
                                          "El trigger de meetings + 6 hooks UserPromptSubmit no van a disparar.")) -ForegroundColor Red
-                Write-Host ("  X " + (T "Re-run manually: & `"$pythonCmd`" `"$userHookInstaller`" --fail-on-missing" `
-                                         "Volvé a correr manualmente: & `"$pythonCmd`" `"$userHookInstaller`" --fail-on-missing")) -ForegroundColor Red
+                Write-Host ("  X " + (T "Re-run manually: $pyCmdDisplay `"$userHookInstaller`" --fail-on-missing" `
+                                         "Volvé a correr manualmente: $pyCmdDisplay `"$userHookInstaller`" --fail-on-missing")) -ForegroundColor Red
                 $Failed += "user-level hook install (exit $LASTEXITCODE) - meeting trigger + 6 other hooks WILL NOT FIRE"
             }
         } catch {

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -203,6 +203,9 @@ INTEGRATION_TESTS=(
   test_bootstrap_corporate_profile
   test_bootstrap_userspace_fallback
   test_bootstrap_python_discovery
+  # Windows half of the same bug (#290): bootstrap.ps1 tested the single name
+  # `python`, never the `py -3.x` launcher, so a box with 3.12 read as no-Python.
+  test_bootstrap_ps1_python_discovery
   test_preflight_git_and_it_request
   test_remediate_runaway_procs
   test_scan_prior_single_instance

--- a/tests/integration/test_bootstrap_ps1_python_discovery.ps1
+++ b/tests/integration/test_bootstrap_ps1_python_discovery.ps1
@@ -1,0 +1,277 @@
+﻿#!/usr/bin/env pwsh
+# Test bootstrap.ps1's Python interpreter discovery (Windows side of #538).
+#
+# Bug (ai-brain-starter#290): bootstrap.ps1 detected Python by testing ONE name:
+#
+#     $v = (python --version 2>&1) -replace 'Python ',''
+#     if ([version]$v -ge [version]"3.10") { $pythonOk = $true }
+#
+# On Windows that is wrong three separate ways:
+#   1. `py -3.12` (the Python Launcher) is the canonical multi-version resolver
+#      and was never consulted, so a box with 3.12 installed but `python` unset
+#      or shadowed read as "no Python at all" and got a redundant install.
+#   2. The WindowsApps `python` STUB is on PATH and opens the Microsoft Store
+#      instead of running an interpreter. It answers a presence check, and its
+#      output does not parse as a [version], so the cast threw and $pythonOk
+#      stayed $false -- installing a Python that was already there.
+#   3. A real but too-old `python` (3.9) shadows a newer one later in PATH, and
+#      installing 3.12 cannot change what the NAME `python` resolves to.
+#
+# Covered here:
+#   A. The resolver is present in the shipped bootstrap.ps1 and is extractable.
+#   B. THE REPORTED CASE: `python` is a Store-style stub, `py -3.12` works ->
+#      the launcher's interpreter is chosen. Paired with a NEGATIVE CONTROL
+#      asserting that stub really does fail the probe on its own, so this cannot
+#      pass because the fixture forgot to model the bug.
+#   C. `python` already qualifies -> it is kept, and a newer `py -3.14` does NOT
+#      displace it. This is the "changes nothing for working installs" claim.
+#   D. `python` present but too old -> falls through to the launcher (+ control).
+#   E. Newest-first ordering among several `py -3.x`.
+#   F. Nothing qualifies -> reports failure instead of silently selecting a
+#      too-old interpreter. Doubles as the PATH-seal positive control: if the
+#      runner's own real Python leaked past the seal, this case would pass.
+#   G. AI_BRAIN_PYTHON names an interpreter no search would find, and WINS over
+#      a qualifying `python`.
+#   H. AI_BRAIN_PYTHON set but not a 3.10+ interpreter -> flagged, search
+#      continues (a silently ignored override is the bug class this repo calls
+#      SILENT-NO-OP).
+#   I. STRUCTURAL: no bare `python` invocation is left in bootstrap.ps1, and the
+#      resolved interpreter is actually used at the call sites. One missed call
+#      site silently runs the wrong interpreter, which is the whole defect.
+#
+# Resolve-Python is EXTRACTED from the real bootstrap.ps1 between its
+# `ai-brain:pick-python` markers, never reimplemented here, so this test cannot
+# drift from the shipped source -- same technique as the bash-side
+# test_bootstrap_python_discovery.sh.
+#
+# PATH is sealed to a stub directory alone, so the runner's own interpreters
+# cannot decide any outcome (case F is the control proving the seal holds).
+# Runs on Windows PowerShell 5.1 and on pwsh 7 (macOS/Linux); stubs are .cmd on
+# Windows and /bin/sh scripts elsewhere.
+#
+# Self-contained; no network; never writes outside its own temp dir.
+
+$ErrorActionPreference = "Stop"
+
+$RepoRoot  = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$Bootstrap = Join-Path $RepoRoot "bootstrap.ps1"
+if (-not (Test-Path -LiteralPath $Bootstrap)) {
+    Write-Host "ERROR: $Bootstrap not found" -ForegroundColor Red
+    exit 1
+}
+
+$OnWindows = ($PSVersionTable.PSEdition -eq "Desktop") -or ($env:OS -eq "Windows_NT")
+$script:Failures = @()
+
+function Check([bool]$Ok, [string]$Msg) {
+    if ($Ok) {
+        Write-Host "  ok    $Msg"
+    } else {
+        Write-Host "  FAIL  $Msg" -ForegroundColor Red
+        $script:Failures += $Msg
+    }
+}
+
+# --- stub interpreters --------------------------------------------------------
+# A stub prints ONE line to stdout and exits with a fixed code. That is enough
+# for both probes the resolver makes, because the sys.executable probe only ever
+# runs after the version probe passed:
+#   version probe     -> only the exit code is read
+#   sys.executable    -> only the first stdout line is read
+# So no stub ever has to parse the Python source it is handed, which keeps the
+# cmd.exe side free of quoting hazards.
+function New-InterpreterStub([string]$Dir, [string]$Name, [int]$ExitCode, [string]$EchoLine, [string]$StderrLine) {
+    if ($OnWindows) {
+        $p = Join-Path $Dir "$Name.cmd"
+        $body = "@echo off`r`n"
+        if ($EchoLine)   { $body += "echo $EchoLine`r`n" }
+        if ($StderrLine) { $body += "echo $StderrLine 1>&2`r`n" }
+        $body += "exit /b $ExitCode`r`n"
+        [System.IO.File]::WriteAllText($p, $body, [System.Text.Encoding]::ASCII)
+    } else {
+        $p = Join-Path $Dir $Name
+        $body = "#!/bin/sh`n"
+        if ($EchoLine)   { $body += "echo '$EchoLine'`n" }
+        if ($StderrLine) { $body += "echo '$StderrLine' >&2`n" }
+        $body += "exit $ExitCode`n"
+        [System.IO.File]::WriteAllText($p, $body, [System.Text.Encoding]::ASCII)
+        & /bin/chmod "+x" $p
+    }
+    return $p
+}
+
+# The Python Launcher: dispatches on its FIRST argument (-3.12, -3.13, ...) and
+# prints the interpreter it selected. An unknown version exits non-zero, which
+# is what the real launcher does when that version is not installed.
+function New-PyLauncherStub([string]$Dir, [hashtable]$VersionMap) {
+    if ($OnWindows) {
+        $p = Join-Path $Dir "py.cmd"
+        $body = "@echo off`r`n"
+        foreach ($k in $VersionMap.Keys) {
+            $body += "if `"%1`"==`"$k`" ( echo $($VersionMap[$k]) & exit /b 0 )`r`n"
+        }
+        $body += "exit /b 103`r`n"
+        [System.IO.File]::WriteAllText($p, $body, [System.Text.Encoding]::ASCII)
+    } else {
+        $p = Join-Path $Dir "py"
+        $body = "#!/bin/sh`ncase `"`$1`" in`n"
+        foreach ($k in $VersionMap.Keys) {
+            $body += "  $k) echo '$($VersionMap[$k])'; exit 0 ;;`n"
+        }
+        $body += "esac`nexit 103`n"
+        [System.IO.File]::WriteAllText($p, $body, [System.Text.Encoding]::ASCII)
+        & /bin/chmod "+x" $p
+    }
+    return $p
+}
+
+$TmpRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("abs-ps1-py-" + [System.Guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Force -Path $TmpRoot | Out-Null
+$PathSaved     = $env:PATH
+$OverrideSaved = $env:AI_BRAIN_PYTHON
+
+function New-Case([string]$Name) {
+    $d = Join-Path $TmpRoot $Name
+    New-Item -ItemType Directory -Force -Path $d | Out-Null
+    $env:PATH = $d                 # sealed: nothing but this directory
+    $env:AI_BRAIN_PYTHON = $null
+    $script:PythonExe             = $null
+    $script:PythonArgs            = @()
+    $script:PythonOverrideIgnored = $false
+    return $d
+}
+
+try {
+    # --- A. the resolver ships in bootstrap.ps1 and is extractable ------------
+    Write-Host "A. resolver is present and extractable"
+    $src = [System.IO.File]::ReadAllText($Bootstrap)
+    $startMark = "# ai-brain:pick-python:start"
+    $endMark   = "# ai-brain:pick-python:end"
+    $si = $src.IndexOf($startMark)
+    $ei = $src.IndexOf($endMark)
+    Check ($si -ge 0) "bootstrap.ps1 carries the $startMark marker"
+    Check ($ei -gt $si) "bootstrap.ps1 carries the $endMark marker after it"
+    if ($si -lt 0 -or $ei -le $si) {
+        Write-Host "ERROR: cannot extract the resolver; the rest of this test would be vacuous." -ForegroundColor Red
+        exit 1
+    }
+    $block = $src.Substring($si, $ei - $si)
+    Check ($block -match "function Resolve-Python")       "extracted block defines Resolve-Python"
+    Check ($block -match "function Test-PythonCandidate") "extracted block defines Test-PythonCandidate"
+    # The block is dot-sourced in isolation, so a bootstrap-only helper leaking
+    # into it would make this test pass while the shipped script throws.
+    Check ($block -notmatch "(?m)^\s*(Warn|Log|Ok|Err|Hdr|Dry)\s") "extracted block calls no bootstrap-only helper"
+    Check ($block -match "py") "extracted block consults the py launcher"
+
+    $blockFile = Join-Path $TmpRoot "resolver.ps1"
+    [System.IO.File]::WriteAllText($blockFile, $block, (New-Object System.Text.UTF8Encoding($false)))
+    . $blockFile
+
+    # --- B. THE REPORTED CASE ------------------------------------------------
+    Write-Host "B. Store-stub python + working py -3.12"
+    $d = New-Case "b"
+    # Writes to STDERR and exits 9009, exactly like the real WindowsApps alias.
+    # The stderr half matters: under $ErrorActionPreference = "Stop" a native
+    # command writing to stderr is what crashed this bootstrap before (Bug 1 in
+    # windows-install.yml), so this doubles as a regression control on the probe
+    # surviving a noisy candidate.
+    $storeStub = New-InterpreterStub $d "python" 9009 "" "Python was not found; run without arguments to install from the Microsoft Store"
+    $p312      = New-InterpreterStub $d "python312" 0 ""
+    $null      = New-PyLauncherStub  $d @{ "-3.12" = $p312 }
+    # NEGATIVE CONTROL: the fixture really does model the bug.
+    Check (-not (Test-PythonCandidate $storeStub @())) "control: the Store-style stub FAILS the probe on its own"
+    $ok = Resolve-Python
+    Check $ok "resolver reports success"
+    Check ($script:PythonExe -eq $p312) "picked the launcher's 3.12 (got '$($script:PythonExe)')"
+    Check ($script:PythonArgs.Count -eq 0) "collapsed 'py -3.12' to a plain exe (no prefix args to forget)"
+
+    # --- C. a qualifying python is kept --------------------------------------
+    Write-Host "C. qualifying python is kept, newer py does not displace it"
+    $d = New-Case "c"
+    $pyth = New-InterpreterStub $d "python" 0 ""
+    $p314 = New-InterpreterStub $d "python314" 0 ""
+    $null = New-PyLauncherStub  $d @{ "-3.14" = $p314 }
+    $ok = Resolve-Python
+    Check $ok "resolver reports success"
+    Check ($script:PythonExe -eq $pyth) "kept 'python' (got '$($script:PythonExe)')"
+
+    # --- D. too-old python falls through to the launcher ---------------------
+    Write-Host "D. python present but older than 3.10"
+    $d = New-Case "d"
+    $old  = New-InterpreterStub $d "python" 1 ""    # exits 1 => below 3.10
+    $p312 = New-InterpreterStub $d "python312" 0 ""
+    $null = New-PyLauncherStub  $d @{ "-3.12" = $p312 }
+    Check (-not (Test-PythonCandidate $old @())) "control: the too-old stub FAILS the probe on its own"
+    $ok = Resolve-Python
+    Check $ok "resolver reports success"
+    Check ($script:PythonExe -eq $p312) "skipped the too-old python (got '$($script:PythonExe)')"
+
+    # --- E. newest-first among launcher versions -----------------------------
+    Write-Host "E. newest-first ordering across py -3.x"
+    $d = New-Case "e"
+    $p312 = New-InterpreterStub $d "python312" 0 ""
+    $p313 = New-InterpreterStub $d "python313" 0 ""
+    $null = New-PyLauncherStub  $d @{ "-3.12" = $p312; "-3.13" = $p313 }
+    $ok = Resolve-Python
+    Check $ok "resolver reports success"
+    Check ($script:PythonExe -eq $p313) "took 3.13 over 3.12 (got '$($script:PythonExe)')"
+
+    # --- F. nothing qualifies (also the PATH-seal control) -------------------
+    Write-Host "F. nothing qualifying on PATH"
+    $d = New-Case "f"
+    $ok = Resolve-Python
+    Check (-not $ok) "resolver reports FAILURE rather than picking something unusable"
+    Check ($null -eq $script:PythonExe) "PythonExe left null (seal control: no real interpreter leaked in)"
+
+    # --- G. AI_BRAIN_PYTHON wins ---------------------------------------------
+    Write-Host "G. AI_BRAIN_PYTHON names an interpreter no search would find"
+    $d = New-Case "g"
+    $hidden = New-InterpreterStub $TmpRoot "conda-ish-python" 0 ""   # NOT on PATH
+    $null   = New-InterpreterStub $d "python" 0 ""                   # would otherwise win
+    $env:AI_BRAIN_PYTHON = $hidden
+    $ok = Resolve-Python
+    Check $ok "resolver reports success"
+    Check ($script:PythonExe -eq $hidden) "override chosen over a qualifying python (got '$($script:PythonExe)')"
+    Check (-not $script:PythonOverrideIgnored) "override not flagged as ignored"
+
+    # --- H. AI_BRAIN_PYTHON set but unusable ---------------------------------
+    Write-Host "H. AI_BRAIN_PYTHON set but not a 3.10+ interpreter"
+    $d = New-Case "h"
+    $badOverride = New-InterpreterStub $TmpRoot "too-old-override" 1 ""
+    $good        = New-InterpreterStub $d "python" 0 ""
+    $env:AI_BRAIN_PYTHON = $badOverride
+    $ok = Resolve-Python
+    Check $ok "resolver still finds a working interpreter"
+    Check ($script:PythonExe -eq $good) "fell back to the PATH python (got '$($script:PythonExe)')"
+    Check ($script:PythonOverrideIgnored) "ignored override is FLAGGED, not swallowed"
+
+    # --- I. structural: no bare python invocation survives --------------------
+    Write-Host "I. structural check over the shipped bootstrap.ps1"
+    $env:PATH = $PathSaved
+    $bare = @()
+    $lineNo = 0
+    foreach ($line in ([System.IO.File]::ReadAllLines($Bootstrap))) {
+        $lineNo++
+        if ($line -match '^\s*#') { continue }                 # comment
+        if ($line -match '(\||&|\{|^)\s*python3?\s+-') { $bare += "$lineNo : $($line.Trim())" }
+        elseif ($line -match '\(\s*python3?\s+--version') { $bare += "$lineNo : $($line.Trim())" }
+    }
+    Check ($bare.Count -eq 0) "no bare python invocation left in bootstrap.ps1"
+    foreach ($b in $bare) { Write-Host "        $b" -ForegroundColor Red }
+    $routed = ([regex]::Matches($src, '&\s+\$PythonExe\s+@PythonArgs')).Count
+    Check ($routed -ge 5) "resolved interpreter is used at the call sites (found $routed, want >= 5)"
+}
+finally {
+    $env:PATH = $PathSaved
+    if ($OverrideSaved) { $env:AI_BRAIN_PYTHON = $OverrideSaved } else { $env:AI_BRAIN_PYTHON = $null }
+    Remove-Item -Recurse -Force -LiteralPath $TmpRoot -ErrorAction SilentlyContinue
+}
+
+Write-Host ""
+if ($script:Failures.Count -gt 0) {
+    Write-Host "FAILED - bootstrap.ps1 Python discovery ($($script:Failures.Count) check(s)):" -ForegroundColor Red
+    foreach ($f in $script:Failures) { Write-Host "  x $f" -ForegroundColor Red }
+    exit 1
+}
+Write-Host "PASSED - bootstrap.ps1 Python discovery" -ForegroundColor Green
+exit 0

--- a/tests/integration/test_bootstrap_ps1_python_discovery.sh
+++ b/tests/integration/test_bootstrap_ps1_python_discovery.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# CI integration wrapper - runs the PowerShell bootstrap Python-discovery suite
+# (tests/integration/test_bootstrap_ps1_python_discovery.ps1, ai-brain-starter#290)
+# as part of scripts/ci.sh. Same pattern as test_relocate_ps1.sh: pwsh is
+# preinstalled on GitHub's ubuntu-latest runner, so CI always exercises it; if
+# pwsh is absent locally we LOUDLY skip rather than block a contributor's other
+# gates.
+#
+# NOTE ON COVERAGE: this run proves the resolver's LOGIC on pwsh 7. It cannot
+# prove the two things that are Windows-only - Windows PowerShell 5.1 semantics
+# and a real `py` launcher - because a Linux runner structurally cannot express
+# them. windows-install.yml runs the SAME .ps1 under 5.1 on windows-latest for
+# that half. Neither runner alone is the gate.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+
+if ! command -v pwsh >/dev/null 2>&1; then
+  echo "SKIP: pwsh not installed here; CI's ubuntu + windows runners enforce this suite."
+  echo "      install: brew install --cask powershell (macOS) / https://aka.ms/powershell (other)"
+  exit 0
+fi
+
+pwsh -NoProfile -File "$ROOT/tests/integration/test_bootstrap_ps1_python_discovery.ps1"


### PR DESCRIPTION
Windows half of the interpreter-discovery bug fixed on the shell side in #538.

## The bug

`bootstrap.ps1` decided "is Python here?" by testing one name:

```powershell
$v = (python --version 2>&1) -replace 'Python ',''
if ([version]$v -ge [version]"3.10") { $pythonOk = $true }
```

Three separate ways to be wrong on Windows:

1. **`py -3.12` was never consulted.** The Python Launcher is the canonical multi-version resolver on Windows, so a box with 3.12 installed but `python` unset or shadowed read as "no Python at all".
2. **The WindowsApps `python` stub.** It is on PATH (so a presence check passes) and opens the Microsoft Store instead of running an interpreter. Its output does not parse as a `[version]`, so the cast threw, `$pythonOk` stayed `$false`, and the installer installed a Python that was already there.
3. **A too-old `python` shadowing a newer one.** Installing 3.12 cannot change what the *name* `python` resolves to.

## The fix

`Resolve-Python` resolves ONE interpreter up front by **executing** each candidate and letting Python itself answer the `>= 3.10` question: `AI_BRAIN_PYTHON`, then `python` / `python3`, then `py -3.14` down to `-3.10`, then bare `py`. A `py -3.x` hit is collapsed to the interpreter the launcher selected, so every call site downstream is a plain exe with no prefix argument to forget.

All five executed python call sites route through it (pipx, MCP registration, plugin registration, the user-level hook installer, the version banner). The hook installer's own weaker duplicate search is deleted, so there is one answer to "which Python" for the whole install.

Also fixes a latent crash: with no Python resolved, `$pyMcp | python -` raised `CommandNotFound` under `EAP=Stop` and killed the whole bootstrap. Those sites now name the cause and continue.

## Three things the doubt-pass changed

Each reads as correct and is not:

- **`Select-Object -First 1` on a native-command pipeline stops the pipeline early, and an early-stopped pipeline never updates `$LASTEXITCODE`.** The collapse step read its own seeded sentinel and discarded a good `sys.executable` every time. Found by the new test, not by review. Measured on pwsh 7.5: with `-First 1` the variable keeps the sentinel; without it, `0`.
- **The probe seeds `$LASTEXITCODE` with a sentinel rather than `0`,** so a process that never runs *without throwing* is rejected instead of read as a pass.
- **Each probe neutralises `$ErrorActionPreference` around the call,** as `Run-Native` already does. EAP is `Stop` script-wide and 5.1 turns native stderr into a terminating `NativeCommandError` (Bug 1 in `windows-install.yml`), so a pyenv/conda shim printing a deprecation warning would have been rejected as "not a Python" - earning exactly the redundant install this change removes. I could not verify this one locally: pwsh 7 does not reproduce 5.1's behaviour, so the safe form ships rather than the assumption.

## Verification

`tests/integration/test_bootstrap_ps1_python_discovery.ps1` extracts `Resolve-Python` **verbatim** from the shipped `bootstrap.ps1` between its `ai-brain:pick-python` markers - never reimplemented, so it cannot drift from source - and drives it against stub interpreters on a PATH sealed to the stub directory alone.

25 checks: the reported Store-stub case (the stub writes to stderr and exits 9009, like the real alias), too-old fallthrough, newest-first ordering, override honoured, override ignored-but-**flagged**, and a structural check that no bare `python` invocation survives in the script.

Negative controls throughout: every "this stub fails the probe on its own" assertion, plus case F (nothing qualifies) doubling as the PATH-seal control - if the runner's real Python leaked past the seal, that case would pass. **Mutation-checked**: deleting the `py` ladder turns 6 checks red.

Runs in both places on purpose:

- `scripts/ci.sh` runs it on ubuntu under pwsh 7 - proves the logic, and structurally cannot express Windows PowerShell 5.1 semantics or a real `py` launcher.
- `windows-install.yml` runs the same suite under 5.1 on `windows-latest` for that half, as a step on the already-paid runner rather than a second job at the 2x multiplier.

Neither runner alone is the gate.

## Not done here, deliberately

Seven sibling Python-detection sites in other `.ps1` files carry weaker variants of the same shape (`preflight.ps1`, `diagnose.ps1`, `vault-backup.ps1`, `sync-vault-scripts.ps1`, `relocate-vault.ps1`, `relocate-machinery-sidecar.ps1`). None drives an install decision - they are informational, or pick an interpreter to run a script - so they are filed separately rather than widening the diff on the one file every Windows user executes.

Closes #290
