### PR TITLE
fix(sidecar): a repair path for anyone whose notes were already deleted and pushed (MYC-4010)

### DIFF
--- a/docs/CLOUD_SYNC.md
+++ b/docs/CLOUD_SYNC.md
@@ -174,6 +174,35 @@ powershell -ExecutionPolicy Bypass -File scripts\relocate-machinery-sidecar.ps1 
 iCloud-only convention OneDrive ignores, so on Windows the sidecar relocation is
 the supported path.)
 
+### If an OLD version of this script already ate notes
+
+An earlier version picked what to move by folder NAME, so `⚙️ Meta/Sessions` —
+which holds notes, not cache — was relocated in vaults that tracked it. The
+folder became a symlink, `git status` reported every note as deleted, the hourly
+auto-snapshot (`git add -A`) committed that, and the multi-machine sync pushed
+it. The current script cannot do this: it tests the git index before it moves
+anything, whatever the folder is called.
+
+`--rollback` puts the folder back but does not touch the history, and it cannot
+reach the other machines that already pulled the deletion. For that:
+
+```bash
+# look only — changes nothing, prints exactly what it found
+bash scripts/repair-sidecar-note-deletion.sh "/path/to/vault"
+# put the notes back (one ordinary commit, scoped to the damaged folder)
+bash scripts/repair-sidecar-note-deletion.sh "/path/to/vault" --repair
+```
+
+It reports a folder only when a commit deleted tracked files under it AND that
+path is a symlink out of the vault (live, or recorded by that same commit) —
+one half alone is just someone deleting notes. Live copies still in the sidecar
+win over the older ones in history; anything else is restored from the commit
+before the deletion; two conflicting copies are reported, never merged. Your
+other machines get the notes back on the next sync.
+
+On Windows, run it from Git Bash (installed with Git for Windows). There is no
+PowerShell twin yet.
+
 Then turn on iCloud Drive (or Desktop & Documents) for that folder. The docs
 sync to every device; the machinery never leaves your Mac. Verify the calm
 yourself: run a `git gc` plus a full session and watch Activity Monitor —

--- a/hooks/worktree-footprint-signal.py
+++ b/hooks/worktree-footprint-signal.py
@@ -48,6 +48,7 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import subprocess
 import sys
 import time
 from pathlib import Path
@@ -279,6 +280,97 @@ def _machinery_relocated(vault: Path) -> bool:
                 if mv == vkey:
                     return True
     return False
