### PR TITLE
fix(diagnose): the vault BOM check stopped reading after 20 files and called it clean

### DIFF
--- a/scripts/check-ps1-bom.sh
+++ b/scripts/check-ps1-bom.sh
@@ -9,7 +9,7 @@
 # non-ASCII byte decodes wrong and the parser dies on a file that is valid UTF-8
 # everywhere else. The BOM is how 5.1 is told the encoding.
 #
-# ONE implementation, TWO callers, so the rule cannot drift between them:
+# ONE implementation, THREE callers, so the rule cannot drift between them:
 #
 #   1. .github/workflows/lint.yml - the ENFORCING gate. A red here blocks merge.
 #   2. scripts/ci.sh              - the locally-runnable pre-push gate, for fast
@@ -18,14 +18,29 @@
 #      `bash scripts/ci.sh` and failed only after a push - one full CI
 #      round-trip per occurrence. Measured 2026-08-19 on
 #      tests/integration/test_bootstrap_ps1_slash_commands.ps1.
+#   3. scripts/diagnose.sh        - the USER-facing health report, via
+#      --porcelain. Different target (an installed vault, which is usually not
+#      a git repo), different verdict (a warning, not a merge block), same rule.
+#      Its private copy was capped at `head -20`, so a vault with more than 20
+#      .ps1 files reported "All .ps1 files have UTF-8 BOM" while never reading
+#      the rest - and diagnose.ps1, which has no cap, reported the same vault
+#      honestly. Folding it in removed the copy and the truncation together.
 #
-# The drift invariant is pinned by scripts/test_ps1_bom_gate.py: it fails if
-# either caller stops delegating here, or if anyone re-inlines a private copy of
-# the byte comparison.
+# scripts/diagnose.ps1 is DELIBERATELY not a caller. It is the Windows-native
+# surface, run as `pwsh diagnose.ps1 -Vault C:\path` on a box that need not have
+# bash at all, and no .ps1 in this repo shells out to bash. This repo's idiom
+# for sh/ps1 parity is a shared data source plus a test that reads both (see
+# sync-vault-scripts.ps1), not a cross-language call - so the .ps1 keeps its own
+# byte check and scripts/test_ps1_bom_gate.py pins the two to the same bytes.
+#
+# The drift invariant is pinned by scripts/test_ps1_bom_gate.py: it fails if any
+# caller stops delegating here, if anyone re-inlines a private copy of the byte
+# comparison, or if either surface starts capping its enumeration again.
 #
 # Usage:
-#   bash scripts/check-ps1-bom.sh              # scan this repo
-#   bash scripts/check-ps1-bom.sh --self-test  # negative control: prove it bites
+#   bash scripts/check-ps1-bom.sh                    # scan this repo (gate)
+#   bash scripts/check-ps1-bom.sh --self-test        # negative control
+#   bash scripts/check-ps1-bom.sh --porcelain DIR... # report on arbitrary trees
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -93,6 +108,49 @@ _scan_repo() {
     return 1
   fi
   return "$rc"
+}
+
+# --- porcelain mode (arbitrary trees, e.g. an installed vault) ----------------
+#
+# `find`, not `git ls-files`, and deliberately so: this mode reports on a user's
+# VAULT, which diagnose.sh itself warns may not be a git repo. Asking git to
+# enumerate a non-repo returns nothing, and "nothing" is indistinguishable from
+# "clean" - the exact silent-green this file exists to prevent. The gate above
+# keeps its git enumeration because a repo checkout IS a repo.
+#
+# NO cap. The copy this replaced ended in `| head -20`, which is what let a
+# 25-file vault report green on 20 files. A scanner states how much of its input
+# it read, so the count travels with the verdict and the caller can print it.
+_ps1_files_find() {
+  find "$@" -name '*.ps1' -not -path '*/.git/*' -print0 2>/dev/null
+}
+
+# Emit ONE machine-readable line. Contract, matching check-cloud-sync.py's
+# --porcelain style so diagnose.sh can `case` on it:
+#
+#   NONE:0                       - no *.ps1 anywhere under the given roots
+#   OK:<scanned>                 - every file scanned carries the BOM
+#   MISSING_BOM:<missing>:<scanned>
+#
+# Exit is 0 for all three: this is a REPORT, not a gate. A caller that cannot
+# parse the line must warn ("could not evaluate"), never assume clean.
+_report() {
+  local abs head3 scanned=0 missing=0
+  while IFS= read -r -d '' abs; do
+    [ -f "$abs" ] || continue
+    scanned=$((scanned + 1))
+    head3="$(head -c 3 "$abs" 2>/dev/null | od -An -tx1 | tr -d ' \n')"
+    [ "$head3" != "efbbbf" ] && missing=$((missing + 1))
+  done < <(_ps1_files_find "$@")
+
+  if [ "$scanned" -eq 0 ]; then
+    echo "NONE:0"
+  elif [ "$missing" -eq 0 ]; then
+    echo "OK:$scanned"
+  else
+    echo "MISSING_BOM:$missing:$scanned"
+  fi
+  return 0
 }
 
 # --- negative control --------------------------------------------------------
