### PR TITLE
fix(baselines): the list of what to check was itself hand-maintained

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -168,13 +168,17 @@ jobs:
       - name: baseline section-header negative controls (the guard must still bite)
         run: python3 scripts/_baseline_sections.py --self-test
 
-      # utf8-stdout-baseline.txt is validated from HERE rather than from inside
-      # check-utf8-stdout.py, because that checker is itself content-pinned by
-      # scripts/cloud-safe-walker-baseline.txt - editing it would oblige an
-      # unrelated safe_read migration. vault-root's own checker validates its
-      # baseline inline (it alone can count reads), so it is not repeated here.
-      - name: utf8 baseline burn-down counts match its rows
-        run: python3 scripts/_baseline_sections.py --check scripts/utf8-stdout-baseline.txt
+      # Every tiered baseline, DISCOVERED BY GLOB rather than named here. Naming
+      # them would be the original bug one level up: a hand-maintained list of
+      # what to check goes stale exactly as silently as a hand-maintained count,
+      # and a baseline added later would simply never be looked at. Flat
+      # baselines have no ledger and are skipped; matching NOTHING is an error,
+      # never a pass. (utf8's checker cannot host this itself - it is content-
+      # pinned by the cloud-safe walker ratchet, where any edit obliges a
+      # safe_read migration. vault-root's checker also validates its own
+      # baseline inline, since only the scanner can count reads.)
+      - name: baseline burn-down counts match their rows (all tiered baselines)
+        run: python3 scripts/_baseline_sections.py --check-all scripts
 
       # Self-test first (cheap, and proves the guard still bites), then the tree.
       - name: naive VAULT_ROOT read negative controls (the guard must still bite)

--- a/scripts/_baseline_sections.py
+++ b/scripts/_baseline_sections.py
@@ -69,6 +69,11 @@ Usage:
     _baseline_sections.py --check PATH [--reads] # validate one baseline file
                                                  #   --reads = the (N file(s),
                                                  #   M read(s)) two-number format
+    _baseline_sections.py --check-all [DIR]      # every *baseline*.txt in DIR
+                                                 #   (default: this directory).
+                                                 #   Format auto-detected per
+                                                 #   file; flat ones exempt;
+                                                 #   finding NONE exits 2.
 
 Exit: 0 clean, 1 stale header, 2 usage/IO error.
 """
@@ -264,6 +269,28 @@ _CLEAN_WITH_READS = (
     "{b} SEV-B scripts/two.py\n"
 ).format(a=_SHA_A, b=_SHA_B)
 
+def _empty_dir():
+    """A real directory with no baselines in it - the wrong-path shape."""
+    import tempfile
+    return tempfile.mkdtemp(prefix="bl-none-")
+
+
+def _planted_drift_dir():
+    """A baseline this module was never explicitly wired to, carrying drift.
+
+    This is the case the per-file wiring could not cover: a NEW baseline that
+    nobody remembered to add to ci.sh. Discovery by glob is what makes it fail.
+    """
+    import tempfile
+    d = tempfile.mkdtemp(prefix="bl-planted-")
+    body = (
+        "# ---- SEV-NEW  (7 file(s)) ----\n"
+        "{a} SEV-NEW hooks/one.py\n"
+    ).format(a=_SHA_A)
+    Path(d, "brand-new-baseline.txt").write_text(body, encoding="utf-8")
+    return d
+
+
 _CASES = (
     # (name, callable -> errors, expect_error)
     (
@@ -350,6 +377,16 @@ _CASES = (
         True,
     ),
     (
+        "the SWEEP fails loud when its glob matches nothing (never a silent pass)",
+        lambda: [] if check_all(_empty_dir()) == 2 else ["expected exit 2"],
+        False,
+    ),
+    (
+        "the SWEEP catches a drifted baseline it was never explicitly wired to",
+        lambda: [] if check_all(_planted_drift_dir()) == 1 else ["expected exit 1"],
+        False,
+    ),
+    (
         "prose naming a historical count is not a header and never fires",
         lambda: check_row_counts(
             "# Counts at the time of pinning: 21 SEV-1, 42 SEV-4, 78 total.\n"
@@ -378,8 +415,12 @@ def self_test():
     return 0
 
 
-def check_baseline_file(path, declares_reads=False):
-    """Validate one baseline file's FILE counts. 0 clean, 1 stale, 2 IO error."""
+def check_baseline_file(path, declares_reads=False, quiet=False):
+    """Validate one baseline file's FILE counts. 0 clean, 1 stale, 2 IO error.
+
+    `quiet` suppresses only the success line -- check_all() prints its own
+    per-file summary. Failures are never quiet.
+    """
     try:
         text = Path(path).read_text(encoding="utf-8", errors="replace")
     except OSError as exc:
@@ -396,14 +437,84 @@ def check_baseline_file(path, declares_reads=False):
         print("  counts and skip every '#' line, so nothing else can catch this.")
         print("  Correct the header to the real count -- do not delete the count.")
         return 1
-    print("baseline section headers: OK ({})".format(path))
+    if not quiet:
+        print("baseline section headers: OK ({})".format(path))
     return 0
+
+
+# Any baseline this repo grows, without anyone remembering to wire it up. The
+# ORIGINAL bug was a hand-maintained count next to machine-checkable data; a
+# hand-maintained LIST of which baselines to check is the same bug one level up,
+# and it fails the same silent way -- the new file just never gets looked at.
+_BASELINE_GLOB = "*baseline*.txt"
+
+
+def _declares_reads(text):
+    """True if ANY header in this file publishes a read count.
+
+    Per-file, not a global switch: the two tiered baselines use different
+    formats, and a future one picks its own. Detecting it here keeps the
+    symmetry check meaningful WITHIN a file (all its headers must agree)
+    without forcing every baseline into one shape.
+    """
+    for sec in parse_sections(text)[0]:
+        if sec.declared_reads is not None:
+            return True
+    return False
+
+
+def check_all(directory):
+    """Validate every baseline in `directory`. 0 clean, 1 drift, 2 nothing found.
+
+    Finding NOTHING is an ERROR, not a pass. A glob that quietly matches zero
+    files reports success while checking nothing, which is precisely the
+    silent-no-op this module exists to prevent -- and it is how a wrong path or
+    a renamed directory would turn this whole gate into decoration.
+    """
+    d = Path(directory)
+    paths = sorted(d.glob(_BASELINE_GLOB))
+    if not paths:
+        print(
+            "ERROR: no {} found under {} -- this gate checked NOTHING. Fix the "
+            "path rather than reading this as a pass.".format(_BASELINE_GLOB, d),
+            file=sys.stderr,
+        )
+        return 2
+
+    worst = 0
+    tiered = flat = 0
+    for path in paths:
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            print("ERROR: cannot read {}: {}".format(path, exc), file=sys.stderr)
+            worst = max(worst, 2)
+            continue
+        sections, _ = parse_sections(text)
+        if not sections:
+            flat += 1
+            print("  flat   {} (no tiers, no ledger to go stale)".format(path.name))
+            continue
+        tiered += 1
+        rc = check_baseline_file(path, declares_reads=_declares_reads(text), quiet=True)
+        worst = max(worst, rc)
+        if rc == 0:
+            print("  tiered {} ({} tier(s)) OK".format(path.name, len(sections)))
+    print(
+        "baseline headers: {} tiered checked, {} flat exempt, {} file(s) total"
+        .format(tiered, flat, len(paths))
+    )
+    return worst
 
 
 def main(argv):
     args = list(argv)
     if "--self-test" in args:
         return self_test()
+    if "--check-all" in args:
+        rest = [a for a in args if a != "--check-all"]
+        directory = rest[0] if rest else str(Path(__file__).resolve().parent)
+        return check_all(directory)
     if "--check" in args:
         declares_reads = "--reads" in args
         rest = [a for a in args if a not in ("--check", "--reads")]
@@ -413,7 +524,8 @@ def main(argv):
         return check_baseline_file(rest[0], declares_reads=declares_reads)
     print(
         "usage: _baseline_sections.py --self-test\n"
-        "       _baseline_sections.py --check PATH [--reads]",
+        "       _baseline_sections.py --check PATH [--reads]\n"
+        "       _baseline_sections.py --check-all [DIR]",
         file=sys.stderr,
     )
     return 2

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -922,16 +922,29 @@ fi
 # itself content-pinned by the cloud-safe walker ratchet (test_cloud_safe_file_walkers),
 # whose rule is that any edit obliges a safe_read migration; vault-root's own
 # checker validates its baseline inline, since only the scanner can count reads.