+
+
+# Folders an OLD version of relocate-machinery-sidecar.sh listed as "cache" and
+# would therefore move even when git tracked notes inside them.
+SIDECAR_NOTE_DIRS = (
+    "⚙️ Meta/Sessions",
+    "⚙️ Meta/Worktree Snapshots",
+    "⚙️ Meta/logs",
+    "⚙️ Meta/graphify-out",
+    "graphify-out",
+)
+
+
+def _tracked_symlink_note_dirs(vault: Path) -> list[str]:
+    """Machinery paths git has recorded as a SYMLINK — the committed-deletion mark.
+
+    Nothing a person does produces this. It is what `git add -A` writes after the
+    old relocation replaced a tracked notes folder with a link, and it is exactly
+    what a SECOND machine pulls, so this fires there too.
+
+    ONE bounded `git ls-files` — an index lookup, not a history walk. The history
+    question ("which commit, how many notes, was it pushed") costs a full
+    `git log` and belongs in the repair script, never in a SessionStart hook.
+    That split is also why this is a doorbell and not a diagnosis: a vault whose
+    link was committed and later dropped from the index is not seen here.
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(vault), "ls-files", "-s", "-z", "--", *SIDECAR_NOTE_DIRS],
+            capture_output=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []          # could not look; the repair script is the honest check
+    if proc.returncode != 0:
+        return []
+    hits: list[str] = []
+    for entry in proc.stdout.split(b"\0"):
+        # `<mode> SP <sha> SP <stage> TAB <path>`; 120000 is git's symlink mode.
+        if not entry.startswith(b"120000 "):
+            continue
+        _, _, raw = entry.partition(b"\t")
+        if raw:
+            # Vault paths are full of non-ASCII; decode explicitly rather than
+            # letting a locale decide, and never let a decode error escape.
+            hits.append(raw.decode("utf-8", "replace"))
+    return hits
+
+
+def sidecar_deletion_alert(main_repo: Path | None) -> list[str]:
+    """One block per vault whose notes an old relocation deleted from history.
+
+    Louder than the cloud-sync offer on purpose: that one prevents a slow machine,
+    this one is a person whose notes are already gone from their history and, if
+    the vault syncs, from their other computers.
+    """
+    lines: list[str] = []
+    for vault in _candidate_vaults(main_repo)[:3]:
+        try:
+            hits = _tracked_symlink_note_dirs(vault)
+        except OSError:
+            continue
+        if not hits:
+            continue
+        repair = f'bash {SKILL_SCRIPTS}/repair-sidecar-note-deletion.sh "{vault}"'
+        where = ", ".join(f"`{h}`" for h in hits[:3])
+        note = ""
+        if _offer_os() == "windows":
+            note = (
+                " Run it in Git Bash (it comes with Git for Windows) — the repair "
+                "does not have a PowerShell twin yet."
+            )
+        lines.append(
+            f"🔴 [notes-deleted] The user's brain `{vault}` carries the mark an OLD "
+            f"version of the machinery cleanup left: git has {where} recorded as a "
+            f"shortcut, not a folder. That means the notes that lived there were "
+            f"removed from their saved history — and if this brain syncs, their "
+            f"other computers have already lost them too. The notes themselves are "
+            f"very likely still on the disk. TELL THEM AND FIX IT. Do not make them "
+            f"read anything or choose between options.\n"
+            f"  Look first — this changes nothing and prints what it found:\n"
+            f"      {repair}\n"
+            f"  Then put the notes back:\n"
+            f"      {repair} --repair\n"
+            f"Say it to them roughly like: \"Some of your notes got removed from your "
+            f"history by an old version of a cleanup step. They're still on your "
+            f"computer and I can put them back. Want me to?\" Don't explain shortcuts "
+            f"or git.{note} Repeats each session until it is fixed."
+        )
+    return lines
 
 
 def _suggest_local_dest(vault: Path) -> Path:
@@ -713,6 +805,11 @@ def main() -> int:
     # onboarding is still caught and the fix is OFFERED, not just documented.
     # (MYC-2360) Replaces the old passive "move it out, see docs" warning.
     lines.extend(cloud_sync_offer(main_repo))
+
+    # Notes an OLD version of the sidecar relocation deleted from history
+    # (MYC-4010). Deliberately BEFORE every performance signal: a slow machine
+    # can wait, missing notes cannot.
+    lines[:0] = sidecar_deletion_alert(main_repo)
 
     # Aggregate bloat-dir footprint (MYC-577). Deliberately NOT gated on
     # main_repo: the dirs that regrew in the melt (.smart-env above all) live in

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -231,6 +231,7 @@ INTEGRATION_TESTS=(
   test_cloud_sync_offer
   test_worktree_on_vault_guard
   test_machinery_sidecar
+  test_repair_sidecar_note_deletion
   test_relocate_vault
   test_relocate_sweep
   test_relocate_watch

--- a/scripts/repair-sidecar-note-deletion.sh
+++ b/scripts/repair-sidecar-note-deletion.sh
@@ -1,0 +1,460 @@
+#!/usr/bin/env bash
+# repair-sidecar-note-deletion.sh — find notes an OLD machinery-relocation
+# deleted from a vault's history, and put them back.
+#
+# WHO THIS IS FOR
+# ---------------
+# An earlier version of scripts/relocate-machinery-sidecar.sh treated
+# "⚙️ Meta/Sessions" as a cache because of its NAME. In a real vault that folder
+# holds notes, and git tracks them. Relocating it turned the folder into a
+# symlink, `git status` reported every note as deleted, the hourly auto-snapshot
+# (`git add -A`) COMMITTED that deletion, and the multi-machine sync PUSHED it.
+# The whole time, the message on screen said "nothing was deleted".
+#
+# The current script can no longer do this — it tests the git index before it
+# moves anything, and `--rollback` puts the folder back. But rollback only fixes
+# the FOLDER. It does not fix the HISTORY, and it cannot reach the other
+# computers that already pulled the deletion. That is what this script is for.
+#
+# WHAT IT LOOKS FOR (the exact fingerprint, not a guess)
+# ------------------------------------------------------
+# A folder is reported ONLY when BOTH of these are true:
+#   1. git history contains a commit that DELETED tracked files under that path
+#      (an ordinary note deletion by hand looks the same on this half alone), AND
+#   2. that same path is a SYMLINK pointing outside the vault, or that very
+#      commit recorded the path ITSELF as a symlink.
+# Nothing a person does by hand produces (2). A folder replaced by a link to
+# somewhere else, in the same commit that removed everything inside it, is a
+# machine doing it — this one.
+#
+# Condition (2) is also what makes this work on a SECOND computer, which never
+# ran the relocation and has no sidecar at all: it pulled the commit, so it has
+# the dangling link and the same deletion.
+#
+# WHAT IT DOES NOT CATCH: a vault where the deletion was committed but the link
+# was never committed AND has since been removed. Nothing durable is left to
+# distinguish that from a person deleting a folder on purpose, so this refuses
+# to guess. `git log -- "<folder>"` shows it by hand.
+#
+# WHAT --repair DOES
+#   · takes the link out of the way (never overwrites anything real)
+#   · if the notes are still on this machine in the sidecar, moves them back —
+#     these are the LIVE copies, so they win over the older ones in history
+#   · anything still missing is restored from the commit BEFORE the deletion
+#   · saves that as one ordinary commit, touching only the damaged folder
+#   · never pushes. The next sync carries the repair to the other computers.
+#
+# It never deletes note content, never force-anythings, and refuses rather than
+# overwrite whenever both a real folder and a saved copy exist.
+#
+# Pure bash + git + python3 (path handling only). No third-party deps.
+#
+# Usage:
+#   repair-sidecar-note-deletion.sh <vault-path>              # look only, change nothing
+#   repair-sidecar-note-deletion.sh <vault-path> --repair     # put the notes back
+#
+# Options:
+#   --sidecar <dir>   sidecar root to consult for recorded moves
+#                     (default: $BRAIN_SIDECAR or ~/.brain-sidecar)
+#   --repair          perform the repair (default is look-only)
+#   --quiet           only print the verdict line
+#   -h, --help        this help
+#
+# Exit codes: 0 nothing wrong / repaired · 1 could not check, or a repair leg
+#             failed · 2 usage · 10 damage found (look-only mode)
+set -euo pipefail
+
+# ---- folders an old version listed as "cache" and could therefore have taken --
+# Used when the sidecar record is gone (or the vault was damaged on another
+# machine). Recorded moves are read too and merged in.
+CANDIDATE_DIRS=(
+  "⚙️ Meta/Sessions"
+  "⚙️ Meta/Worktree Snapshots"
+  "⚙️ Meta/logs"
+  "⚙️ Meta/graphify-out"
+  "graphify-out"
+  ".smart-env"
+  ".codegraph"
+  ".obsidian/.smart-env"
+  ".claude/worktrees"
+)
+
+VAULT="" ; SIDECAR="${BRAIN_SIDECAR:-${MYCELIUM_SIDECAR:-$HOME/.brain-sidecar}}"
+REPAIR=0 ; QUIET=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --sidecar) SIDECAR="${2:?--sidecar needs a path}"; shift 2;;
+    --repair)  REPAIR=1; shift;;
+    --quiet)   QUIET=1; shift;;
+    -h|--help) awk 'NR==1{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "$0"; exit 0;;
+    -*) echo "unknown option: $1" >&2; exit 2;;
+    *) if [ -z "$VAULT" ]; then VAULT="$1"; else echo "unexpected arg: $1" >&2; exit 2; fi; shift;;
+  esac
+done
+[ -n "$VAULT" ] || { echo "usage: $(basename "$0") <vault-path> [--repair]" >&2; exit 2; }
+[ -d "$VAULT" ] || { echo "not a directory: $VAULT" >&2; exit 2; }
+
+say()  { [ "$QUIET" = 1 ] || printf '%s\n' "$*"; }
+warn() { printf 'WARN  %s\n' "$*" >&2; }
+err()  { printf 'ERROR %s\n' "$*" >&2; }
+
+PYBIN="$(command -v python3 || command -v python || true)"
+[ -n "$PYBIN" ] || { err "python3 is required (used only to read paths safely)"; exit 1; }
+
+VAULT="$(cd "$VAULT" && pwd -P)"
+
+# Same sidecar path resolution and same per-vault slug as
+# relocate-machinery-sidecar.sh, so this reads THIS vault's record and no other.
+# A shared sidecar holds one record per vault; matching on the folder name alone
+# would let a different vault's record answer for this one.
+case "$SIDECAR" in /*) :;; ~*) SIDECAR="${SIDECAR/#\~/$HOME}";; *) SIDECAR="$PWD/$SIDECAR";; esac
+SIDECAR="$("$PYBIN" -c 'import os,sys; print(os.path.realpath(os.path.expanduser(sys.argv[1])))' "$SIDECAR")"
+_base="$(basename "$VAULT")"
+_slug="$(printf '%s' "$_base" | tr -c 'A-Za-z0-9._-' '-' | sed 's/-\{2,\}/-/g; s/^-//; s/-$//')"
+_hash="$(printf '%s' "$VAULT" | (shasum 2>/dev/null || sha1sum) | cut -c1-8)"
+SLUG="${_slug:-vault}-${_hash}"
+
+_tmp="$(mktemp -d)"
+trap 'rm -rf "$_tmp"' EXIT
+
+# ---- git access -------------------------------------------------------------
+# A read that FAILS is not a read that found nothing. If git cannot be asked,
+# this says so and stops rather than reporting a clean vault.
+if ! command -v git >/dev/null 2>&1; then
+  err "git is not installed, so this cannot check the vault's history."
+  exit 1
+fi
+_gitdir_out=""; _rc=0
+_gitdir_out="$(LC_ALL=C git -C "$VAULT" rev-parse --git-dir 2>&1)" || _rc=$?
+if [ "$_rc" -ne 0 ]; then
+  case "$_gitdir_out" in
+    *"not a git repository"*)
+      say "This folder is not tracked by git, so nothing could have been deleted from its history."
+      say "OK: nothing to repair."
+      exit 0;;
+    *)
+      err "git could not read $VAULT: $_gitdir_out"
+      err "Nothing was checked. Fix that first — an unreadable vault is not a clean one."
+      exit 1;;
+  esac
+fi
+
+git_v() { LC_ALL=C git -C "$VAULT" "$@"; }
+
+# ---- helpers ----------------------------------------------------------------
+
+# Absolute destination of a symlink, WITHOUT requiring it to exist (the sidecar
+# is gone on a second computer, and that is exactly the case that matters).
+link_target_abs() {  # $1 = absolute path of the symlink
+  "$PYBIN" - "$1" <<'PY'
+import os, sys
+p = sys.argv[1]
+try:
+    t = os.readlink(p)
+except OSError:
+    sys.exit(1)
+if not os.path.isabs(t):
+    t = os.path.join(os.path.dirname(p), t)
+print(os.path.realpath(t))
+PY
+}
+
+inside_vault() {  # $1 = absolute path; 0 = inside the vault
+  case "$1/" in "$VAULT"/*) return 0;; *) return 1;; esac
+}
+
+# Vault-relative paths this vault has a RECORDED move for. Silent when there is
+# no record — the built-in candidate list still covers those vaults.
+recorded_rels() {
+  local rec
+  for rec in "$SIDECAR/manifests/$SLUG.json" "$SIDECAR/manifests/$SLUG.journal.jsonl"; do
+    [ -f "$rec" ] || continue
+    V="$VAULT" R="$rec" "$PYBIN" - <<'PY' || true
+import json, os
+src, vault = os.environ["R"], os.environ["V"]
+recs = []
+try:
+    if src.endswith(".jsonl"):
+        with open(src, encoding="utf-8", errors="replace") as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    try:
+                        recs.append(json.loads(line))
+                    except ValueError:
+                        continue
+    else:
+        with open(src, encoding="utf-8", errors="replace") as f:
+            doc = json.load(f)
+        if doc.get("vault") and os.path.realpath(doc["vault"]) != os.path.realpath(vault):
+            recs = []
+        else:
+            recs = doc.get("moves", [])
+except (OSError, ValueError):
+    recs = []
+for r in recs:
+    if isinstance(r, dict) and r.get("type") in ("cache", "worktrees") and r.get("vault_rel"):
+        print(r["vault_rel"] + "\t" + (r.get("target") or ""))
+PY
+  done
+}
+
+RECORDED="$_tmp/recorded.tsv"
+recorded_rels > "$RECORDED" 2>/dev/null || : > "$RECORDED"
+
+# Every path worth testing: the built-in candidates plus anything recorded.
+candidate_rels() {
+  { printf '%s\n' "${CANDIDATE_DIRS[@]}"; cut -f1 "$RECORDED"; } | awk 'NF && !seen[$0]++'
+}
+
+# Where a recorded move put this folder. Needed when the symlink is already gone
+# (someone deleted it, or a half-finished rollback) — otherwise a second copy of
+# the user's notes sits in the sidecar and nothing ever mentions it.
+recorded_target_for() {  # $1 = rel
+  awk -F'\t' -v k="$1" '$1==k && $2!="" {print $2; exit}' "$RECORDED" 2>/dev/null || true
+}
+
+# The most recent commit that DELETED tracked files under $1. Empty = none.
+deletion_commit() {  # $1 = vault-relative path
+  git_v log --diff-filter=D --format=%H -n 1 -- "$1" 2>/dev/null || true
+}
+
+# Did commit $1 record path $2 as a symlink? (mode 120000 at exactly that path.)
+commit_recorded_symlink() {  # $1 = commit, $2 = rel
+  local out
+  out="$(git_v -c core.quotepath=false ls-tree "$1" -- "$2" 2>/dev/null || true)"
+  case "$out" in 120000\ *) return 0;; *) return 1;; esac
+}
+
+# Files deleted by $1 under $2, NUL-separated, into $3.
+deleted_paths_into() {  # $1 = commit, $2 = rel, $3 = out file
+  git_v -c core.quotepath=false diff --diff-filter=D --name-only -z \
+        "$1^" "$1" -- "$2" > "$3" 2>/dev/null || return 1
+}
+
+count_nul() { tr -cd '\0' < "$1" | wc -c | tr -d ' '; }
+
+# Is the commit already on a remote branch — i.e. did the other computers get it?
+pushed_already() {  # $1 = commit
+  local out
+  out="$(git_v branch -r --contains "$1" 2>/dev/null || true)"
+  [ -n "$out" ]
+}
+
+# ---- detection --------------------------------------------------------------
+DAMAGED_RELS=() ; DAMAGED_COMMITS=() ; DAMAGED_COUNTS=() ; DAMAGED_TARGETS=() ; DAMAGED_PUSHED=()
+DAMAGED_LISTS=()
+
+detect() {
+  local rel link target commit n listf
+  while IFS= read -r rel; do
+    [ -n "$rel" ] || continue
+    link="$VAULT/$rel"
+
+    commit="$(deletion_commit "$rel")"
+    [ -n "$commit" ] || continue                      # nothing was ever deleted here
+
+    # A root commit has no "before" to restore from; it also cannot be this bug.
+    git_v rev-parse --verify --quiet "$commit^" >/dev/null 2>&1 || continue
+
+    # Half two of the fingerprint — without it this is just someone deleting notes.
+    target=""
+    if [ -L "$link" ]; then
+      target="$(link_target_abs "$link" || true)"
+      if [ -z "$target" ] || inside_vault "$target"; then
+        commit_recorded_symlink "$commit" "$rel" || continue
+      fi
+    else
+      commit_recorded_symlink "$commit" "$rel" || continue
+    fi
+    # no live link to read: consult the record, so a stranded second copy of the
+    # notes is still seen rather than silently left behind
+    [ -n "$target" ] || target="$(recorded_target_for "$rel")"
+
+    listf="$_tmp/deleted.${#DAMAGED_RELS[@]}"
+    deleted_paths_into "$commit" "$rel" "$listf" || {
+      warn "could not list what commit ${commit:0:8} removed under $rel — skipped"
+      continue
+    }
+    n="$(count_nul "$listf")"
+    [ "${n:-0}" -gt 0 ] || continue
+
+    DAMAGED_RELS+=("$rel")
+    DAMAGED_COMMITS+=("$commit")
+    DAMAGED_COUNTS+=("$n")
+    DAMAGED_TARGETS+=("$target")
+    DAMAGED_LISTS+=("$listf")
+    if pushed_already "$commit"; then DAMAGED_PUSHED+=("yes"); else DAMAGED_PUSHED+=("no"); fi
+  done < <(candidate_rels)
+}
+
+report() {
+  local i rel n commit target pushed when total=0
+  say "Checking for notes an old relocation removed from this vault's history"
+  say "  vault: $VAULT"
+  say ""
+  if [ "${#DAMAGED_RELS[@]}" -eq 0 ]; then
+    say "Good news: nothing was deleted. Your notes and your history are intact."
+    return 0
+  fi
+  for i in "${!DAMAGED_RELS[@]}"; do
+    rel="${DAMAGED_RELS[$i]}"; n="${DAMAGED_COUNTS[$i]}"; commit="${DAMAGED_COMMITS[$i]}"
+    target="${DAMAGED_TARGETS[$i]}"; pushed="${DAMAGED_PUSHED[$i]}"
+    total=$((total + n))
+    when="$(git_v log -1 --format=%cd --date=format:'%B %-d, %Y' "$commit" 2>/dev/null || echo 'an earlier date')"
+    say "  \"$rel\""
+    say "    $n note(s) were removed from your saved history on $when."
+    if [ -n "$target" ] && [ -d "$target" ] && [ -d "$VAULT/$rel" ] && [ ! -L "$VAULT/$rel" ]; then
+      say "    There are TWO copies of this folder: the one here, and one at:"
+      say "      $target"
+      say "    Nothing can be put back automatically until you decide which to keep."
+    elif [ -n "$target" ] && [ -d "$target" ]; then
+      say "    The notes themselves are still on this computer, at:"
+      say "      $target"
+    elif [ -n "$target" ]; then
+      say "    The folder here is now a shortcut pointing at $target, which does not exist."
+      say "    The notes come back out of your saved history."
+    else
+      say "    The notes come back out of your saved history."
+    fi
+    if [ "$pushed" = "yes" ]; then
+      say "    Your other computers already received this, so they are missing the notes too."
+    fi
+    say ""
+  done
+  say "In total, $total note(s) need to be put back."
+  return 0
+}
+
+# ---- repair -----------------------------------------------------------------
+
+# Commit exactly one folder and nothing else — even if the hourly auto-snapshot
+# has something unrelated staged in this vault right this second.
+#
+# `git commit --only -- <folder>` is the obvious way and it does NOT work here.
+# HEAD holds a SYMLINK at that path while the worktree now holds a directory, and
+# --only rebuilds a temporary index that dies on exactly that type change
+# ("does not have a commit checked out"). So the commit is assembled directly:
+# HEAD's tree, with this one folder replaced by what is in the index for it.
+# Anything else staged stays staged and stays out of the commit.
+commit_path_only() {  # $1 = rel, $2 = message
+  local rel="$1" msg="$2" priv="$_tmp/commit-index" tree new
+  rm -f "$priv"
+  GIT_INDEX_FILE="$priv" git_v read-tree HEAD || return 1
+  # clear whatever HEAD had at this path (the symlink), leaving the rest of HEAD
+  GIT_INDEX_FILE="$priv" git_v ls-files -z -- "$rel" \
+    | GIT_INDEX_FILE="$priv" git_v update-index -z --force-remove --stdin || return 1
+  # and put the repaired folder in its place
+  git_v ls-files -s -z -- "$rel" \
+    | GIT_INDEX_FILE="$priv" git_v update-index -z --index-info || return 1
+  tree="$(GIT_INDEX_FILE="$priv" git_v write-tree)" || return 1
+  new="$(git_v commit-tree "$tree" -p HEAD -m "$msg")" || return 1
+  git_v update-ref -m "$msg" HEAD "$new" || return 1
+  # bring the real index in step for this folder only; leave everything else alone
+  git_v reset -q "$new" -- "$rel" || return 1
+  return 0
+}
+
+repair_one() {  # $1 rel, $2 commit, $3 target, $4 deleted-list; 0 ok / 1 failed
+  local rel="$1" commit="$2" target="$3" listf="$4"
+  local link="$VAULT/$rel" from_sidecar=0 d missing=0
+
+  # 1. the shortcut goes away — but never on top of anything real.
+  if [ -L "$link" ]; then
+    if [ -n "$target" ] && [ -d "$target" ]; then
+      rm -f "$link" || { err "  · $rel: could not remove the shortcut"; return 1; }
+      mkdir -p "$(dirname "$link")" || { err "  · $rel: could not create the parent folder"; return 1; }
+      mv "$target" "$link" || { err "  · $rel: could not move the notes back from $target"; return 1; }
+      from_sidecar=1
+      say "  · moved your notes back into $rel"
+    else
+      rm -f "$link" || { err "  · $rel: could not remove the shortcut"; return 1; }
+      say "  · removed the broken shortcut at $rel"
+    fi
+  elif [ -e "$link" ] && [ -n "$target" ] && [ -d "$target" ]; then
+    err "  · $rel NOT repaired: there is a real folder here AND a copy at $target."
+    err "    Refusing to overwrite either. Look at both and keep the one you want."
+    return 1
+  fi
+
+  # 2. put the FILE LIST back the way it was just before the deletion — index
+  #    only, worktree untouched. This is what actually undoes the damage, and it
+  #    is done through git rather than `git add` on purpose: `git add` obeys
+  #    .gitignore, so a stray ignore rule would silently leave the notes out of
+  #    history again and the repair would look like it worked.
+  git_v reset -q "$commit^" -- "$rel" \
+    || { err "  · $rel: could not restore the file list from your history"; return 1; }
+
+  # 3. make the folder on disk match, without clobbering anything newer.
+  if [ "$from_sidecar" = 1 ]; then
+    # the live copies are already here; only fill genuine gaps
+    while IFS= read -r -d '' d; do
+      [ -n "$d" ] || continue
+      if [ ! -e "$VAULT/$d" ]; then
+        git_v checkout -- "$d" || { err "  · $rel: could not restore $d"; return 1; }
+        missing=$((missing + 1))
+      fi
+    done < "$listf"
+    [ "$missing" -eq 0 ] || say "  · restored $missing further note(s) from your history"
+  else
+    # nothing is on disk — one call brings the whole folder back
+    git_v checkout -- "$rel" || { err "  · $rel: could not restore $rel from your history"; return 1; }
+    say "  · restored $rel from your history"
+  fi
+
+  # 4. pick up anything newer than the copies in history, then save. Scoped to
+  #    this folder so nothing else in flight is swept in.
+  git_v add --all -- "$rel" || { err "  · $rel: could not stage the restored notes"; return 1; }
+  if git_v diff --cached --quiet -- "$rel"; then
+    say "  · $rel was already correct in your history — nothing to save"
+    return 0
+  fi
+  # --only keeps the commit to exactly this folder even if something else is staged.
+  commit_path_only "$rel" "restore notes an old machinery relocation deleted from $rel" \
+    || { err "  · $rel: could not save the restored notes"; return 1; }
+  say "  · saved the restored notes to your history"
+  return 0
+}
+
+verify_one() {  # $1 rel — proves the repair at the artifact, not from its own prose
+  local rel="$1" n
+  [ -d "$VAULT/$rel" ] && [ ! -L "$VAULT/$rel" ] || { err "  · $rel is still not a real folder"; return 1; }
+  n="$(git_v -c core.quotepath=false ls-files -- "$rel" 2>/dev/null | wc -l | tr -d ' ')"
+  [ "${n:-0}" -gt 0 ] || { err "  · $rel holds no tracked notes after the repair"; return 1; }
+  say "  · $rel: $n note(s) are back in your history"
+  return 0
+}
+
+# ---- main -------------------------------------------------------------------
+detect
+report
+
+if [ "${#DAMAGED_RELS[@]}" -eq 0 ]; then
+  exit 0
+fi
+
+if [ "$REPAIR" != 1 ]; then
+  say ""
+  say "Nothing has been changed. To put the notes back, run the same command with --repair:"
+  say "  bash $(basename "$0") \"$VAULT\" --repair"
+  exit 10
+fi
+
+say ""
+say "Putting your notes back ..."
+FAILED=0
+for i in "${!DAMAGED_RELS[@]}"; do
+  repair_one "${DAMAGED_RELS[$i]}" "${DAMAGED_COMMITS[$i]}" "${DAMAGED_TARGETS[$i]}" \
+           "${DAMAGED_LISTS[$i]}" \
+    || { FAILED=$((FAILED + 1)); continue; }
+  verify_one "${DAMAGED_RELS[$i]}" || FAILED=$((FAILED + 1))
+done
+
+say ""
+if [ "$FAILED" -gt 0 ]; then
+  err "$FAILED folder(s) could not be repaired — see the messages above. Nothing was deleted."
+  exit 1
+fi
+say "Done. Your notes are back, and they are saved in your history again."
+say "Your other computers get them back the next time this vault syncs."
+exit 0

--- a/scripts/test-repair-sidecar-note-deletion.sh
+++ b/scripts/test-repair-sidecar-note-deletion.sh
@@ -268,6 +268,60 @@ out="$(PATH="$ROOT/bin:$PATH" bash "$SUT" "$VN" 2>&1)"; rc=$?
 [ "$rc" = "0" ] && pass "'not a repository' is an ANSWER and reads as clean (exit 0)" \
                 || fail "'not a repository' exited $rc, expected 0: $out"
 
+# =============================================================================
+echo "--- 6. the doorbell: the affected user is TOLD, unprompted -----------------"
+# This population is non-technical by definition. A repair nobody is told about
+# repairs nobody, so the SessionStart hook has to name it without being asked.
+HOOK="$(cd "$HERE/.." && pwd)/hooks/worktree-footprint-signal.py"
+HSCRATCH="$ROOT/hookscratch"; mkdir -p "$HSCRATCH/empty-dev"
+
+hook_ctx() {  # $1 = cwd
+  ( cd "$1" && env WORKTREE_FREE_GB=0 WORKTREE_WARN=9999 \
+      ABS_DEV_ROOT="$HSCRATCH/empty-dev" \
+      WORKTREE_FOOTPRINT_CACHE="$HSCRATCH/bloat-cache.json" \
+      WORKTREE_FOOTPRINT_FILE_WARN=999999999 \
+      OBSIDIAN_CONFIG="$ROOT/no-such-obsidian.json" \
+      python3 "$HOOK" </dev/null ) | python3 -c 'import json,sys
+try:
+    d = json.load(sys.stdin)
+except (ValueError, OSError):
+    print(""); sys.exit(0)
+print(d.get("additionalContext", "") if isinstance(d, dict) else "")'
+}
+
+VD="$ROOT/doorbell"; SD="$ROOT/sided"
+make_vault "$VD" 3; : > "$VD/CLAUDE.md"
+gitq "$VD" add CLAUDE.md; gitq "$VD" commit -m claude
+ctx="$(hook_ctx "$VD")"
+case "$ctx" in *"notes-deleted"*) fail "fired on a healthy vault";;
+               *) pass "healthy vault: the alert stays quiet";; esac
+
+old_style_relocate "$VD" "$SESS" "$SD"
+auto_snapshot "$VD"
+ctx="$(hook_ctx "$VD")"
+case "$ctx" in *"notes-deleted"*) pass "damaged vault: the alert fires unprompted";;
+               *) fail "the alert did not fire on a damaged vault: ${ctx:0:160}";; esac
+case "$ctx" in *"repair-sidecar-note-deletion.sh"*) pass "names the repair command";;
+               *) fail "did not name the repair command";; esac
+case "$ctx" in *"--repair"*) pass "names the step that actually puts them back";;
+               *) fail "did not name --repair";; esac
+
+# and it goes quiet once the repair has run — a permanent alarm is wallpaper
+bash "$SUT" "$VD" --sidecar "$SD" --repair >/dev/null 2>&1
+ctx="$(hook_ctx "$VD")"
+case "$ctx" in *"notes-deleted"*) fail "still firing after the repair";;
+               *) pass "goes quiet once the notes are back";; esac
+
+# a correctly relocated CACHE must never ring it
+VDC="$ROOT/doorbell-cache"; SDC="$ROOT/sidedc"
+make_vault "$VDC" 3; : > "$VDC/CLAUDE.md"
+gitq "$VDC" add CLAUDE.md; gitq "$VDC" commit -m claude
+old_style_relocate "$VDC" ".smart-env" "$SDC"
+auto_snapshot "$VDC"
+ctx="$(hook_ctx "$VDC")"
+case "$ctx" in *"notes-deleted"*) fail "rang on an ordinary cache relocation";;
+               *) pass "an ordinary cache relocation does not ring it";; esac
+
 echo
 if [ "$fails" -eq 0 ]; then echo "ALL PASS"; exit 0; fi
 echo "$fails FAILING"; exit 1

--- a/scripts/test-repair-sidecar-note-deletion.sh
+++ b/scripts/test-repair-sidecar-note-deletion.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+# Fixture test for scripts/repair-sidecar-note-deletion.sh.
+#
+# It reproduces the WHOLE incident chain end to end, because every earlier
+# safeguard passed on this bug and only the finished chain shows it:
+#
+#   1. a real vault whose "⚙️ Meta/Sessions" notes are TRACKED
+#   2. the OLD relocation behaviour: move the folder to a sidecar, leave a symlink
+#      (modelled directly — the current script correctly refuses to do this, and a
+#      test that could only run through the fixed script could never build the
+#      damaged state it has to repair)
+#   3. the hourly auto-snapshot: `git add -A` + commit  → the deletion is now history
+#   4. the multi-machine sync: `git push`               → the other computers have it
+#   5. the repair
+#
+# NEGATIVE CONTROLS — the fingerprint has to DISCRIMINATE, or "found nothing" is
+# worth nothing. Four vaults that must stay silent:
+#   · a healthy vault
+#   · a correctly relocated CACHE (untracked, no deletion in history) — the thing
+#     the current script does on purpose, every day
+#   · a person deleting a notes folder by hand and committing it
+#   · a look-only run: it must change nothing at all
+#
+# Plus the case nobody thinks of until it eats data: the copy in the sidecar is
+# NEWER than the copy in history. The repair must keep the newer one.
+#
+# Run: bash scripts/test-repair-sidecar-note-deletion.sh
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SUT="$HERE/repair-sidecar-note-deletion.sh"
+ROOT="$(mktemp -d)"
+trap 'rm -rf "$ROOT"' EXIT
+fails=0
+pass() { echo "PASS  $1"; }
+fail() { echo "FAIL  $1"; fails=$((fails+1)); }
+
+gitq() { git -C "$1" "${@:2}" >/dev/null 2>&1; }
+
+SESS="⚙️ Meta/Sessions"
+
+# A vault the way a real one looks: notes under "⚙️ Meta/Sessions" are TRACKED,
+# machinery caches are not.
+make_vault() {  # $1 = vault dir, $2 = number of session notes
+  local v="$1" n="${2:-4}" i
+  mkdir -p "$v/$SESS" "$v/.smart-env"
+  gitq "$v" init -b main
+  gitq "$v" config user.email "t@t.test"
+  gitq "$v" config user.name  "Test"
+  gitq "$v" config commit.gpgsign false
+  printf 'a note\n' > "$v/note.md"
+  for i in $(seq 1 "$n"); do printf 'session %s body\n' "$i" > "$v/$SESS/2026-08-0$i-work.md"; done
+  printf 'cache bytes\n' > "$v/.smart-env/index.bin"
+  gitq "$v" add note.md "$SESS"
+  gitq "$v" commit -m init
+}
+
+# Exactly what the OLD script did: move the folder out, leave a symlink behind,
+# and write the move to the sidecar journal. No index test — that omission IS the
+# bug being repaired. The journal is written for real (same schema, same per-vault
+# slug) so the repair's record-reading path is exercised rather than assumed.
+sidecar_slug() {  # $1 = vault (already absolute)
+  local base slug hash
+  base="$(basename "$1")"
+  slug="$(printf '%s' "$base" | tr -c 'A-Za-z0-9._-' '-' | sed 's/-\{2,\}/-/g; s/^-//; s/-$//')"
+  hash="$(printf '%s' "$1" | (shasum 2>/dev/null || sha1sum) | cut -c1-8)"
+  printf '%s-%s\n' "${slug:-vault}" "$hash"
+}
+
+journal_move() {  # $1 = journal file, $2 = rel, $3 = absolute target
+  J="$1" REL="$2" TGT="$3" python3 -c 'import json, os
+rec = {"type": "cache", "vault_rel": os.environ["REL"],
+       "target": os.path.realpath(os.environ["TGT"]), "mode": "sidecar"}
+with open(os.environ["J"], "a", encoding="utf-8") as f:
+    f.write(json.dumps(rec, ensure_ascii=False) + "\n")'
+}
+
+old_style_relocate() {  # $1 = vault, $2 = rel, $3 = sidecar root
+  local v="$1" rel="$2" side="$3" vabs slug
+  vabs="$(cd "$v" && pwd -P)"
+  slug="$(sidecar_slug "$vabs")"
+  mkdir -p "$side/$(dirname "$rel")" "$side/manifests"
+  mv "$v/$rel" "$side/$rel"
+  ln -s "$side/$rel" "$v/$rel"
+  journal_move "$side/manifests/$slug.journal.jsonl" "$rel" "$side/$rel"
+}
+
+# The hourly auto-snapshot. `git add -A` is the real thing, verbatim.
+auto_snapshot() { gitq "$1" add -A; gitq "$1" commit -m "auto-snapshot"; }
+
+tracked_under() { git -C "$1" ls-files -- "$2" 2>/dev/null | wc -l | tr -d ' '; }
+files_on_disk()  { find "$1/$2" -type f 2>/dev/null | wc -l | tr -d ' '; }
+
+# =============================================================================
+echo "--- 1. full chain: relocate → auto-commit → push → repair -----------------"
+V1="$ROOT/v1"; S1="$ROOT/side1"; R1="$ROOT/remote1.git"
+make_vault "$V1" 4
+git init --bare -q "$R1"
+gitq "$V1" remote add origin "$R1"
+gitq "$V1" push -u origin main
+
+BEFORE_TRACKED="$(tracked_under "$V1" "$SESS")"
+old_style_relocate "$V1" "$SESS" "$S1"
+auto_snapshot "$V1"
+gitq "$V1" push origin main                       # the loss reaches the other machines
+AFTER_TRACKED="$(tracked_under "$V1" "$SESS")"
+
+[ "$BEFORE_TRACKED" = "4" ] && [ "$AFTER_TRACKED" = "1" ] \
+  && pass "fixture really destroyed the notes (4 tracked → 1, the symlink)" \
+  || fail "fixture did not reproduce the damage (before=$BEFORE_TRACKED after=$AFTER_TRACKED)"
+
+out="$(bash "$SUT" "$V1" --sidecar "$S1" 2>&1)"; rc=$?
+[ "$rc" = "10" ] && pass "look-only exits 10 when damage is found" \
+                 || fail "look-only exit was $rc, expected 10"
+case "$out" in *"4 note(s) were removed"*) pass "names the right number of notes";;
+               *) fail "did not name 4 notes: $out";; esac
+case "$out" in *"other computers already received this"*) pass "says the loss already spread";;
+               *) fail "did not report that the deletion was pushed";; esac
+case "$out" in *"$S1"*) pass "points at where the notes still are";;
+               *) fail "did not name the sidecar location";; esac
+
+# look-only must change NOTHING
+HEAD_BEFORE="$(git -C "$V1" rev-parse HEAD)"
+STAT_BEFORE="$(git -C "$V1" status --porcelain)"
+bash "$SUT" "$V1" --sidecar "$S1" >/dev/null 2>&1
+[ "$HEAD_BEFORE" = "$(git -C "$V1" rev-parse HEAD)" ] && [ "$STAT_BEFORE" = "$(git -C "$V1" status --porcelain)" ] \
+  && pass "look-only changed nothing" || fail "look-only modified the vault"
+
+out="$(bash "$SUT" "$V1" --sidecar "$S1" --repair 2>&1)"; rc=$?
+[ "$rc" = "0" ] && pass "--repair exits 0" || fail "--repair exit was $rc: $out"
+
+[ -d "$V1/$SESS" ] && [ ! -L "$V1/$SESS" ] && pass "the folder is a real folder again" \
+  || fail "the folder is still a symlink"
+[ "$(tracked_under "$V1" "$SESS")" = "4" ] && pass "all 4 notes are tracked again" \
+  || fail "tracked after repair = $(tracked_under "$V1" "$SESS"), expected 4"
+[ "$(files_on_disk "$V1" "$SESS")" = "4" ] && pass "all 4 notes are back on disk" \
+  || fail "on disk after repair = $(files_on_disk "$V1" "$SESS")"
+grep -q 'session 3 body' "$V1/$SESS/2026-08-03-work.md" 2>/dev/null \
+  && pass "note contents survived intact" || fail "note contents wrong after repair"
+[ "$(git -C "$V1" ls-files -s -- "$SESS" | awk '$1=="120000"' | wc -l | tr -d ' ')" = "0" ] \
+  && pass "the symlink is gone from the saved history" || fail "a symlink is still tracked"
+git -C "$V1" status --porcelain -- "$SESS" | grep -q . \
+  && fail "the folder is not clean after the repair" || pass "the folder is clean after the repair"
+
+# the fix travels the same road the loss did
+gitq "$V1" push origin main && pass "the repair pushes to the other computers" \
+  || fail "could not push the repair"
+[ "$(git -C "$R1" ls-tree -r --name-only main | grep -c "Sessions/")" = "4" ] \
+  && pass "the remote has all 4 notes back" \
+  || fail "remote has $(git -C "$R1" ls-tree -r --name-only main | grep -c 'Sessions/') notes"
+
+# re-running is a no-op, not a second commit
+H="$(git -C "$V1" rev-parse HEAD)"
+bash "$SUT" "$V1" --sidecar "$S1" >/dev/null 2>&1; rc=$?
+[ "$rc" = "0" ] && [ "$H" = "$(git -C "$V1" rev-parse HEAD)" ] \
+  && pass "a repaired vault reports clean and is left alone" || fail "not idempotent (rc=$rc)"
+
+# =============================================================================
+echo "--- 2. the SECOND computer: only ever pulled the deletion ------------------"
+# It never ran the relocation, has no sidecar, and the link dangles. The notes
+# have to come back out of history alone.
+V2="$ROOT/v2"; S2="$ROOT/side2"; R2="$ROOT/remote2.git"
+VX="$ROOT/vx"
+make_vault "$VX" 3
+git init --bare -q "$R2"
+gitq "$VX" remote add origin "$R2"; gitq "$VX" push -u origin main
+old_style_relocate "$VX" "$SESS" "$ROOT/sidex"
+auto_snapshot "$VX"; gitq "$VX" push origin main
+# the second computer never had the sidecar — that is the whole point of this case
+rm -rf "$ROOT/sidex"
+
+git clone -q "$R2" "$V2"
+gitq "$V2" config user.email "t@t.test"; gitq "$V2" config user.name "Test"
+gitq "$V2" config commit.gpgsign false
+
+[ -L "$V2/$SESS" ] && [ ! -e "$V2/$SESS" ] \
+  && pass "second computer has a dangling link where its notes were" \
+  || fail "second computer fixture is not the dangling-link state"
+
+out="$(bash "$SUT" "$V2" --sidecar "$S2" 2>&1)"; rc=$?
+[ "$rc" = "10" ] && pass "detected on a machine with no sidecar at all" \
+                 || fail "second-computer detection exit was $rc: $out"
+bash "$SUT" "$V2" --sidecar "$S2" --repair >/dev/null 2>&1; rc=$?
+[ "$rc" = "0" ] && [ "$(tracked_under "$V2" "$SESS")" = "3" ] && [ "$(files_on_disk "$V2" "$SESS")" = "3" ] \
+  && pass "second computer restored all 3 notes from history alone" \
+  || fail "second-computer repair failed (rc=$rc tracked=$(tracked_under "$V2" "$SESS"))"
+
+# =============================================================================
+echo "--- 3. the live copy is NEWER than the copy in history ---------------------"
+V3="$ROOT/v3"; S3="$ROOT/side3"
+make_vault "$V3" 3
+old_style_relocate "$V3" "$SESS" "$S3"
+auto_snapshot "$V3"
+# sessions kept being written after the relocation — straight into the sidecar
+printf 'EDITED AFTER THE MOVE\n' > "$S3/$SESS/2026-08-02-work.md"
+printf 'brand new session\n'     > "$S3/$SESS/2026-08-09-new.md"
+bash "$SUT" "$V3" --sidecar "$S3" --repair >/dev/null 2>&1
+grep -q 'EDITED AFTER THE MOVE' "$V3/$SESS/2026-08-02-work.md" 2>/dev/null \
+  && pass "the newer edit won over the older copy in history" \
+  || fail "the repair clobbered a newer note with an older one"
+[ -f "$V3/$SESS/2026-08-09-new.md" ] && [ "$(tracked_under "$V3" "$SESS")" = "4" ] \
+  && pass "a session written after the move was kept and saved" \
+  || fail "a post-move session was lost (tracked=$(tracked_under "$V3" "$SESS"))"
+
+# =============================================================================
+echo "--- 4. it refuses rather than overwrite ------------------------------------"
+V4="$ROOT/v4"; S4="$ROOT/side4"
+make_vault "$V4" 2
+old_style_relocate "$V4" "$SESS" "$S4"
+auto_snapshot "$V4"
+rm "$V4/$SESS"                      # link gone, but the sidecar copy is still there
+mkdir -p "$V4/$SESS"; printf 'someone put something here\n' > "$V4/$SESS/manual.md"
+out="$(bash "$SUT" "$V4" --sidecar "$S4" --repair 2>&1)"; rc=$?
+[ "$rc" = "1" ] && pass "refuses when a real folder AND a saved copy both exist" \
+                || fail "did not refuse the two-copies case (rc=$rc)"
+[ -f "$V4/$SESS/manual.md" ] && [ -d "$S4/$SESS" ] \
+  && pass "refusing destroyed neither copy" || fail "the refusal lost data"
+
+# =============================================================================
+echo "--- 5. NEGATIVE CONTROLS: it must stay silent ------------------------------"
+VN="$ROOT/healthy"; make_vault "$VN" 3
+out="$(bash "$SUT" "$VN" --sidecar "$ROOT/nosidecar" 2>&1)"; rc=$?
+[ "$rc" = "0" ] && pass "healthy vault: silent, exit 0" || fail "healthy vault flagged (rc=$rc): $out"
+
+# the correct, everyday relocation of a genuine untracked cache
+VC="$ROOT/cacheok"; SC="$ROOT/sidec"; make_vault "$VC" 3
+old_style_relocate "$VC" ".smart-env" "$SC"
+auto_snapshot "$VC"
+out="$(bash "$SUT" "$VC" --sidecar "$SC" 2>&1)"; rc=$?
+[ "$rc" = "0" ] && pass "a correctly relocated cache is NOT flagged" \
+                || fail "flagged an untracked cache relocation (rc=$rc): $out"
+
+# a person deleting a notes folder on purpose
+VH="$ROOT/byhand"; make_vault "$VH" 3
+rm -rf "$VH/$SESS"; auto_snapshot "$VH"
+out="$(bash "$SUT" "$VH" --sidecar "$ROOT/nosidecar" 2>&1)"; rc=$?
+[ "$rc" = "0" ] && pass "a deliberate deletion by hand is NOT flagged" \
+                || fail "flagged a hand deletion (rc=$rc): $out"
+
+# a folder that is not a git repo at all
+VP="$ROOT/plain"; mkdir -p "$VP"
+out="$(bash "$SUT" "$VP" 2>&1)"; rc=$?
+[ "$rc" = "0" ] && pass "a non-git folder is reported clean, not crashed" || fail "non-git exit $rc"
+
+# git answers with an ERROR — "could not look" must never read as "nothing there".
+# A corrupt .git is NOT this case: git calls that "not a git repository", which is
+# a real answer. The case that matters is git failing to answer at all.
+mkdir -p "$ROOT/bin"
+cat > "$ROOT/bin/git" <<'SHIM'
+#!/bin/sh
+echo "fatal: unable to read the index file" >&2
+exit 128
+SHIM
+chmod +x "$ROOT/bin/git"
+out="$(PATH="$ROOT/bin:$PATH" bash "$SUT" "$VN" 2>&1)"; rc=$?
+[ "$rc" = "1" ] && pass "a git that cannot answer fails closed (exit 1), never 'clean'" \
+                || fail "unreadable vault exited $rc, expected 1: $out"
+
+# ...and the OTHER arm of the same shim, so the fail-closed test above is proven
+# to discriminate rather than just always exiting 1: git answering "this is not a
+# repository" IS an answer, and must read as clean.
+cat > "$ROOT/bin/git" <<'SHIM'
+#!/bin/sh
+echo "fatal: not a git repository (or any of the parent directories): .git" >&2
+exit 128
+SHIM
+chmod +x "$ROOT/bin/git"
+out="$(PATH="$ROOT/bin:$PATH" bash "$SUT" "$VN" 2>&1)"; rc=$?
+[ "$rc" = "0" ] && pass "'not a repository' is an ANSWER and reads as clean (exit 0)" \
+                || fail "'not a repository' exited $rc, expected 0: $out"
+
+echo
+if [ "$fails" -eq 0 ]; then echo "ALL PASS"; exit 0; fi
+echo "$fails FAILING"; exit 1

--- a/scripts/test-repair-sidecar-note-deletion.sh
+++ b/scripts/test-repair-sidecar-note-deletion.sh
@@ -94,7 +94,7 @@ files_on_disk()  { find "$1/$2" -type f 2>/dev/null | wc -l | tr -d ' '; }
 echo "--- 1. full chain: relocate → auto-commit → push → repair -----------------"
 V1="$ROOT/v1"; S1="$ROOT/side1"; R1="$ROOT/remote1.git"
 make_vault "$V1" 4
-git init --bare -q "$R1"
+git init --bare -q -b main "$R1"
 gitq "$V1" remote add origin "$R1"
 gitq "$V1" push -u origin main
 
@@ -161,14 +161,16 @@ echo "--- 2. the SECOND computer: only ever pulled the deletion ----------------
 V2="$ROOT/v2"; S2="$ROOT/side2"; R2="$ROOT/remote2.git"
 VX="$ROOT/vx"
 make_vault "$VX" 3
-git init --bare -q "$R2"
+git init --bare -q -b main "$R2"
 gitq "$VX" remote add origin "$R2"; gitq "$VX" push -u origin main
 old_style_relocate "$VX" "$SESS" "$ROOT/sidex"
 auto_snapshot "$VX"; gitq "$VX" push origin main
 # the second computer never had the sidecar — that is the whole point of this case
-rm -rf "$ROOT/sidex"
+rm -rf "${ROOT:?}/sidex"
 
 git clone -q "$R2" "$V2"
+[ -f "$V2/note.md" ] && pass "second-computer clone actually checked out a tree" \
+  || fail "second-computer clone produced no checkout — everything below would test nothing"
 gitq "$V2" config user.email "t@t.test"; gitq "$V2" config user.name "Test"
 gitq "$V2" config commit.gpgsign false
 
@@ -231,7 +233,7 @@ out="$(bash "$SUT" "$VC" --sidecar "$SC" 2>&1)"; rc=$?
 
 # a person deleting a notes folder on purpose
 VH="$ROOT/byhand"; make_vault "$VH" 3
-rm -rf "$VH/$SESS"; auto_snapshot "$VH"
+rm -rf "${VH:?}/$SESS"; auto_snapshot "$VH"
 out="$(bash "$SUT" "$VH" --sidecar "$ROOT/nosidecar" 2>&1)"; rc=$?
 [ "$rc" = "0" ] && pass "a deliberate deletion by hand is NOT flagged" \
                 || fail "flagged a hand deletion (rc=$rc): $out"

--- a/tests/integration/test_repair_sidecar_note_deletion.sh
+++ b/tests/integration/test_repair_sidecar_note_deletion.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# CI integration wrapper — runs the repair-path fixture
+# (scripts/test-repair-sidecar-note-deletion.sh) as part of `scripts/ci.sh`.
+# Kept thin so the test logic has ONE home next to the script it exercises.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+exec bash "$ROOT/scripts/test-repair-sidecar-note-deletion.sh"


### PR DESCRIPTION
Closes MYC-4010.

PR #545 stopped the destruction and made `--rollback` restore the folder. It does not help the user whose deletion was already **committed** by the hourly auto-snapshot and **pushed** to their other machines: rollback fixes the working tree, the history still says the notes are gone, and every other machine already pulled that. That user has no path at all today, and nothing detects them.

### The fingerprint

A folder is reported only when **both** halves hold:

1. a commit deleted tracked files under that path, and
2. that path is a symlink out of the vault — live, or recorded as a symlink by that same commit.

One half alone is just someone deleting notes. The pair is a machine. Half two is also what makes this work on a machine that only ever **pulled** the deletion and has no sidecar at all, which is the population `--rollback` cannot reach.

### The repair

- Live copies still in the sidecar win over the older ones in history, so sessions written after the move are not clobbered.
- Anything still missing is restored from the commit before the deletion.
- Two conflicting copies are reported and refused, never merged.
- The index is restored through git rather than `git add`, because `git add` obeys `.gitignore` and a stray rule would leave the notes out of history again while looking repaired.
- The commit is assembled from a private index rather than `git commit --only`, which cannot survive the symlink-to-directory type change at that path, and which would otherwise sweep in whatever the auto-snapshot had staged mid-flight.
- It never pushes. The next sync carries the repair outward the same way the loss travelled.

### Reachability

This population is non-technical by definition, so a repair nobody is told about repairs nobody. The SessionStart hook that already enumerates brain vaults now rings when one carries a **tracked symlink** at a machinery notes path — one bounded `git ls-files`, an index lookup, no history walk, so SessionStart stays bounded and `audit-sessionstart-boundedness.py` stays green. It is a doorbell, not a diagnosis: which commit, how many notes, and whether it was pushed cost a full `git log` and stay in the script.

### Proof

`scripts/test-repair-sidecar-note-deletion.sh`, wired into `scripts/ci.sh`, 33 assertions. It reproduces the whole chain — relocate the old way, auto-snapshot the deletion, push it, repair, push the repair — and asserts the remote gets the notes back.

Negative controls, because "found nothing" is worth nothing without them: a healthy vault, a correctly relocated untracked cache, a deliberate deletion by hand, a look-only run that must change nothing, a second machine with no sidecar, a newer-copy-in-the-sidecar case, and both arms of the git probe (a git that cannot answer exits 1; a git that answers "not a repository" reads as clean).

### Deliberately not in scope

No PowerShell twin. On Windows the repair runs from Git Bash, which ships with Git for Windows; native `.ps1` parity is the same shape as MYC-2383 was for the sidecar itself, and is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