@@ -192,17 +250,75 @@ _self_test() {
     failures=$((failures + 1))
   fi
 
+  # --- case 4: porcelain mode, on the tree diagnose.sh actually reports on -
+  #     a plain directory that is NOT a git repo. If this mode ever enumerated
+  #     with git it would return zero files here and print OK, which is the
+  #     silent-green the gate half already guards against.
+  local vault="$tmp/vault-not-a-repo"
+  mkdir -p "$vault"
+  cp "$with_bom" "$vault/ok.ps1"
+  if [ "$(_report "$vault")" != "OK:1" ]; then
+    echo "self-test FAILED: porcelain on a non-repo dir with one good file returned '$(_report "$vault")', expected OK:1." >&2
+    failures=$((failures + 1))
+  fi
+  cp "$no_bom" "$vault/bad.ps1"
+  if [ "$(_report "$vault")" != "MISSING_BOM:1:2" ]; then
+    echo "self-test FAILED: porcelain did not report 1 missing of 2 (got '$(_report "$vault")')." >&2
+    failures=$((failures + 1))
+  fi
+  rm -rf "$vault"
+  mkdir -p "$vault"
+  if [ "$(_report "$vault")" != "NONE:0" ]; then
+    echo "self-test FAILED: porcelain on an empty dir returned '$(_report "$vault")', expected NONE:0." >&2
+    failures=$((failures + 1))
+  fi
+
+  # --- case 5: the TRUNCATION class, which is why this mode exists. The copy
+  #     in diagnose.sh ended in `| head -20`, so a vault with more than 20 .ps1
+  #     files reported green while never reading the rest. Plant 25 good files
+  #     and exactly one bad one, and require the bad one to be found regardless
+  #     of where it lands in enumeration order.
+  local big="$tmp/big-vault" n
+  mkdir -p "$big"
+  for n in $(seq 1 25); do
+    cp "$with_bom" "$big/f$n.ps1"
+  done
+  cp "$no_bom" "$big/needle.ps1"
+  if [ "$(_report "$big")" != "MISSING_BOM:1:26" ]; then
+    echo "self-test FAILED: porcelain missed the one BOM-less file among 26 (got '$(_report "$big")', expected MISSING_BOM:1:26). A cap on the enumeration is back." >&2
+    failures=$((failures + 1))
+  fi
+
   if [ "$failures" -gt 0 ]; then
     echo "self-test FAILED ($failures)" >&2
     return 1
   fi
-  echo "    self-test OK - flags BOM-less .ps1 (tracked and not-yet-committed), stays quiet on BOM'd and gitignored files, goes green once fixed, and refuses to pass on an empty enumeration"
+  echo "    self-test OK - flags BOM-less .ps1 (tracked and not-yet-committed), stays quiet on BOM'd and gitignored files, goes green once fixed, refuses to pass on an empty enumeration, and reports honestly on a non-repo vault of 26 files with no cap"
   return 0
 }
 
 main() {
   if [ "${1:-}" = "--self-test" ]; then
     _self_test
+    return $?
+  fi
+  if [ "${1:-}" = "--porcelain" ]; then
+    shift
+    if [ "$#" -eq 0 ]; then
+      echo "usage: check-ps1-bom.sh --porcelain DIR [DIR...]" >&2
+      return 2
+    fi
+    # Drop roots that do not exist so `find` cannot fail the whole report over
+    # one absent path (an install without the skill dir is normal, not an error).
+    local roots=() d
+    for d in "$@"; do
+      [ -d "$d" ] && roots+=("$d")
+    done
+    if [ "${#roots[@]}" -eq 0 ]; then
+      echo "NONE:0"
+      return 0
+    fi
+    _report "${roots[@]}"
     return $?
   fi
   echo "==> UTF-8 BOM on *.ps1: $REPO_ROOT"

--- a/scripts/diagnose.ps1
+++ b/scripts/diagnose.ps1
@@ -235,6 +235,17 @@ foreach ($root in $searchRoots) {
 if ($ps1Files.Count -eq 0) {
   Ok "No .ps1 files to check"
 } else {
+  # The BOM byte check stays NATIVE here on purpose, and is the one place in
+  # this repo that duplicates scripts/check-ps1-bom.sh.
+  #
+  # This script's whole job is to run on a Windows box - `pwsh diagnose.ps1
+  # -Vault C:\path` - and such a box need not have bash at all. Delegating to a
+  # .sh would break the diagnostic on the exact platform the BOM rule exists to
+  # protect. No .ps1 in this repo shells out to bash; the established idiom for
+  # sh/ps1 parity here is a shared data source plus a test that reads both (see
+  # sync-vault-scripts.ps1), which is what scripts/test_ps1_bom_gate.py does:
+  # it pins these three bytes to the shell implementation's, and fails if either
+  # side changes the rule alone or reintroduces a cap on the enumeration.
   $bomFail = 0; $emFail = 0; $parseFail = 0
   foreach ($f in $ps1Files) {
     $bytes = [System.IO.File]::ReadAllBytes($f.FullName)

--- a/scripts/diagnose.sh
+++ b/scripts/diagnose.sh
@@ -258,23 +258,48 @@ fi
 
 # ----- 8. .ps1 sanity (if any exist) -----
 section "8. PowerShell files (Windows compat)"
-ps1_files=$(find "$VAULT" "$HOME/.claude/skills/ai-brain-starter" \
-  -name '*.ps1' -not -path '*/.git/*' 2>/dev/null | head -20)
-if [ -z "$ps1_files" ]; then
-  ok "No .ps1 files to check"
+# The BOM rule is NOT reimplemented here. It is one rule with one owner,
+# scripts/check-ps1-bom.sh, which the CI gate and the pre-push gate also call -
+# so a fix lands everywhere at once. This block used to carry its own copy,
+# capped at `head -20`: a vault with more than 20 .ps1 files printed "All .ps1
+# files have UTF-8 BOM" without ever reading the rest, while diagnose.ps1 (no
+# cap) reported the same vault honestly. Same vault, two different answers.
+CHECK_BOM=""
+for c in "$(cd "$(dirname "$0")" && pwd)/check-ps1-bom.sh" \
+         "$HOME/.claude/skills/ai-brain-starter/scripts/check-ps1-bom.sh"; do
+  [ -f "$c" ] && CHECK_BOM="$c" && break
+done
+if [ -n "$CHECK_BOM" ]; then
+  bom_verdict="$(bash "$CHECK_BOM" --porcelain "$VAULT" "$HOME/.claude/skills/ai-brain-starter" 2>/dev/null)"
+  case "$bom_verdict" in
+    NONE:0)
+      ok "No .ps1 files to check" ;;
+    OK:*)
+      ok "All .ps1 files have UTF-8 BOM (${bom_verdict#OK:} scanned)" ;;
+    MISSING_BOM:*:*)
+      bom_rest="${bom_verdict#MISSING_BOM:}"
+      warn "${bom_rest%%:*} of ${bom_rest##*:} .ps1 file(s) missing UTF-8 BOM" \
+        "Windows PowerShell 5.1 will crash on non-ASCII bytes." ;;
+    *)
+      warn "Could not evaluate .ps1 BOM status" "check-ps1-bom.sh returned: ${bom_verdict:-<empty>}" ;;
+  esac
 else
