### PR TITLE
fix(ci): the .ps1 BOM rule was CI-only, so every miss cost a full round-trip

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -85,18 +85,20 @@ jobs:
           done < <(find . \( -name 'hooks.json' -o -name '*.mcp.json' \) -not -path './.git/*')
           exit $fail
 
+      # The rule lives in scripts/check-ps1-bom.sh, NOT inline here, so this
+      # enforcing gate and the locally-runnable one (scripts/ci.sh, which the
+      # pre-push hook requires) cannot drift. As an inline loop this check was
+      # unreachable locally: a BOM-less .ps1 passed a full green
+      # `bash scripts/ci.sh` and failed only after a push, costing a whole CI
+      # round-trip each time (measured 2026-08-19 on
+      # tests/integration/test_bootstrap_ps1_slash_commands.ps1).
+      # scripts/test_ps1_bom_gate.py fails if either caller stops delegating or
+      # if anyone re-inlines a private copy of the byte comparison.
+      - name: BOM negative controls (the guard must still bite)
+        run: bash scripts/check-ps1-bom.sh --self-test
+
       - name: UTF-8 BOM on .ps1 (Windows PS 5.1 fix)
-        run: |
-          set -e
-          fail=0
-          while IFS= read -r f; do
-            head=$(head -c 3 "$f" | od -An -tx1 | tr -d ' \n')
-            if [ "$head" != "efbbbf" ]; then
-              echo "::error file=$f::missing UTF-8 BOM (Windows PowerShell 5.1 will crash on non-ASCII bytes). Fix: prepend the bytes EF BB BF to the file."
-              fail=1
-            fi
-          done < <(find . -name '*.ps1' -not -path './.git/*')
-          exit $fail
+        run: bash scripts/check-ps1-bom.sh
 
       # Em dashes in bash are stylistic. Em dashes in .ps1 are technical: they were the
       # exact byte that crashed the Windows PowerShell 5.1 parser before the BOM fix.

