### PR TITLE
fix(hooks): three guards that disable themselves silently — a blocked journal, a false close, and a refused commit

### DIFF
--- a/hooks/detect-closing-signal.py
+++ b/hooks/detect-closing-signal.py
@@ -1137,6 +1137,25 @@ def main() -> int:
         # uniquely identify Claude Code feedback re-injection. Same session
         # spawned 6 spurious stubs (T14-16, T14-20, T14-23, T14-25, T14-27,
         # T14-30) before the broader filter shipped.
+        # Expanded 2026-08-19: background-task notifications are the same bug
+        # class. When a subagent spawned with run_in_background finishes,
+        # Claude Code injects its full report as the next "user message",
+        # wrapped in a [SYSTEM NOTIFICATION - NOT USER INPUT] block. The
+        # agent's own prose then gets scanned for close signals.
+        #
+        # Observed: a session that dispatched ten Spanish-language subagents
+        # to process meeting recordings fired this hook THREE times off the
+        # agents' own reports — the Spanish pack's `\bya (está|estuvo|fue)\b`
+        # matched ordinary phrases like "ya está" and "ya fue" inside those
+        # summaries. Each false fire pre-built an empty session stub (T14-41,
+        # T16-10) that would have polluted the Last Session aggregator with
+        # blank entries, and asked the model to say goodbye while five agents
+        # were still running.
+        #
+        # The wrapper text is emitted by the harness and is stable, so
+        # matching it is safe. The notification body can be tens of KB of
+        # agent output, but the markers are always in the header, well inside
+        # the 2KB prefix scan.
         prefix = prompt[:2000]
         feedback_markers = (
             "Stop hook feedback:",
@@ -1145,9 +1164,14 @@ def main() -> int:
             "verify-session-close-cascade",
             "verify-discoverability-on-close",
             "verify-cascade",
+            # Background-task notifications (subagents, scheduled tasks)
+            "[SYSTEM NOTIFICATION - NOT USER INPUT]",
+            "<task-notification>",
+            "NOT a message from the user",
+            "automated background-task event",
         )
         if any(m in prefix for m in feedback_markers):
-            log_debug("Stop-hook-feedback prompt, skipping close detection")
+            log_debug("Hook-feedback or task-notification prompt, skipping close detection")
             emit_passthrough()
             return 0
 

--- a/hooks/warn-journal-saved-without-context.py
+++ b/hooks/warn-journal-saved-without-context.py
@@ -73,25 +73,57 @@ def _norm(text):
 
 
 def _vault_root(text):
-    """Absolute dir before the '<optional emoji >Journals/<Month YYYY>/' segment.
+    r"""Absolute dir before the '<optional emoji >Journals/<Month YYYY>/' segment.
     Anchored on the absolute path (starts at a real '/', or a `C:/` drive root),
     so a leading shell prefix like `cat > '/vault/.../x.md'` is NOT captured into
     the root (that was the 2026-07-07 Bash-path fail-open bug). Quotes bound the
     segment on the Bash path.
 
     The drive-letter alternative is guarded by `(?<![A-Za-z])` so a URL like
-    `http://host/Journals/May 2026/` cannot have its `p:` read as a drive."""
+    `http://host/Journals/May 2026/` cannot have its `p:` read as a drive.
+
+    The optional group before 'Journals/' exists ONLY to skip a folder-name emoji
+    prefix ('📓 '), so it must reject quotes, whitespace and shell metacharacters.
+    With the older `[^/\n]*\s` it also matched ACROSS a command boundary: in
+    `cd "/x/Brain" && cat > "📓 Journals/Aug 2026/e.md"` (relative save path) it
+    swallowed `Brain" && cat > "📓 ` and resolved the root to `/x` — a directory
+    holding no marker, so EVERY journal save was blocked regardless of whether the
+    preflight had run. Codified 2026-08-18 after that false block. With the
+    tightened class a relative save path finds no absolute root and fails OPEN per
+    this module's contract, while absolute paths (the form SKILL.md mandates)
+    resolve exactly as before — the guard keeps its teeth where they count."""
     m = re.search(
-        r"((?:(?<![A-Za-z])[A-Za-z]:)?/[^\n\"']*?)/(?:[^/\n]*\s)?"
+        r"((?:(?<![A-Za-z])[A-Za-z]:)?/[^\n\"']*?)/(?:[^/\n\"'>&|;\s]*\s)?"
         r"Journals/[A-Z][a-zA-Z]+\s+\d{4}/",
         text)
     return m.group(1) if m else None
 
 
 def _marker_exists(vault, date_iso):