-  bom_fail=0; emdash_fail=0
+  warn "check-ps1-bom.sh not found" "Cannot verify .ps1 files carry a UTF-8 BOM."
+fi
+
+# Em dashes are a separate rule with its own owner (the lint.yml step); this is
+# the user-facing warning half. No cap here either - the same truncation that
+# hid a missing BOM would hide an em dash.
+ps1_files=$(find "$VAULT" "$HOME/.claude/skills/ai-brain-starter" \
+  -name '*.ps1' -not -path '*/.git/*' 2>/dev/null)
+if [ -z "$ps1_files" ]; then
+  : # "no .ps1 files" was already reported by the BOM verdict above
+else
+  emdash_fail=0
   while IFS= read -r f; do
     [ -z "$f" ] && continue
-    head_bytes=$(head -c 3 "$f" 2>/dev/null | od -An -tx1 | tr -d ' \n')
-    [ "$head_bytes" != "efbbbf" ] && bom_fail=$((bom_fail+1))
-    grep -l $'\xe2\x80\x94' "$f" >/dev/null 2>&1 && emdash_fail=$((emdash_fail+1))
+    grep -q $'\xe2\x80\x94' "$f" 2>/dev/null && emdash_fail=$((emdash_fail+1))
   done <<< "$ps1_files"