--- a/scripts/check-ps1-bom.sh
+++ b/scripts/check-ps1-bom.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+#
+# scripts/check-ps1-bom.sh - every *.ps1 must begin with a UTF-8 BOM (EF BB BF).
+#
+# Why this is correctness, not style. Windows PowerShell 5.1 - the version that
+# ships with every Windows 10/11 box, and the one bootstrap.ps1 actually runs
+# under - does not assume UTF-8. Without a BOM it reads a .ps1 as the console's
+# ANSI code page (cp1252 on a US box, cp1251 on a Russian one), so the first
+# non-ASCII byte decodes wrong and the parser dies on a file that is valid UTF-8
+# everywhere else. The BOM is how 5.1 is told the encoding.
+#
+# ONE implementation, TWO callers, so the rule cannot drift between them:
+#
+#   1. .github/workflows/lint.yml - the ENFORCING gate. A red here blocks merge.
+#   2. scripts/ci.sh              - the locally-runnable pre-push gate, for fast
+#      feedback. Before this script existed the rule lived ONLY as an inline
+#      loop in lint.yml, so a BOM-less .ps1 passed a full green local
+#      `bash scripts/ci.sh` and failed only after a push - one full CI
+#      round-trip per occurrence. Measured 2026-08-19 on
+#      tests/integration/test_bootstrap_ps1_slash_commands.ps1.
+#
+# The drift invariant is pinned by scripts/test_ps1_bom_gate.py: it fails if
+# either caller stops delegating here, or if anyone re-inlines a private copy of
+# the byte comparison.
+#
+# Usage:
+#   bash scripts/check-ps1-bom.sh              # scan this repo
+#   bash scripts/check-ps1-bom.sh --self-test  # negative control: prove it bites
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+
+# The message a failure prints. Kept as one constant because it is the only
+# thing a contributor sees, and because lint.yml used to own the wording.
+BOM_HINT='missing UTF-8 BOM (Windows PowerShell 5.1 will crash on non-ASCII bytes). Fix: prepend the bytes EF BB BF to the file.'
+
+# Set by scan(); read by its caller. scan() must therefore never be invoked in a
+# command substitution (that forks a subshell and the count is lost) - redirect
+# its output to a file instead, which keeps it in the current shell.
+SCANNED=0
+
+# Enumerate the *.ps1 files of a checkout.
+#
+# git, not `find`, and specifically --cached PLUS --others --exclude-standard:
+#   * --cached picks up every committed file (what CI sees).
+#   * --others --exclude-standard adds files that exist but are not committed
+#     yet, which is the whole point of a local pre-push gate: the file that cost
+#     a CI round-trip was brand new.
+#   * .gitignore, .git/ and node_modules/ are excluded for free, and git does
+#     not descend into a nested checkout, so a `.claude/worktrees/<slug>/` copy
+#     of this repo is not scanned from its parent (verified: 0 leaks).
+#
+# In a clean CI checkout this returns exactly what lint.yml's old
+# `find . -name '*.ps1' -not -path './.git/*'` returned (both: 14 files at the
+# commit this script was written against), so CI semantics are unchanged.
+_ps1_files() {
+  git -C "$1" ls-files -z --cached --others --exclude-standard -- '*.ps1'
+}
+
+# Scan one checkout. Returns 0 when every *.ps1 carries a BOM, 1 otherwise.
+# Prints one `::error file=...` line per offender (GitHub renders these as
+# inline annotations; on a terminal they are still readable).
+scan() {
+  local repo="$1"
+  local rel abs head3 fail=0
+  SCANNED=0
+  while IFS= read -r -d '' rel; do
+    abs="$repo/$rel"
+    # A path can be in the index while absent from the working tree (a staged
+    # delete). Nothing to read, nothing to assert.
+    [ -f "$abs" ] || continue
+    SCANNED=$((SCANNED + 1))
+    head3="$(head -c 3 "$abs" | od -An -tx1 | tr -d ' \n')"
+    if [ "$head3" != "efbbbf" ]; then
+      echo "::error file=$rel::$BOM_HINT"
+      fail=1
+    fi
+  done < <(_ps1_files "$repo")
+  return "$fail"
+}
+
+# Scan a repo AND assert the enumeration actually matched something. Split from
+# scan() so the self-test can exercise both halves independently.
+_scan_repo() {
+  local repo="$1" rc=0
+  scan "$repo" || rc=1
+  if [ "$SCANNED" -eq 0 ]; then
+    echo "::error::no *.ps1 matched in $repo - this gate scanned nothing and would pass on anything." >&2
+    echo "    Either the enumeration broke (a pathspec typo reads exactly like a clean repo), or this" >&2
+    echo "    fork genuinely ships no PowerShell - in which case delete this gate rather than leaving" >&2
+    echo "    it green over an empty set." >&2
+    return 1
+  fi
+  return "$rc"
+}
+
+# --- negative control --------------------------------------------------------
+#
+# A guard that has never failed on the thing it catches is unproven. This builds
+# a real git repo in a temp dir and copies the committed fixtures into it AS
+# .ps1 files, so the state under test is the state a real checkout is in - not a
+# synthetic one production can never reach. It then drives a full red -> green
+# transition on that same tree, which is what separates a working check from one
+# that is merely always-red.
+_self_test() {
+  local fixtures="$REPO_ROOT/tests/fixtures/ps1-bom"
+  local no_bom="$fixtures/no-bom.ps1.txt"
+  local with_bom="$fixtures/with-bom.ps1.txt"
+  local failures=0 tmp empty out f expect quiet
+
+  for f in "$no_bom" "$with_bom"; do
+    if [ ! -f "$f" ]; then
+      echo "self-test FAILED: missing fixture $f" >&2
+      return 1
+    fi
+  done
+
+  # Fixture integrity. If someone "fixes" the BOM-less fixture by adding a BOM,
+  # the negative control below silently stops being a negative control, so
+  # assert the bytes directly and say exactly what went wrong.
+  if [ "$(head -c 3 "$no_bom" | od -An -tx1 | tr -d ' \n')" = "efbbbf" ]; then
+    echo "self-test FAILED: $no_bom starts with a BOM. It is the NEGATIVE control and must not." >&2
+    return 1
+  fi
+  if [ "$(head -c 3 "$with_bom" | od -An -tx1 | tr -d ' \n')" != "efbbbf" ]; then
+    echo "self-test FAILED: $with_bom does not start with a BOM. It is the POSITIVE control and must." >&2
+    return 1
+  fi
+
+  tmp="$(mktemp -d)"
+  # shellcheck disable=SC2064  # expand $tmp now: the trap must survive the local
+  trap "rm -rf '$tmp'" RETURN
+
+  git init -q "$tmp"
+  printf 'ignored/\n' > "$tmp/.gitignore"
+  cp "$with_bom" "$tmp/good.ps1"           # committed, correct  -> must pass
+  cp "$no_bom" "$tmp/tracked-bad.ps1"      # committed, no BOM   -> must fail
+  git -C "$tmp" add .gitignore good.ps1 tracked-bad.ps1
+  cp "$no_bom" "$tmp/untracked-bad.ps1"    # not committed yet   -> must fail
+  mkdir -p "$tmp/ignored"
+  cp "$no_bom" "$tmp/ignored/vendored.ps1" # gitignored          -> must be skipped
+
+  out="$tmp/.scan-out"
+
+  # --- case 1: RED. The two BOM-less files must both be named, the good one
+  #     and the ignored one must not, and the count must prove the ignored file
+  #     was excluded rather than silently unreadable.
+  if scan "$tmp" > "$out" 2>&1; then
+    echo "self-test FAILED: scan returned 0 on a tree with two BOM-less .ps1 files." >&2
+    failures=$((failures + 1))
+  fi
+  for expect in tracked-bad.ps1 untracked-bad.ps1; do
+    if ! grep -q "file=$expect::" "$out"; then
+      echo "self-test FAILED: $expect is BOM-less and was not flagged." >&2
+      failures=$((failures + 1))
+    fi
+  done
+  for quiet in good.ps1 vendored.ps1; do
+    if grep -q "file=.*$quiet::" "$out"; then
+      echo "self-test FAILED: $quiet was flagged and should not have been." >&2
+      failures=$((failures + 1))
+    fi
+  done
+  if [ "$SCANNED" -ne 3 ]; then
+    echo "self-test FAILED: scanned $SCANNED file(s), expected 3 (good + tracked-bad + untracked-bad; the gitignored one is excluded)." >&2
+    failures=$((failures + 1))
+  fi
+
+  # --- case 2: GREEN on the SAME tree once the BOM is added. Without this a
+  #     check that fails unconditionally would pass case 1.
+  for f in "$tmp/tracked-bad.ps1" "$tmp/untracked-bad.ps1"; do
+    printf '\357\273\277' | cat - "$f" > "$f.fixed" && mv "$f.fixed" "$f"
+  done
+  if scan "$tmp" > "$out" 2>&1; then
+    :
+  else
+    echo "self-test FAILED: scan still red after prepending a BOM to every offender:" >&2
+    sed 's|^|  |' "$out" >&2
+    failures=$((failures + 1))
+  fi
+
+  # --- case 3: the enumeration's own blind spot. A pathspec that matches
+  #     NOTHING is the failure mode this repo keeps hitting (a guard that reads
+  #     as clean because it looked at zero files), so an empty scan must be loud
+  #     rather than a green.
+  empty="$tmp/empty-repo"
+  mkdir -p "$empty"
+  git init -q "$empty"
+  if _scan_repo "$empty" > "$out" 2>&1; then
+    echo "self-test FAILED: a repo with zero .ps1 files scanned green instead of reporting an empty enumeration." >&2
+    failures=$((failures + 1))
+  fi
+
+  if [ "$failures" -gt 0 ]; then
+    echo "self-test FAILED ($failures)" >&2
+    return 1
+  fi
+  echo "    self-test OK - flags BOM-less .ps1 (tracked and not-yet-committed), stays quiet on BOM'd and gitignored files, goes green once fixed, and refuses to pass on an empty enumeration"
+  return 0
+}
+
+main() {
+  if [ "${1:-}" = "--self-test" ]; then
+    _self_test
+    return $?
+  fi
+  echo "==> UTF-8 BOM on *.ps1: $REPO_ROOT"
+  if _scan_repo "$REPO_ROOT"; then
+    echo "    OK - $SCANNED .ps1 file(s), all starting with EF BB BF"
+    return 0
+  fi
+  return 1
+}
+
+main "$@"

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -73,6 +73,15 @@
 #                           subprocess.run(). Shipped twice: #313 (write side) and
 #                           #430 (read side, memory stranded outside the vault).
 #                           Content-pinned in scripts/utf8-subprocess-baseline.txt.
