### PR TITLE
fix(sidecar): never relocate a path git tracks — Meta/Sessions was listed as a cache

### DIFF
--- a/scripts/relocate-machinery-sidecar.ps1
+++ b/scripts/relocate-machinery-sidecar.ps1
@@ -22,19 +22,42 @@
   fix is: the vault MAY be synced; the machinery NEVER is. This relocates the
   machinery and leaves the docs.
 
-  WHAT IT MOVES
+  THE ONE RULE: IT NEVER MOVES ANYTHING GIT TRACKS
+  ------------------------------------------------
+  Every candidate is tested against the REAL git index before it is touched. A
+  path holding tracked content is your NOTES, whatever it is named - moving it
+  turns the directory into a link, 'git status' reports every file as deleted,
+  and the next auto-commit/push propagates that deletion to every machine. So:
+  tracked content -> never moved, reported, left exactly as it is. Genuinely
+  ignored/untracked caches still move. If the index cannot be read, the path is
+  left alone (a path I cannot prove is a cache is not a cache).
+
+  WHAT IT MOVES (only when the path holds NO tracked content)
     .git              -> <sidecar>/git      via 'git init --separate-git-dir'
                          (leaves a one-line .git POINTER FILE - static, safe)
     .claude/worktrees -> <sidecar>/worktrees   (relocate + link)
     caches            -> <sidecar>/cache/<name> (relocate + link)
+                         NOTE several candidate names hold TRACKED notes in a
+                         real vault. The index test decides, never the name.
 
   SEQUENCING GOTCHA: 'git init --separate-git-dir' ORPHANS existing linked
   worktrees. So this REFUSES to run while any linked worktree or live Claude
   session exists, unless -Force. After relocation it runs 'git worktree repair'.
+  The probes FAIL CLOSED: if git or the session lock cannot be read, that counts
+  as LIVE and the run is refused. "I could not look" and "I looked and it was
+  empty" are different answers.
 
-  SAFETY: idempotent (re-run = no-op report), reversible (-Rollback reads the
-  manifest and puts everything back), -DryRun changes nothing, and it never
-  deletes content - only moves it and leaves a link/pointer.
+  SAFETY: idempotent (re-run = no-op report), interrupt-safe (every move is
+  written to an append-only journal in the sidecar BEFORE it happens, so
+  -Rollback works from any kill point), reversible (-Rollback reads that record
+  and puts everything back, exits non-zero and KEEPS the record if any leg
+  fails), -DryRun changes nothing, and it never deletes content - only moves it
+  and leaves a link/pointer.
+
+  The SIDECAR DESTINATION is checked with the same cloud-sync detector as the
+  vault: on a roaming / OneDrive-managed / network profile $HOME is itself
+  synced, so the default ~/.brain-sidecar is too - relocating machinery from one
+  synced tree into another does not fix the melt, so it is refused.
 
   Usage:
     relocate-machinery-sidecar.ps1 <vault-path> [options]
@@ -43,13 +66,15 @@
   Options:
     -Sidecar <dir>   sidecar root (default: $env:BRAIN_SIDECAR or ~/.brain-sidecar)
     -DryRun          print intended actions, change nothing
-    -Rollback        reverse a previous relocation using the manifest
-    -Force           proceed even if linked worktrees / live sessions exist
+    -Rollback        reverse a previous relocation using the recorded moves
+    -Force           proceed even if linked worktrees / live sessions exist, a
+                     probe could not run, or the sidecar looks cloud-synced
                      (DANGEROUS: separate-git-dir orphans live worktrees)
     -Quiet           only print warnings/errors + the final summary line
     -Help            this help
 
-  Exit codes: 0 ok / no-op . 1 refused (live worktree/session) . 2 usage .
+  Exit codes: 0 ok / no-op . 1 refused (live worktree/session, unsafe sidecar,
+              or a probe that could not run) . 2 usage / nothing to roll back .
               3 not a git vault and could not init . 4 partial failure
 #>
 [CmdletBinding()]
@@ -67,7 +92,16 @@ $ErrorActionPreference = "Stop"
 $ScriptDir = $PSScriptRoot
 $script:OnWindows = if ($null -eq $IsWindows) { $true } else { [bool]$IsWindows }
 
+# git's messages are classified below (e.g. "not a git repository"), so pin the
+# locale; and make python's stdout UTF-8 so emoji vault paths survive the round
+# trip through a cp1252 console (PS 5.1).
+$env:LC_ALL = "C"
+$env:PYTHONIOENCODING = "utf-8"
+$env:PYTHONUTF8 = "1"
+try { [Console]::OutputEncoding = [System.Text.Encoding]::UTF8 } catch { }
+
 # ---- machinery the script relocates (relative to the vault root) -------------
+# CANDIDATES, not a denylist: each moves ONLY if git tracks nothing there.
 $CacheDirs = @(
   ".smart-env",
   ".codegraph",
@@ -83,11 +117,21 @@ $WorktreesRel = ".claude/worktrees"
 function Say  { param([string]$m) if (-not $Quiet) { Write-Host $m } }
 function Warn { param([string]$m) Write-Host "WARN  $m" -ForegroundColor Yellow }
 function Err  { param([string]$m) [Console]::Error.WriteLine("ERROR $m") }
+# Never emits: callers return $true/$false/ints, and a stray pipeline object
+# from an action would be swallowed into that return value.
 function Invoke-OrDry { param([string]$What, [scriptblock]$Action)
-  if ($DryRun) { Write-Host "DRY   $What" } else { & $Action }
+  if ($DryRun) { Write-Host "DRY   $What" } else { & $Action | Out-Null }
 }
 
-# ---- python (manifest + live-session probe) ---------------------------------
+# Test-only fault injection for the interrupt matrix in
+# test-relocate-machinery-sidecar.ps1. Unset in production. Set to a step label
+# to hard-kill this process right after that step (no finally, no cleanup) - the
+# only honest way to prove -Rollback works from every kill point.
+function Invoke-MaybeDie { param([string]$Label)
+  if ("$($env:BRAIN_SIDECAR_TEST_KILL_AT)" -eq $Label) { Stop-Process -Id $PID -Force }
+}
+
+# ---- python (records + live-session probe) ----------------------------------
 $script:PyExe = $null
 function Get-PyExe {
   if ($script:PyExe) { return $script:PyExe }
@@ -100,7 +144,7 @@ function Get-PyExe {
       } catch { }
     }
   }
-  Err "python 3 required for the manifest"; exit 4
+  Err "python 3 required for the move record"; exit 4
 }
 function Invoke-Py { param([string]$Code, [object[]]$PyArgs = @())
   $py = Get-PyExe
@@ -111,6 +155,20 @@ function Get-AbsPath { param([string]$p)
 }
 function Get-PhysicalPath { param([string]$p)
   return (Invoke-Py 'import os,sys; print(os.path.realpath(os.path.expanduser(sys.argv[1])))' @($p))
+}
+# Exact containment (case-insensitive on Windows), not string prefixing: /var vs
+# /private/var and C:\Users vs c:\users both make a naive prefix test miss.
+function Test-PathInside { param([string]$Child, [string]$Parent)
+  $code = @'
+import os, sys
+child = os.path.realpath(os.path.expanduser(sys.argv[1]))
+parent = os.path.realpath(os.path.expanduser(sys.argv[2]))
+if os.name == "nt":
+    child, parent = child.lower(), parent.lower()
+inside = child == parent or child.startswith(parent.rstrip(os.sep) + os.sep)
+print("1" if inside else "0")
+'@
+  return (("$(Invoke-Py $code @($Child, $Parent))").Trim() -eq "1")
 }
 
 function Get-HomeBase { if ($env:USERPROFILE) { return $env:USERPROFILE } else { return $HOME } }
@@ -166,72 +224,162 @@ function Get-Slug { param([string]$p)
   return "$clean-$($hex.Substring(0, 8))"
 }
 
-# ---- manifest staging (TSV -> python JSON, dodges the PS single-element-array
-#      JSON quirk and matches the .sh writer byte-for-byte) --------------------
-$script:RecFile = $null
-function Add-Record { param([string]$Type, [string]$Rel, [string]$Target, [string]$Mode)
-  if (-not $script:RecFile) { $script:RecFile = [System.IO.Path]::GetTempFileName() }
-  ("{0}`t{1}`t{2}`t{3}" -f $Type, $Rel, $Target, $Mode) |
-    Out-File -LiteralPath $script:RecFile -Encoding UTF8 -Append
-}
-function Write-Manifest {
-  if ($DryRun) { return }
-  # An idempotent re-run (everything already relocated) records ZERO new moves.
-  # Do NOT clobber a prior valid manifest with an empty one - that silently
-  # breaks -Rollback. Only write when there is something to record, or when no
-  # manifest exists yet.
-  $hasRecords = $script:RecFile -and (Test-Path -LiteralPath $script:RecFile) -and ((Get-Item -LiteralPath $script:RecFile).Length -gt 0)
-  if (-not $hasRecords -and (Test-Path -LiteralPath $Manifest)) {
-    Say "  . no new moves; keeping existing manifest $Manifest"
-    return
-  }
-  New-Item -ItemType Directory -Force -Path (Split-Path -Parent $Manifest) | Out-Null
-  $rec = if ($script:RecFile) { $script:RecFile } else { "" }
+# ---- write-ahead journal ----------------------------------------------------
+# One JSON object per move, appended AND fsynced BEFORE the move happens, so a
+# kill at any point still leaves -Rollback a full map. A move this fails to
+# record is a move that does NOT happen.
+function Add-JournalRecord { param([string]$Type, [string]$Rel, [string]$Target, [string]$Mode)
+  if ($DryRun) { return $true }
   $code = @'
 import json, os, sys
-rec, man, vault, sidecar, slug, nosync = sys.argv[1:7]
+jnl, typ, rel, target, mode = sys.argv[1:6]
+os.makedirs(os.path.dirname(jnl), exist_ok=True)
+with open(jnl, "a", encoding="utf-8") as f:
+    f.write(json.dumps({"type": typ, "vault_rel": rel, "target": target,
+                        "mode": mode}, ensure_ascii=False) + "\n")
+    f.flush()
+    os.fsync(f.fileno())
+'@
+  try {
+    Invoke-Py $code @($Journal, $Type, $Rel, $Target, $Mode) | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "python exited $LASTEXITCODE" }
+    return $true
+  } catch {
+    Err "could not record the move in ${Journal}: $_"
+    return $false
+  }
+}
+
+# Recorded moves from the journal (.jsonl) or a manifest (.json), as TSV rows.
+# Later records win per (type, vault_rel) so a relocate -> rollback -> relocate
+# cycle never replays a stale row.
+$script:RecordReaderPy = @'
+import json, os, sys
+src, rev = sys.argv[1], sys.argv[2]
 recs = []
-if rec and os.path.isfile(rec):
-    with open(rec, encoding="utf-8") as f:
+if src.endswith(".jsonl"):
+    with open(src, encoding="utf-8") as f:
         for line in f:
-            line = line.rstrip("\n")
+            line = line.strip()
             if not line:
                 continue
-            parts = line.split("\t")
-            while len(parts) < 4:
-                parts.append("")
-            recs.append({"type": parts[0], "vault_rel": parts[1],
-                         "target": parts[2], "mode": parts[3]})
+            try:
+                recs.append(json.loads(line))
+            except ValueError:
+                continue  # a torn final line from a kill is not a reason to stop
+else:
+    with open(src, encoding="utf-8") as f:
+        recs = json.load(f).get("moves", [])
+seen, order = {}, []
+for r in recs:
+    if not isinstance(r, dict):
+        continue
+    k = (r.get("type", ""), r.get("vault_rel", ""))
+    if k not in seen:
+        order.append(k)
+    seen[k] = r
+rows = [seen[k] for k in order]
+if rev == "1":
+    rows.reverse()
+for r in rows:
+    print("\t".join([r.get("type", ""), r.get("vault_rel", ""),
+                     r.get("target", ""), r.get("mode", "")]))
+'@
+function Get-RecordRows { param([string]$Src, [switch]$Reverse)
+  $rev = if ($Reverse) { "1" } else { "0" }
+  return (Invoke-Py $script:RecordReaderPy @($Src, $rev))
+}
+
+function Write-Manifest {
+  if ($DryRun) { return }
+  $hasJournal = (Test-Path -LiteralPath $Journal) -and ((Get-Item -LiteralPath $Journal).Length -gt 0)
+  if (-not $hasJournal) {
+    # An idempotent re-run records ZERO new moves. Do NOT clobber a prior valid
+    # manifest with an empty one - that silently breaks -Rollback.
+    if (Test-Path -LiteralPath $Manifest) { Say "  . no recorded moves; keeping existing manifest $Manifest" }
+    return
+  }
+  $code = @'
+import json, os, sys
+jnl, man, vault, sidecar, slug = sys.argv[1:6]
+recs = []
+with open(jnl, encoding="utf-8") as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            recs.append(json.loads(line))
+        except ValueError:
+            continue
+seen, order = {}, []
+for r in recs:
+    if not isinstance(r, dict):
+        continue
+    k = (r.get("type", ""), r.get("vault_rel", ""))
+    if k not in seen:
+        order.append(k)
+    seen[k] = r
+moves = [{"type": seen[k].get("type", ""), "vault_rel": seen[k].get("vault_rel", ""),
+          "target": seen[k].get("target", ""), "mode": seen[k].get("mode", "")}
+         for k in order]
 doc = {"schema": "machinery-sidecar/1", "vault": vault, "sidecar": sidecar,
-       "slug": slug, "nosync": nosync == "1", "moves": recs}
+       "slug": slug, "nosync": False, "moves": moves}
 os.makedirs(os.path.dirname(man), exist_ok=True)
 with open(man, "w", encoding="utf-8") as f:
     json.dump(doc, f, ensure_ascii=False, indent=2)
     f.write("\n")
 '@
-  Invoke-Py $code @($rec, $Manifest, $VaultAbs, $Sidecar, $Slug, "0") | Out-Null
+  Invoke-Py $code @($Journal, $Manifest, $VaultAbs, $Sidecar, $Slug) | Out-Null
 }
 