-  if [ "$bom_fail" -eq 0 ]; then
-    ok "All .ps1 files have UTF-8 BOM"
-  else
-    warn "$bom_fail .ps1 file(s) missing UTF-8 BOM" "Windows PowerShell 5.1 will crash on non-ASCII bytes."
-  fi
   if [ "$emdash_fail" -eq 0 ]; then
     ok "No em dashes in .ps1 files"
   else

--- a/scripts/test_ps1_bom_gate.py
+++ b/scripts/test_ps1_bom_gate.py
@@ -36,6 +36,8 @@ REPO = Path(__file__).resolve().parent.parent
 CHECKER = REPO / "scripts" / "check-ps1-bom.sh"
 LINT_YML = REPO / ".github" / "workflows" / "lint.yml"
 CI_SH = REPO / "scripts" / "ci.sh"
+DIAGNOSE_SH = REPO / "scripts" / "diagnose.sh"
+DIAGNOSE_PS1 = REPO / "scripts" / "diagnose.ps1"
 FIXTURES = REPO / "tests" / "fixtures" / "ps1-bom"
 
 BOM = b"\xef\xbb\xbf"
@@ -50,6 +52,21 @@ INLINE_MARKER = "efbbbf"
 # So match the command, and strip comment lines before looking.
 SCAN_CALL = re.compile(r"(?:^|\s)bash\s+scripts/check-ps1-bom\.sh\s*$", re.M)
 SELFTEST_CALL = re.compile(r"(?:^|\s)bash\s+scripts/check-ps1-bom\.sh\s+--self-test\b")
+# diagnose.sh resolves the script through a candidate list rather than a fixed
+# repo-relative path (it also runs from an installed vault), so it is matched on
+# the porcelain invocation instead.
+PORCELAIN_CALL = re.compile(r'bash\s+"\$CHECK_BOM"\s+--porcelain\b')
+
+# diagnose.ps1 is the one intentional duplicate: it must run on a Windows box
+# with no bash. Pin it to the SAME three bytes as the shell implementation, so
+# the rule cannot be changed on one side alone.
+PS1_BOM_BYTES = re.compile(
+    r"0xEF.*?0xBB.*?0xBF", re.S | re.I
+)
+# `| head -N` / `-First N` on the enumeration is what silently truncated the
+# scan. Neither user-facing surface may cap again.
+SH_CAP = re.compile(r"-name\s+'\*\.ps1'[^\n]*\|\s*head\b")
+PS1_CAP = re.compile(r"Filter\s+'\*\.ps1'[^\n]*(-First|Select-Object)\b")
 
 
 def _executable_lines(text: str) -> str:
@@ -100,6 +117,64 @@ def test_both_callers_delegate() -> None:
             f"copy of the BOM rule. Call scripts/check-ps1-bom.sh instead - two copies drift, "
             f"and the local one is the half that goes stale silently.",
         )