+#   (e7) ps1 UTF-8 BOM    - scripts/check-ps1-bom.sh fails a *.ps1 that does not
+#                           start with EF BB BF. Windows PowerShell 5.1 reads a
+#                           BOM-less .ps1 as the console ANSI code page instead of
+#                           UTF-8 and dies on the first non-ASCII byte. lint.yml
+#                           holds the enforcing copy but used to hold the ONLY
+#                           copy, as an inline loop no local command could run -
+#                           so the class was caught one full CI round-trip AFTER
+#                           the push. Both callers now run the same script and
+#                           scripts/test_ps1_bom_gate.py pins that (2026-08-19).
 #   (f) Python unit tests - the scripts/test_*.py stdlib suites (the claude-router
 #                           structured-envelope gate, the graph-liveness
 #                           STAMP-GREEN-WHILE-GONE guard). Gate (a) py_compiles them,
@@ -86,12 +95,15 @@
 #                           Unlike (c)/(d)/(e) it has no dedicated CI job, so it runs
 #                           in BOTH CI and the local pre-push gate (like (a) and (b)).
 #
-# It does NOT run the OTHER pure-lint jobs (bash -n, pwsh ParseFile, BOM, em-dash,
+# It does NOT run the OTHER pure-lint jobs (bash -n, pwsh ParseFile, em-dash,
 # JSON, privacy, references, no-remote-pipe-install). Those stay as their own
