### PR TITLE
fix(vault-safe-commit): commit ONLY the named paths, not the whole index

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -359,6 +359,15 @@ INTEGRATION_TESTS=(
   # copy, with a negative control that a first install from a dev tree still
   # wires a runner that exists.
   test_hook_runner_path_stability
+  # vault-safe-commit.sh is the ONLY sanctioned route past the raw-git block
+  # guard, so a bare `git commit -m` there gave that guard zero real scoping
+  # while it looked fully enforced — a sibling session's staged work rode along
+  # under an unrelated message (measured: 1,191 files / 598,702 insertions from
+  # two calls that each named ONE path). Carries a negative control that re-runs
+  # the pre-fix commit line against the same fixture and asserts it DOES sweep,
+  # so a green positive proves the `--only` scoping rather than a scenario that
+  # never reproduces.
+  test_vault_safe_commit_index_scoping
   # In-flight git-operation gate (incident 2026-07-28): proves a fresh install
   # REGISTERS the guard, wires it in the block-preserving `if [ -f ]` form, and
   # that the SHIPPED command refuses a commit into a genuinely stalled rebase

--- a/scripts/vault-safe-commit.sh
+++ b/scripts/vault-safe-commit.sh
@@ -200,20 +200,37 @@ while [ -e "${LOCK_FILE}" ]; do
 done
 
 # --- stage paths ---
+# NOTE: `git add ... | while read` runs the add inside a pipeline, so a FAILING add is
+# silently swallowed (the `while` exits 0) and the script commits anyway. Capture the
+# output, check the real status, then log.
 log "staging: ${PATHS[*]}"
-git add -- "${PATHS[@]}" 2>&1 | while IFS= read -r line; do
-    log "git add: ${line}"
-done
+if ! add_output=$(git add -- "${PATHS[@]}" 2>&1); then
+    [ -n "${add_output}" ] && log "git add: ${add_output}"
+    die "git add failed for: ${PATHS[*]}"
+fi
+[ -n "${add_output}" ] && log "git add: ${add_output}"
 
-# --- check there's actually something to commit ---
-if git diff --cached --quiet; then
-    log "no changes staged — skipping commit"
-    echo "vault-safe-commit: nothing to commit (staged tree matches HEAD)" >&2
+# --- check OUR paths actually have something to commit ---
+# Scoped with `-- "${PATHS[@]}"`. Unscoped, this asks "is ANYTHING staged?" — so with a
+# sibling session's change sitting in the shared index and our own paths unchanged, it
+# answers yes and we commit THEIR work under OUR message.
+if git diff --cached --quiet -- "${PATHS[@]}"; then
+    log "no changes staged for the named paths — skipping commit"
+    echo "vault-safe-commit: nothing to commit (named paths match HEAD)" >&2
     exit 0
 fi
 
-# --- commit ---
-git commit --quiet -m "${MESSAGE}" || die "commit failed"
+# --- commit ONLY the named paths ---
+# `--only` (-o) commits the working-tree contents of the named paths and DISREGARDS the
+# rest of the index, so a sibling session's staged work cannot ride along. Without it,
+# `git commit` takes the ENTIRE index: measured on a live vault, two consecutive calls
+# that each named ONE path produced commits of 1,191 files / 598,702 insertions, sweeping
+# other live sessions' data, hook edits and logs into an unrelated message.
+# This wrapper is the ONLY sanctioned route past the raw-git block guard, so without
+# `--only` that guard provides zero real scoping while looking fully enforced.
+# `--only` needs paths git already knows; the `git add` above guarantees that, including
+# for new files.
+git commit --quiet --only -m "${MESSAGE}" -- "${PATHS[@]}" || die "commit failed"
 COMMIT_HASH=$(git log --oneline -1 | awk '{print $1}')
 log "committed ${COMMIT_HASH}: ${MESSAGE}"
 echo "vault-safe-commit: ${COMMIT_HASH} — ${MESSAGE}"

--- a/tests/integration/test_vault_safe_commit_index_scoping.sh
+++ b/tests/integration/test_vault_safe_commit_index_scoping.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# test_vault_safe_commit_index_scoping.sh
+#
+# vault-safe-commit.sh is the ONLY sanctioned route past the raw-git block guard,
+# so if it commits the whole index instead of the named paths, that guard provides
+# zero real scoping while looking fully enforced.
+#
+# Measured on a live vault before the fix: two consecutive calls that each named ONE
+# path produced commits of 1,191 files / 598,702 insertions, sweeping other live
+# sessions' data into an unrelated message.
+#
+# POSITIVE control: naming one path commits exactly that path.
+# NEGATIVE control: the pre-fix commit line (bare `git commit -m`) is re-run against
+#   the same fixture and MUST sweep the sibling file — proving this test can actually
+#   fail, rather than passing because the scenario never reproduces.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WRAPPER="$REPO_ROOT/scripts/vault-safe-commit.sh"
+
+FAILED=0
+pass() { printf '  PASS: %s\n' "$1"; }
+fail() { printf '  FAIL: %s\n' "$1"; FAILED=1; }
+
+make_fixture() {
+    # Echoes a fresh temp repo path with: ours.md (modified) + sibling.md (STAGED by
+    # a "concurrent session"). Both tracked, both dirty in the index.
+    local d
+    d=$(mktemp -d)
+    git -C "$d" init --quiet
+    git -C "$d" config user.email test@example.com
+    git -C "$d" config user.name  test
+    printf 'v1\n' > "$d/ours.md"
+    printf 'v1\n' > "$d/sibling.md"
+    git -C "$d" add ours.md sibling.md
+    git -C "$d" commit --quiet -m "baseline"
+    # our edit (unstaged) + the sibling session's edit (already staged in shared index)
+    printf 'v2-ours\n'    > "$d/ours.md"
+    printf 'v2-sibling\n' > "$d/sibling.md"
+    git -C "$d" add sibling.md
+    echo "$d"
+}
+
+files_in_head() { git -C "$1" show --name-only --format="" HEAD | sed '/^$/d' | sort | tr '\n' ' '; }
+
+echo "test_vault_safe_commit_index_scoping"
+
+# --- POSITIVE: the shipped wrapper must commit ONLY ours.md ---------------------
+REPO=$(make_fixture)
+out=$(cd "$REPO" && VAULT_ROOT="$REPO" bash "$WRAPPER" "scoped: ours only" "ours.md" 2>&1)
+rc=$?
+got=$(files_in_head "$REPO")
+if [ $rc -ne 0 ]; then
+    fail "wrapper exited $rc: $out"
+elif [ "$got" = "ours.md " ]; then
+    pass "wrapper committed only the named path (got: $got)"
+else
+    fail "wrapper swept extra files — expected 'ours.md ', got '$got'"
+fi
+# the sibling's staged work must still be pending, not consumed
+if git -C "$REPO" diff --cached --quiet -- sibling.md; then
+    fail "sibling.md staged work was consumed by our commit"
+else
+    pass "sibling's staged work left intact for its own session"
+fi
+rm -rf "$REPO"
+
+# --- NEGATIVE control: pre-fix commit line MUST sweep the sibling ---------------
+# Proves the fixture genuinely reproduces the bug, so a green POSITIVE means the
+# `--only` scoping is doing the work (not that the scenario never happens).
+REPO=$(make_fixture)
+(cd "$REPO" && git add -- ours.md && git commit --quiet -m "pre-fix: bare commit") >/dev/null 2>&1
+got=$(files_in_head "$REPO")
+if [ "$got" = "ours.md sibling.md " ]; then
+    pass "negative control reproduced the bug (pre-fix swept: $got)"
+else
+    fail "negative control did NOT reproduce — fixture is not exercising the bug (got: '$got')"
+fi
+rm -rf "$REPO"
+
+# --- guard: the scoping flags must actually be present in the shipped script ----
+# grep, not rg: CI runners do not ship ripgrep.
+if grep -q -- '--only' "$WRAPPER" && grep -qF 'diff --cached --quiet -- "${PATHS[@]}"' "$WRAPPER"; then
+    pass "shipped script carries --only and scoped staged-check"
+else
+    fail "shipped script is missing --only and/or the scoped staged-check"
+fi
+
+[ $FAILED -eq 0 ] && echo "OK" || echo "FAILURES"
+exit $FAILED


### PR DESCRIPTION
`vault-safe-commit.sh` committed the **entire git index**, not the paths it was given.

It is the only sanctioned route past the raw-git block guard, so that guard was providing zero real scoping while looking fully enforced. Any work a concurrent session had staged rode along under an unrelated message.

Measured on a live vault before this fix: two consecutive calls that each named **one** path produced commits of **1,191 files / 598,702 insertions**.

## Changes

- `git commit --only -- "${PATHS[@]}"` so the rest of the index is disregarded.
- Scope the "anything to commit?" check to the named paths. Unscoped, it answered yes off a sibling session's staged work and committed under our message.
- `git add` no longer runs inside a pipeline, where a failing add was swallowed by the `while` loop and the script committed anyway.
- New integration test `test_vault_safe_commit_index_scoping`, registered in `INTEGRATION_TESTS`.

## Why the test is trustworthy

It ships a **negative control**: the pre-fix commit line is re-run against the same fixture and asserted to *sweep* the sibling file. A green positive therefore proves the `--only` scoping is doing the work, rather than the scenario never reproducing.

`ci-test` GREEN locally (`EXIT=0`, marker `8785c5f1`): full canonical gate, 121 integration tests, not a subset.

## Review-risky areas

`--only` requires paths git already knows. The preceding `git add` guarantees that, including for new files, but it is the load-bearing assumption in this change.

## Coordination

This **conflicts textually** with open PR #466 (`fix/vault-safe-commit-derive-vault-root`), a different author addressing `VAULT_ROOT` derivation in the same file. `git merge-tree` reports a content conflict. Whichever lands second needs a rebase. I have not modified #466.

Drafted with Claude Code; gate run and diff reviewed before push.