+
+
+def test_diagnose_sh_delegates() -> None:
+    """The user-facing bash report must use the shared rule, not a private copy."""
+    body = DIAGNOSE_SH.read_text(encoding="utf-8")
+    code = _executable_lines(body)
+    rel = DIAGNOSE_SH.relative_to(REPO)
+
+    check(
+        PORCELAIN_CALL.search(code) is not None,
+        f"{rel} no longer calls check-ps1-bom.sh --porcelain. It carried its own copy of the "
+        f"BOM rule once and the two answers diverged; the shared script is the only owner.",
+    )
+    check(
+        INLINE_MARKER not in body,
+        f"{rel} contains the raw byte comparison '{INLINE_MARKER}' again. That is a re-inlined "
+        f"copy of the BOM rule - delegate to check-ps1-bom.sh --porcelain instead.",
+    )
+    # The absent-helper path must WARN, never fall through to a silent pass. A
+    # health report that cannot run a check has three states, not two.
+    check(
+        "check-ps1-bom.sh not found" in body,
+        f"{rel} does not warn when check-ps1-bom.sh is missing. A check that could not run "
+        f"must say so - reporting nothing reads exactly like reporting clean.",
+    )
+    check(
+        SH_CAP.search(code) is None,
+        f"{rel} caps its *.ps1 enumeration with `| head` again. That is the truncation that "
+        f"made a 25-file vault report 'All .ps1 files have UTF-8 BOM' after reading 20.",
+    )
+
+
+def test_diagnose_ps1_stays_native_and_pinned() -> None:
+    """The Windows surface keeps its own check - but pinned to the same bytes.
+
+    Folding this one in would break it: it runs as `pwsh diagnose.ps1` on a box
+    that need not have bash. So the duplicate is deliberate, and this is what
+    stops the two implementations from drifting apart silently.
+    """
+    body = DIAGNOSE_PS1.read_text(encoding="utf-8")
+    rel = DIAGNOSE_PS1.relative_to(REPO)
+
+    check(
+        PS1_BOM_BYTES.search(body) is not None,
+        f"{rel} no longer compares the bytes 0xEF 0xBB 0xBF. It is the Windows-native copy of "
+        f"the rule in check-ps1-bom.sh and must test the same three bytes.",
+    )
+    check(
+        "check-ps1-bom.sh" in body,
+        f"{rel} no longer explains why it duplicates check-ps1-bom.sh. Without that note the "
+        f"duplicate reads as an oversight and the next person 'fixes' it by adding a bash call, "
+        f"which breaks the diagnostic on Windows.",
+    )
+    check(
+        PS1_CAP.search(body) is None,
+        f"{rel} caps its *.ps1 enumeration. It is currently the honest half of this pair; "
+        f"capping it would hide the same defect diagnose.sh used to hide.",
+    )
 
 
 def test_fixture_integrity() -> None:
@@ -180,6 +255,8 @@ def main() -> int:
     tests = [
         test_checker_exists,
         test_both_callers_delegate,
+        test_diagnose_sh_delegates,
+        test_diagnose_ps1_stays_native_and_pinned,
         test_fixture_integrity,
         test_negative_control_passes,
         test_repo_is_clean,
@@ -192,8 +269,9 @@ def main() -> int:
         for f in failures:
             print(f"  * {f}")
         return 1
-    print(f"    OK - {len(tests)} checks: one implementation, two delegating callers, "
-          f"controls intact, repo clean")
+    print(f"    OK - {len(tests)} checks: one implementation; lint.yml + ci.sh + diagnose.sh "
+          f"delegate, diagnose.ps1 pinned native; no capped enumerations; controls intact; "
+          f"repo clean")
     return 0
 
 

--- a/scripts/test_ps1_bom_gate.py
+++ b/scripts/test_ps1_bom_gate.py
@@ -60,13 +60,42 @@ PORCELAIN_CALL = re.compile(r'bash\s+"\$CHECK_BOM"\s+--porcelain\b')
 # diagnose.ps1 is the one intentional duplicate: it must run on a Windows box
 # with no bash. Pin it to the SAME three bytes as the shell implementation, so
 # the rule cannot be changed on one side alone.
-PS1_BOM_BYTES = re.compile(
-    r"0xEF.*?0xBB.*?0xBF", re.S | re.I
-)
+#
+# Deliberately NOT re.DOTALL. With it, `0xEF.*?0xBB.*?0xBF` matched three
+# unrelated occurrences 600 lines apart, so the assertion would survive the real
+# comparison being deleted. The bytes are compared on one line; keep the match
+# on one line.
+PS1_BOM_BYTES = re.compile(r"0xEF.*0xBB.*0xBF", re.I)
+
 # `| head -N` / `-First N` on the enumeration is what silently truncated the
 # scan. Neither user-facing surface may cap again.
-SH_CAP = re.compile(r"-name\s+'\*\.ps1'[^\n]*\|\s*head\b")
-PS1_CAP = re.compile(r"Filter\s+'\*\.ps1'[^\n]*(-First|Select-Object)\b")
+#
+# Scoped to the PowerShell section rather than the whole file, and matched
+# anywhere in it rather than on the enumeration's own line. A line-anchored
+# version missed a cap applied on the FOLLOWING line, and a file-wide version
+# would trip on the legitimate `git remote -v | head -1` elsewhere in
+# diagnose.sh.
+SH_CAP = re.compile(r"\|\s*head\b")
+PS1_CAP = re.compile(r"(-First\b|Select-Object\b)")
+
+# Section 8 is "PowerShell files (Windows compat)" in both reports.
+SH_SECTION = ("# ----- 8.", "# ----- 9.")
+PS1_SECTION = ('Section "8.', "# ----- 9.")
+
+
+def _section(text: str, bounds: tuple[str, str], path: Path) -> str:
+    """Return the named section, or fail loudly rather than scanning an empty string."""
+    start_marker, end_marker = bounds
+    start = text.find(start_marker)
+    end = text.find(end_marker, start + 1) if start != -1 else -1
+    if start == -1 or end == -1:
+        failures.append(
+            f"{path} no longer has a section delimited by {start_marker!r}..{end_marker!r}, "
+            f"so the no-cap check has nothing to scan. An empty scan reads as clean; fix the "
+            f"markers rather than leaving this assertion inert."
+        )
+        return ""
+    return text[start:end]
 
 
 def _executable_lines(text: str) -> str:
@@ -142,9 +171,10 @@ def test_diagnose_sh_delegates() -> None:
         f"{rel} does not warn when check-ps1-bom.sh is missing. A check that could not run "
         f"must say so - reporting nothing reads exactly like reporting clean.",
     )
+    section = _executable_lines(_section(body, SH_SECTION, rel))
     check(
-        SH_CAP.search(code) is None,
-        f"{rel} caps its *.ps1 enumeration with `| head` again. That is the truncation that "
+        SH_CAP.search(section) is None,
+        f"{rel} pipes the PowerShell section through `head` again. That is the truncation that "
         f"made a 25-file vault report 'All .ps1 files have UTF-8 BOM' after reading 20.",
     )
 
@@ -170,10 +200,12 @@ def test_diagnose_ps1_stays_native_and_pinned() -> None:
         f"duplicate reads as an oversight and the next person 'fixes' it by adding a bash call, "
         f"which breaks the diagnostic on Windows.",
     )
+    section = _executable_lines(_section(body, PS1_SECTION, rel))
     check(
-        PS1_CAP.search(body) is None,
-        f"{rel} caps its *.ps1 enumeration. It is currently the honest half of this pair; "
-        f"capping it would hide the same defect diagnose.sh used to hide.",
+        PS1_CAP.search(section) is None,
+        f"{rel} caps its *.ps1 enumeration (-First / Select-Object in the PowerShell section). "
+        f"It is currently the honest half of this pair; capping it would hide the same defect "
+        f"diagnose.sh used to hide.",
     )
 
 


### PR DESCRIPTION
Follow-on to #556, which made `scripts/check-ps1-bom.sh` the single owner of the `.ps1` BOM rule for the CI gate and the pre-push gate. Two copies were left behind in the user-facing health reports.

Folding `diagnose.sh` in turned out to matter for a reason unrelated to tidiness: **the two copies had already drifted, and one of them was wrong.**

## The bug

`diagnose.sh` enumerated with `find ... | head -20`. `diagnose.ps1` enumerates with `Get-ChildItem -Recurse` and no cap. On a vault with more than 20 `.ps1` files the same defect produced two different answers:

| Surface | Enumeration | Reads | Reports |
|---|---|---|---|
| `diagnose.sh` | `find ... \| head -20` | 20 of 26 | "All .ps1 files have UTF-8 BOM" |
| `diagnose.ps1` | `Get-ChildItem -Recurse` | 26 of 26 | the missing BOM |

Reproduced with 25 BOM'd files plus one BOM-less file placed past position 20 in `find` order: the capped enumeration found 0, the uncapped one found 1.

## The fix

`diagnose.sh` now delegates to `check-ps1-bom.sh --porcelain`, a new mode that reports on arbitrary directory trees rather than a git checkout.

It has to be `find` there and not `git ls-files`: `diagnose.sh` itself warns a few checks earlier that the vault may not be a git repo, and asking git to enumerate a non-repo returns nothing — indistinguishable from clean. The gate half keeps its git enumeration, because a repo checkout *is* a repo.

The verdict carries the count, so the report states how much of its input it read:

```
NONE:0                            -> "No .ps1 files to check"
OK:<scanned>                      -> "All .ps1 files have UTF-8 BOM (26 scanned)"
MISSING_BOM:<missing>:<scanned>   -> "1 of 26 .ps1 file(s) missing UTF-8 BOM"
```

It follows `check-cloud-sync.py`'s `--porcelain` contract, including the `*)` arm: an unparseable verdict warns "could not evaluate", and a missing helper warns "check-ps1-bom.sh not found". A check that could not run says so, because reporting nothing reads exactly like reporting clean.

The em-dash loop that shared the old enumeration lost its cap too — the same truncation that hid a missing BOM would hide an em dash.

## Why diagnose.ps1 is deliberately NOT folded in

It runs as `pwsh diagnose.ps1 -Vault C:\path` on a Windows box that need not have bash at all. Delegating to a `.sh` would break the diagnostic on the exact platform the BOM rule exists to protect. No `.ps1` in this repo shells out to bash, and this repo's idiom for sh/ps1 parity is a shared data source plus a test that reads both (`sync-vault-scripts.ps1` parses the `.sh` array).

So it keeps its native byte check, now with a comment saying why — and the test pins both sides to the same three bytes, so the rule cannot change on one side alone.

## Verification

`test_ps1_bom_gate.py` grows from 5 checks to 7, covering all four surfaces with the right expectation for each. 13 of 13 mutations caught:

| Mutation | Caught |
|---|---|
| `diagnose.sh` stops delegating | yes |
| `diagnose.sh` re-inlines the byte comparison | yes |
| `diagnose.sh` drops the absent-helper warning | yes |
| `diagnose.sh` re-adds the `head -20` cap | yes |
| `diagnose.sh` caps on a *separate* line | yes |
| `diagnose.ps1` changes the BOM bytes | yes |
| `diagnose.ps1` scatters the bytes far apart | yes |
| `diagnose.ps1` loses the duplication note | yes |
| `diagnose.ps1` caps its enumeration | yes |
| `diagnose.ps1` caps on the continuation line | yes |
| section markers removed (assertion would scan an empty string) | yes |
| porcelain mode re-introduces a cap | yes |
| porcelain mode reports OK when it scanned nothing | yes |

The last five exist because the doubt-pass on my own diff found two real weaknesses in the first cut of these assertions:

- `PS1_BOM_BYTES` used `re.DOTALL`, so `0xEF.*?0xBB.*?0xBF` matched three unrelated occurrences 600 lines apart — the assertion would have survived the real comparison being deleted. Now line-scoped.
- The cap checks were anchored to the enumeration's own line, so a cap applied on the *following* line walked straight through. Now scoped to the whole PowerShell section, with a loud failure if the section markers ever stop matching (a file-wide ban would have tripped on the legitimate `git remote -v | head -1` elsewhere in `diagnose.sh`).

Two new self-test cases cover the porcelain path: a non-repo directory, and a 26-file tree whose single BOM-less file sits past any plausible cap.

End to end: the vault shape that used to report green now reports "1 of 26"; a clean vault still reports OK with its count; an empty vault reports nothing to check; and an install missing the helper warns instead of passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