-# lint.yml jobs - they are lint, not the unit/type gate. Two are exceptions,
+# lint.yml steps - they are lint, not the unit/type gate. Three are exceptions,
 # enforced pre-push because they are cross-platform CORRECTNESS gates, not style:
-# the shell static-analysis gate (the GNU-vs-BSD `stat` mtime class) and the UTF-8
-# console guard (the Windows cp1252 print-crash class).
+# the shell static-analysis gate (the GNU-vs-BSD `stat` mtime class), the UTF-8
+# console guard (the Windows cp1252 print-crash class), and the .ps1 BOM gate
+# (the Windows PS 5.1 parse-crash class). Each of the three is a defect a Linux
+# runner or a Mac laptop structurally cannot observe at RUN time, so a byte/static
+# assertion is the only thing that can see it before a user does.
 #
 # Environment the integration tests need (lint.yml provides these in the `ci`
 # job; this script adds a non-invasive fallback so a fresh `bash scripts/ci.sh`
@@ -965,6 +977,28 @@ echo "==> (e6) py3.9 annotation parity: $PY scripts/check-py39-annotations.py"
 "$PY" scripts/check-py39-annotations.py --self-test >/dev/null
 "$PY" scripts/check-py39-annotations.py
 
+# ---- (e7) UTF-8 BOM on *.ps1 -----------------------------------------------
+# Windows PowerShell 5.1 reads a BOM-less .ps1 as the console ANSI code page,
+# not UTF-8, so the first non-ASCII byte decodes wrong and the parser dies on a
+# file that is valid UTF-8 everywhere else. A Linux runner cannot observe that
+# crash, which is why this is a byte assertion rather than a parse.
+#
+# lint.yml carries the ENFORCING copy, but until now that was the ONLY copy: the
+# rule was an inline shell loop in the workflow, unreachable from any local
+# command. So a BOM-less .ps1 passed a full green `bash scripts/ci.sh` and went
+# red only after a push - a whole CI round-trip per occurrence (measured
+# 2026-08-19 on tests/integration/test_bootstrap_ps1_slash_commands.ps1).
+# Both callers now run scripts/check-ps1-bom.sh, so neither can drift; the
+# delegation itself is pinned by scripts/test_ps1_bom_gate.py.
+#
+# Unlike (c)/(d)/(e) this is NOT skipped in CI. Those skip because a dedicated
+# lint.yml job owns them and double-running muddies attribution; here the cost
+# is a millisecond byte read over 14 files, and the local gate is the entire
+# point. Self-test first (proves the check still bites), then the fleet.
+echo "==> (e7) ps1 UTF-8 BOM: bash scripts/check-ps1-bom.sh"
+bash scripts/check-ps1-bom.sh --self-test >/dev/null
+bash scripts/check-ps1-bom.sh
+
 # ---- (f) Python unit tests (scripts/ + hooks/ + tests/) --------------------
 # Every Python unit suite in the repo, run under the SAME interpreter as the rest
 # of the gate. Gate (a) py_compiles them (proves they parse); this proves their
