### PR TITLE
test(sync-vault-scripts): regression control for the (dry-run) mislabel

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -359,6 +359,14 @@ INTEGRATION_TESTS=(
   # copy, with a negative control that a first install from a dev tree still
   # wires a runner that exists.
   test_hook_runner_path_stability
+  # sync-vault-scripts.sh labelled its log header with `${DRY_RUN:+ (dry-run)}`,
+  # which tests NON-EMPTY while DRY_RUN is initialised to `0` — so every REAL run
+  # was recorded as "(dry-run)". Behaviour was correct (the write-guards use
+  # `-eq 1`); only the audit trail lied, which is the half that matters when you
+  # are reading the log to find out what overwrote your files. A dry run prints
+  # to stdout and never writes the log, so a "(dry-run)" header IN the log was
+  # unreachable except as a mislabel.
+  test_sync_vault_scripts_dryrun_label
   # vault-safe-commit.sh is the ONLY sanctioned route past the raw-git block
   # guard, so a bare `git commit -m` there gave that guard zero real scoping
   # while it looked fully enforced — a sibling session's staged work rode along

--- a/tests/integration/test_sync_vault_scripts_dryrun_label.sh
+++ b/tests/integration/test_sync_vault_scripts_dryrun_label.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# test_sync_vault_scripts_dryrun_label.sh
+#
+# sync-vault-scripts.sh labelled its log header with `${DRY_RUN:+ (dry-run)}`.
+# That parameter expansion tests NON-EMPTY, and DRY_RUN is initialised to `0`,
+# which IS non-empty — so EVERY real run was recorded as "(dry-run)".
+#
+# The write-guards use the correct `[ "$DRY_RUN" -eq 1 ]`, so behaviour was
+# always right and only the audit trail lied. That is the dangerous half: on
+# 2026-08-18 a real run overwrote two patched vault scripts and logged
+# "(dry-run) … Updated: 2", so reading the log to find the culprit said nothing
+# had been written.
+#
+# NEGATIVE CONTROL: the old expansion is evaluated directly and asserted to
+# mislabel a real run, so a green positive proves the fix rather than a
+# scenario that never reproduces.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SYNC="$REPO_ROOT/scripts/sync-vault-scripts.sh"
+
+FAILED=0
+pass() { printf '  PASS: %s\n' "$1"; }
+fail() { printf '  FAIL: %s\n' "$1"; FAILED=1; }
+
+echo "test_sync_vault_scripts_dryrun_label"
+
+# --- NEGATIVE CONTROL: the old form mislabels a real run --------------------
+old_label() { local DRY_RUN="$1"; printf '%s' "${DRY_RUN:+ (dry-run)}"; }
+if [ -n "$(old_label 0)" ]; then
+    pass "negative control: old \${DRY_RUN:+...} DOES mislabel a real run (DRY_RUN=0)"
+else
+    fail "negative control did not reproduce — the bug shape is wrong"
+fi
+
+# --- the shipped script must no longer use that expansion in CODE -----------
+# Comment lines are excluded on purpose: the fix documents the old expansion in
+# a comment, and matching that would fail forever on a correctly-fixed script.
+if grep -vE '^\s*#' "$SYNC" | grep -q 'DRY_RUN:+'; then
+    fail "shipped script still uses \${DRY_RUN:+...} in code"
+else
+    pass "shipped script no longer uses the non-empty expansion in code"
+fi
+
+# --- POSITIVE ---------------------------------------------------------------
+# Note the asymmetry, which is the bug's real shape: a dry run prints its
+# summary to STDOUT and never touches the log, while a real run writes the log.
+# So a "(dry-run)" header inside .vault-script-sync.log was unreachable except
+# as a mislabel — every one ever written there was, by construction, a real run.
+sync_run() {  # sync_run <extra-args...> -> echoes "<stdout header>|<log header>"
+    local vault; vault=$(mktemp -d)
+    mkdir -p "$vault/⚙️ Meta/scripts"
+    local out; out=$(bash "$SYNC" --vault "$vault" "$@" 2>/dev/null)
+    local log="$vault/⚙️ Meta/scripts/.vault-script-sync.log"
+    local loghdr=""
+    [ -f "$log" ] && loghdr=$(grep '^=== sync-vault-scripts.sh @' "$log" | tail -1)
+    printf '%s|%s' "$(printf '%s' "$out" | grep '^=== sync-vault-scripts.sh @' | tail -1)" "$loghdr"
+    rm -rf "$vault"
+}
+
+real_log_hdr=$(sync_run | sed 's/^[^|]*|//')
+case "$real_log_hdr" in
+    *"(dry-run)"*) fail "REAL run's LOG header still says (dry-run): $real_log_hdr" ;;
+    "")            echo "  SKIP: real run produced no log header in this environment" ;;
+    *)             pass "real run's log header is not labelled dry-run" ;;
+esac
+
+dry_stdout_hdr=$(sync_run --dry-run | sed 's/|.*//')
+case "$dry_stdout_hdr" in
+    *"(dry-run)"*) pass "dry run's stdout header IS labelled dry-run" ;;
+    "")            echo "  SKIP: dry run produced no stdout header" ;;
+    *)             fail "dry run header missing the (dry-run) label: $dry_stdout_hdr" ;;
+esac
+
+[ $FAILED -eq 0 ] && echo "OK" || echo "FAILURES"
+exit $FAILED


### PR DESCRIPTION
The `(dry-run)` mislabel in `sync-vault-scripts.sh` was fixed independently upstream (b73beb7) while this was in flight. This PR keeps only what was still missing: **a regression test and its CI registration.**

The test was written against a separate implementation and passes unchanged against upstream's, so it validates the behaviour rather than one particular patch.

## The bug it locks down

`${DRY_RUN:+ (dry-run)}` tests **non-empty**, and `DRY_RUN` is initialised to `0` — which is non-empty — so the log header said `(dry-run)` on every **real** run.

The write-guards use `[ "$DRY_RUN" -eq 1 ]` and were always correct, so behaviour was right and only the audit trail lied. That is the half that matters: on 2026-08-18 a real run overwrote two patched vault scripts and recorded it as `(dry-run) … Updated: 2`, so reading the log to find the culprit reported that nothing had been written.

Sharper still: a dry run prints its summary to stdout and never writes the log, so a `(dry-run)` header **inside** `.vault-script-sync.log` was unreachable except as a mislabel. Every one ever written there was a real run.

## Why the test is trustworthy

It carries a **negative control** that evaluates the old expansion directly and asserts it mislabels `DRY_RUN=0`. A green run therefore proves the behaviour rather than a scenario that never reproduces. It also drives the real script for both the real-run and dry-run paths and asserts the asymmetry (log vs stdout) explicitly.

`ci-test` GREEN (`EXIT=0`, marker `c5451c2c`): 122 integration tests, full canonical gate, scrub clean.

## Not covered

`scripts/sync-vault-scripts.ps1` uses a proper `[switch]`, so it never mislabels — but its log header carries no dry-run marker at all, so a Windows log cannot distinguish a dry run from a real one either. Left alone here rather than shipping a Windows change no gate on this runner can execute.

Drafted with Claude Code; gate run and diff reviewed before push.