-echo "==> (e1b) baseline burn-down headers: $PY scripts/_baseline_sections.py --check scripts/utf8-stdout-baseline.txt"
-"$PY" scripts/_baseline_sections.py --self-test >/dev/null
-"$PY" scripts/_baseline_sections.py --check scripts/utf8-stdout-baseline.txt
-# Same ledger discipline for gate (e8)'s baseline. Worth stating why it is a
-# SEPARATE line rather than an oversight if it were missing: --check passes a
-# baseline that has NO section headers at all (rows outside any counted section
-# are not objected to), so a flat ledger is vacuously green here. That is why
-# utf8-file-io-baseline.txt is written with counted SEV-A/SEV-B sections instead
-# of a flat list -- an unsectioned baseline would be "checked" and prove nothing.
-"$PY" scripts/_baseline_sections.py --check scripts/utf8-file-io-baseline.txt
+echo "==> (e1b) baseline burn-down headers: $PY scripts/_baseline_sections.py --check-all scripts"
+# Quiet on success: two of its negative controls deliberately PRINT an error
+# (empty-glob, planted drift), and a gate that emits "ERROR ... checked
+# NOTHING" on every green run teaches people to skim past error lines.
+# On failure, re-run verbosely so the reason is visible.
+"$PY" scripts/_baseline_sections.py --self-test >/dev/null 2>&1 || {
+  "$PY" scripts/_baseline_sections.py --self-test
+  exit 1
+}
+# One sweep, not one line per baseline. The two explicit --check lines this
+# replaces are exactly the defect: utf8-file-io-baseline.txt needed a SECOND
+# hand-added line, and the third baseline would have needed a third. --check-all
+# globs them, so a new baseline is covered the day it lands.
+#
+# Carrying forward the note from that wiring, because it is still true and is
+# WHY the sweep reports flat files rather than silently passing them: a baseline
+# with NO section headers has no counted ledger, so there is nothing to compare
+# and checking it proves nothing. utf8-file-io-baseline.txt is deliberately
+# written with counted SEV-A/SEV-B sections instead of a flat list for that
+# reason. --check-all prints "flat ... (no tiers, no ledger to go stale)" for the
+# genuinely flat ones, so a baseline that SHOULD be sectioned and is not is
+# visible in the gate output instead of being indistinguishable from a pass.
+"$PY" scripts/_baseline_sections.py --check-all scripts
 
 # ---- (e2) Hook block-protocol ----------------------------------------------
 # scripts/check-hook-block-protocol.py fails a hook that is registered with the


### PR DESCRIPTION
## The bug, one level up from #557

#557 made each tiered baseline's section headers self-checking, then wired the gate by **naming one file**:

```
python3 scripts/_baseline_sections.py --check scripts/utf8-stdout-baseline.txt
```

That is the original defect repeated at the next level. A hand-maintained **list of what to check** goes stale exactly as silently as a hand-maintained **count**. Add a fifth baseline, or add tiers to one of the two flat ones, and it ships unguarded — nothing looks at it, and nothing says so.

## The fix

`--check-all` discovers baselines by glob instead of by name:

- **format auto-detected per file**, so a new baseline picks its own shape rather than being forced into one
- **flat baselines reported exempt, not skipped silently** — no tiers means no ledger to rot
- **matching NOTHING exits 2.** A glob that quietly matches zero files reports success while checking nothing. That is the same silent-no-op class this module exists to prevent, and it is how a renamed directory would turn the whole gate into decoration.

Measured on `scripts/`: 4 baselines — 2 tiered (`utf8-stdout` 2 tiers, `vault-root-read` 5 tiers), 2 flat exempt (`cloud-safe-walker`, `utf8-subprocess`).

## Negative controls

Two new cases, both exercising the **sweep** rather than the parser:

- a baseline this module was **never explicitly wired to**, carrying drift, is caught
- an empty glob **fails loud** instead of passing

17/17 self-tests, wired into `lint.yml` so they cannot go dormant.

## Sibling class, audited and clean

Also checked the adjacent risk — hand-written counts in baseline **prose**. Exactly one exists (`"All 12 rows deleted"`) and it is historical: SEV-A is permanently CLEARED at 0/0, so it describes a finished burn-down and cannot rot. No action needed.

## Gate status — disclosed

`ci-test` is **RED**, on a failure that is **not from this diff**:

```
FAILED - unpushed/no-remote drift surface
  hooks/test_unpushed_drift_surface.py
  an unchanged finding-set went SILENT instead of condensing
```

It reproduces **byte-identically on a pristine `origin/main` checkout**, so `main` is red for anyone running the gate on a dev box. The test pins its state dir but not its *findings*, so it reads live machine state (this box has 32 claim branches); it likely passes on the clean CI runner, which is the familiar "CI green, local gate red" shape. Filed separately in the tracker; deliberately not fixed here — different subsystem, own negative controls, and bundling it would couple two unrelated guards.

Pushed with the gate's own documented `CI_PARITY_BYPASS`. Every surface this PR touches is green: `--self-test` 17/17, `--check-all` 0, `check-vault-root-reads` 0, `check-utf8-stdout` 0. Exactly one suite in the entire gate fails, and it is the pre-existing one above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