@@ -1058,4 +1092,4 @@ done
 echo "    OK - ${#PY_DIRECT[@]} hooks/+tests/ direct suite(s) passed; dormancy invariant clean"
 
 echo
-echo "All gates passed: py_compile ($count file(s)) + ${#INTEGRATION_TESTS[@]} integration tests + $unit_count scripts/ + ${#PY_DIRECT[@]} hooks/tests unit suite(s) + shellcheck [$shellcheck_note] + phase-doc python [$phasepy_note] + utf8 console guard [$utf8_note] + hook block-protocol [passed] + vault-root reads [passed] + home-hook deploy [passed] + subprocess decode [passed] + py3.9 annotation parity [passed]."
+echo "All gates passed: py_compile ($count file(s)) + ${#INTEGRATION_TESTS[@]} integration tests + $unit_count scripts/ + ${#PY_DIRECT[@]} hooks/tests unit suite(s) + shellcheck [$shellcheck_note] + phase-doc python [$phasepy_note] + utf8 console guard [$utf8_note] + hook block-protocol [passed] + vault-root reads [passed] + home-hook deploy [passed] + subprocess decode [passed] + py3.9 annotation parity [passed] + ps1 UTF-8 BOM [passed]."

--- a/scripts/test_ps1_bom_gate.py
+++ b/scripts/test_ps1_bom_gate.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""
+Pin the .ps1 UTF-8 BOM rule to ONE implementation, and keep its control honest.
+
+The rule: every *.ps1 must start with EF BB BF, because Windows PowerShell 5.1
+reads a BOM-less file as the console ANSI code page rather than UTF-8 and dies on
+the first non-ASCII byte.
+
+The rule used to live as an inline shell loop inside .github/workflows/lint.yml
+and nowhere else. That made it structurally unreachable from any local command:
+a BOM-less .ps1 passed a full green `bash scripts/ci.sh` -- the canonical gate
+the pre-push hook requires -- and failed only after a push, costing a whole CI
+round-trip per occurrence (measured 2026-08-19 on
+tests/integration/test_bootstrap_ps1_slash_commands.ps1).
+
+The fix was to extract scripts/check-ps1-bom.sh and have both callers run it.
+This suite defends the two ways that fix silently rots:
+
+  1. A caller stops delegating (someone re-inlines the byte comparison into
+     lint.yml "just for this one step", and the two copies drift apart again).
+  2. The negative control stops being negative (someone "fixes" the BOM-less
+     fixture by adding a BOM, and the control passes trivially forever).
+
+Runs automatically: scripts/ci.sh gate (f) globs scripts/test_*.py, so a new
+suite here can never sit dormant.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+CHECKER = REPO / "scripts" / "check-ps1-bom.sh"
+LINT_YML = REPO / ".github" / "workflows" / "lint.yml"
+CI_SH = REPO / "scripts" / "ci.sh"
+FIXTURES = REPO / "tests" / "fixtures" / "ps1-bom"
+
+BOM = b"\xef\xbb\xbf"
+# The byte comparison, as it reads in shell. If this string appears in a CALLER
+# rather than in the checker, that caller has grown its own private copy.
+INLINE_MARKER = "efbbbf"
+
+# Both callers must actually INVOKE the script. Matching the bare path is not
+# enough: every caller also NAMES the path in a comment, so a substring test
+# stays green when the real invocation is deleted (measured while mutation
+# testing this suite - two of seven mutations walked straight through it).
+# So match the command, and strip comment lines before looking.
+SCAN_CALL = re.compile(r"(?:^|\s)bash\s+scripts/check-ps1-bom\.sh\s*$", re.M)
+SELFTEST_CALL = re.compile(r"(?:^|\s)bash\s+scripts/check-ps1-bom\.sh\s+--self-test\b")
+
+
+def _executable_lines(text: str) -> str:
+    """Drop whole-line comments, so a path named in prose never reads as a call."""
+    return "\n".join(ln for ln in text.splitlines() if not ln.lstrip().startswith("#"))
+
+failures: list[str] = []
+
+
+def check(condition: bool, message: str) -> None:
+    if not condition:
+        failures.append(message)
+
+
+def test_checker_exists() -> None:
+    check(CHECKER.is_file(), f"missing {CHECKER.relative_to(REPO)} - the single source of truth")
+
+
+def test_both_callers_delegate() -> None:
+    """Each caller must INVOKE the shared script, not reimplement it."""
+    for caller in (LINT_YML, CI_SH):
+        body = caller.read_text(encoding="utf-8")
+        code = _executable_lines(body)
+        rel = caller.relative_to(REPO)
+
+        check(
+            SCAN_CALL.search(code) is not None,
+            f"{rel} no longer RUNS `bash scripts/check-ps1-bom.sh`. The BOM rule must have "
+            f"exactly one implementation and both callers must invoke it; a caller that stops "
+            f"delegating is how the two copies drifted in the first place. (Naming the path in "
+            f"a comment does not count.)",
+        )
+
+        # The negative control has to run where the gate runs. A caller that
+        # scans the fleet without first proving the checker still bites is
+        # trusting a guard that may have gone inert.
+        check(
+            SELFTEST_CALL.search(code) is not None,
+            f"{rel} runs the BOM scan without running `check-ps1-bom.sh --self-test` first. "
+            f"An unproven guard reads exactly like a clean repo.",
+        )
+
+        # The re-inlining guard. Only the checker may carry the raw byte
+        # comparison; a caller carrying it means a second copy is back.
+        check(
+            INLINE_MARKER not in body,
+            f"{rel} contains the raw byte comparison '{INLINE_MARKER}'. That is a re-inlined "
+            f"copy of the BOM rule. Call scripts/check-ps1-bom.sh instead - two copies drift, "
+            f"and the local one is the half that goes stale silently.",
+        )
+
+
+def test_fixture_integrity() -> None:
+    """The negative control is only a control while the fixture lacks a BOM."""
+    no_bom = FIXTURES / "no-bom.ps1.txt"
+    with_bom = FIXTURES / "with-bom.ps1.txt"
+
+    check(no_bom.is_file(), f"missing negative-control fixture {no_bom.relative_to(REPO)}")
+    check(with_bom.is_file(), f"missing positive-control fixture {with_bom.relative_to(REPO)}")
+    if not (no_bom.is_file() and with_bom.is_file()):
+        return
+
+    check(
+        not no_bom.read_bytes().startswith(BOM),
+        f"{no_bom.relative_to(REPO)} starts with a BOM. It is the NEGATIVE control: with a BOM "
+        f"the check passes it trivially and proves nothing.",
+    )
+    check(
+        with_bom.read_bytes().startswith(BOM),
+        f"{with_bom.relative_to(REPO)} does not start with a BOM. It is the POSITIVE control "
+        f"and exists to prove the check is not simply always-red.",
+    )
+    # Same bytes apart from the BOM, so the red/green difference between them is
+    # the BOM and nothing else.
+    check(
+        with_bom.read_bytes()[len(BOM):] == no_bom.read_bytes(),
+        "the two fixtures differ by more than the BOM, so a red on one and a green on the "
+        "other no longer isolates the BOM as the cause.",
+    )
+
+    # A fixture named *.ps1 would be scanned by the very gate it is a fixture
+    # for (and by the em-dash and pwsh-parse steps), so the negative control
+    # would red the repo forever. The .ps1.txt suffix is load-bearing.
+    stray = sorted(p.relative_to(REPO).as_posix() for p in FIXTURES.glob("*.ps1"))
+    check(
+        not stray,
+        f"fixture(s) named *.ps1 in {FIXTURES.relative_to(REPO)}: {stray}. Use the .ps1.txt "
+        f"suffix - a real .ps1 here is scanned by the gate itself.",
+    )
+
+
+def test_negative_control_passes() -> None:
+    """Run the control. It builds a real git repo and drives a red -> green cycle."""
+    if not CHECKER.is_file():
+        return
+    proc = subprocess.run(
+        ["bash", str(CHECKER), "--self-test"],
+        cwd=str(REPO),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    check(
+        proc.returncode == 0,
+        f"check-ps1-bom.sh --self-test failed (exit {proc.returncode}):\n"
+        f"{(proc.stdout + proc.stderr).strip()}",
+    )
+
+
+def test_repo_is_clean() -> None:
+    """The rule itself, over this repo. Cheap, and names the offender directly."""
+    if not CHECKER.is_file():
+        return
+    proc = subprocess.run(
+        ["bash", str(CHECKER)],
+        cwd=str(REPO),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    check(
+        proc.returncode == 0,
+        f"a tracked *.ps1 is missing its UTF-8 BOM:\n{(proc.stdout + proc.stderr).strip()}",
+    )
+
+
+def main() -> int:
+    tests = [
+        test_checker_exists,
+        test_both_callers_delegate,
+        test_fixture_integrity,
+        test_negative_control_passes,
+        test_repo_is_clean,
+    ]
+    for t in tests:
+        t()
+
+    if failures:
+        print(f"FAILED - {len(failures)} problem(s) with the .ps1 BOM gate:")
+        for f in failures:
+            print(f"  * {f}")
+        return 1
+    print(f"    OK - {len(tests)} checks: one implementation, two delegating callers, "
+          f"controls intact, repo clean")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/fixtures/ps1-bom/no-bom.ps1.txt
+++ b/tests/fixtures/ps1-bom/no-bom.ps1.txt
@@ -1,0 +1,18 @@
+# FROZEN FIXTURE - do not add a UTF-8 BOM to no-bom.ps1.txt.
+#
+# The controls for scripts/check-ps1-bom.sh. Two files, identical except for
+# the leading three bytes:
+#
+#   no-bom.ps1.txt   - NEGATIVE control. No BOM. The check MUST flag it.
+#   with-bom.ps1.txt - POSITIVE control. EF BB BF. The check must stay quiet.
+#
+# Both carry a real non-ASCII byte, because that is the byte a BOM-less .ps1
+# decodes wrong under Windows PowerShell 5.1 (it falls back to the console ANSI
+# code page instead of UTF-8). A pure-ASCII fixture would still be flagged, but
+# it would not show WHY the rule exists.
+#
+# Suffixed .ps1.txt, not .ps1, so the repo own *.ps1 globs - this gate, the
+# em-dash gate, the pwsh ParseFile step - never scan the fixtures themselves.
+# The self-test copies them into a temp git repo AS .ps1, which is the state a
+# real checkout is in.
+Write-Host "Vault listo, Andrés"

--- a/tests/fixtures/ps1-bom/with-bom.ps1.txt
+++ b/tests/fixtures/ps1-bom/with-bom.ps1.txt
@@ -1,0 +1,18 @@
+﻿# FROZEN FIXTURE - do not add a UTF-8 BOM to no-bom.ps1.txt.
+#
+# The controls for scripts/check-ps1-bom.sh. Two files, identical except for
+# the leading three bytes:
+#
+#   no-bom.ps1.txt   - NEGATIVE control. No BOM. The check MUST flag it.
+#   with-bom.ps1.txt - POSITIVE control. EF BB BF. The check must stay quiet.
+#
+# Both carry a real non-ASCII byte, because that is the byte a BOM-less .ps1
+# decodes wrong under Windows PowerShell 5.1 (it falls back to the console ANSI
+# code page instead of UTF-8). A pure-ASCII fixture would still be flagged, but
+# it would not show WHY the rule exists.
+#
+# Suffixed .ps1.txt, not .ps1, so the repo own *.ps1 globs - this gate, the
+# em-dash gate, the pwsh ParseFile step - never scan the fixtures themselves.
+# The self-test copies them into a temp git repo AS .ps1, which is the state a
+# real checkout is in.
+Write-Host "Vault listo, Andrés"


### PR DESCRIPTION
## The problem

Every `*.ps1` must start with `EF BB BF`, because Windows PowerShell 5.1 reads a BOM-less file as the console ANSI code page instead of UTF-8 and dies on the first non-ASCII byte.

That rule existed as an inline shell loop inside `lint.yml` and nowhere else, which made it unreachable from any local command. `scripts/ci.sh` — the canonical gate the pre-push hook requires — did not carry it.

Measured 2026-08-19: `tests/integration/test_bootstrap_ps1_slash_commands.ps1` passed a full green local `bash scripts/ci.sh` while missing its BOM, and went red only after the push. One full CI round-trip per occurrence.

## The fix

Extracted the rule into `scripts/check-ps1-bom.sh` and pointed **both** callers at it, so there is nothing left to drift. `lint.yml` keeps the enforcing copy; `ci.sh` gains gate `(e7)` for fast feedback.

Enumeration moved from `find` to `git ls-files --cached --others --exclude-standard`. In a clean CI checkout that returns the same 14 files, so CI semantics are unchanged — but it also covers a `.ps1` that exists and is not committed yet (the case that actually cost the round-trip), while excluding ignored paths and nested worktree checkouts for free.

## Negative control

Two committed fixtures under `tests/fixtures/ps1-bom/`, identical apart from the leading three bytes, so a red on one and a green on the other isolates the BOM as the cause.

`--self-test` copies them into a **real temp git repo as `.ps1` files** and drives a full red to green cycle:

- both BOM-less copies must be flagged (one committed, one not)
- the BOM'd and gitignored ones must not be
- the same tree must go green once the BOM is prepended
- an empty enumeration must be loud rather than green (a pathspec matching nothing reads exactly like a clean repo)

Fixtures are suffixed `.ps1.txt`, not `.ps1`, so the repo's own `*.ps1` globs (this gate, the em-dash gate, the pwsh ParseFile step) never scan the controls themselves.

## Anti-drift pin

`scripts/test_ps1_bom_gate.py` fails if either caller stops invoking the script, if either drops the self-test, if anyone re-inlines the raw byte comparison, or if a fixture stops being a valid control. It runs via `ci.sh` gate `(f)`'s `scripts/test_*.py` glob, so it can never sit dormant.

It matches the **invocation**, not the path. A first cut matched the bare path, which both callers also name in a comment, so deleting the real call left it green — two of seven mutations walked through that version.

## Verification

Both guards were mutation-tested rather than assumed.

| Mutation of the checker | Caught by `--self-test` |
|---|---|
| comparison never fires | yes |
| comparison always fires | yes |
| pathspec typo (`*.psX`) | yes |
| `--others` dropped | yes |
| `--exclude-standard` dropped | yes |

| Mutation of the wiring | Caught by the suite |
|---|---|
| lint.yml stops delegating | yes |
| lint.yml re-inlines the byte check | yes |
| ci.sh stops delegating | yes |
| ci.sh drops the negative control | yes |
| negative fixture given a BOM | yes |
| fixture committed as a real `.ps1` | yes |
| positive fixture loses its BOM | yes |

Also verified end to end by planting a BOM-less `.ps1` and confirming the local gate reds on it, and the checker parses and runs on bash 3.2 (macOS stock). Full `ci-test` green on `f425cf59`.

## Not in scope, worth knowing

`scripts/diagnose.sh` and `scripts/diagnose.ps1` carry their own copy of the byte comparison. Those are warn-level user health reports rather than gates, so they are left alone and are not pinned by the new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