-# ---- live-worktree / live-session guard -------------------------------------
-function Get-LinkedWorktrees {
-  $out = & git -C $VaultAbs worktree list --porcelain 2>$null
-  if ($LASTEXITCODE -ne 0) { return @() }
+# ---- git probes (fail CLOSED: "could not look" != "nothing there") -----------
+$script:GitState = "unknown"
+function Get-GitState {   # repo | norepo | error
+  $out = & git -C $VaultAbs rev-parse --git-dir 2>&1
+  if ($LASTEXITCODE -eq 0) { return "repo" }
+  if ("$out" -match "not a git repository") { return "norepo" }
+  Warn "git could not read ${VaultAbs}: $out"
+  return "error"
+}
+
+# Number of TRACKED files at a vault-relative path. -1 = the index could not be
+# read at all, and the caller must then leave the path alone.
+function Get-TrackedCount { param([string]$Rel)
+  if ($script:GitState -eq "norepo") { return 0 }
+  if ($script:GitState -ne "repo")   { return -1 }
+  $out = & git -C $VaultAbs ls-files -- $Rel 2>$null
+  if ($LASTEXITCODE -ne 0) { return -1 }
+  return @($out | Where-Object { "$_" -ne "" }).Count
+}
+
+function Get-LinkedWorktrees {   # @() = none; $null = the probe could not run
+  if ($script:GitState -eq "norepo") { return @() }
+  if ($script:GitState -ne "repo")   { return $null }
+  $out = & git -C $VaultAbs worktree list --porcelain 2>&1
+  if ($LASTEXITCODE -ne 0) {
+    Warn "could not list git worktrees in ${VaultAbs}: $out"
+    return $null
+  }
   $n = 0; $res = @()
   foreach ($line in @($out)) {
     if ($line -like 'worktree *') { $n++; if ($n -gt 1) { $res += $line.Substring(9) } }
   }
-  return $res
+  return ,$res
 }
-function Get-LiveSessions {
+
+function Get-LiveSessions {   # integer count; -1 = the lock could not be read
   $lock = Join-Path $VaultAbs ".claude/.session-lock.json"
   if (-not (Test-Path -LiteralPath $lock)) { return 0 }
   $code = @'
 import json, os, sys, time
 lock = sys.argv[1]
 try:
-    data = json.load(open(lock, encoding="utf-8"))
-except Exception:
-    raise SystemExit(0)
+    with open(lock, encoding="utf-8") as f:
+        data = json.load(f)
+except Exception as e:  # an unreadable/corrupt lock is NOT "zero sessions"
+    print("cannot read %s: %s" % (lock, e), file=sys.stderr)
+    raise SystemExit(3)
 sessions = data.get("sessions", {}) if isinstance(data, dict) else {}
 cut = time.time() - 35 * 60
 self_pid = int(sys.argv[2] or 0)
@@ -255,23 +403,81 @@ for s in sessions.values():
 print(n)
 '@
   $out = Invoke-Py $code @($lock, "$PID")
-  $val = 0; [int]::TryParse("$out".Trim(), [ref]$val) | Out-Null
+  if ($LASTEXITCODE -ne 0) { Warn "could not read $lock (probe exited $LASTEXITCODE)"; return -1 }
+  $val = 0
+  if (-not [int]::TryParse("$out".Trim(), [ref]$val)) {
+    Warn "unreadable session count from ${lock}: $out"
+    return -1
+  }
   return $val
 }
+
 function Test-NoLive {
-  $wts  = @(Get-LinkedWorktrees)
+  $wts  = Get-LinkedWorktrees
   $sess = Get-LiveSessions
-  if ($wts.Count -gt 0 -or $sess -gt 0) {
+  $probeFailed = ($null -eq $wts) -or ($sess -lt 0)
+  $wtCount = if ($null -eq $wts) { 0 } else { @($wts).Count }
+  $sessCount = if ($sess -lt 0) { 0 } else { $sess }
+
+  if ($wtCount -gt 0 -or $sessCount -gt 0 -or $probeFailed) {
     if ($Force) {
-      Warn "linked worktrees and/or $sess live session(s) present - proceeding under -Force (separate-git-dir will orphan live worktrees)"
+      Warn "live worktrees/sessions present or unprobeable - proceeding under -Force (separate-git-dir will orphan live worktrees)"
       return $true
     }
-    Err "refusing: relocation must run in a no-live-worktree window."
-    if ($wts.Count -gt 0) { Err "  linked worktrees still registered:"; $wts | ForEach-Object { [Console]::Error.WriteLine("    $_") } }
-    if ($sess -gt 0) { Err "  $sess live Claude session(s) in $VaultAbs/.claude/.session-lock.json" }
+    Err "refusing: relocation must run in a proven no-live-worktree window."
+    if ($probeFailed) {
+      Err "  a safety probe could not run (see the WARN above), so I cannot prove nothing is live."
+      Err "  a probe that errors and a vault that is idle look identical - this refuses rather than guess."
+      Err "  common cause: git 'dubious ownership' on a restored/migrated/external/network vault. Fix with:"
+      Err "    git config --global --add safe.directory `"$VaultAbs`""
+    }
+    if ($wtCount -gt 0) { Err "  linked worktrees still registered:"; $wts | ForEach-Object { [Console]::Error.WriteLine("    $_") } }
+    if ($sessCount -gt 0) { Err "  $sessCount live Claude session(s) in $VaultAbs/.claude/.session-lock.json" }
     Err "  close all sessions + 'git worktree remove' scratch trees, then re-run. Override: -Force"
     return $false
   }
+  return $true
+}
+
+# ---- sidecar destination guard ----------------------------------------------
+function Test-SidecarLocation {
+  if (Test-PathInside $Sidecar $VaultAbs) {
+    Err "refusing: the sidecar ($Sidecar) is INSIDE the vault ($VaultAbs)."
+    Err "  the machinery would never leave the synced tree. Pass -Sidecar <a path outside the vault>."
+    return $false
+  }
+  if (Test-PathInside $VaultAbs $Sidecar) {
+    Err "refusing: the vault ($VaultAbs) is INSIDE the sidecar ($Sidecar)."
+    Err "  pass -Sidecar <a path outside the vault>."
+    return $false
+  }
+  $ccs = Join-Path $ScriptDir "check-cloud-sync.py"
+  if (-not (Test-Path -LiteralPath $ccs)) {
+    Warn "could not verify the sidecar destination: $ccs is missing (cloud-sync detector unavailable)"
+    return $true
+  }
+  $out = ""
+  try {
+    $py = Get-PyExe
+    $out = "$(& $py $ccs --porcelain $Sidecar 2>$null)".Trim()
+  } catch { $out = "" }
+  if ($out -like 'CLOUD_SYNC_RISK*') {
+    $svc = $out -replace '^CLOUD_SYNC_RISK:?\s*', ''
+    if ($Force) {
+      Warn "sidecar destination is inside $svc - proceeding under -Force (the sync melt is NOT fixed by this run)"
+      return $true
+    }
+    Err "refusing: the sidecar destination is inside $svc, a cloud-sync folder."
+    Err "  sidecar: $Sidecar"
+    Err "  moving the machinery from one synced folder into another does not stop the melt;"
+    Err "  it only splits your notes from their repo. This usually means the profile folder"
+    Err "  itself is synced (roaming / OneDrive-managed / network), so the default"
+    Err "  ~/.brain-sidecar is too. Re-run with a local path, e.g. -Sidecar C:\brain-sidecar"
+    Err "  Override (NOT recommended): -Force"
+    return $false
+  }
+  if ($out -eq 'OK_LOCAL') { return $true }
+  Warn "could not verify the sidecar destination is outside a cloud-sync folder (check-cloud-sync.py said: '$out') - proceeding"
   return $true
 }
 
@@ -280,20 +486,40 @@ function Test-NoLive {
 # =============================================================================
 function Move-CacheDir { param([string]$Rel, [string]$Dst, [string]$RType)
   $src = Get-VaultPath $Rel
-  if (Test-ReparsePoint $src) { Say "  . $Rel already a link - skip"; return }
-  if (-not (Test-Path -LiteralPath $src)) { return }   # absent -> nothing to do
+  if (Test-ReparsePoint $src) { Say "  . $Rel already a link - skip"; return $true }
+  if (-not (Test-Path -LiteralPath $src)) { return $true }   # absent -> nothing to do
+
+  # THE ONE RULE: never move anything git tracks, whatever the path is named.
+  $n = Get-TrackedCount $Rel
+  if ($n -lt 0) {
+    Warn "  . $Rel - KEPT: could not read the git index, so I cannot prove this is a cache"
+    return $true
+  }
+  if ($n -gt 0) {
+    Say "  . $Rel - KEPT: git tracks $n file(s) here. Those are notes, not a cache;"
+    Say "        relocating them would show every one as DELETED and sync that deletion."
+    return $true
+  }
+
   if (Test-Path -LiteralPath $Dst) {
     $bak = "$Dst.bak-$((Get-Date).ToString('yyyyMMddHHmmss'))"
     Invoke-OrDry "move existing $Dst -> $bak" { Move-Item -LiteralPath $Dst -Destination $bak }
     Warn "  . prior sidecar copy at $Dst backed up"
   }
-  Invoke-OrDry "move $src -> $Dst + link" {
+  if (-not (Add-JournalRecord $RType $Rel $Dst "relocate")) {
+    Err "  . $Rel NOT moved: an unrecordable move cannot be reversed"
+    return $false
+  }
+  Invoke-MaybeDie "post-journal:$Rel"
+  Invoke-OrDry "move $src -> $Dst" {
     New-Item -ItemType Directory -Force -Path (Split-Path -Parent $Dst) | Out-Null
     Move-Item -LiteralPath $src -Destination $Dst
-    New-DirLink -Link $src -Target $Dst
   }
-  Add-Record $RType $Rel $Dst "relocate"
+  Invoke-MaybeDie "post-mv:$Rel"
+  Invoke-OrDry "link $src -> $Dst" { New-DirLink -Link $src -Target $Dst }
+  Invoke-MaybeDie "post-link:$Rel"
   Say "  . $Rel -> $Dst + link"
+  return $true
 }
 
 # =============================================================================
@@ -309,24 +535,26 @@ function Move-GitDir {
     return $true
   }
   if (Test-Path -LiteralPath $gitpath -PathType Container) {
+    if (-not (Add-JournalRecord "git" ".git" $SideGit "separated")) { return $false }
+    Invoke-MaybeDie "post-journal:.git"
     Invoke-OrDry "git init --separate-git-dir $SideGit" {
       New-Item -ItemType Directory -Force -Path (Split-Path -Parent $SideGit) | Out-Null
       & git -C $VaultAbs init --separate-git-dir $SideGit | Out-Null
     }
+    Invoke-MaybeDie "post-git"
     if (-not $DryRun -and -not (Test-Path -LiteralPath $gitpath -PathType Leaf)) {
       Err "  separate-git-dir did not produce a .git pointer file"; return $false
     }
     Invoke-OrDry "git worktree repair" { & git -C $VaultAbs worktree repair *> $null }
-    Add-Record "git" ".git" $SideGit "separated"
     Say "  . .git -> $SideGit (pointer file left in vault)"
     return $true
   }
   # no .git at all -> fresh repo with a separated gitdir
+  if (-not (Add-JournalRecord "git" ".git" $SideGit "fresh-init")) { return $false }
   Invoke-OrDry "git init --separate-git-dir $SideGit (fresh)" {
     New-Item -ItemType Directory -Force -Path (Split-Path -Parent $SideGit) | Out-Null
     & git -C $VaultAbs init --separate-git-dir $SideGit | Out-Null
   }
-  Add-Record "git" ".git" $SideGit "fresh-init"
   Say "  . initialized fresh repo with gitdir at $SideGit"
   return $true
 }
@@ -334,59 +562,107 @@ function Move-GitDir {
 # =============================================================================
 # ROLLBACK
 # =============================================================================
+# Each leg returns 0 restored / 3 nothing to do / 1 failed.
+function Restore-GitDir { param([string]$Target)
+  $ptr = Join-Path $VaultAbs ".git"
+  if ((Test-Path -LiteralPath $ptr -PathType Container) -and -not (Test-ReparsePoint $ptr)) {
+    if (Test-Path -LiteralPath $Target -PathType Container) {
+      Err "  . .git NOT restored: BOTH $ptr (a real dir) and $Target exist."
+      Err "    refusing to overwrite either - inspect them and keep the one you want."
+      return 1
+    }
+    Say "  . .git already a real directory - nothing to restore"
+    return 3
+  }
+  if (-not (Test-Path -LiteralPath $Target -PathType Container)) {
+    Err "  . .git NOT restored: the sidecar gitdir is missing ($Target)"
+    return 1
+  }
+  try {
+    Invoke-OrDry "restore .git dir from $Target" {
+      if (Test-Path -LiteralPath $ptr) { Remove-Item -LiteralPath $ptr -Force }
+      Move-Item -LiteralPath $Target -Destination $ptr
+      & git -C $VaultAbs config --unset core.worktree 2>$null | Out-Null
+      & git -C $VaultAbs worktree repair *> $null
+    }
+  } catch {
+    Err "  . .git NOT restored: $_"
+    return 1
+  }
+  Say "  . restored .git (directory) from $Target"
+  return 0
+}
+
+function Restore-CacheDir { param([string]$Rel, [string]$Target)
+  $link = Get-VaultPath $Rel
+  $isLink = Test-ReparsePoint $link
+  if ((Test-Path -LiteralPath $link) -and -not $isLink) {
+    if (Test-Path -LiteralPath $Target) {
+      Err "  . $Rel NOT restored: BOTH the vault path and $Target exist - refusing to overwrite either"
+      return 1
+    }
+    Say "  . $Rel already in place - nothing to restore"
+    return 3
+  }
+  if (-not (Test-Path -LiteralPath $Target)) {
+    if ($isLink) {
+      Err "  . $Rel NOT restored: $Target is missing and the vault path is a dangling link"
+      return 1
+    }
+    Say "  . ${Rel}: nothing to restore (the move never happened)"
+    return 3
+  }
+  try {
+    Invoke-OrDry "restore $Rel from $Target" {
+      if (Test-ReparsePoint $link) { Remove-DirLink $link }
+      New-Item -ItemType Directory -Force -Path (Split-Path -Parent $link) | Out-Null
+      Move-Item -LiteralPath $Target -Destination $link
+    }
+  } catch {
+    Err "  . $Rel NOT restored: $_"
+    return 1
+  }
+  Say "  . restored $Rel"
+  return 0
+}
+
 function Invoke-Rollback {
-  if (-not (Test-Path -LiteralPath $Manifest)) { Err "no manifest at $Manifest - nothing to roll back"; exit 2 }
+  $src = ""
+  if ((Test-Path -LiteralPath $Journal) -and ((Get-Item -LiteralPath $Journal).Length -gt 0)) { $src = $Journal }
+  elseif (Test-Path -LiteralPath $Manifest) { $src = $Manifest }
+  else {
+    Err "no relocation record at $Journal or $Manifest - nothing to roll back"
+    return 2
+  }
   Say "Rolling back machinery sidecar for: $VaultAbs"
-  Say "  manifest: $Manifest"
-  $code = @'
-import json, os, sys
-man = sys.argv[1]
-doc = json.load(open(man, encoding="utf-8"))
-for m in reversed(doc.get("moves", [])):
-    print("\t".join([m.get("type",""), m.get("vault_rel",""),
-                     m.get("target",""), m.get("mode","")]))
-'@
-  $rows = Invoke-Py $code @($Manifest)
+  Say "  record: $src"
+  $rows = Get-RecordRows -Src $src -Reverse
+  $restored = 0; $already = 0; $failed = 0
   foreach ($row in @($rows)) {
     if (-not "$row") { continue }
     $parts = "$row" -split "`t"
     while ($parts.Count -lt 4) { $parts += "" }
     $typ = $parts[0]; $rel = $parts[1]; $target = $parts[2]
     if (-not $typ) { continue }
-    switch ($typ) {
-      "git" {
-        $ptr = Join-Path $VaultAbs ".git"
-        if ((Test-Path -LiteralPath $ptr -PathType Leaf) -and (Test-Path -LiteralPath $target -PathType Container)) {
-          Invoke-OrDry "restore .git dir from $target" {
-            Remove-Item -LiteralPath $ptr -Force
-            Move-Item -LiteralPath $target -Destination $ptr
-            & git -C $VaultAbs config --unset core.worktree 2>$null | Out-Null
-            & git -C $VaultAbs worktree repair *> $null
-          }
-          Say "  restored .git (dir) from $target"
-        } else {
-          Warn "  git rollback skipped (pointer or gitdir missing)"
-        }
-      }
-      default {
-        if ($typ -eq "cache" -or $typ -eq "worktrees") {
-          $link = Get-VaultPath $rel
-          if (Test-ReparsePoint $link) { Invoke-OrDry "remove link $link" { Remove-DirLink $link } }
-          if (Test-Path -LiteralPath $target) {
-            Invoke-OrDry "restore $rel from $target" {
-              New-Item -ItemType Directory -Force -Path (Split-Path -Parent $link) | Out-Null
-              Move-Item -LiteralPath $target -Destination $link
-            }
-          } else {
-            Warn "  missing sidecar source: $target"
-          }
-          Say "  restored $rel"
-        }
-      }
-    }
+    $r = 1
+    if ($typ -eq "git") { $r = Restore-GitDir $target }
+    elseif ($typ -eq "cache" -or $typ -eq "worktrees") { $r = Restore-CacheDir $rel $target }
+    else { Warn "  . unknown record type '$typ' for '$rel' - skipped"; $r = 1 }
+    if ($r -eq 0) { $restored++ } elseif ($r -eq 3) { $already++ } else { $failed++ }
   }
-  if (-not $DryRun) { Remove-Item -LiteralPath $Manifest -Force -ErrorAction SilentlyContinue }
-  Say "Rollback complete."
+  if ($failed -eq 0) {
+    if (-not $DryRun) {
+      Remove-Item -LiteralPath $Journal  -Force -ErrorAction SilentlyContinue
+      Remove-Item -LiteralPath $Manifest -Force -ErrorAction SilentlyContinue
+    }
+    Say "Rollback complete: $restored restored, $already already in place, 0 failed."
+    return 0
+  }
+  # The record is the only map back. It is NEVER deleted on a partial rollback.
+  Err "Rollback INCOMPLETE: $restored restored, $already already in place, $failed FAILED."
+  Err "  the relocation record was kept so you can fix the cause and re-run:"
+  Err "    relocate-machinery-sidecar.ps1 `"$VaultAbs`" -Sidecar `"$Sidecar`" -Rollback"
+  return 1
 }
 
 # =============================================================================
@@ -412,17 +688,21 @@ if (-not $Sidecar) {
              elseif ($env:MYCELIUM_SIDECAR) { $env:MYCELIUM_SIDECAR }
              else { Join-Path (Get-HomeBase) ".brain-sidecar" }
 }
-$Sidecar = "$(Get-AbsPath $Sidecar)".Trim()
+# PHYSICALLY resolve it (realpath, not abspath): the containment checks below
+# have to compare real locations, and the sidecar usually does not exist yet.
+$Sidecar = "$(Get-PhysicalPath $Sidecar)".Trim()
 
 $Slug     = Get-Slug $VaultAbs
 $SideGit  = Join-Path (Join-Path $Sidecar "git") $Slug
 $SideCache = Join-Path (Join-Path $Sidecar "cache") $Slug
 $SideWt   = Join-Path (Join-Path $Sidecar "worktrees") $Slug
 $Manifest = Join-Path (Join-Path $Sidecar "manifests") "$Slug.json"
+# Append-only write-ahead record, kept across runs (see Add-JournalRecord).
+$Journal  = Join-Path (Join-Path $Sidecar "manifests") "$Slug.journal.jsonl"
 
-if ($Rollback) { Invoke-Rollback; exit 0 }
+if ($Rollback) { $rbrc = @(Invoke-Rollback)[-1]; exit ([int]$rbrc) }
 
-# informational cloud detect (the whole point is the cloud is ALLOWED)
+# informational cloud detect for the VAULT (the whole point is the cloud is ALLOWED)
 $cloud = ""
 $ccs = Join-Path $ScriptDir "check-cloud-sync.py"
 if (Test-Path -LiteralPath $ccs) {
@@ -442,26 +722,37 @@ if ($cloud -like 'CLOUD_SYNC_RISK*') {
 }
 if ($DryRun) { Say "  mode    : -DryRun (no changes)" }
 
+# the destination is NOT informational: a synced sidecar fixes nothing
+if (-not (Test-SidecarLocation)) { exit 1 }
+
+$script:GitState = Get-GitState
 if (-not (Test-NoLive)) { exit 1 }
 
+$failedPaths = 0
 Say "Relocating .git ..."
 if (-not (Move-GitDir)) { exit 4 }
+$script:GitState = Get-GitState   # a fresh-init just created the repo
 
 Say "Relocating worktrees ..."
-Move-CacheDir -Rel $WorktreesRel -Dst $SideWt -RType "worktrees"
+if (-not (Move-CacheDir -Rel $WorktreesRel -Dst $SideWt -RType "worktrees")) { $failedPaths++ }
 
 Say "Relocating caches ..."
 foreach ($rel in $CacheDirs) {
-  Move-CacheDir -Rel $rel -Dst (Join-Path $SideCache ($rel -replace '/', [System.IO.Path]::DirectorySeparatorChar)) -RType "cache"
+  $dst = Join-Path $SideCache ($rel -replace '/', [System.IO.Path]::DirectorySeparatorChar)
+  if (-not (Move-CacheDir -Rel $rel -Dst $dst -RType "cache")) { $failedPaths++ }
 }
 
 Write-Manifest
-if ($script:RecFile -and (Test-Path -LiteralPath $script:RecFile)) { Remove-Item -LiteralPath $script:RecFile -Force -ErrorAction SilentlyContinue }
 
 if ($DryRun) {
   Say "DRY-RUN complete - no changes made. Manifest would be: $Manifest"
-} else {
-  Say "Done. Manifest: $Manifest"
-  Say "Reverse anytime: relocate-machinery-sidecar.ps1 `"$VaultAbs`" -Rollback"
+  exit 0
 }
+if ($failedPaths -gt 0) {
+  Err "$failedPaths path(s) could not be relocated (see the errors above). Record: $Journal"
+  Err "Reverse what DID move: relocate-machinery-sidecar.ps1 `"$VaultAbs`" -Sidecar `"$Sidecar`" -Rollback"
+  exit 4
+}
+Say "Done. Manifest: $Manifest"
+Say "Reverse anytime: relocate-machinery-sidecar.ps1 `"$VaultAbs`" -Rollback"
 exit 0

--- a/scripts/relocate-machinery-sidecar.sh
+++ b/scripts/relocate-machinery-sidecar.sh
@@ -16,7 +16,17 @@
 # git's view of it. The bytes must physically leave the synced tree (relocate +
 # symlink) or be flagged `.nosync` (iCloud ignores any name ending in .nosync).
 #
-# WHAT IT MOVES
+# THE ONE RULE: IT NEVER MOVES ANYTHING GIT TRACKS
+# ------------------------------------------------
+# Every candidate below is tested against the REAL git index before it is
+# touched. A path holding tracked content is your NOTES, whatever it is named —
+# moving it turns the directory into a symlink, `git status` reports every file
+# as deleted, and the next auto-commit/push propagates that deletion to every
+# machine. So: tracked content -> never moved, reported, left exactly as it is.
+# Genuinely ignored/untracked caches still move. If the index cannot be read,
+# the path is left alone (a path I cannot prove is a cache is not a cache).
+#
+# WHAT IT MOVES (only when the path holds NO tracked content)
 #   .git              -> <sidecar>/git    via `git init --separate-git-dir`
 #                        (leaves a one-line `.git` POINTER FILE — static, safe)
 #   .claude/worktrees -> <sidecar>/worktrees  (relocate + symlink; MYC-543 layer)
@@ -24,17 +34,29 @@
 #                        .smart-env .codegraph "⚙️ Meta/graphify-out"
 #                        "⚙️ Meta/Sessions" "⚙️ Meta/Worktree Snapshots"
 #                        "⚙️ Meta/logs"  (only those that exist as REAL dirs)
+#                        NOTE several of these names hold TRACKED notes in a real
+#                        vault. They are candidates only — the index test
+#                        decides, never the name.
 #
 # SEQUENCING GOTCHA (verified): `git init --separate-git-dir` ORPHANS existing
 # linked worktrees. So this REFUSES to run while any linked worktree or live
 # Claude session exists, unless --force. After relocation it runs
-# `git worktree repair`.
+# `git worktree repair`. The probes FAIL CLOSED: if git or the session lock
+# cannot be read, that counts as LIVE and the run is refused. "I could not look"
+# and "I looked and it was empty" are different answers.
 #
-# SAFETY: idempotent (re-run = no-op report), reversible (--rollback reads the
-# manifest and puts everything back), --dry-run changes nothing, and it never
-# deletes content — only moves it and leaves a symlink/pointer.
+# SAFETY: idempotent (re-run = no-op report), interrupt-safe (every move is
+# written to an append-only journal in the sidecar BEFORE it happens, so
+# --rollback works from any kill point), reversible (--rollback reads that
+# record and puts everything back, exits non-zero and KEEPS the record if any
+# leg fails), --dry-run changes nothing, and it never deletes content — only
+# moves it and leaves a symlink/pointer.
 #
-# Pure bash + git + python3 (manifest JSON only). No third-party deps.
+# The SIDECAR DESTINATION is checked with the same cloud-sync detector as the
+# vault: relocating machinery from one synced tree into another (a redirected
+# $HOME on a roaming/OneDrive profile) does not fix the melt, so it is refused.
+#
+# Pure bash + git + python3 (JSON only). No third-party deps.
 #
 # Usage:
 #   relocate-machinery-sidecar.sh <vault-path> [options]
@@ -45,17 +67,20 @@
 #   --nosync          keep caches in-tree as <name>.nosync (iCloud-ignored) +
 #                     symlink, instead of relocating them to the sidecar
 #   --dry-run         print intended actions, change nothing
-#   --rollback        reverse a previous relocation using the manifest
-#   --force           proceed even if linked worktrees / live sessions exist
+#   --rollback        reverse a previous relocation using the recorded moves
+#   --force           proceed even if linked worktrees / live sessions exist, a
+#                     probe could not run, or the sidecar looks cloud-synced
 #                     (DANGEROUS: separate-git-dir orphans live worktrees)
 #   --quiet           only print warnings/errors + the final summary line
 #   -h, --help        this help
 #
-# Exit codes: 0 ok / no-op · 1 refused (live worktree/session) · 2 usage ·
+# Exit codes: 0 ok / no-op · 1 refused (live worktree/session, unsafe sidecar,
+#             or a probe that could not run) · 2 usage / nothing to roll back ·
 #             3 not a git vault and could not init · 4 partial failure
 set -euo pipefail
 
 # ---- machinery the script relocates (relative to the vault root) -------------
+# CANDIDATES, not a denylist: each moves ONLY if git tracks nothing there.
 CACHE_DIRS=(
   ".smart-env"
   ".codegraph"
@@ -79,7 +104,9 @@ while [ $# -gt 0 ]; do
     --rollback) ROLLBACK=1; shift;;
     --force) FORCE=1; shift;;
     --quiet) QUIET=1; shift;;
-    -h|--help) sed -n '2,55p' "$0" | sed 's/^# \{0,1\}//'; exit 0;;
+    # print the leading comment block, however long it grows (a hardcoded line
+    # range silently truncates the help the moment the header changes)
+    -h|--help) awk 'NR==1{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "$0"; exit 0;;
     -*) echo "unknown option: $1" >&2; exit 2;;
     *) if [ -z "$VAULT" ]; then VAULT="$1"; else echo "unexpected arg: $1" >&2; exit 2; fi; shift;;
   esac
@@ -87,9 +114,37 @@ done
 [ -n "$VAULT" ] || { echo "usage: $(basename "$0") <vault-path> [options]" >&2; exit 2; }
 [ -d "$VAULT" ] || { echo "not a directory: $VAULT" >&2; exit 2; }
 
+say()  { [ "$QUIET" = 1 ] || printf '%s\n' "$*"; }
+warn() { printf 'WARN  %s\n' "$*" >&2; }
+err()  { printf 'ERROR %s\n' "$*" >&2; }
+
+# run <argv...> — NO eval, NO shell. The vault path is data, never code: a
+# folder named `Notes $HOME Backup` used to re-expand, and one containing a
+# backtick or $( ) would have EXECUTED under the old eval-a-string form.
+run()        { if [ "$DRYRUN" = 1 ]; then printf 'DRY   %s\n' "$*"; return 0; fi; "$@"; }
+run_quiet()  { if [ "$DRYRUN" = 1 ]; then printf 'DRY   %s\n' "$*"; return 0; fi; "$@" >/dev/null; }
+run_silent() { if [ "$DRYRUN" = 1 ]; then printf 'DRY   %s\n' "$*"; return 0; fi; "$@" >/dev/null 2>&1; }
+
+# Test-only fault injection for the interrupt matrix in test-machinery-sidecar.sh.
+# Unset in production. Set to a step label to SIGKILL this process right after
+# that step (no traps, no cleanup) — the only honest way to prove --rollback
+# works from every kill point.
+_maybe_die() {
+  if [ "${BRAIN_SIDECAR_TEST_KILL_AT:-}" = "$1" ]; then kill -9 $$; fi
+  return 0
+}
+
+PYBIN="$(command -v python3 || command -v python || true)"
+[ -n "$PYBIN" ] || { err "python3 required for the move record"; exit 4; }
+
 # absolutize (portable realpath: cd + pwd -P)
 VAULT="$(cd "$VAULT" && pwd -P)"
 case "$SIDECAR" in /*) :;; ~*) SIDECAR="${SIDECAR/#\~/$HOME}";; *) SIDECAR="$PWD/$SIDECAR";; esac
+# ...and PHYSICALLY resolve it. The sidecar usually does not exist yet, so
+# `cd + pwd -P` cannot be used; realpath() resolves the existing ancestors and
+# keeps the tail. Without this, /var vs /private/var (macOS) makes the
+# "is the sidecar inside the vault" check silently miss.
+SIDECAR="$("$PYBIN" -c 'import os,sys; print(os.path.realpath(os.path.expanduser(sys.argv[1])))' "$SIDECAR")"
 
 # per-vault slug = sanitized basename + short abspath hash (collision-safe)
 _base="$(basename "$VAULT")"
@@ -101,34 +156,88 @@ SIDE_GIT="$SIDECAR/git/$SLUG"
 SIDE_CACHE="$SIDECAR/cache/$SLUG"
 SIDE_WT="$SIDECAR/worktrees/$SLUG"
 MANIFEST="$SIDECAR/manifests/$SLUG.json"
+# Append-only write-ahead record. Written BEFORE each move, fsynced, and kept
+# across runs, so a SIGKILL at ANY point still leaves --rollback a full map.
+JOURNAL="$SIDECAR/manifests/$SLUG.journal.jsonl"
 
-say()  { [ "$QUIET" = 1 ] || printf '%s\n' "$*"; }
-warn() { printf 'WARN  %s\n' "$*" >&2; }
-err()  { printf 'ERROR %s\n' "$*" >&2; }
-# shellcheck disable=SC2294  # run() intentionally evals a command STRING; every caller passes redirections + quoted space/emoji paths that "$@" cannot parse
-run()  { if [ "$DRYRUN" = 1 ]; then printf 'DRY   %s\n' "$*"; else eval "$@"; fi; }
 
-# ---- manifest helpers (python3 for safe JSON over emoji/space paths) ---------
-PYBIN="$(command -v python3 || command -v python || true)"
-[ -n "$PYBIN" ] || { err "python3 required for the manifest"; exit 4; }
+_tsv="$(mktemp)"
+trap 'rm -f "$_tsv"' EXIT
 
-_manifest_records="$(mktemp)"   # TSV staging: type<TAB>vault_rel<TAB>target<TAB>mode
-trap 'rm -f "$_manifest_records"' EXIT
-record() { printf '%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" >> "$_manifest_records"; }
+# ---- write-ahead journal ----------------------------------------------------
+# Appends one JSON object and fsyncs it (file AND directory) before returning.
+# A move this fails to record is a move that does NOT happen.
+journal_append() {  # type  vault_rel  target  mode
+  [ "$DRYRUN" = 1 ] && return 0
+  mkdir -p "$(dirname "$JOURNAL")" || return 1
+  J="$JOURNAL" "$PYBIN" - "$1" "$2" "$3" "$4" <<'PY'
+import json, os, sys
+rec = {"type": sys.argv[1], "vault_rel": sys.argv[2],
+       "target": sys.argv[3], "mode": sys.argv[4]}
+p = os.environ["J"]
+with open(p, "a", encoding="utf-8") as f:
+    f.write(json.dumps(rec, ensure_ascii=False) + "\n")
+    f.flush()
+    os.fsync(f.fileno())
+try:  # directory fsync: POSIX only, best-effort (unsupported on Windows)
+    d = os.open(os.path.dirname(p), os.O_RDONLY)
+    try:
+        os.fsync(d)
+    finally:
+        os.close(d)
+except OSError:
+    pass
+PY
+}
+
+# Read the recorded moves from the journal (.jsonl) or a manifest (.json) and
+# print them as TSV. Later records win per (type, vault_rel) so a relocate ->
+# rollback -> relocate cycle never replays a stale row. REV=1 reverses.
+records_tsv() {  # $1 = source file
+  SRC="$1" REV="${REV:-0}" "$PYBIN" - <<'PY'
+import json, os
+src = os.environ["SRC"]
+recs = []
+if src.endswith(".jsonl"):
+    with open(src, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                recs.append(json.loads(line))
+            except ValueError:
+                continue  # a torn final line from a SIGKILL is not a reason to stop
+else:
+    with open(src, encoding="utf-8") as f:
+        recs = json.load(f).get("moves", [])
+seen, order = {}, []
+for r in recs:
+    if not isinstance(r, dict):
+        continue
+    k = (r.get("type", ""), r.get("vault_rel", ""))
+    if k not in seen:
+        order.append(k)
+    seen[k] = r
+rows = [seen[k] for k in order]
+if os.environ.get("REV") == "1":
+    rows.reverse()
+for r in rows:
+    print("\t".join([r.get("type", ""), r.get("vault_rel", ""),
+                     r.get("target", ""), r.get("mode", "")]))
+PY
+}
 
 write_manifest() {
   [ "$DRYRUN" = 1 ] && return 0
-  # An idempotent re-run (everything already relocated) records ZERO new moves.
-  # Do NOT clobber a prior valid manifest with an empty one - that silently
-  # breaks --rollback. Only write when there is something to record, or when no
-  # manifest exists yet. (Parity with relocate-machinery-sidecar.ps1, MYC-2383.)
-  if [ ! -s "$_manifest_records" ] && [ -f "$MANIFEST" ]; then
-    say "  · no new moves; keeping existing manifest $MANIFEST"
+  if [ ! -s "$JOURNAL" ]; then
+    [ -f "$MANIFEST" ] && { say "  · no recorded moves; keeping existing manifest $MANIFEST"; return 0; }
     return 0
   fi
+  records_tsv "$JOURNAL" > "$_tsv"
   mkdir -p "$(dirname "$MANIFEST")"
   VAULT="$VAULT" SIDECAR="$SIDECAR" SLUG="$SLUG" NOSYNC="$NOSYNC" \
-  REC="$_manifest_records" MAN="$MANIFEST" "$PYBIN" - <<'PY'
+  REC="$_tsv" MAN="$MANIFEST" "$PYBIN" - <<'PY'
 import json, os
 recs = []
 with open(os.environ["REC"], encoding="utf-8") as f:
@@ -156,25 +265,68 @@ with open(os.environ["MAN"], "w", encoding="utf-8") as f:
 PY
 }
 
-# ---- live-worktree / live-session guard -------------------------------------
-linked_worktrees() {
+# ---- git probes (fail CLOSED: "could not look" != "nothing there") -----------
+# LC_ALL=C so git's messages stay in English and the classification below holds
+# on a translated locale.
+GIT_STATE="unknown"
+probe_git_state() {  # prints repo | norepo | error
+  local out rc=0
+  out="$(LC_ALL=C git -C "$VAULT" rev-parse --git-dir 2>&1)" || rc=$?
+  if [ "$rc" -eq 0 ]; then printf 'repo\n'; return 0; fi
+  case "$out" in
+    *"not a git repository"*) printf 'norepo\n';;
+    *) printf 'error\n'; printf 'WARN  git could not read %s: %s\n' "$VAULT" "$out" >&2;;
+  esac
+  return 0
+}
+
+# Prints the number of TRACKED files at a vault-relative path.
+# Returns 1 when the index could not be read at all — the caller must then treat
+# the path as tracked and leave it alone.
+tracked_count() {  # $1 = vault-relative path
+  local rel="$1" out rc=0
+  case "$GIT_STATE" in
+    norepo) printf '0\n'; return 0;;
+    repo) :;;
+    *) return 1;;
+  esac
+  out="$(LC_ALL=C git -C "$VAULT" ls-files -- "$rel" 2>/dev/null)" || rc=$?
+  [ "$rc" -eq 0 ] || return 1
+  [ -n "$out" ] || { printf '0\n'; return 0; }
+  printf '%s\n' "$out" | wc -l | tr -d ' '
+}
+
+linked_worktrees() {  # prints one path per LINKED worktree; returns 2 if unprobeable
+  local out rc=0
+  case "$GIT_STATE" in
+    norepo) return 0;;
+    repo) :;;
+    *) return 2;;
+  esac
   # Registered LINKED worktrees = every "worktree " porcelain block EXCEPT the
   # first (the first is always the MAIN worktree). Filtering by "!= $VAULT" is
   # WRONG after --separate-git-dir: git then reports the main worktree's path as
   # the separated gitdir, not the vault, so the main would masquerade as linked.
-  git -C "$VAULT" worktree list --porcelain 2>/dev/null \
-    | awk '/^worktree /{n++; if (n>1) print substr($0,10)}'
+  out="$(LC_ALL=C git -C "$VAULT" worktree list --porcelain 2>&1)" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    printf 'WARN  could not list git worktrees in %s: %s\n' "$VAULT" "$out" >&2
+    return 2
+  fi
+  printf '%s\n' "$out" | awk '/^worktree /{n++; if (n>1) print substr($0,10)}'
 }
-live_sessions() {
-  local lock="$VAULT/.claude/.session-lock.json"
-  [ -f "$lock" ] || return 0
-  SELF_PID="$$" LOCK="$lock" "$PYBIN" - <<'PY'
-import json, os, time
+
+live_sessions() {  # prints an integer; returns 2 if the lock could not be read
+  local lock="$VAULT/.claude/.session-lock.json" out rc=0
+  [ -f "$lock" ] || { printf '0\n'; return 0; }
+  out="$(SELF_PID="$$" LOCK="$lock" "$PYBIN" - <<'PY'
+import json, os, sys, time
 lock = os.environ["LOCK"]
 try:
-    data = json.load(open(lock, encoding="utf-8"))
-except Exception:
-    raise SystemExit(0)
+    with open(lock, encoding="utf-8") as f:
+        data = json.load(f)
+except Exception as e:  # an unreadable/corrupt lock is NOT "zero sessions"
+    print("cannot read %s: %s" % (lock, e), file=sys.stderr)
+    raise SystemExit(3)
 sessions = data.get("sessions", {}) if isinstance(data, dict) else {}
 cut = time.time() - 35 * 60
 self_pid = int(os.environ.get("SELF_PID", "0") or 0)
@@ -197,95 +349,235 @@ for s in sessions.values():
         n += 1
 print(n)
 PY
+)" || rc=$?
+  if [ "$rc" -ne 0 ]; then return 2; fi
+  case "$out" in
+    ''|*[!0-9]*) printf 'WARN  unreadable session count from %s: %s\n' "$lock" "$out" >&2; return 2;;
+  esac
+  printf '%s\n' "$out"
 }
 
 guard_no_live() {
-  local wts ; wts="$(linked_worktrees || true)"
-  local sess ; sess="$(live_sessions || echo 0)"; sess="${sess:-0}"
-  if [ -n "$wts" ] || [ "$sess" -gt 0 ] 2>/dev/null; then
+  local wts="" sess="0" wt_rc=0 sess_rc=0 probe_failed=0
+  wts="$(linked_worktrees)" || wt_rc=$?
+  sess="$(live_sessions)" || sess_rc=$?
+  if [ "$wt_rc" -ne 0 ] || [ "$sess_rc" -ne 0 ]; then probe_failed=1; fi
+  case "$sess" in ''|*[!0-9]*) sess=0;; esac
+
+  if [ -n "$wts" ] || [ "$sess" -gt 0 ] || [ "$probe_failed" = 1 ]; then
     if [ "$FORCE" = 1 ]; then
-      warn "linked worktrees and/or $sess live session(s) present — proceeding under --force (separate-git-dir will orphan live worktrees)"
+      warn "live worktrees/sessions present or unprobeable — proceeding under --force (separate-git-dir will orphan live worktrees)"
       return 0
     fi
-    err "refusing: relocation must run in a no-live-worktree window."
-    [ -n "$wts" ] && { err "  linked worktrees still registered:"; printf '    %s\n' "$wts" >&2; }
-    [ "$sess" -gt 0 ] 2>/dev/null && err "  $sess live Claude session(s) in $VAULT/.claude/.session-lock.json"
+    err "refusing: relocation must run in a proven no-live-worktree window."
+    if [ "$probe_failed" = 1 ]; then
+      err "  a safety probe could not run (see the WARN above), so I cannot prove nothing is live."
+      err "  a probe that errors and a vault that is idle look identical — this refuses rather than guess."
+      err "  common cause: git 'dubious ownership' on a restored/migrated/external/network vault. Fix with:"
+      err "    git config --global --add safe.directory \"$VAULT\""
+    fi
+    if [ -n "$wts" ]; then err "  linked worktrees still registered:"; printf '    %s\n' "$wts" >&2; fi
+    if [ "$sess" -gt 0 ]; then err "  $sess live Claude session(s) in $VAULT/.claude/.session-lock.json"; fi
     err "  close all sessions + 'git worktree remove' scratch trees, then re-run. Override: --force"
     return 1
   fi
+  return 0
+}
+
+# ---- sidecar destination guard ----------------------------------------------
+# The destination must be OUTSIDE every synced tree. Moving `.git` from one
+# synced folder into another (redirected $HOME on a roaming / OneDrive-managed
+# profile, a network home) passes every success check and changes nothing about
+# the melt — except that the notes are now split from their repo.
+guard_sidecar_location() {
+  local ccs="$_sa/check-cloud-sync.py" out rc=0
+  case "$SIDECAR/" in
+    "$VAULT"/*)
+      err "refusing: the sidecar ($SIDECAR) is INSIDE the vault ($VAULT)."
+      err "  the machinery would never leave the synced tree. Pass --sidecar <a path outside the vault>."
+      return 1;;
+  esac
+  case "$VAULT/" in
+    "$SIDECAR"/*)
+      err "refusing: the vault ($VAULT) is INSIDE the sidecar ($SIDECAR)."
+      err "  pass --sidecar <a path outside the vault>."
+      return 1;;
+  esac
+  if [ ! -f "$ccs" ]; then
+    warn "could not verify the sidecar destination: $ccs is missing (cloud-sync detector unavailable)"
+    return 0
+  fi
+  out="$("$PYBIN" "$ccs" --porcelain "$SIDECAR" 2>/dev/null)" || rc=$?
+  case "$out" in
+    CLOUD_SYNC_RISK*)
+      if [ "$FORCE" = 1 ]; then
+        warn "sidecar destination is inside ${out#CLOUD_SYNC_RISK:} — proceeding under --force (the sync melt is NOT fixed by this run)"
+        return 0
+      fi
+      err "refusing: the sidecar destination is inside ${out#CLOUD_SYNC_RISK:}, a cloud-sync folder."
+      err "  sidecar: $SIDECAR"
+      err "  moving the machinery from one synced folder into another does not stop the melt;"
+      err "  it only splits your notes from their repo. This usually means \$HOME itself is synced"
+      err "  (a roaming / OneDrive-managed / network profile), so the default ~/.brain-sidecar is too."
+      err "  Re-run with a local path, e.g.:  --sidecar /var/tmp/brain-sidecar   (Windows: C:\\brain-sidecar)"
+      err "  Override (NOT recommended): --force"
+      return 1;;
+    OK_LOCAL) return 0;;
+    *)
+      warn "could not verify the sidecar destination is outside a cloud-sync folder"
+      warn "  ($(basename "$ccs") exited $rc and said: ${out:-<nothing>}) — proceeding"
+      return 0;;
+  esac
 }
 
 # =============================================================================
 # ROLLBACK
 # =============================================================================
+rollback_git() {  # $1 = sidecar gitdir; 0 restored / 3 nothing to do / 1 failed
+  local target="$1" ptr="$VAULT/.git"
+  if [ -d "$ptr" ] && [ ! -L "$ptr" ]; then
+    if [ -d "$target" ]; then
+      err "  · .git NOT restored: BOTH $ptr (a real dir) and $target exist."
+      err "    refusing to overwrite either — inspect them and keep the one you want."
+      return 1
+    fi
+    say "  · .git already a real directory — nothing to restore"
+    return 3
+  fi
+  if [ ! -d "$target" ]; then
+    err "  · .git NOT restored: the sidecar gitdir is missing ($target)"
+    return 1
+  fi
+  if [ -e "$ptr" ] || [ -L "$ptr" ]; then
+    run rm -f "$ptr" || { err "  · .git NOT restored: could not remove the pointer $ptr"; return 1; }
+  fi
+  run mv "$target" "$ptr" || { err "  · .git NOT restored: move failed ($target -> $ptr)"; return 1; }
+  run_silent git -C "$VAULT" config --unset core.worktree || true
+  run_silent git -C "$VAULT" worktree repair || true
+  say "  · restored .git (directory) from $target"
+  return 0
+}
+
+rollback_dir() {  # $1 rel, $2 target, $3 mode; 0 restored / 3 nothing to do / 1 failed
+  local rel="$1" target="$2" mode="$3" back parent
+  local link="$VAULT/$rel"
+  if [ "$mode" = "nosync" ]; then back="$VAULT/${rel}.nosync"; else back="$target"; fi
+  if [ -e "$link" ] && [ ! -L "$link" ]; then
+    if [ -e "$back" ]; then
+      err "  · $rel NOT restored: BOTH the vault path and $back exist — refusing to overwrite either"
+      return 1
+    fi
+    say "  · $rel already in place — nothing to restore"
+    return 3
+  fi
+  if [ ! -e "$back" ]; then
+    if [ -L "$link" ]; then
+      err "  · $rel NOT restored: $back is missing and the vault path is a dangling link"
+      return 1
+    fi
+    say "  · $rel: nothing to restore (the move never happened)"
+    return 3
+  fi
+  if [ -L "$link" ]; then
+    run rm -f "$link" || { err "  · $rel NOT restored: could not remove the symlink $link"; return 1; }
+  fi
+  parent="$(dirname "$link")"
+  run mkdir -p "$parent" || { err "  · $rel NOT restored: could not create $parent"; return 1; }
+  run mv "$back" "$link" || { err "  · $rel NOT restored: move failed ($back -> $link)"; return 1; }
+  say "  · restored $rel"
+  return 0
+}
+
 do_rollback() {
-  [ -f "$MANIFEST" ] || { err "no manifest at $MANIFEST — nothing to roll back"; exit 2; }
+  local src="" typ rel target mode r rc=0 restored=0 already=0 failed=0
+  if [ -s "$JOURNAL" ]; then src="$JOURNAL"
+  elif [ -f "$MANIFEST" ]; then src="$MANIFEST"
+  else
+    err "no relocation record at $JOURNAL or $MANIFEST — nothing to roll back"
+    return 2
+  fi
   say "Rolling back machinery sidecar for: $VAULT"
-  say "  manifest: $MANIFEST"
-  # iterate moves in REVERSE order
-  MAN="$MANIFEST" "$PYBIN" - <<'PY' > "$_manifest_records"
-import json, os
-doc = json.load(open(os.environ["MAN"], encoding="utf-8"))
-for m in reversed(doc.get("moves", [])):
-    print("\t".join([m.get("type",""), m.get("vault_rel",""),
-                     m.get("target",""), m.get("mode","")]))
-PY
-  local rc=0
+  say "  record: $src"
+  REV=1 records_tsv "$src" > "$_tsv" || { err "could not read the relocation record $src"; return 4; }
+
   while IFS=$'\t' read -r typ rel target mode; do
     [ -n "$typ" ] || continue
+    r=0
     case "$typ" in
-      git)
-        local ptr="$VAULT/.git"
-        if [ -f "$ptr" ] && [ -d "$target" ]; then
-          run "rm -f \"$ptr\""
-          run "mv \"$target\" \"$ptr\""
-          run "git -C \"$VAULT\" config --unset core.worktree" || true
-          run "git -C \"$VAULT\" worktree repair >/dev/null 2>&1" || true
-          say "  restored .git (dir) from $target"
-        else
-          warn "  git rollback skipped (ptr present=$( [ -f "$ptr" ] && echo y || echo n ), gitdir present=$( [ -d "$target" ] && echo y || echo n ))"
-        fi
-        ;;
-      cache|worktrees)
-        local link="$VAULT/$rel"
-        if [ -L "$link" ]; then run "rm -f \"$link\""; fi
-        if [ "$mode" = "nosync" ]; then
-          local ns="$VAULT/${rel}.nosync"
-          [ -e "$ns" ] && run "mv \"$ns\" \"$link\"" || warn "  missing nosync source: $ns"
-        else
-          [ -e "$target" ] && run "mkdir -p \"$(dirname "$link")\" && mv \"$target\" \"$link\"" \
-                           || warn "  missing sidecar source: $target"
-        fi
-        say "  restored $rel"
-        ;;
+      git)             rollback_git "$target" || r=$?;;
+      cache|worktrees) rollback_dir "$rel" "$target" "$mode" || r=$?;;
+      *)               warn "  · unknown record type '$typ' for '$rel' — skipped"; r=1;;
     esac
-  done < "$_manifest_records"
-  if [ "$DRYRUN" != 1 ]; then run "rm -f \"$MANIFEST\""; fi
-  say "Rollback complete."
-  return $rc
+    case "$r" in
+      0) restored=$((restored + 1));;
+      3) already=$((already + 1));;
+      *) failed=$((failed + 1)); rc=1;;
+    esac
+  done < "$_tsv"
+
+  if [ "$rc" = 0 ]; then
+    if [ "$DRYRUN" != 1 ]; then
+      run rm -f "$JOURNAL" || true
+      run rm -f "$MANIFEST" || true
+    fi
+    say "Rollback complete: $restored restored, $already already in place, 0 failed."
+    return 0
+  fi
+  # The record is the only map back. It is NEVER deleted on a partial rollback.
+  err "Rollback INCOMPLETE: $restored restored, $already already in place, $failed FAILED."
+  err "  the relocation record was kept so you can fix the cause and re-run:"
+  err "    $(basename "$0") \"$VAULT\" --sidecar \"$SIDECAR\" --rollback"
+  return 1
 }
 
 # =============================================================================
 # RELOCATE one cache/worktree dir (relocate+symlink, or nosync+symlink)
 # =============================================================================
 relocate_dir() {  # $1 = vault-relative path, $2 = explicit sidecar destination, $3 = record-type
-  local rel="$1" dst="$2" rtype="$3"
+  local rel="$1" dst="$2" rtype="$3" n ns
   local src="$VAULT/$rel"
   if [ -L "$src" ]; then say "  · $rel already a symlink — skip"; return 0; fi
   if [ ! -e "$src" ]; then return 0; fi          # absent → nothing to do
+
+  # THE ONE RULE: never move anything git tracks, whatever the path is named.
+  if ! n="$(tracked_count "$rel")"; then
+    warn "  · $rel — KEPT: could not read the git index, so I cannot prove this is a cache"
+    return 0
+  fi
+  if [ "$n" != 0 ]; then
+    say "  · $rel — KEPT: git tracks $n file(s) here. Those are notes, not a cache;"
+    say "        relocating them would show every one as DELETED and sync that deletion."
+    return 0
+  fi
+
   if [ "$NOSYNC" = 1 ]; then
-    local ns="$VAULT/${rel}.nosync"
+    ns="$VAULT/${rel}.nosync"
     if [ -e "$ns" ]; then warn "  · $rel.nosync already exists — skip"; return 0; fi
-    run "mv \"$src\" \"$ns\""
-    run "ln -s \"$(basename "$rel").nosync\" \"$src\""
-    record "$rtype" "$rel" "$ns" "nosync"
+    journal_append "$rtype" "$rel" "$ns" "nosync" || {
+      err "  · $rel NOT moved: could not record the move in $JOURNAL (an unrecordable move cannot be reversed)"
+      return 1
+    }
+    _maybe_die "post-journal:$rel"
+    run mv "$src" "$ns" || { err "  · $rel: move failed"; return 1; }
+    _maybe_die "post-mv:$rel"
+    run ln -s "$(basename "$rel").nosync" "$src" || { err "  · $rel: symlink failed"; return 1; }
+    _maybe_die "post-link:$rel"
     say "  · $rel -> ${rel}.nosync (iCloud-ignored) + symlink"
   else
-    if [ -e "$dst" ]; then run "mv \"$dst\" \"$dst.bak-$(date +%s)\""; warn "  · prior sidecar copy at $dst backed up"; fi
-    run "mkdir -p \"$(dirname "$dst")\""
-    run "mv \"$src\" \"$dst\""
-    run "ln -s \"$dst\" \"$src\""
-    record "$rtype" "$rel" "$dst" "relocate"
+    if [ -e "$dst" ]; then
+      run mv "$dst" "$dst.bak-$(date +%s)" || { err "  · $rel: could not back up the prior sidecar copy"; return 1; }
+      warn "  · prior sidecar copy at $dst backed up"
+    fi
+    journal_append "$rtype" "$rel" "$dst" "relocate" || {
+      err "  · $rel NOT moved: could not record the move in $JOURNAL (an unrecordable move cannot be reversed)"
+      return 1
+    }
+    _maybe_die "post-journal:$rel"
+    run mkdir -p "$(dirname "$dst")" || { err "  · $rel: could not create the sidecar parent"; return 1; }
+    run mv "$src" "$dst" || { err "  · $rel: move failed"; return 1; }
+    _maybe_die "post-mv:$rel"
+    run ln -s "$dst" "$src" || { err "  · $rel: symlink failed"; return 1; }
+    _maybe_die "post-link:$rel"
     say "  · $rel -> $dst + symlink"
   fi
 }
@@ -294,41 +586,51 @@ relocate_dir() {  # $1 = vault-relative path, $2 = explicit sidecar destination,
 # RELOCATE .git via --separate-git-dir
 # =============================================================================
 relocate_git() {
-  local gitpath="$VAULT/.git"
+  local gitpath="$VAULT/.git" cur
   if [ -f "$gitpath" ]; then
-    local cur; cur="$(sed -n 's/^gitdir: //p' "$gitpath" | head -1)"
+    cur="$(sed -n 's/^gitdir: //p' "$gitpath" | head -1)"
     say "  · .git already a pointer (-> ${cur:-?}) — skip"
     return 0
   fi
   if [ -d "$gitpath" ]; then
-    run "mkdir -p \"$(dirname "$SIDE_GIT")\""
-    run "git -C \"$VAULT\" init --separate-git-dir \"$SIDE_GIT\" >/dev/null"
+    journal_append "git" ".git" "$SIDE_GIT" "separated" || {
+      err "  .git NOT moved: could not record the move in $JOURNAL"; return 4
+    }
+    _maybe_die "post-journal:.git"
+    run mkdir -p "$(dirname "$SIDE_GIT")" || return 4
+    run_quiet git -C "$VAULT" init --separate-git-dir "$SIDE_GIT" || return 4
+    _maybe_die "post-git"
     if [ "$DRYRUN" != 1 ] && [ ! -f "$gitpath" ]; then
       err "  separate-git-dir did not produce a .git pointer file"; return 4
     fi
-    run "git -C \"$VAULT\" worktree repair >/dev/null 2>&1" || true
-    record "git" ".git" "$SIDE_GIT" "separated"
+    run_silent git -C "$VAULT" worktree repair || true
     say "  · .git -> $SIDE_GIT (pointer file left in vault)"
     return 0
   fi
   # no .git at all → fresh repo with a separated gitdir
-  run "mkdir -p \"$(dirname "$SIDE_GIT")\""
-  run "git -C \"$VAULT\" init --separate-git-dir \"$SIDE_GIT\" >/dev/null"
-  record "git" ".git" "$SIDE_GIT" "fresh-init"
+  journal_append "git" ".git" "$SIDE_GIT" "fresh-init" || {
+    err "  could not record the fresh init in $JOURNAL"; return 4
+  }
+  run mkdir -p "$(dirname "$SIDE_GIT")" || return 4
+  run_quiet git -C "$VAULT" init --separate-git-dir "$SIDE_GIT" || return 4
   say "  · initialized fresh repo with gitdir at $SIDE_GIT"
 }
 
 # =============================================================================
 # MAIN
 # =============================================================================
-if [ "$ROLLBACK" = 1 ]; then do_rollback; exit $?; fi
-
-# detection is informational here — the whole point is iCloud is ALLOWED
-CLOUD=""
-if [ -f "$VAULT/.git" ] || command -v python3 >/dev/null; then :; fi
 _sa="$(cd "$(dirname "$0")" && pwd)"
+
+if [ "$ROLLBACK" = 1 ]; then
+  _rc=0
+  do_rollback || _rc=$?
+  exit "$_rc"
+fi
+
+# detection is informational for the VAULT — the whole point is iCloud is ALLOWED
+CLOUD=""
 if [ -f "$_sa/check-cloud-sync.py" ]; then
-  CLOUD="$(python3 "$_sa/check-cloud-sync.py" --porcelain "$VAULT" 2>/dev/null || true)"
+  CLOUD="$("$PYBIN" "$_sa/check-cloud-sync.py" --porcelain "$VAULT" 2>/dev/null || true)"
 fi
 
 say "Machinery-sidecar relocation"
@@ -341,22 +643,32 @@ esac
 [ "$NOSYNC" = 1 ] && say "  mode    : --nosync (caches stay in-tree as .nosync)"
 [ "$DRYRUN" = 1 ] && say "  mode    : --dry-run (no changes)"
 
+# the destination is NOT informational: a synced sidecar fixes nothing
+guard_sidecar_location || exit 1
+
+GIT_STATE="$(probe_git_state)"
 guard_no_live || exit 1
 
+FAILED=0
 say "Relocating .git ..."
 relocate_git || exit 4
+GIT_STATE="$(probe_git_state)"   # a fresh-init just created the repo
 
 say "Relocating worktrees ..."
-relocate_dir "$WORKTREES_REL" "$SIDE_WT" "worktrees" || true
+relocate_dir "$WORKTREES_REL" "$SIDE_WT" "worktrees" || FAILED=$((FAILED + 1))
 
 say "Relocating caches ..."
 for rel in "${CACHE_DIRS[@]}"; do
-  relocate_dir "$rel" "$SIDE_CACHE/$rel" "cache" || true
+  relocate_dir "$rel" "$SIDE_CACHE/$rel" "cache" || FAILED=$((FAILED + 1))
 done
 
 write_manifest
 if [ "$DRYRUN" = 1 ]; then
   say "DRY-RUN complete — no changes made. Manifest would be: $MANIFEST"
+elif [ "$FAILED" -gt 0 ]; then
+  err "$FAILED path(s) could not be relocated (see the errors above). Record: $JOURNAL"
+  err "Reverse what DID move: $(basename "$0") \"$VAULT\" --sidecar \"$SIDECAR\" --rollback"
+  exit 4
 else
   say "Done. Manifest: $MANIFEST"
   say "Reverse anytime: $(basename "$0") \"$VAULT\" --rollback"

--- a/scripts/relocate-vault.ps1
+++ b/scripts/relocate-vault.ps1
@@ -87,12 +87,29 @@ function Die  { param([string]$m, [int]$code = 1) Write-Host "relocate-vault: RE
 # Obsidian-running probe with a test seam (parity with the .sh sibling's
 # obsidian_running). Default is the real Get-Process probe, so production
 # behavior is unchanged. $env:RELOCATE_VAULT_OBSIDIAN: 'running' -> report
-# running, 'absent' -> report not running, unset/anything else -> real probe.
+# running, 'absent' -> report not running, 'unreadable' -> simulate a probe that
+# could not run, unset/anything else -> real probe.
+#
+# FAILS CLOSED. "I could not read the process list" is not "Obsidian is not
+# running". -ErrorAction SilentlyContinue used to swallow exactly that case:
+# Get-Process returned $null, [bool]$null is $false, and this soft gate waved
+# through the move of a vault Obsidian may have open (a move whose whole risk is
+# an open writer). Only the documented "no process by that name" error means
+# absent; every other failure means refuse.
 function Test-ObsidianRunning {
   switch ("$($env:RELOCATE_VAULT_OBSIDIAN)") {
-    "running" { return $true }
-    "absent"  { return $false }
-    default   { return [bool](Get-Process -Name Obsidian -ErrorAction SilentlyContinue) }
+    "running"    { return $true }
+    "absent"     { return $false }
+    "unreadable" { Warn "process-list probe unavailable (test seam) - treating Obsidian as RUNNING"; return $true }
+    default {
+      try {
+        return (@(Get-Process -Name Obsidian -ErrorAction Stop).Count -gt 0)
+      } catch {
+        if ("$($_.FullyQualifiedErrorId)" -like "NoProcessFoundForGivenName*") { return $false }
+        Warn "could not read the process list ($_) - treating Obsidian as RUNNING (pass -Force to override)"
+        return $true
+      }
+    }
   }
 }
 

--- a/scripts/test-machinery-sidecar.sh
+++ b/scripts/test-machinery-sidecar.sh
@@ -394,6 +394,26 @@ make_vault_tracked "$VP"
                         || fail "L the \$( )-named vault did not relocate"
 
 
+# ---------------------------------------------------------------------------
+# M. AN UNREADABLE SESSION LOCK COUNTS AS LIVE (the other half of the probe)
+#    `[ "$sess" -gt 0 ] 2>/dev/null` read a NON-NUMERIC count as zero, and the
+#    python probe printed nothing when the lock could not be parsed - so a
+#    truncated / half-written .session-lock.json silently disarmed the refusal
+#    that keeps separate-git-dir from orphaning a live session's worktrees.
+# ---------------------------------------------------------------------------
+VQ="$ROOT/Q"; SQ="$ROOT/Q-side"
+make_vault "$VQ"
+mkdir -p "$VQ/.claude"
+printf '{ this is not json' > "$VQ/.claude/.session-lock.json"
+bash "$HELPER" "$VQ" --sidecar "$SQ" >/dev/null 2>&1; rc=$?
+[ "$rc" = 1 ] && pass "M refuses when the session lock cannot be read (exit 1)" \
+              || fail "M expected exit 1, got $rc - an unparseable lock read as zero sessions"
+[ -d "$VQ/.git" ] && pass "M vault untouched by the refusal" || fail "M vault modified despite the refusal"
+printf '{"sessions": {}}' > "$VQ/.claude/.session-lock.json"
+bash "$HELPER" "$VQ" --sidecar "$SQ" --quiet >/dev/null 2>&1; rc=$?
+[ "$rc" = 0 ] && pass "M neg-control: a readable empty lock relocates (exit 0)" || fail "M neg-control exit=$rc"
+
+
 echo
 echo "--- MANUAL (operator-gated, cannot automate in CI) ---"
 echo "iPhone round-trip: with the vault in iCloud Drive + this relocation applied,"

--- a/scripts/test-machinery-sidecar.sh
+++ b/scripts/test-machinery-sidecar.sh
@@ -42,6 +42,31 @@ make_vault() {  # $1 = vault dir
   gitq "$v" commit -m init
 }
 
+# A vault whose "⚙️ Meta/Sessions" notes are COMMITTED — i.e. a real one. The
+# other machinery dirs stay untracked, so one fixture exercises both sides of
+# the rule: tracked content is never moved, untracked caches still are.
+make_vault_tracked() {  # $1 = vault dir
+  local v="$1" i
+  mkdir -p "$v/⚙️ Meta/Sessions" "$v/⚙️ Meta/logs" "$v/.smart-env" "$v/.codegraph" "$v/.claude/worktrees"
+  gitq "$v" init
+  gitq "$v" config user.email "t@t.test"
+  gitq "$v" config user.name  "Test"
+  gitq "$v" config commit.gpgsign false
+  printf 'note\n' > "$v/note.md"
+  for i in 1 2 3; do printf 'session %s\n' "$i" > "$v/⚙️ Meta/Sessions/2026-08-0$i-work.md"; done
+  printf 'idx\n' > "$v/.smart-env/index.bin"
+  printf 'cg\n'  > "$v/.codegraph/graph.bin"
+  printf 'log\n' > "$v/⚙️ Meta/logs/run.log"
+  gitq "$v" add note.md "⚙️ Meta/Sessions"
+  gitq "$v" commit -m init
+}
+
+# How many paths git reports as DELETED. This is the number the user sees, the
+# number auto-snapshot commits, and the number multi-machine sync pushes.
+deleted_in_status() {  # $1 = vault dir
+  git -C "$1" status --porcelain 2>/dev/null | awk '/^.D|^D/{n++} END{print n+0}'
+}
+
 # Count REGULAR machinery files physically inside the vault tree (symlinks not
 # followed). Excludes the `.git` POINTER FILE (a tiny static pointer is allowed).
 machinery_files_in_tree() {  # $1 = vault dir
@@ -190,6 +215,184 @@ make_vault "$VE"
 bash "$HELPER" "$VE" --sidecar "$SIDE" --dry-run --quiet >/dev/null 2>&1
 [ -d "$VE/.git" ] && [ ! -L "$VE/.smart-env" ] && pass "F dry-run changed nothing" \
                                                || fail "F dry-run mutated the vault"
+
+# ---------------------------------------------------------------------------
+# G. TRACKED NOTES ARE NEVER RELOCATED  (the data-loss regression)
+#    "⚙️ Meta/Sessions" is BOTH a CACHE_DIRS name AND, in a real vault, over a
+#    thousand tracked markdown notes. Relocating it turns the directory into an
+#    absolute symlink, `git status` reports every note as DELETED, the hourly
+#    auto-snapshot (`git add -A`) COMMITS that deletion and the multi-machine
+#    sync PUSHES it — while the script prints "your notes did not move".
+#    The rule is the git INDEX, never the name. Negative control: a genuinely
+#    untracked cache still moves, so the rule is not "move nothing".
+# ---------------------------------------------------------------------------
+VH="$ROOT/H"
+make_vault_tracked "$VH"
+gout="$(bash "$HELPER" "$VH" --sidecar "$SIDE" 2>&1)"; rc=$?
+[ "$rc" = 0 ] && pass "G relocate exit 0 on a vault with tracked notes" || fail "G relocate exit=$rc"
+gdel="$(deleted_in_status "$VH")"
+[ "$gdel" = 0 ] && pass "G ZERO deletions in git status after relocation" \
+                || fail "G git status reports $gdel deleted file(s) — tracked notes were moved"
+{ [ -d "$VH/⚙️ Meta/Sessions" ] && [ ! -L "$VH/⚙️ Meta/Sessions" ]; } \
+  && pass "G tracked ⚙️ Meta/Sessions left as a real directory" \
+  || fail "G tracked ⚙️ Meta/Sessions was replaced by a symlink"
+[ -f "$VH/⚙️ Meta/Sessions/2026-08-01-work.md" ] && pass "G the tracked notes are still on disk" \
+                                                  || fail "G tracked notes are gone"
+echo "$gout" | grep -q 'KEPT: git tracks' && pass "G reports WHY the path was kept" \
+                                           || fail "G silent about the skip"
+[ -L "$VH/.smart-env" ] && pass "G neg-control: untracked .smart-env still relocated" \
+                        || fail "G neg-control: untracked cache was NOT relocated (rule too broad)"
+[ -L "$VH/⚙️ Meta/logs" ] && pass "G neg-control: untracked ⚙️ Meta/logs still relocated" \
+                          || fail "G neg-control: untracked emoji-path cache was NOT relocated"
+
+# ---------------------------------------------------------------------------
+# H. INTERRUPT MATRIX: --rollback works from EVERY kill point
+#    The manifest used to be written on the LAST line, so any interrupt left no
+#    record at all and `--rollback` hard-refused (exit 2). A SIGKILL between the
+#    `mv` and the `ln -s` left the directory ABSENT — no dir, no symlink, all the
+#    content stranded in the sidecar, no way back. Now every move is journalled
+#    (append + fsync) BEFORE it happens. BRAIN_SIDECAR_TEST_KILL_AT is the
+#    script's test-only fault-injection seam: SIGKILL right after a named step.
+# ---------------------------------------------------------------------------
+interrupt_case() {  # $1 = kill label, $2 = short id
+  local label="$1" id="$2" v side krc rrc d
+  v="$ROOT/I-$id"; side="$ROOT/I-$id-side"
+  make_vault_tracked "$v"
+  BRAIN_SIDECAR_TEST_KILL_AT="$label" bash "$HELPER" "$v" --sidecar "$side" --quiet >/dev/null 2>&1
+  krc=$?
+  [ "$krc" = 137 ] || fail "H[$id] expected SIGKILL (137) at '$label', got $krc"
+  bash "$HELPER" "$v" --sidecar "$side" --rollback --quiet >/dev/null 2>&1
+  rrc=$?
+  if [ "$rrc" != 0 ]; then
+    fail "H[$id] rollback after kill at '$label' exit=$rrc"
+    return
+  fi
+  d="$(deleted_in_status "$v")"
+  if [ -d "$v/.git" ] && [ ! -L "$v/.git" ] \
+     && [ -d "$v/.smart-env" ] && [ ! -L "$v/.smart-env" ] && [ -f "$v/.smart-env/index.bin" ] \
+     && [ -d "$v/⚙️ Meta/logs" ] && [ ! -L "$v/⚙️ Meta/logs" ] && [ -f "$v/⚙️ Meta/logs/run.log" ] \
+     && [ -f "$v/⚙️ Meta/Sessions/2026-08-01-work.md" ] && [ "$d" = 0 ]; then
+    pass "H[$id] kill at '$label' -> rollback restored everything (0 deletions)"
+  else
+    fail "H[$id] kill at '$label' -> vault NOT fully restored (git-status deletions=$d)"
+  fi
+}
+interrupt_case "post-journal:.git"        gitpre
+interrupt_case "post-git"                 gitpost
+interrupt_case "post-journal:.smart-env"  cachepre
+interrupt_case "post-mv:.smart-env"       cachemid
+interrupt_case "post-link:.smart-env"     cachepost
+interrupt_case "post-mv:⚙️ Meta/logs"      nested
+
+# H2. the kill lands BEFORE any manifest could be written — the write-ahead
+#     journal is the only reason rollback has anything to read.
+VJ="$ROOT/J"; SJ="$ROOT/J-side"
+make_vault_tracked "$VJ"
+BRAIN_SIDECAR_TEST_KILL_AT="post-link:.smart-env" bash "$HELPER" "$VJ" --sidecar "$SJ" --quiet >/dev/null 2>&1
+ls "$SJ/manifests/"*.json >/dev/null 2>&1 \
+  && fail "H2 a manifest exists — the premise (killed before the manifest) is wrong" \
+  || pass "H2 killed before any manifest was written"
+ls "$SJ/manifests/"*.journal.jsonl >/dev/null 2>&1 \
+  && pass "H2 the write-ahead journal survived the kill" \
+  || fail "H2 no journal — rollback would have nothing to read"
+
+# ---------------------------------------------------------------------------
+# I. A FAILED ROLLBACK SAYS SO (and keeps the evidence)
+#    `local rc=0` was never reassigned, a failed restore was only a `warn`, and
+#    `rm -f "$MANIFEST"` ran unconditionally — so a rollback that restored
+#    NOTHING printed "Rollback complete.", exited 0, and deleted the only map
+#    back. Here the sidecar gitdir goes missing (unplugged drive / sync deleted
+#    it): the cache legs restore, the git leg cannot, and that must be loud.
+# ---------------------------------------------------------------------------
+VK="$ROOT/K"; SK="$ROOT/K-side"
+make_vault "$VK"
+bash "$HELPER" "$VK" --sidecar "$SK" --quiet
+rm -rf "$SK/git"
+kout="$(bash "$HELPER" "$VK" --sidecar "$SK" --rollback 2>&1)"; rc=$?
+[ "$rc" != 0 ] && pass "I rollback exits non-zero when a leg fails (rc=$rc)" \
+               || fail "I rollback reported success while restoring nothing"
+echo "$kout" | grep -q 'INCOMPLETE' && pass "I rollback names the failure" \
+                                     || fail "I rollback did not report the failed leg"
+ls "$SK/manifests/"*.jsonl >/dev/null 2>&1 \
+  && pass "I the relocation record was KEPT after a failed rollback" \
+  || fail "I the record was deleted — the only map back is gone"
+[ -f "$VK/.git" ] && pass "I the dangling .git pointer was left for inspection, not silently removed" \
+                  || fail "I the .git pointer was removed without restoring the gitdir"
+
+# ---------------------------------------------------------------------------
+# J. A PROBE THAT CANNOT RUN COUNTS AS LIVE (fail closed)
+#    `git worktree list ... 2>/dev/null | awk` gave the same empty answer for
+#    "no worktrees" and "git refused to look" — so a `dubious ownership` error
+#    (real on restored / migrated / external-drive / network / Windows vaults)
+#    defeated the refusal and separate-git-dir orphaned live worktrees anyway.
+#    The shim below fails ONLY `git worktree list`; everything else is real git.
+# ---------------------------------------------------------------------------
+VL="$ROOT/L"; SL="$ROOT/L-side"
+make_vault "$VL"
+mkdir -p "$ROOT/gitshim"
+REALGIT="$(command -v git)"
+printf '#!/bin/bash\ncase " $* " in *" worktree list "*) echo "fatal: detected dubious ownership in repository at %s" >&2; exit 128;; esac\nexec %s "$@"\n' \
+  "$VL" "$REALGIT" > "$ROOT/gitshim/git"
+chmod +x "$ROOT/gitshim/git"
+lout="$(PATH="$ROOT/gitshim:$PATH" bash "$HELPER" "$VL" --sidecar "$SL" 2>&1)"; rc=$?
+[ "$rc" = 1 ] && pass "J refuses when the live-worktree probe cannot run (exit 1)" \
+              || fail "J expected exit 1, got $rc — an errored probe read as 'nothing live'"
+echo "$lout" | grep -q 'could not run' && pass "J explains that a probe failed" \
+                                        || fail "J did not explain the refusal"
+[ -d "$VL/.git" ] && pass "J the vault was not touched by the refused run" \
+                  || fail "J the vault was modified despite the refusal"
+bash "$HELPER" "$VL" --sidecar "$SL" --quiet >/dev/null 2>&1; rc=$?
+[ "$rc" = 0 ] && pass "J neg-control: same vault with a working git relocates (exit 0)" \
+              || fail "J neg-control exit=$rc"
+
+# ---------------------------------------------------------------------------
+# K. THE SIDECAR DESTINATION IS CHECKED TOO
+#    $HOME can itself be synced (Windows roaming profile, OneDrive-managed or
+#    network home), so the default ~/.brain-sidecar lands INSIDE a sync root:
+#    .git moves from one synced tree to another, every success check passes,
+#    and the melt is unchanged — now with the notes split off as well.
+# ---------------------------------------------------------------------------
+VM="$ROOT/M"
+make_vault "$VM"
+mout="$(bash "$HELPER" "$VM" --sidecar "$ROOT/OneDrive/brain-sidecar" 2>&1)"; rc=$?
+[ "$rc" = 1 ] && pass "K refuses a sidecar inside a cloud-sync root (exit 1)" \
+              || fail "K expected exit 1, got $rc — machinery would move synced-tree to synced-tree"
+echo "$mout" | grep -q 'refusing: the sidecar destination is inside OneDrive' \
+  && pass "K names the sync service in the refusal" \
+  || fail "K did not name the sync service in a refusal line"
+[ -d "$VM/.git" ] && pass "K vault untouched by the refusal" || fail "K vault modified despite the refusal"
+mout="$(bash "$HELPER" "$VM" --sidecar "$VM/.sidecar" 2>&1)"; rc=$?
+[ "$rc" = 1 ] && pass "K refuses a sidecar INSIDE the vault (exit 1)" || fail "K sidecar-inside-vault exit=$rc"
+bash "$HELPER" "$VM" --sidecar "$ROOT/M-side" --quiet >/dev/null 2>&1; rc=$?
+[ "$rc" = 0 ] && pass "K neg-control: a local sidecar is accepted (exit 0)" || fail "K neg-control exit=$rc"
+
+# ---------------------------------------------------------------------------
+# L. THE VAULT PATH IS DATA, NEVER CODE
+#    run() used `eval "$@"`, so every path was expanded a SECOND time: a folder
+#    named `Notes $HOME Backup` mis-resolved, and the same eval drove mv, rm -f
+#    and ln -s — so a folder name containing a backtick or $( ) would have
+#    EXECUTED. Now run() takes an argv array and no shell ever sees the path.
+# ---------------------------------------------------------------------------
+VN="$ROOT/Notes \$HOME Backup"
+make_vault_tracked "$VN"
+bash "$HELPER" "$VN" --sidecar "$ROOT/N-side" --quiet >/dev/null 2>&1; rc=$?
+[ "$rc" = 0 ] && pass "L a vault path containing a literal \$HOME relocates (exit 0)" \
+              || fail "L exit=$rc — the path was expanded twice"
+{ [ -L "$VN/.smart-env" ] && [ -f "$VN/.smart-env/index.bin" ]; } \
+  && pass "L cache relocated and still readable through the symlink" \
+  || fail "L relocation mis-resolved the doubly-expanded path"
+ndel="$(deleted_in_status "$VN")"
+[ "$ndel" = 0 ] && pass "L no deletions in the \$HOME-named vault" || fail "L $ndel deletion(s)"
+
+VP="$ROOT/Notes \$(touch pwned-proof) X"
+make_vault_tracked "$VP"
+( cd "$ROOT" && bash "$HELPER" "$VP" --sidecar "$ROOT/P-side" --quiet >/dev/null 2>&1 )
+[ -e "$ROOT/pwned-proof" ] \
+  && fail "L a folder name EXECUTED — command substitution in the path ran" \
+  || pass "L a folder name containing \$( ) is data, not code"
+[ -L "$VP/.smart-env" ] && pass "L the \$( )-named vault still relocated correctly" \
+                        || fail "L the \$( )-named vault did not relocate"
+
 
 echo
 echo "--- MANUAL (operator-gated, cannot automate in CI) ---"

--- a/scripts/test-relocate-machinery-sidecar.ps1
+++ b/scripts/test-relocate-machinery-sidecar.ps1
@@ -49,6 +49,42 @@ function New-Vault { param([string]$Path)
   Set-Content -LiteralPath (Join-Path $Path ".smart-env/cache.bin") -Value "x"
 }
 
+function New-VaultTracked { param([string]$Path)
+  # A vault whose "<gear> Meta/Sessions" notes are COMMITTED - i.e. a real one.
+  # The caches are gitignored, so one fixture exercises both sides of the rule:
+  # tracked content is never moved, untracked caches still are.
+  New-Item -ItemType Directory -Force -Path $Path | Out-Null
+  & git -C $Path init -q | Out-Null
+  & git -C $Path config user.email "t@example.com" | Out-Null
+  & git -C $Path config user.name "t" | Out-Null
+  & git -C $Path config commit.gpgsign false | Out-Null
+  New-Item -ItemType Directory -Force -Path (Join-Path $Path ".smart-env") | Out-Null
+  New-Item -ItemType Directory -Force -Path (Join-Path $Path ".codegraph") | Out-Null
+  New-Item -ItemType Directory -Force -Path (Join-Path $Path "$gear Meta/Sessions") | Out-Null
+  Set-Content -LiteralPath (Join-Path $Path ".gitignore") -Value ".smart-env/`n.codegraph/`n"
+  Set-Content -LiteralPath (Join-Path $Path ".smart-env/cache.bin") -Value "x"
+  Set-Content -LiteralPath (Join-Path $Path "$gear Meta/Sessions/2026-08-01-work.md") -Value "note one"
+  Set-Content -LiteralPath (Join-Path $Path "$gear Meta/Sessions/2026-08-02-work.md") -Value "note two"
+  & git -C $Path add -A | Out-Null
+  & git -C $Path commit -qm init | Out-Null
+}
+# How many paths git reports as DELETED: the number the user sees, the number
+# auto-snapshot commits, and the number multi-machine sync pushes.
+function Get-DeletedCount { param([string]$v)
+  $out = & git -C $v status --porcelain 2>$null
+  return @($out | Where-Object { "$_" -match '^.D|^D' }).Count
+}
+# -like, never -Filter: the Win32 filter can match *.json against *.jsonl (the
+# 8.3 short-name rule), which would count the journal as a manifest.
+function Get-ManifestFiles { param([string]$Side)
+  return @(Get-ChildItem -LiteralPath (Join-Path $Side "manifests") -File -ErrorAction SilentlyContinue |
+           Where-Object { $_.Name -like "*.json" })
+}
+function Get-JournalFiles { param([string]$Side)
+  return @(Get-ChildItem -LiteralPath (Join-Path $Side "manifests") -File -ErrorAction SilentlyContinue |
+           Where-Object { $_.Name -like "*.journal.jsonl" })
+}
+
 $TMP = Join-Path ([System.IO.Path]::GetTempPath()) ("ms-test-" + [Guid]::NewGuid().ToString("N").Substring(0, 10))
 New-Item -ItemType Directory -Force -Path $TMP | Out-Null
 try {
@@ -69,7 +105,7 @@ try {
   Check "relocate: emoji-Meta/Sessions is a link" (Is-Reparse (Join-Path $v1 "$gear Meta/Sessions"))
   Check "relocate: .claude/worktrees is a link" (Is-Reparse (Join-Path $v1 ".claude/worktrees"))
   Check "relocate: cached file survived the move" (Test-Path -LiteralPath (Join-Path $v1 ".smart-env/cache.bin"))
-  $man = @(Get-ChildItem -LiteralPath (Join-Path $side "manifests") -Filter *.json -ErrorAction SilentlyContinue)
+  $man = Get-ManifestFiles $side
   Check "relocate: manifest written"           ($man.Count -eq 1)
   if ($man.Count -eq 1) {
     $doc = Get-Content -Raw -LiteralPath $man[0].FullName | ConvertFrom-Json
@@ -111,6 +147,91 @@ try {
   # negative control: -Force proceeds past the same guard
   $r = Run-MS -MsArgs @($v5, "-Sidecar", (Join-Path $TMP "sidecar5"), "-Force")
   Check "guard neg-control: -Force proceeds (rc 0)" ($r.rc -eq 0)
+
+  # ---- 6. TRACKED NOTES ARE NEVER RELOCATED (the data-loss regression) ------
+  # "<gear> Meta/Sessions" is BOTH a CacheDirs name AND, in a real vault, over a
+  # thousand tracked markdown notes. Relocating it turns the directory into a
+  # junction/symlink, `git status` reports every note as deleted, and the next
+  # auto-commit + push propagates that deletion to every machine. The rule is the
+  # git INDEX, never the name. Negative control: the ignored cache still moves.
+  $v6 = Join-Path $TMP "vault6"; New-VaultTracked $v6
+  $side6 = Join-Path $TMP "sidecar6"
+  $r = Run-MS -MsArgs @($v6, "-Sidecar", $side6)
+  Check "tracked: rc 0"                        ($r.rc -eq 0)
+  Check "tracked: ZERO deletions in git status" ((Get-DeletedCount $v6) -eq 0)
+  Check "tracked: Sessions left as a real directory" `
+        ((Test-Path -LiteralPath (Join-Path $v6 "$gear Meta/Sessions") -PathType Container) -and `
+         -not (Is-Reparse (Join-Path $v6 "$gear Meta/Sessions")))
+  Check "tracked: the notes are still on disk" `
+        (Test-Path -LiteralPath (Join-Path $v6 "$gear Meta/Sessions/2026-08-01-work.md"))
+  Check "tracked: reports WHY it kept the path" ($r.out -match "KEPT: git tracks")
+  Check "tracked neg-control: the ignored cache still relocated" (Is-Reparse (Join-Path $v6 ".smart-env"))
+
+  # ---- 7. INTERRUPT: -Rollback works after a kill between move and link -----
+  # The manifest used to be written on the LAST line, so any interrupt left no
+  # record and -Rollback hard-refused. A kill between Move-Item and the link left
+  # the directory ABSENT with its content stranded in the sidecar. Every move is
+  # now journalled (append + fsync) BEFORE it happens.
+  $v7 = Join-Path $TMP "vault7"; New-VaultTracked $v7
+  $side7 = Join-Path $TMP "sidecar7"
+  $env:BRAIN_SIDECAR_TEST_KILL_AT = "post-mv:.smart-env"
+  $r = Run-MS -MsArgs @($v7, "-Sidecar", $side7)
+  $env:BRAIN_SIDECAR_TEST_KILL_AT = ""
+  Check "interrupt: the run was killed (rc non-zero)" ($r.rc -ne 0)
+  Check "interrupt: .smart-env is ABSENT mid-move (the window that used to be unrecoverable)" `
+        (-not (Test-Path -LiteralPath (Join-Path $v7 ".smart-env")))
+  Check "interrupt: no manifest was written" ((Get-ManifestFiles $side7).Count -eq 0)
+  Check "interrupt: the write-ahead journal survived" ((Get-JournalFiles $side7).Count -eq 1)
+  $r = Run-MS -MsArgs @($v7, "-Sidecar", $side7, "-Rollback")
+  Check "interrupt: rollback after the kill -> rc 0" ($r.rc -eq 0)
+  Check "interrupt: .smart-env restored as a real dir" `
+        ((Test-Path -LiteralPath (Join-Path $v7 ".smart-env") -PathType Container) -and -not (Is-Reparse (Join-Path $v7 ".smart-env")))
+  Check "interrupt: the cached file came back"  (Test-Path -LiteralPath (Join-Path $v7 ".smart-env/cache.bin"))
+  Check "interrupt: .git restored as a real dir" (Test-Path -LiteralPath (Join-Path $v7 ".git") -PathType Container)
+  Check "interrupt: ZERO deletions after rollback" ((Get-DeletedCount $v7) -eq 0)
+
+  # ---- 8. A FAILED ROLLBACK SAYS SO (and keeps the evidence) ----------------
+  # The old rollback reported "Rollback complete." and exited 0 no matter what,
+  # then deleted the manifest - the only map back - on the way out.
+  $v8 = Join-Path $TMP "vault8"; New-Vault $v8
+  $side8 = Join-Path $TMP "sidecar8"
+  $r = Run-MS -MsArgs @($v8, "-Sidecar", $side8)
+  Remove-Item -LiteralPath (Join-Path $side8 "git") -Recurse -Force
+  $r = Run-MS -MsArgs @($v8, "-Sidecar", $side8, "-Rollback")
+  Check "failed rollback: rc non-zero"          ($r.rc -ne 0)
+  Check "failed rollback: says INCOMPLETE"      ($r.out -match "INCOMPLETE")
+  Check "failed rollback: the record was KEPT" ((Get-JournalFiles $side8).Count -eq 1)
+
+  # ---- 9. A PROBE THAT CANNOT RUN COUNTS AS LIVE (fail closed) --------------
+  # The live-session probe printed nothing when the lock could not be parsed and
+  # the caller read that as ZERO sessions, so an unreadable lock silently
+  # disarmed the refusal that keeps separate-git-dir from orphaning live work.
+  $v9 = Join-Path $TMP "vault9"; New-Vault $v9
+  New-Item -ItemType Directory -Force -Path (Join-Path $v9 ".claude") | Out-Null
+  $lock9 = Join-Path $v9 ".claude/.session-lock.json"
+  Set-Content -LiteralPath $lock9 -Value "{ this is not json"
+  $r = Run-MS -MsArgs @($v9, "-Sidecar", (Join-Path $TMP "sidecar9"))
+  Check "fail-closed: an unreadable session lock -> rc 1 (refuse)" ($r.rc -eq 1)
+  Check "fail-closed: explains that a probe could not run" ($r.out -match "could not run")
+  Check "fail-closed: .git untouched"           (Test-Path -LiteralPath (Join-Path $v9 ".git") -PathType Container)
+  Set-Content -LiteralPath $lock9 -Value '{"sessions": {}}'
+  $r = Run-MS -MsArgs @($v9, "-Sidecar", (Join-Path $TMP "sidecar9"))
+  Check "fail-closed neg-control: a readable empty lock -> rc 0" ($r.rc -eq 0)
+
+  # ---- 10. THE SIDECAR DESTINATION IS CHECKED TOO ---------------------------
+  # On a roaming / OneDrive-managed / network profile the profile folder is
+  # itself synced, so the default ~/.brain-sidecar lands INSIDE a sync root:
+  # .git moves from one synced tree to another, every success check passes, and
+  # the melt is unchanged - now with the notes split off as well.
+  $v10 = Join-Path $TMP "vault10"; New-Vault $v10
+  $r = Run-MS -MsArgs @($v10, "-Sidecar", (Join-Path (Join-Path $TMP "OneDrive") "brain-sidecar"))
+  Check "sidecar guard: a cloud-synced destination -> rc 1" ($r.rc -eq 1)
+  Check "sidecar guard: names the service"      ($r.out -match "refusing: the sidecar destination is inside OneDrive")
+  Check "sidecar guard: vault untouched"        (Test-Path -LiteralPath (Join-Path $v10 ".git") -PathType Container)
+  $r = Run-MS -MsArgs @($v10, "-Sidecar", (Join-Path $v10 ".sidecar"))
+  Check "sidecar guard: a destination inside the vault -> rc 1" ($r.rc -eq 1)
+  $r = Run-MS -MsArgs @($v10, "-Sidecar", (Join-Path $TMP "sidecar10"))
+  Check "sidecar guard neg-control: a local destination -> rc 0" ($r.rc -eq 0)
 }
 finally {
   # detach any worktree gitdir lock before cleanup

--- a/scripts/test-relocate-vault.ps1
+++ b/scripts/test-relocate-vault.ps1
@@ -154,6 +154,28 @@ try {
   } finally {
     $env:RELOCATE_VAULT_OBSIDIAN = "absent"
   }
+
+  # ---- 7. THE OBSIDIAN PROBE FAILS CLOSED -----------------------------------
+  # A probe that CANNOT RUN is not a probe that found nothing. The old default
+  # branch used -ErrorAction SilentlyContinue, so an unreadable / restricted
+  # process list returned $null, [bool]$null was $false, and this gate waved
+  # through the move of a vault Obsidian may have had open. Only the documented
+  # "no process by that name" error now means absent; anything else refuses.
+  $old7 = Join-Path $TMP "cloud7/Brain"; New-Item -ItemType Directory -Force -Path $old7 | Out-Null
+  Set-Content -LiteralPath (Join-Path $old7 "CLAUDE.md") -Value "# brain"
+  $new7 = Join-Path $TMP "local7/Brain"
+  $cfg7 = Join-Path $TMP "cfg7"
+  $env:RELOCATE_VAULT_OBSIDIAN = "unreadable"
+  try {
+    $r = Run-RV -RvArgs @($old7, $new7) -ConfigDir $cfg7
+    Check "obsidian probe fail-closed: unreadable process list -> rc 1" ($r.rc -eq 1)
+    Check "obsidian probe fail-closed: refusal names Obsidian"          ($r.out -match "Obsidian is running")
+    Check "obsidian probe fail-closed: target not created"              (-not (Test-Path -LiteralPath $new7))
+    $r = Run-RV -RvArgs @($old7, $new7, "-Force") -ConfigDir $cfg7
+    Check "obsidian probe fail-closed neg-control: -Force still overrides -> rc 0" ($r.rc -eq 0)
+  } finally {
+    $env:RELOCATE_VAULT_OBSIDIAN = "absent"
+  }
 }
 finally {
   Remove-Item -LiteralPath $TMP -Recurse -Force -ErrorAction SilentlyContinue


### PR DESCRIPTION
Fixes proven data loss in `relocate-machinery-sidecar.sh`, which is reachable today from the SessionStart offer and phase-01.

**The defect.** `CACHE_DIRS` listed `⚙️ Meta/Sessions` as a cache. It holds tracked markdown notes. After relocation the directory became a symlink into the sidecar, `git status` reported every note as deleted, the hourly snapshot committed that, and multi-machine sync pushed it — while the user was told "Your notes did not move. Nothing was deleted."

**Six fixes** (bash + PowerShell):
1. Never relocate a path git tracks. The gate is the index (`git ls-files`), not a name list, so genuine caches still move.
2. Durable journal written during the moves, so rollback works from every interrupt point.
3. `--rollback` exits non-zero when a leg fails and no longer deletes the manifest on failure.
4. `guard_no_live()` distinguishes "probe failed" from "nothing found" and treats failure as live.
5. PowerShell process probe fails closed, matching bash.
6. Sidecar destination is checked against the cloud detector.
Also: `run()` no longer `eval`s, so a vault path is not expanded twice.

**Evidence.** Identical fixture, 3 committed notes + 1 untracked cache. Before: 3 ` D` deletions and a symlink. After: only the untracked cache relocated. New tests produce 24 failures (bash) and 17 (ps1) against pre-fix code. Seven interrupt points all roll back with zero deletions. The new rollback also repairs a vault damaged by the old script.

**Not verified.** Windows was not executed — junction creation and PS 5.1 semantics are unexercised. A sibling relocation script has the same class of fail-open probe, unfixed and out of scope. Users whose deletion was already committed and pushed need a revert; nothing here detects or repairs that.