+    """True when a preflight run covered date_iso.
+
+    The preflight auto-spans since the last entry and names its marker after the
+    day it RAN, not the day being journaled. Backfills (journaling Friday on
+    Monday) therefore have no `<entry-date>.json` even though the run's
+    since->until window covered the entry. Accept either: the exact-name marker,
+    or any marker whose window contains date_iso."""
     for meta in ("⚙️ Meta", "Meta"):
-        if os.path.exists(os.path.join(vault, meta, ".journal-context", f"{date_iso}.json")):
+        d = os.path.join(vault, meta, ".journal-context")
+        if os.path.exists(os.path.join(d, f"{date_iso}.json")):
             return True
+        if not os.path.isdir(d):
+            continue
+        for f in os.listdir(d):
+            if not f.endswith(".json"):
+                continue
+            try:
+                with open(os.path.join(d, f), encoding="utf-8") as fh:
+                    m = json.load(fh)
+                since, until = m.get("since"), m.get("until")
+                if since and until and since <= date_iso <= until:
+                    return True
+            except Exception:
+                continue  # unreadable marker -> ignore, don't open a hole
     return False
 
 

--- a/scripts/sync-vault-scripts.sh
+++ b/scripts/sync-vault-scripts.sh
@@ -90,6 +90,7 @@ done
 VAULT_SCRIPTS=(
   "_meta_resolver.py"          # shared meta-folder resolver (deterministic keystone)
   "_project_key.py"            # shared project-key resolver (dep of check-rule-conflicts.py)
+  "_session_close_guard.sh"    # shared git-dir/index-lock resolver (dep of vault-safe-commit.sh AND session-end-hook.sh; vault-safe-commit FAILS CLOSED without it, refusing every commit)
   "aggregate-sessions.py"      # session-close: Last Session.md index
   "aggregate-decisions.py"     # session-close: Decision Log index
   "session-close-runner.sh"    # session-close: deterministic aggregation runner (#173)


### PR DESCRIPTION
Two hooks fail in ways that are silent to the user. Both were found on a live Spanish-language vault this week; both are still present on `main`.

## 1. `warn-journal-saved-without-context.py` — a relative save path resolved a bogus vault root

The optional group before `Journals/` exists only to skip a folder-name emoji prefix, but `[^/\n]*\s` also matches **across a command boundary**:

```
cd "/x/Brain" && cat > "<emoji> Journals/Aug 2026/e.md"
```

It swallows `Brain" && cat > "<emoji> ` and resolves the root to `/x` — a directory holding no marker — so the guard blocked **every** journal save whether or not the preflight had run. Journaling was dead for several days with nothing indicating the guard was the cause.

Tightening the class to reject quotes, whitespace and shell metacharacters makes a relative save path find no absolute root and **fail open**, which is this module's stated contract. Absolute paths — the form `SKILL.md` mandates — resolve exactly as before.

The Windows drive-letter alternative from #498 is preserved unchanged. I diffed the function against the pre-change version across six cases; the bogus-root case is the only behavioral difference:

| input | before | after |
|---|---|---|
| `cat > "/Users/m/Brain/<emoji> Journals/Aug 2026/e.md"` | `/Users/m/Brain` | `/Users/m/Brain` |
| `cd "/Users/m/Brain" && cat > "<emoji> Journals/..."` | `/Users/m` ← bug | `None` |
| `C:/vault/Journals/May 2026/x.md` | `C:/vault` | `C:/vault` |
| `http://host/Journals/May 2026/x.md` | `//host` | `//host` |
| `/Users/m/Brain/Journals/Aug 2026/e.md` | `/Users/m/Brain` | `/Users/m/Brain` |
| `/Users/m/Brain/<emoji> Journals/Aug 2026/e.md` | `/Users/m/Brain` | `/Users/m/Brain` |

**Second fix, same file.** `_marker_exists` only accepted a marker named for the entry date, but the preflight names its marker after the day it *ran*. Journaling Friday on Monday therefore had no `<entry-date>.json` even though the run's `since`→`until` window covered the entry, so backfills were blocked. A marker whose window contains the date now also counts. Unreadable markers are ignored rather than treated as a pass, so this opens no hole.

## 2. `detect-closing-signal.py` — a finished background subagent fired the close

When a subagent spawned with `run_in_background` finishes, Claude Code injects its full report as the next "user message", wrapped in a `[SYSTEM NOTIFICATION - NOT USER INPUT]` block. The hook then scans the agent's own prose for closing signals.

A session that dispatched ten Spanish-language subagents to process meeting recordings fired this hook **three times** off the agents' own reports — the Spanish pack's `\bya (está|estuvo|fue)\b` matched ordinary phrases like "ya está" and "ya fue" inside those summaries. Each false fire pre-built an empty session stub that would have polluted the Last Session aggregator, and asked the model to say goodbye while five agents were still running.

Same bug class as the Stop-hook-feedback re-injection, fixed at the same point: four more markers in `feedback_markers`. The filter matches the harness wrapper, not the language, so every detection pack is untouched.

## Testing

- `tests/integration/test_journal_guard_windows_paths.sh` — pass
- `tests/integration/test_detect_closing_signal_es_guards.sh` — pass
- `tests/integration/test_detect_closing_signal_unscaffolded_vault.sh` — pass
- `tests/integration/test_detect_closing_signal_trilingual_vault_root.sh` — pass
- `hooks/test_hook_smoke.py` — 91 hooks import and run
- Full `scripts/ci.sh` — one failure, `test_post_update_email_ask`, which **also fails on pristine `origin/main`** in a clean worktree. Pre-existing, unrelated to this branch.

Live checks on the closing-signal hook: the two notifications that misfired now pass through; `listo, gracias, hasta mañana`, `/wrap-up` and `bueno ya está, cerremos por hoy` still fire.


---

## 3. `sync-vault-scripts.sh` — ships `vault-safe-commit.sh` without the guard it sources, so every commit is refused

`VAULT_SCRIPTS` syncs `vault-safe-commit.sh` and `session-end-hook.sh`, but not `_session_close_guard.sh`, the shared git-dir/index-lock resolver both of them source. On a real vault the file is simply absent.

`vault-safe-commit.sh` fails **closed** on a missing guard, by design — with no way to resolve the index lock it cannot prove no other writer holds it, so it refuses. Correct behavior, wrong premise: the guard is missing not because a writer holds the lock, but because nothing ever copied it. Every commit through the vault's own commit helper then dies with

```
cannot resolve the git directory for <vault> — refusing to commit without a working index-lock mutex
```

That also takes out the session-close cascade, since Phase 2b commits through this script. `session-end-hook.sh` sources the same guard and fails open, so it degrades quietly instead.

Found on a live vault today **immediately after a routine `sync-vault-scripts.sh` run** — the sync updated `vault-safe-commit.sh` to a version that needs the guard without shipping the guard, so the update itself is what broke committing.

Verified both directions on throwaway vaults:

| | guard present | `vault-safe-commit.sh "msg" file` |
|---|---|---|
| with this change | yes | commits |
| without (negative control, same fixture) | no | dies on the message above |

## A fourth defect, not fixed here

`build-journal-index.py` is in `VAULT_SCRIPTS` and resolves its `_lib` import as `Path(__file__).parent.parent / "hooks"`. That is `<repo>/hooks` in the checkout, but `<vault>/⚙️ Meta/hooks` in the synced copy — a directory that does not exist. The vault copy is dead on arrival:

```
$ python3 "⚙️ Meta/scripts/build-journal-index.py" --help
ModuleNotFoundError: No module named '_lib'
```

Same class — a synced script without what it needs to run — but the fix is a design call I did not want to make for you: either sync the `_lib` package alongside the scripts, or vendor `safe_read` into the script. Happy to do whichever you prefer, here or in a separate PR.
