### PR TITLE
fix(meeting): fire on five phrasings people actually type, and stay silent on not-done-yet

### DIFF
--- a/hooks/inject-meeting-workflow-on-trigger.py
+++ b/hooks/inject-meeting-workflow-on-trigger.py
@@ -41,6 +41,18 @@ import json
 import os
 import re
 import sys
+
+# Windows consoles default to cp1252; this file carries non-ASCII (the "⚙️ Meta"
+# rule path it echoes back, em-dashes in the injected header), and an
+# unreconfigured stream raises UnicodeEncodeError mid-write
+# (ai-brain-starter#313). json.dumps escapes the stdout payload, but a
+# traceback or any stderr write of the resolved rule path does not.
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+    except (AttributeError, ValueError):
+        pass
+
 import unicodedata
 from typing import Optional
 
@@ -88,26 +100,50 @@ DET_EN = r"a|an|the|my|our|your|today'?s|that|this|some|another"
 DET_ES = r"una|la|mi|nuestra|el|este|esa|esta|nuestro|otro|otra"
 MOD = r"(?:[\w\-]+\s+){0,3}"  # 0-3 hyphen-aware adjective tokens
 
+# Adverbs allowed between "is/was" and "done/over/finished". This is an
+# ALLOW-list on purpose: a permissive `(?:\w+\s+){0,2}` slot admits NEGATION
+# and hedges — "the meeting is not done yet", "the call is almost over",
+# "is never over" — each of which fired the full cascade on a meeting that
+# had NOT ended. Denylisting negations loses against an open set (not / never
+# / almost / nearly / hardly / barely / n't / far from / nowhere near ...);
+# enumerating the affirmative adverbs is bounded and cannot silently widen.
+ADV_DONE = r"(?:finally|officially|now|all|totally|completely|basically|actually|thankfully|mercifully|already|just)"
+
+# Core meeting nouns — the unambiguous subset. Used ONLY by the bare
+# "finished|ended <det> <noun>" trigger, which carries no "just" anchor and so
+# would otherwise fire on ordinary work talk ("finished the review of the
+# contract", "ended the session"). The ambiguous nouns from NOUN_EN
+# (review, session, chat, conversation, catch-up, check-in, alignment) are
+# deliberately absent here; they still fire through every anchored pattern.
+NOUN_EN_CORE = (
+    r"meeting(?:s)?|call(?:s)?|sync(?:s)?|standup(?:s)?|stand-?up(?:s)?|"
+    r"1[:\- ]on[:\- ]1|1[:\- ]1|one[:\- ]?on[:\- ]?one|"
+    r"interview(?:s)?|huddle(?:s)?|kickoff(?:s)?|kick[\-\s]?off(?:s)?|"
+    r"retro(?:s)?|retrospective(?:s)?|briefing(?:s)?|workshop(?:s)?|"
+    r"offsite(?:s)?|demo(?:s)?|all-?hands"
+)
+
 TRIGGERS_EN = [
     # "I just <verb> <det> [adj×0-3] <noun>" — the standard form.
-    rf"\bi\s+just\s+(?:had|finished|wrapped(?:\s+up)?|got\s+out\s+of|came\s+out\s+of|ended|got\s+off)\s+"
+    rf"\bi\s+just\s+(?:had|did|finished|wrapped(?:\s+up)?|got\s+out\s+of|came\s+out\s+of|ended|got\s+off)\s+"
     rf"(?:{DET_EN})\s+{MOD}({NOUN_EN})\b",
     # "Just <verb> <det> [adj×0-3] <noun>" — terse, no "I".
-    rf"\bjust\s+(?:had|finished|wrapped(?:\s+up)?|got\s+out\s+of|came\s+out\s+of|ended|got\s+off)\s+"
+    rf"\bjust\s+(?:had|did|finished|wrapped(?:\s+up)?|got\s+out\s+of|came\s+out\s+of|ended|got\s+off)\s+"
     rf"(?:{DET_EN})\s+{MOD}({NOUN_EN})\b",
     # "<det> [adj×0-3] <noun> [with X×1-5] just (ended|wrapped|finished|is done)"
     rf"\b(?:{DET_EN})\s+{MOD}({NOUN_EN})\s+(?:with\s+(?:[\w\-]+\s+){{1,5}})?(?:just\s+)?"
-    rf"(?:ended|wrapped(?:\s+up)?|finished|is\s+done|was\s+done|is\s+over)\b",
+    rf"(?:ended|wrapped(?:\s+up)?|finished|(?:is|was)\s+(?:{ADV_DONE}\s+){{0,2}}(?:done|over|finished))\b",
     # "<noun> [with X×1-5] just (ended|wrapped|...)"  — no det, e.g. "meeting just ended"
     rf"\b({NOUN_EN})\s+(?:with\s+(?:[\w\-]+\s+){{1,5}})?(?:just\s+)?"
-    rf"(?:ended|wrapped(?:\s+up)?|is\s+done|was\s+done|is\s+over)\b",
+    rf"(?:ended|wrapped(?:\s+up)?|(?:is|was)\s+(?:{ADV_DONE}\s+){{0,2}}(?:done|over|finished))\b",
     # "[name]'s [adj×0-2] <noun> (is done|just ended|...)"
     rf"\b[\w\-]+(?:'s|s')\s+(?:[\w\-]+\s+){{0,2}}({NOUN_EN})\s+"
     rf"(?:is\s+done|just\s+ended|ended|wrapped|finished)\b",
     # "done|finished with <det> [adj×0-3] <noun>"
     rf"\b(?:done|finished)\s+with\s+(?:{DET_EN})\s+{MOD}({NOUN_EN})\b",
-    # "wrapped (up) <det> [adj×0-3] <noun>"
-    rf"\bwrapped(?:\s+up)?\s+(?:{DET_EN})\s+{MOD}({NOUN_EN})\b",
+    # "wrapped|finished|ended (up) <det> [adj×0-3] <noun>" — no "just"
+    # required; "finished a call with the client" is a completion signal.
+    rf"\b(?:wrapped(?:\s+up)?|finished|ended)\s+(?:{DET_EN})\s+{MOD}({NOUN_EN_CORE})\b",
     # "Pull|process|file|save|capture|extract [det] [adj×0-3] (notes|transcript|...)"
     # Artifact list — pull/process targeting the meeting artifact.
     rf"\b(?:pull|process|file|save|capture|extract)\s+(?:{DET_EN}|all)?\s*"
@@ -117,6 +153,15 @@ TRIGGERS_EN = [
     # → no fire). "process today's meeting" / "file the standup note" → fire.
     rf"\b(?:pull|process|file|save|capture|extract)\s+(?:{DET_EN})\s+"
     rf"{MOD}({NOUN_EN})\b",
+    # "<noun>'s done" / "the standup's over" — contracted "is". The
+    # possessive pattern above catches "[name]'s meeting is done"; this
+    # catches the 's riding on the NOUN itself, which is how people type.
+    rf"\b({NOUN_EN})(?:'s|s')\s+(?:\w+\s+){{0,2}}"
+    rf"(?:done|over|finished|ended|wrapped(?:\s+up)?)\b",
+    # "had a meeting just now" — postfix temporal anchor. Needs the literal
+    # "just now", so bare past tense ("I had a meeting last week") stays out.
+    rf"\b(?:had|did|finished|wrapped(?:\s+up)?|got\s+out\s+of)\s+"
+    rf"(?:{DET_EN})\s+{MOD}({NOUN_EN})\s+just\s+now\b",
     # "I just got off the phone (with X)" — phone-call end signal.
     r"\b(?:i\s+just\s+)?got\s+off\s+the\s+phone\b",
 ]
@@ -165,6 +210,11 @@ def matches_trigger(prompt: str) -> Optional[str]:
 def find_vault_root() -> Optional[str]:
     """Walk up from cwd looking for the canonical Current Priorities marker
     or a Meta/ folder. VAULT_ROOT env var wins if set."""
+    # vault-root-ok: read-only CONTEXT injection, never a write. The env var is
+    # honored only after isdir() confirms it, and every miss degrades through a
+    # shipped chain (vault rule -> starter template -> FALLBACK_SUMMARY), so a
+    # wrong or absent root cannot fail silently open the way a writer would --
+    # the worst case is injecting the generic cascade instead of the tuned one.
     env_root = os.environ.get("VAULT_ROOT")
     if env_root and os.path.isdir(env_root):
         return env_root

--- a/scripts/utf8-stdout-baseline.txt
+++ b/scripts/utf8-stdout-baseline.txt
@@ -111,7 +111,6 @@ b647243fdf0a358d46a6a79b0bf7f817ee121f68d5d685fabe4b0ee2a93af94d SEV-4-json-enco
 a04ec6c84be6756813f4cde517ff379338b57ec9bf4c9c4172172951e62f91c3 SEV-4-json-encoded hooks/imessage-mcp-auto-export.py
 7eea06988957bbacac62bc43c9ebcb8067cc1cadd5184375f6d60d46ee99c4cc SEV-4-json-encoded hooks/inject-best-of-best-on-consulting.py
 33804a89b8c6ac80575f93ea2a5e0f9f6e47aeb3bb6e8dab0413729fd3fc8c94 SEV-4-json-encoded hooks/inject-love-language-context.py
-439b81f59712732d566301a7a1fe2b7f4f61c8f49a48c56a2b45f69a331c3087 SEV-4-json-encoded hooks/inject-meeting-workflow-on-trigger.py
 ff65d244e721a3952150a2faf259728a64309c5855b71be54a0096972c3080a7 SEV-4-json-encoded hooks/list-wip-stashes-on-session-start.py
 adad427e89295283853dd1dfb9963e698eb45fe5c4ca3c302adce4a3d47b5b35 SEV-4-json-encoded hooks/nudge-checkpoint-after-pytest-pass.py
 056a2f7966b8c4f75a62e80be906bd899956f9871a92eb98738e262988bc8dc5 SEV-4-json-encoded hooks/reconcile-worktree-shared.py

--- a/scripts/vault-root-read-baseline.txt
+++ b/scripts/vault-root-read-baseline.txt
@@ -91,7 +91,6 @@ fd7dcaf462d1fe6a8a3d350573c2b63c896ca4089a02b7888048b70e9807b459 SEV-C-script-lo
 # ---- SEV-E-no-default  (15 file(s), 17 read(s)) ----
 85006d7e25f42ba787b2ce616bd1c71590c3990f89f3153a6f958156c93029ed SEV-E-no-default hooks/coach-auto-prescribe-on-journal.py
 33804a89b8c6ac80575f93ea2a5e0f9f6e47aeb3bb6e8dab0413729fd3fc8c94 SEV-E-no-default hooks/inject-love-language-context.py
-439b81f59712732d566301a7a1fe2b7f4f61c8f49a48c56a2b45f69a331c3087 SEV-E-no-default hooks/inject-meeting-workflow-on-trigger.py
 d11e46cfd26ba07935e39f6bd73c36095e242d4a2a5a6856d12a07f7b929195b SEV-E-no-default scripts/backfill-journal-body-context.py
 66295b6759ce0653131ffa32fcbdb4e2c467fb833fe9770f1d72948ece7df513 SEV-E-no-default scripts/extractors/_base.py
 9ceedddb923461f4c803b48b1d8349c9e54f9f6ff73e40969aeb3332206c8824 SEV-E-no-default scripts/granola_core.py

--- a/tests/integration/test_meeting_workflow_trigger_hook.sh
+++ b/tests/integration/test_meeting_workflow_trigger_hook.sh
@@ -104,6 +104,15 @@ EN_POSITIVE=(
     # Artifact pulls + capture verbs
     "extract action items from the sync"
     "capture the to-dos from the meeting"
+    # Natural phrasings that silently missed before (measured against a
+    # 36-phrase probe of how people actually type this). Each maps to one
+    # trigger added in the same change:
+    "meeting's done"                      # contracted "is" riding on the noun
+    "the standup's over"                  # same, different noun
+    "that meeting is finally over"        # affirmative adverb between is/over
+    "had a meeting just now"              # postfix "just now" temporal anchor
+    "just did a call with the client"     # "did" as a completion verb
+    "finished a call with the client"     # bare finished + core meeting noun
 )
 for p in "${EN_POSITIVE[@]}"; do
     out=$(run_hook "$p")
@@ -189,6 +198,21 @@ NEGATIVE=(
     "process this CSV file"
     "I just had lunch"
     "I just had coffee"
+    # Negation + hedges around the completion verb. These read as "done"
+    # lexically but mean the meeting is STILL RUNNING. Guards ADV_DONE being
+    # an allow-list; a permissive adverb slot fires the cascade on all of them.
+    "the meeting is not done yet"
+    "the call is not over"
+    "my meeting isn't done"
+    "the meeting is almost over"
+    "the call is nearly finished"
+    "the meeting is never over"
+    "is the meeting done?"
+    "is the call over yet?"
+    # Bare finished/ended + an AMBIGUOUS noun is ordinary work talk, not a
+    # meeting signal. Guards NOUN_EN_CORE excluding review/session/chat.
+    "finished the review of the contract"
+    "ended the session early"
     "saca un café"
     "trae el café"
 )


### PR DESCRIPTION
## Why

The meeting cascade only runs if the trigger regex matches, so the regex *is* the product surface. I probed it with 36 phrasings of how people actually signal a meeting just ended. **7 silently missed** — the user types the thing, nothing happens, and there is no error to notice.

## What fires now that didn't

Each has a regression case that **fails against the pre-fix hook** (verified by reverting the hook and re-running the suite):

| Phrase | Why it missed |
|---|---|
| `meeting's done` / `the standup's over` | the possessive pattern only caught `[name]'s meeting is done`, never the `'s` on the noun itself |
| `that meeting is finally over` | no adverb was allowed between `is` and `over` |
| `had a meeting just now` | no postfix temporal anchor |
| `just did a call with the client` | `did` wasn't a completion verb |
| `finished a call with the client` | bare `finished`/`ended` needed a `just` |

**Deliberately not added:** `I just spoke with the client` / `just talked to the client`. Both are real meeting-end signals, but neither carries a meeting noun — matching them also matches *"I just talked to my mom."* A miss costs one retype; a false fire sends Claude hunting for a transcript that does not exist.

## The bug my own first cut introduced

The adverb slot started as a permissive `(?:\w+\s+){0,2}`. That admitted **negation**:

```
"the meeting is not done yet"   -> FIRED the full cascade
"the call is almost over"       -> FIRED
"the meeting is never over"     -> FIRED
```

Firing the post-meeting cascade on a meeting still in progress is worse than the miss I was fixing. Replaced with `ADV_DONE`, an allow-list of affirmative adverbs — denylisting negations loses against an open set (`not`/`never`/`almost`/`nearly`/`hardly`/`barely`/`n't`/`far from`/...). Same reasoning narrowed the bare `finished|ended` trigger to `NOUN_EN_CORE`, so `finished the review of the contract` stays ordinary work talk. **Ten negative cases** added to lock both.

## Cross-platform — measured, not assumed

- **Windows wiring:** `platformize_template_for_windows()` routes **60/60** hooks (this one included) through `hook_runner.py`; **0** commands carry POSIX shell syntax (`||`, `2>/dev/null`, `[ -f ]`) that PowerShell 5.1 cannot parse.
- **Output parity:** the hook's stdout is **byte-identical** via the POSIX form and the Windows `hook_runner` form — 507 bytes, valid JSON, pure ASCII, vault rule body present.
- **cp1252 guard added.** The file carries non-ASCII (the `Meta` rule path it echoes back). `json.dumps` escapes the stdout payload, but a traceback or stderr write of that path does not, and an unreconfigured stream raises `UnicodeEncodeError` mid-write on a Windows console.

## Baseline rows: deleted, not re-pinned

Editing a hash-pinned file makes its row stale by design. The ratchet's own rule is to **delete** rather than re-pin, since re-pinning converts a backlog into a permanent exemption.

- `utf8-stdout-baseline.txt` — row deleted, no replacement needed (the file is guarded now).
- `vault-root-read-baseline.txt` — row replaced by an inline `# vault-root-ok:` reason a reviewer can actually check: this hook only **reads** a rule to inject as context, honors `VAULT_ROOT` only after `isdir()` confirms it, and degrades through a shipped fallback chain (vault rule → starter template → `FALLBACK_SUMMARY`) rather than failing open the way a writer would.

## Gate

`bash scripts/ci.sh` → **EXIT=0** — 119 integration tests (incl. all four meeting suites), shellcheck, utf8 console guard, vault-root reads, hook block-protocol, py3.9 parity.

## Note for the second merger

No conflict with #533 (it edits the `SEV-C-script-loc` section; this edits `SEV-E-no-default`), confirmed via `git merge-tree`. Pre-existing stale section-header counts in both baselines were left alone deliberately — #533 is editing one of those very lines, and correcting them here would manufacture a conflict for a cosmetic fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
