### PR TITLE
fix(vault-lock): resolve the real git dir so the commit mutex survives a sidecar

### DIFF
--- a/docs/CLOUD_SYNC.md
+++ b/docs/CLOUD_SYNC.md
@@ -184,6 +184,38 @@ yourself: run a `git gc` plus a full session and watch Activity Monitor —
 > sidecar. On iPhone there is no git, so the pointer is harmless — you just see
 > your notes.
 
+#### Writing to a relocated vault: locking resolves the real git dir
+
+Every vault writer here — the session-close snapshot, the daily-maintenance
+reconcile, `vault-safe-commit.sh`, `vault-multi-machine-sync.sh` — serializes on
+git's `index.lock` before it commits, so two sessions closing at once cannot lose
+each other's update. **That lock path must be RESOLVED from git, never assembled
+as `$VAULT/.git/index.lock`.** Once the machinery is in a sidecar, `.git` is a
+pointer *file*: the assembled path sits under a file, can never exist, and the
+check reports "free" forever. The mutex is then silently disarmed — no error, no
+log line, both sessions commit.
+
+The contract, one shared helper in `scripts/_session_close_guard.sh`:
+
+| Helper | Answers |
+|---|---|
+| `vault_git_dir <root>` | absolute git dir via `git rev-parse --absolute-git-dir`; correct for a directory, a pointer file, or a linked worktree. Empty + rc 1 when unresolvable |
+| `vault_git_index_lock <root>` | `<real-git-dir>/index.lock` |
+| `vault_git_locked <root>` | rc 0 = locked **or unresolvable**, rc 1 = provably free |
+| `vault_git_wait_unlocked <root> [secs]` | spins to `$VAULT_GIT_LOCK_MAX_WAIT` (default 60); rc 0 once free |
+
+**These fail CLOSED.** An unresolvable git dir reports *locked*, so the caller
+defers instead of committing blind — the work stays on disk and the
+daily-maintenance reconcile catches up. A mutex that fails open is the defect
+this contract exists to prevent, and it costs a lost update that nothing
+recovers. (The load gate and cascade mutex alongside them fail *open* by design;
+this asymmetry is deliberate.)
+
+Regression cover: `tests/integration/test_vault_lock_separated_gitdir.sh` builds
+a `--separate-git-dir` fixture vault, has a live writer hold the real lock, and
+asserts all four writers take their locked branch — plus that an unlocked vault
+still commits, so "always locked" cannot pass.
+
 > **`.gitignore` is not enough.** It stops you *committing* the machinery; it
 > does **not** stop a cloud daemon from *syncing* it. The bytes must physically
 > leave the synced tree (Shape B) or be flagged `.nosync` (the helper's

--- a/scripts/_session_close_guard.sh
+++ b/scripts/_session_close_guard.sh
@@ -128,3 +128,83 @@ close_mutex_release() {
   _CLOSE_MUTEX_HELD=0
   trap - EXIT
 }
+
+# --- real git dir + index lock ---------------------------------------------
+# A vault that has been through scripts/relocate-machinery-sidecar.sh
+# (docs/CLOUD_SYNC.md "Shape B") keeps its git machinery OUTSIDE the synced tree
+# via `git init --separate-git-dir`. Its `$VAULT/.git` is then a one-line
+# POINTER FILE, not a directory, and the real index lives in the sidecar.
+#
+# So NEVER build a lock path by joining `.git/index.lock` onto the vault root.
+# On a relocated vault that path sits under a FILE and can never exist, so the
+# check reports "free" forever and the vault-wide commit mutex is SILENTLY
+# disarmed: two sessions closing at once both see "no lock" and both commit.
+# Ask git instead — `rev-parse --absolute-git-dir` answers correctly whether
+# `.git` is a directory, a pointer file, or a linked worktree.
+#
+# FAIL CLOSED. When the git dir cannot be resolved (not a repo, git missing,
+# unreadable) these report LOCKED / refuse. A mutex that fails OPEN is the exact
+# defect this exists to prevent. Refusing costs a deferred snapshot — the work
+# stays on disk and the daily-maintenance reconcile catches up — while failing
+# open costs a lost update, which nothing recovers.
+: "${VAULT_GIT_LOCK_MAX_WAIT:=60}"
+
+vault_git_dir() {
+  # Echoes the ABSOLUTE git directory for the repo at $1. Empty + rc 1 on any
+  # failure, so callers can distinguish "resolved" from "could not resolve".
+  local root="${1:-}" gd=""
+  { [ -n "$root" ] && [ -d "$root" ]; } || { echo ""; return 1; }
+  # --absolute-git-dir (git >= 2.13) resolves a pointer file and a linked
+  # worktree. Fall back to --git-dir on older git, absolutizing a relative
+  # answer (a normal repo answers a bare ".git") against the vault root.
+  gd=$(git -C "$root" rev-parse --absolute-git-dir 2>/dev/null)
+  if [ -z "$gd" ]; then
+    gd=$(git -C "$root" rev-parse --git-dir 2>/dev/null)
+    [ -n "$gd" ] || { echo ""; return 1; }
+    case "$gd" in
+      /*)     ;;                              # POSIX absolute (incl. Git Bash)
+      ?:/*|?:\\*) ;;                          # Windows drive-absolute
+      *)      gd="$root/$gd" ;;               # relative -> anchor to the vault
+    esac
+  fi
+  [ -d "$gd" ] || { echo ""; return 1; }
+  echo "$gd"
+}
+
+vault_git_index_lock() {
+  # Echoes <real-git-dir>/index.lock. Empty + rc 1 when the git dir cannot be
+  # resolved. Never join .git/index.lock onto the vault root yourself.
+  local gd
+  gd=$(vault_git_dir "${1:-}") || { echo ""; return 1; }
+  [ -n "$gd" ] || { echo ""; return 1; }
+  echo "$gd/index.lock"
+}
+
+vault_git_locked() {
+  # Returns 0 (LOCKED) when the real index lock is present, OR when the git dir
+  # cannot be resolved (fail closed). Returns 1 (provably free) only when
+  # resolution SUCCEEDED and no lock file is present.
+  local lock
+  lock=$(vault_git_index_lock "${1:-}") || return 0
+  [ -n "$lock" ] || return 0
+  [ -e "$lock" ] && return 0
+  return 1
+}
+
+vault_git_wait_unlocked() {
+  # Spin until the real index lock clears. $1 = vault root, $2 = max seconds
+  # (default $VAULT_GIT_LOCK_MAX_WAIT). Returns 0 once provably free; 1 if it is
+  # still held at the deadline or the git dir never resolved (fail closed).
+  local root="${1:-}" max_wait="${2:-$VAULT_GIT_LOCK_MAX_WAIT}" waited=0
+  # Validate the budget. A non-numeric value (a typo'd env var) would make the
+  # deadline test below error instead of returning true, so the loop would spin
+  # forever on a genuinely held lock - a hang, on the interactive close path.
+  case "$max_wait" in ''|*[!0-9]*) max_wait=60 ;; esac
+  vault_git_dir "$root" >/dev/null || return 1
+  while vault_git_locked "$root"; do
+    [ "$waited" -ge "$max_wait" ] && return 1
+    sleep 2
+    waited=$((waited + 2))
+  done
+  return 0
+}

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -221,6 +221,7 @@ INTEGRATION_TESTS=(
   test_scheduled_task_registration
   test_vault_backup_task_healing
   test_resource_aware_session_close
+  test_vault_lock_separated_gitdir
   test_cloud_sync_guard
   test_cloud_safe_file_walkers
   test_delegated_task_needs_source

--- a/scripts/session-end-hook.sh
+++ b/scripts/session-end-hook.sh
@@ -54,6 +54,11 @@ else
   close_load_per_core() { echo "0"; }
   close_mutex_acquire() { return 0; }
   close_mutex_release() { :; }
+  # The index-lock resolver FAILS CLOSED, unlike the three above. Without the
+  # guard we cannot resolve the real git dir, so we cannot prove no other
+  # session holds the lock - defer the snapshot (work stays on disk, daily
+  # maintenance reconciles) rather than commit into an unknown lock state.
+  vault_git_wait_unlocked() { return 1; }
 fi
 
 # Resolve VAULT to the MAIN vault root, never a worktree.
@@ -253,14 +258,12 @@ fi
 # are typically local-only snapshot repos).
 
 if [ -d "$VAULT/.git" ] || git -C "$VAULT" rev-parse --git-dir >/dev/null 2>&1; then
-  # Wait for any concurrent index lock (up to 60s, then give up gracefully)
-  WAITED=0
-  while [ -f "$VAULT/.git/index.lock" ] && [ $WAITED -lt 60 ]; do
-    sleep 2
-    WAITED=$((WAITED + 2))
-  done
-
-  if [ ! -f "$VAULT/.git/index.lock" ]; then
+  # Wait for any concurrent writer's index lock, then give up gracefully. The
+  # lock path is RESOLVED from git, never assembled as "$VAULT/.git/index.lock":
+  # on a sidecar-relocated vault .git is a POINTER FILE, the assembled path can
+  # never exist, and this mutex would silently pass forever. Fails closed - an
+  # unresolvable git dir defers the snapshot instead of committing blind.
+  if vault_git_wait_unlocked "$VAULT"; then
     # Stage only paths we know about
     PATHS_TO_STAGE=()
     [ -f "$SESSION_FILE" ] && PATHS_TO_STAGE+=("$SESSION_FILE")
@@ -289,7 +292,7 @@ if [ -d "$VAULT/.git" ] || git -C "$VAULT" rev-parse --git-dir >/dev/null 2>&1; 
       }
     fi
   else
-    log_err "git index.lock held >60s; skipped snapshot"
+    log_err "git index.lock held (or git dir unresolvable) after ${VAULT_GIT_LOCK_MAX_WAIT:-60}s; skipped snapshot"
   fi
 fi
 

--- a/scripts/vault-daily-maintenance.sh
+++ b/scripts/vault-daily-maintenance.sh
@@ -63,6 +63,11 @@ else
   close_load_per_core() { echo "0"; }
   close_mutex_acquire() { return 0; }
   close_mutex_release() { :; }
+  # The index-lock resolver FAILS CLOSED, unlike the three above. Without the
+  # guard we cannot resolve the real git dir, so we cannot prove no other writer
+  # holds the lock - skip the reconcile commit (artifacts stay on disk for the
+  # next run) rather than commit into an unknown lock state.
+  vault_git_wait_unlocked() { return 1; }
 fi
 
 # Auto-detect the Meta folder via the shared resolver (prefers the variant
@@ -169,9 +174,10 @@ AGG_DECISIONS="$SCRIPT_DIR/aggregate-decisions.py"
 # Commit any close artifacts left uncommitted by a load-deferred close. Targeted
 # paths only - NEVER `git add -A` (vaults are commonly 10k-60k+ files).
 if [ -d "$VAULT/.git" ] || git -C "$VAULT" rev-parse --git-dir >/dev/null 2>&1; then
-  WAITED=0
-  while [ -f "$VAULT/.git/index.lock" ] && [ $WAITED -lt 60 ]; do sleep 2; WAITED=$((WAITED + 2)); done
-  if [ ! -f "$VAULT/.git/index.lock" ]; then
+  # Lock path RESOLVED from git, never assembled as "$VAULT/.git/index.lock": on
+  # a sidecar-relocated vault .git is a POINTER FILE, so the assembled path can
+  # never exist and this check would pass forever. Fails closed.
+  if vault_git_wait_unlocked "$VAULT"; then
     PATHS=()
     for p in "$META_DIR/Sessions" "$META_DIR/Decisions" \
              "$META_DIR/Last Session.md" "$META_DIR/Decision Log.md" \
@@ -185,7 +191,7 @@ if [ -d "$VAULT/.git" ] || git -C "$VAULT" rev-parse --git-dir >/dev/null 2>&1; 
       log "[reconcile-commit] staged ${#PATHS[@]} close-artifact path(s)"
     fi
   else
-    log "[reconcile-commit] SKIPPED - git index.lock held >60s"
+    log "[reconcile-commit] SKIPPED - git index.lock held (or git dir unresolvable) after ${VAULT_GIT_LOCK_MAX_WAIT:-60}s"
   fi
 fi
 

--- a/scripts/vault-multi-machine-sync.sh
+++ b/scripts/vault-multi-machine-sync.sh
@@ -32,6 +32,21 @@
 
 set -uo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Shared git-dir / index-lock resolver. FAIL CLOSED when the guard is missing:
+# without it we cannot resolve the real lock path, so we cannot prove no other
+# session is mid-commit, and this script's whole concurrency stance is "abort if
+# someone else is writing".
+CLOSE_GUARD="$SCRIPT_DIR/_session_close_guard.sh"
+if [ -f "$CLOSE_GUARD" ]; then
+  # shellcheck source=scripts/_session_close_guard.sh
+  . "$CLOSE_GUARD"
+else
+  vault_git_locked() { return 0; }
+  vault_git_index_lock() { echo ""; return 1; }
+fi
+
 ACTION="${1:-status}"
 DRY_RUN=0
 VAULT=""
@@ -88,8 +103,13 @@ fi
 
 # === lock check ===
 
-if [[ -f ".git/index.lock" ]]; then
-  warn "Concurrent git operation detected (.git/index.lock present)"
+# Lock path RESOLVED from git, never assembled as ".git/index.lock": on a
+# sidecar-relocated vault .git is a POINTER FILE, so the assembled path can
+# never exist and this abort would never fire. Fails closed - an unresolvable
+# git dir counts as locked.
+if vault_git_locked "$VAULT"; then
+  warn "Concurrent git operation detected (git index.lock present, or the git dir could not be resolved)"
+  echo "  Lock path: $(vault_git_index_lock "$VAULT" 2>/dev/null || echo '<unresolvable>')"
   echo "  Wait for that to finish, or remove the lock if it's stale."
   exit 2
 fi

--- a/scripts/vault-safe-commit.sh
+++ b/scripts/vault-safe-commit.sh
@@ -26,17 +26,36 @@
 # Vault-wide mutex: uses /tmp/vault-commit-<hash>.lock to serialize
 # concurrent vault-safe-commit.sh invocations. Prevents two sessions from
 # racing each other even if the index.lock check passes.
+#
+# The index-lock path is RESOLVED from git (vault_git_index_lock in
+# _session_close_guard.sh), never assembled as "$VAULT_ROOT/.git/index.lock". A
+# vault relocated by relocate-machinery-sidecar.sh has a .git POINTER FILE, so
+# the assembled path can never exist and this mutex would be silently disarmed.
+# An unresolvable git dir => refuse (fail closed).
 
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Shared git-dir / index-lock resolver. FAIL CLOSED when the guard is missing:
+# with no way to resolve the real lock path we cannot prove the vault is free,
+# and an unprovable mutex must refuse rather than assume free.
+CLOSE_GUARD="$SCRIPT_DIR/_session_close_guard.sh"
+if [ -f "$CLOSE_GUARD" ]; then
+    # shellcheck source=scripts/_session_close_guard.sh
+    . "$CLOSE_GUARD"
+else
+    vault_git_index_lock() { echo ""; return 1; }
+fi
 
 if [ -z "${VAULT_ROOT:-}" ]; then
     echo "vault-safe-commit: VAULT_ROOT env var not set" >&2
     exit 1
 fi
 
-LOCK_FILE="${VAULT_ROOT}/.git/index.lock"
+LOCK_FILE="$(vault_git_index_lock "${VAULT_ROOT}" || true)"
 LOG_FILE="${VAULT_ROOT}/.vault-snapshot.log"
-MAX_WAIT_SECONDS=60
+MAX_WAIT_SECONDS="${VAULT_GIT_LOCK_MAX_WAIT:-60}"
 VAULT_MUTEX="/tmp/vault-commit-$(echo "${VAULT_ROOT}" | md5 2>/dev/null | cut -c1-8 || echo "${VAULT_ROOT}" | md5sum | cut -c1-8).lock"
 GIT_BIN=$(command -v git)
 
@@ -49,6 +68,13 @@ die() {
     echo "vault-safe-commit: $1" >&2
     exit 1
 }
+
+# Fail closed: an unresolvable git dir means we cannot see the index lock at
+# all, so we cannot prove no other writer holds it. Refuse instead of
+# committing blind. (Checked here, not at assignment, so it can use die/log.)
+if [ -z "${LOCK_FILE}" ]; then
+    die "cannot resolve the git directory for ${VAULT_ROOT} — refusing to commit without a working index-lock mutex"
+fi
 
 # --- parse --kill-leaked flag ---
 KILL_LEAKED=0
@@ -115,11 +141,20 @@ _MUTEX_ACQUIRED=1
 log "acquired vault mutex ($$)"
 
 # --- is_real_write_process: check if any ACTUAL git binary write is running ---
+# Echoes a count, never a failure. The `|| n=0` is load-bearing under
+# `set -euo pipefail`: no match makes grep exit 1, pipefail propagates it, and
+# an unguarded `n=$(...)` would abort the whole script — silently, with the
+# vault mutex released and nothing committed. That was unreachable while the
+# lock path could never exist (the wait loop never ran); resolving the real git
+# dir makes this path live, so it has to be correct.
 is_real_write_process() {
-    ps -ax -o pid,command 2>/dev/null \
+    local n
+    n=$(ps -ax -o pid,command 2>/dev/null \
         | grep -E "^\s*[0-9]+ .*${GIT_BIN}.*(add|commit|checkout|reset|merge|rebase)" \
         | grep -v grep \
-        | wc -l | tr -d ' '
+        | wc -l | tr -d ' ') || n=0
+    case "$n" in ''|*[!0-9]*) n=0 ;; esac
+    echo "$n"
 }
 
 # --- lock safety check loop ---

--- a/tests/integration/test_vault_lock_separated_gitdir.sh
+++ b/tests/integration/test_vault_lock_separated_gitdir.sh
@@ -1,0 +1,290 @@
+#!/usr/bin/env bash
+# Test that the vault's git index-lock mutex SURVIVES a separated git directory.
+#
+# WHY THIS EXISTS
+#
+# scripts/relocate-machinery-sidecar.sh (docs/CLOUD_SYNC.md "Shape B") moves the
+# vault's git machinery out of the synced tree with `git init --separate-git-dir`.
+# After that, `$VAULT/.git` is a one-line POINTER FILE, not a directory, and the
+# real index lives in the sidecar.
+#
+# Every vault writer here serializes on the git index lock before it commits.
+# Five sites used to build that lock path by joining `.git/index.lock` onto the
+# vault root. On a relocated vault that path is under a FILE, so it can never
+# exist — the check reports "free" forever and the mutex is silently disarmed.
+# Two sessions closing at once both see "no lock" and both commit. This is the
+# bottom-of-stack lost-update defense, off with no signal.
+#
+# The fix: resolve the REAL git dir (`git rev-parse --absolute-git-dir`), which
+# answers correctly whether `.git` is a directory, a pointer file, or a worktree.
+# One shared helper in scripts/_session_close_guard.sh, five call sites.
+#
+# NEGATIVE CONTROL: Part B drives all five sites against a fixture vault with a
+# separated gitdir while a live concurrent writer holds the real index.lock, and
+# asserts each one takes its LOCKED branch. Every Part B assertion is RED against
+# the pre-fix code. Part D then proves the fix is not "always locked": with no
+# lock held the same close DOES commit.
+#
+# Part B asserts on the GATE'S DECISION, not merely on "did it commit". That
+# distinction is the whole point: git has its own internal index lock, so a
+# script that sails past a disarmed mutex still fails to commit — it just fails
+# the WRONG way. Measured on the pre-fix code (separated gitdir, lock held), the
+# close never logs "index.lock held; skipped snapshot"; instead `git add` and
+# `git commit` both die with "fatal: Unable to create ... index.lock: File
+# exists", the close logs "git snapshot commit failed", and the session file is
+# left uncommitted. The graceful defer path — the one whose contract is "daily
+# maintenance will catch up" — never runs, and daily maintenance carries the
+# same bug. So each assertion below requires the skip/refuse signal AND the
+# absence of the blundered-into-git's-own-lock signal.
+#
+# Fail-closed contract: when the git dir cannot be resolved at all, the helper
+# reports LOCKED (refuse). A mutex that fails open is the defect being fixed.
+#
+# Self-contained: temp vaults + temp sidecars + temp HOME, cleaned on exit.
+# NEVER touches a real vault. Exit 0 = pass.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GUARD="$REPO_ROOT/scripts/_session_close_guard.sh"
+HOOK="$REPO_ROOT/scripts/session-end-hook.sh"
+MAINT="$REPO_ROOT/scripts/vault-daily-maintenance.sh"
+SYNC="$REPO_ROOT/scripts/vault-multi-machine-sync.sh"
+SAFE="$REPO_ROOT/scripts/vault-safe-commit.sh"
+
+# shellcheck source=tests/integration/lib/sandbox_home.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/sandbox_home.sh"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+for f in "$GUARD" "$HOOK" "$MAINT" "$SYNC" "$SAFE"; do
+  [ -f "$f" ] || fail "missing required file: $f"
+  bash -n "$f" 2>/dev/null || fail "bash -n failed: $f"
+done
+
+command -v git >/dev/null 2>&1 || fail "git is required for this test"
+
+TMP="$(mktemp -d)"
+HOLDER_PID=""
+cleanup() {
+  [ -n "$HOLDER_PID" ] && kill "$HOLDER_PID" 2>/dev/null
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+# Bound every lock wait so the suite stays fast. The scripts default to 60s.
+export VAULT_GIT_LOCK_MAX_WAIT=2
+
+# ─── fixtures ───────────────────────────────────────────────────────────────
+
+# make_sidecar_vault <vault> <sidecar> — a vault whose .git is a POINTER FILE.
+make_sidecar_vault() {
+  local v="$1" side="$2"
+  mkdir -p "$v/⚙️ Meta/Sessions"
+  git init --quiet --initial-branch=master --separate-git-dir "$side" "$v"
+  git -C "$v" config user.email "t@example.com"
+  git -C "$v" config user.name "t"
+  echo "# vault" > "$v/README.md"
+  git -C "$v" add README.md
+  git -C "$v" commit --quiet -m "init"
+  printf -- '---\ntype: session\n---\n# session\nbody\n' \
+    > "$v/⚙️ Meta/Sessions/$(date +%Y-%m-%d)T00-00-main.md"
+}
+
+# make_plain_vault <vault> — a normal vault whose .git is a real DIRECTORY.
+make_plain_vault() {
+  local v="$1"
+  mkdir -p "$v/⚙️ Meta/Sessions"
+  git init --quiet --initial-branch=master "$v"
+  git -C "$v" config user.email "t@example.com"
+  git -C "$v" config user.name "t"
+  echo "# vault" > "$v/README.md"
+  git -C "$v" add README.md
+  git -C "$v" commit --quiet -m "init"
+}
+
+# hold_lock <gitdir> — a LIVE concurrent writer holding the real index.lock.
+# A live holder PID is required: every site here reclaims a lock whose holder
+# is dead, so a fake PID would be swept and prove nothing.
+hold_lock() {
+  sleep 300 &
+  HOLDER_PID=$!
+  disown "$HOLDER_PID" 2>/dev/null   # keep "Terminated" job noise out of the log
+  echo "$HOLDER_PID" > "$1/index.lock"
+}
+release_lock() {
+  [ -n "$HOLDER_PID" ] && kill "$HOLDER_PID" 2>/dev/null
+  HOLDER_PID=""
+  rm -f "$1/index.lock"
+}
+
+commit_count() { git -C "$1" log --oneline 2>/dev/null | wc -l | tr -d ' '; }
+
+# run_close <vault> <home> — drive one session-end-hook close. Echoes nothing;
+# the assertion is on the commit count.
+run_close() {
+  local v="$1" home="$2" sid="sid$$_${RANDOM}" sf
+  sf="$(ls "$v/⚙️ Meta/Sessions/"*.md 2>/dev/null | head -1)"
+  mkdir -p "$home/.claude"
+  printf '{"session_file":"%s","is_trivial":false}\n' "$sf" \
+    > "$home/.claude/.closing-signal-$sid.json"
+  printf '{"session_id":"%s","transcript_path":""}' "$sid" | \
+    run_sandboxed "$home" env VAULT_ROOT="$v" CLOSE_MAX_LOAD_PER_CORE=99999 \
+      CLOSE_MUTEX="$home/close.lock" VAULT_GIT_LOCK_MAX_WAIT=2 \
+      bash "$HOOK" >/dev/null 2>&1
+}
+
+# ─── Part A: the shape — prove the fixture reproduces the defect ────────────
+
+VS="$TMP/vault-sidecar"; SIDE="$TMP/sidecar.git"
+make_sidecar_vault "$VS" "$SIDE"
+
+[ -f "$VS/.git" ] || fail "fixture wrong: .git should be a pointer FILE after --separate-git-dir"
+[ -d "$VS/.git" ] && fail "fixture wrong: .git is still a directory"
+grep -q '^gitdir:' "$VS/.git" || fail "fixture wrong: .git file is not a gitdir pointer"
+echo "PASS: A1 --separate-git-dir leaves .git as a one-line pointer FILE"
+
+REAL_GITDIR="$(git -C "$VS" rev-parse --absolute-git-dir)"
+[ -d "$REAL_GITDIR" ] || fail "rev-parse --absolute-git-dir did not resolve to a directory"
+echo "PASS: A2 rev-parse --absolute-git-dir resolves the real git dir outside the vault"
+
+hold_lock "$REAL_GITDIR"
+
+# The naive predicate the five sites used. It cannot ever be true here.
+[ -f "$VS/.git/index.lock" ] && fail "naive path unexpectedly exists — fixture is not reproducing the bug"
+# ...while git itself is genuinely locked.
+if ( cd "$VS" && echo x > probe.txt && git add probe.txt ) >/dev/null 2>&1; then
+  fail "git accepted a write while index.lock was held — the lock holder is not real"
+fi
+echo "PASS: A3 lock held: git REFUSES the write while the naive \$VAULT/.git/index.lock check reports FREE"
+
+# ─── Part B: NEGATIVE CONTROL — all five sites must refuse ─────────────────
+# Every assertion below is RED against the pre-fix code.
+
+# --- B1: session-end-hook.sh (sites :258, :263) ---
+BEFORE="$(commit_count "$VS")"
+run_close "$VS" "$TMP/home-b1"
+AFTER="$(commit_count "$VS")"
+B1_LOG="$(cat "$TMP/home-b1/.claude/logs/session-close-errors.log" 2>/dev/null)"
+echo "$B1_LOG" | grep -q "index.lock held" \
+  || fail "B1 session-end-hook.sh never took its LOCKED branch on a separated gitdir — no 'index.lock held' decision was logged. Got: $(echo "$B1_LOG" | tr '\n' ' ' | head -c 300)"
+echo "$B1_LOG" | grep -q "Unable to create" \
+  && fail "B1 session-end-hook.sh blundered into git's own lock (fatal: Unable to create index.lock) instead of gating on it"
+echo "$B1_LOG" | grep -q "git snapshot commit failed" \
+  && fail "B1 session-end-hook.sh failed its snapshot instead of deferring it"
+[ "$BEFORE" = "$AFTER" ] \
+  || fail "B1 session-end-hook.sh COMMITTED through a held index.lock (before=$BEFORE after=$AFTER)"
+echo "PASS: B1 session-end-hook.sh takes its LOCKED branch and defers, rather than failing into git's own lock"
+
+# --- B2: vault-daily-maintenance.sh (sites :173, :174) ---
+BEFORE="$(commit_count "$VS")"
+B2_LOG="$(run_sandboxed "$TMP/home-b2" env VAULT_GIT_LOCK_MAX_WAIT=2 \
+  bash "$MAINT" --vault-root "$VS" --reconcile-only --force 2>&1)"
+AFTER="$(commit_count "$VS")"
+echo "$B2_LOG" | grep -q "reconcile-commit] SKIPPED" \
+  || fail "B2 vault-daily-maintenance.sh never took its LOCKED branch on a separated gitdir — no '[reconcile-commit] SKIPPED' decision. Got: $(echo "$B2_LOG" | tr '\n' ' ' | head -c 300)"
+echo "$B2_LOG" | grep -q "Unable to create" \
+  && fail "B2 vault-daily-maintenance.sh blundered into git's own lock instead of gating on it"
+[ "$BEFORE" = "$AFTER" ] \
+  || fail "B2 vault-daily-maintenance.sh COMMITTED through a held index.lock (before=$BEFORE after=$AFTER)"
+echo "PASS: B2 vault-daily-maintenance.sh takes its LOCKED branch and skips the reconcile commit"
+
+# --- B3: vault-multi-machine-sync.sh (site :91) ---
+# Needs a remote to reach the lock gate; a bare repo in tmp is enough.
+git init --quiet --bare "$TMP/remote.git"
+git -C "$VS" remote add origin "$TMP/remote.git"
+SYNC_OUT="$(run_sandboxed "$TMP/home-b3" env VAULT_GIT_LOCK_MAX_WAIT=2 \
+  bash "$SYNC" status --vault "$VS" 2>&1)"
+SYNC_RC=$?
+echo "$SYNC_OUT" | grep -qi "Concurrent git operation detected" \
+  || fail "B3 vault-multi-machine-sync.sh did NOT detect the held lock on a separated gitdir (rc=$SYNC_RC, out: $(echo "$SYNC_OUT" | tr '\n' ' ' | head -c 300))"
+echo "PASS: B3 vault-multi-machine-sync.sh aborts on a concurrent git operation"
+
+# --- B4: vault-safe-commit.sh (site :37) ---
+BEFORE="$(commit_count "$VS")"
+printf 'edit\n' >> "$VS/README.md"
+B4_LOG="$(run_sandboxed "$TMP/home-b4" env VAULT_ROOT="$VS" VAULT_GIT_LOCK_MAX_WAIT=2 \
+  bash "$SAFE" "test commit" "README.md" 2>&1)"
+B4_RC=$?
+AFTER="$(commit_count "$VS")"
+echo "$B4_LOG" | grep -q "lock held for" \
+  || fail "B4 vault-safe-commit.sh never took its LOCKED branch on a separated gitdir — no 'lock held for' refusal (rc=$B4_RC). Got: $(echo "$B4_LOG" | tr '\n' ' ' | head -c 300)"
+[ "$B4_RC" -ne 0 ] \
+  || fail "B4 vault-safe-commit.sh exited 0 while the real index.lock was held"
+[ "$BEFORE" = "$AFTER" ] \
+  || fail "B4 vault-safe-commit.sh COMMITTED through a held index.lock (before=$BEFORE after=$AFTER)"
+echo "PASS: B4 vault-safe-commit.sh refuses loudly (non-zero) while the real lock is held"
+
+release_lock "$REAL_GITDIR"
+
+# ─── Part C: the shared helper's contract ──────────────────────────────────
+
+# shellcheck source=/dev/null
+( . "$GUARD"
+  for fn in vault_git_dir vault_git_index_lock vault_git_locked vault_git_wait_unlocked; do
+    command -v "$fn" >/dev/null 2>&1 || { echo "missing fn $fn" >&2; exit 1; }
+  done ) || fail "C1 guard does not define the git-lock helpers"
+echo "PASS: C1 guard defines vault_git_{dir,index_lock,locked,wait_unlocked}"
+
+# shellcheck source=/dev/null
+( . "$GUARD"
+  got="$(vault_git_dir "$VS")"
+  [ "$got" = "$REAL_GITDIR" ] || { echo "vault_git_dir=$got want=$REAL_GITDIR" >&2; exit 1; }
+  got="$(vault_git_index_lock "$VS")"
+  [ "$got" = "$REAL_GITDIR/index.lock" ] || { echo "lock path=$got" >&2; exit 1; }
+  exit 0 ) || fail "C2 helper does not resolve the separated gitdir"
+echo "PASS: C2 helper resolves the separated gitdir and its real index.lock path"
+
+# shellcheck source=/dev/null
+( . "$GUARD"
+  vault_git_locked "$VS" && { echo "reported LOCKED with no lock present" >&2; exit 1; }
+  exit 0 ) || fail "C3 helper reported locked on a free separated-gitdir vault"
+echo "PASS: C3 helper reports FREE when no lock is held (no false positive)"
+
+hold_lock "$REAL_GITDIR"
+# shellcheck source=/dev/null
+( . "$GUARD"
+  vault_git_locked "$VS" || { echo "reported FREE while the real lock is held" >&2; exit 1; }
+  vault_git_wait_unlocked "$VS" 2 && { echo "wait_unlocked returned success under a held lock" >&2; exit 1; }
+  exit 0 ) || fail "C4 helper missed a lock held in the separated gitdir"
+echo "PASS: C4 helper reports LOCKED for a lock held in the sidecar gitdir"
+release_lock "$REAL_GITDIR"
+
+# FAIL CLOSED: an unresolvable git dir must read as LOCKED, never as free.
+mkdir -p "$TMP/not-a-repo"
+# shellcheck source=/dev/null
+( . "$GUARD"
+  got="$(vault_git_dir "$TMP/not-a-repo")"
+  [ -z "$got" ] || { echo "vault_git_dir on a non-repo returned '$got'" >&2; exit 1; }
+  vault_git_locked "$TMP/not-a-repo" || { echo "non-repo reported FREE — fails OPEN" >&2; exit 1; }
+  vault_git_wait_unlocked "$TMP/not-a-repo" 2 && { echo "non-repo wait returned success — fails OPEN" >&2; exit 1; }
+  vault_git_locked "$TMP/does-not-exist-at-all" || { echo "missing dir reported FREE — fails OPEN" >&2; exit 1; }
+  exit 0 ) || fail "C5 helper FAILS OPEN when the git dir cannot be resolved"
+echo "PASS: C5 helper FAILS CLOSED (reports LOCKED) when the git dir cannot be resolved"
+
+# Regression: a normal, non-separated vault must still work in both directions.
+VP="$TMP/vault-plain"; make_plain_vault "$VP"
+# shellcheck source=/dev/null
+( . "$GUARD"
+  got="$(vault_git_dir "$VP")"
+  [ "$got" = "$(git -C "$VP" rev-parse --absolute-git-dir)" ] || { echo "plain gitdir=$got" >&2; exit 1; }
+  vault_git_locked "$VP" && { echo "plain repo reported LOCKED with no lock" >&2; exit 1; }
+  : > "$VP/.git/index.lock"
+  vault_git_locked "$VP" || { echo "plain repo missed a real lock" >&2; exit 1; }
+  rm -f "$VP/.git/index.lock"
+  exit 0 ) || fail "C6 helper regressed on a normal (non-separated) repo"
+echo "PASS: C6 helper still correct on a normal repo whose .git is a directory"
+
+# ─── Part D: liveness — the fix must not be "always locked" ────────────────
+# Without this, a helper hardwired to report LOCKED would pass all of Part B.
+
+BEFORE="$(commit_count "$VS")"
+git -C "$VS" remote remove origin 2>/dev/null   # keep the close path local-only
+run_close "$VS" "$TMP/home-d1"
+AFTER="$(commit_count "$VS")"
+[ "$AFTER" -gt "$BEFORE" ] \
+  || fail "D1 close did NOT commit on an UNLOCKED separated-gitdir vault (before=$BEFORE after=$AFTER) — the lock check is stuck closed"
+echo "PASS: D1 with no lock held, the close DOES commit on a separated-gitdir vault"
+
+echo
+echo "All assertions passed. The vault index-lock mutex survives a separated git directory."


### PR DESCRIPTION
The vault-wide commit mutex is silently disarmed on any vault whose git machinery has been moved to a sidecar.

Five sites built a lock path by joining `.git/index.lock` onto the vault root. After `git init --separate-git-dir`, `.git` is a pointer file, so that path can never exist and the lock is permanently free. Two concurrent sessions closing at once both see "no lock" and both commit — the lost-update protection the docs call the bottom-of-stack defense, off with no signal.

A shared helper now resolves the real git directory, and fails closed when it cannot.

**Evidence.** Negative control on a separated-gitdir fixture with a live holder: red before, 14 assertions green after. The first version of that test passed against unfixed code and was rewritten — asserting "did it commit" measures git's own internal lock, not this mutex.

**Not verified.** macOS only; no Linux or Git Bash run. Conflicts with #466 in the same function; resolution is written in the branch discussion.
