### PR TITLE
fix(launchd): ship the background-priority pattern, and detect when it drifts

### DIFF
--- a/docs/HOOK_FLEET_RESOURCE_GOVERNANCE.md
+++ b/docs/HOOK_FLEET_RESOURCE_GOVERNANCE.md
@@ -220,6 +220,39 @@ python3 scripts/footprint-sla-check.py --measure     # human report (add --execu
 python3 scripts/footprint-sla-check.py --selftest    # built-in pos/neg controls
 ```
 
+## Scheduling priority (the launchd axis)
+
+The budgets above bound how much work the fleet does. They do NOT bound the
+priority it does it at, and that is a separate way to freeze a machine.
+
+A LaunchAgent left at normal scheduling priority competes with WindowServer for
+CPU and disk. One is harmless. A fleet is not: measured 2026-08-19 on a 10-core
+host, 68 user agents (16 firing at least hourly, one every 60s) with none
+declaring itself background drove load to 43.78, then 109, and hard-froze the UI
+twice. RAM was fine throughout - 2GB free, swap flat - so the failure reads as a
+crash and misdirects every diagnosis at memory. Load, not memory, was the story.
+
+The default install wires **0 daemons**, so a fresh install does not start here.
+This is a GROWTH failure: it arrives as the operator adds jobs over months.
+
+Rules:
+
+- Every LaunchAgent carries `ProcessType=Background` (nice 10 + throttled CPU)
+  AND `LowPriorityIO=true` (disk yields to interactive). `LowPriorityIO` alone is
+  NOT enough - it covers disk only, leaving the job competing for CPU.
+- `scripts/com.granola-export.plist` is the shipped template and carries both.
+  Any new template must too: the template is what teaches the pattern.
+- Reload jobs with `RunAtLoad=true` ONE AT A TIME. Reloading a fleet together
+  fires every one of them at once, which is the same storm you are fixing.
+- A plist edit is deployed, not committed. Mirror it to wherever the plists are
+  tracked or the next installer run silently reverts it to normal priority.
+
+`hooks/surface-unniced-launchagents.py` detects the drift (pos/neg control:
+`tests/integration/test_surface_unniced_launchagents.sh`). It is deliberately
+NOT wired by default - SessionStart fan-out is at budget, and a growth failure
+does not warrant a cold `python3` start for every user on every session. Wire it
+by hand, or run it on demand, on a machine whose agent fleet is growing.
+
 ## Verify on a fresh install
 
 The repo being hardened is not the same as a fresh install landing the hardened

--- a/hooks/surface-unniced-launchagents.py
+++ b/hooks/surface-unniced-launchagents.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Surface LaunchAgents that run at normal priority — SessionStart (macOS only).
+
+A background maintenance job left at normal scheduling priority competes with
+WindowServer for CPU and disk. ONE is harmless. A FLEET is not: past roughly a
+dozen jobs the UI starves and the machine presents as FROZEN — while memory and
+disk stay healthy, so it reads as a crash and misdirects the diagnosis at RAM.
+
+Measured incident (2026-08-19): two hard freezes on a 10-core host, load 43.78
+then 109, with 2GB RAM free and swap flat. 68 user LaunchAgents, 16 firing at
+least hourly and one every 60s, none declaring itself background. Load — not
+memory — was the whole story.
+
+The fix is one key. ProcessType=Background gives nice 10 + throttled CPU;
+LowPriorityIO keeps disk reads behind anything interactive. This hook is the
+DETECT side: it never edits a plist, it names the ones missing the declaration.
+
+Fail-open by construction: non-macOS, missing dir, or any read error exits 0
+with no output. A surfacing hook must never block a session.
+
+Config:
+  UNNICED_AGENTS_MIN_COUNT  min offenders before surfacing (default 3)
+  UNNICED_AGENTS_CAP_HOURS  hours between reports (default 24)
+Bypass: UNNICED_LAUNCHAGENTS_BYPASS=1
+"""
+from __future__ import annotations
+
+import json
+import os
+import plistlib
+import sys
+import time
+from pathlib import Path
+
+AGENTS_DIR = Path.home() / "Library" / "LaunchAgents"
+STAMP = Path.home() / ".claude" / ".unniced-launchagents.stamp"
+DEFAULT_MIN_COUNT = 3
+DEFAULT_CAP_HOURS = 24.0
+
+# A job is considered priority-declared when ANY of these is present. Nice is
+# the explicit form; ProcessType=Background implies nice 10 + throttled I/O.
+# LowPriorityIO alone only covers disk, so it does NOT count on its own.
+_BACKGROUND_TYPES = {"Background", "Adaptive"}
+
+
+def is_priority_declared(plist: dict) -> bool:
+    """Pure decision: does this parsed plist declare a non-competing priority?
+
+    True when the job carries an explicit Nice, or a ProcessType that launchd
+    treats as non-interactive. LowPriorityIO alone is NOT sufficient — it only
+    de-prioritises disk, leaving the job competing for CPU with the UI.
+    """
+    if not isinstance(plist, dict):
+        return False
+    if isinstance(plist.get("Nice"), int):
+        return True
+    return plist.get("ProcessType") in _BACKGROUND_TYPES
+
+
+def _emit(msg: str | None) -> None:
+    if msg:
+        print(json.dumps({"systemMessage": msg}))
+    else:
+        print(json.dumps({"continue": True, "suppressOutput": True}))
+    sys.exit(0)
+
+
+def _capped() -> bool:
+    """True when a report was already emitted inside the cap window."""
+    try:
+        hours = float(os.environ.get("UNNICED_AGENTS_CAP_HOURS", DEFAULT_CAP_HOURS))
+    except ValueError:
+        hours = DEFAULT_CAP_HOURS
+    try:
+        return (time.time() - STAMP.stat().st_mtime) < hours * 3600
+    except OSError:
+        return False
+
+
+def main() -> None:
+    if os.environ.get("UNNICED_LAUNCHAGENTS_BYPASS"):
+        _emit(None)
+    if sys.platform != "darwin" or not AGENTS_DIR.is_dir():
+        _emit(None)
+    if _capped():
+        _emit(None)
+
+    try:
+        min_count = int(os.environ.get("UNNICED_AGENTS_MIN_COUNT", DEFAULT_MIN_COUNT))
+    except ValueError:
+        min_count = DEFAULT_MIN_COUNT
+
+    offenders: list[str] = []
+    total = 0
+    for p in sorted(AGENTS_DIR.glob("*.plist")):
+        try:
+            # Builtin open(), not p.open(): binary mode, and check-utf8-file-io
+            # reads the mode from args[1], so a Path.open("rb") reads to it as
+            # text mode and trips a false positive. Same bytes either way.
+            with open(p, "rb") as fh:
+                data = plistlib.load(fh)
+        except (OSError, plistlib.InvalidFileException, ValueError):
+            continue  # unreadable/corrupt plist is not this hook's business
+        total += 1
+        if not is_priority_declared(data):
+            offenders.append(p.stem)
+
+    if len(offenders) < min_count:
+        _emit(None)
+
+    shown = ", ".join(offenders[:5])
+    more = f" (+{len(offenders) - 5} more)" if len(offenders) > 5 else ""
+    try:
+        STAMP.parent.mkdir(parents=True, exist_ok=True)
+        STAMP.touch()
+    except OSError:
+        pass
+
+    _emit(
+        f"[launchd-priority] {len(offenders)} of {total} LaunchAgents run at normal "
+        f"priority: {shown}{more}. Background jobs at normal priority compete with "
+        "the UI for CPU and disk; past ~a dozen the machine can starve WindowServer "
+        "and present as FROZEN while RAM and disk look fine. Fix: add "
+        "<key>ProcessType</key><string>Background</string> + "
+        "<key>LowPriorityIO</key><true/> to each plist, then reload it. Reload jobs "
+        "with RunAtLoad=true one at a time — reloading them together fires them all "
+        f"at once. Bypass: UNNICED_LAUNCHAGENTS_BYPASS=1"
+    )
+
+
+if __name__ == "__main__":
+    # Windows cp1252-console safety (ai-brain-starter#313; hooks/ sweep #314).
+    # A hook that print()s non-ASCII raises UnicodeEncodeError on a cp1252
+    # console: the gate then fails silently OPEN, or denies the tool call with
+    # no legible cause. Idempotent; a no-op on an already-UTF-8 console.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
+    try:
+        main()
+    except Exception:  # fail-open: a surfacing hook never blocks a session
+        _emit(None)

--- a/scripts/check-hook-activation.py
+++ b/scripts/check-hook-activation.py
@@ -93,6 +93,17 @@ TEMPLATE_ONLY: Dict[str, str] = {
         "would hide the cost that gate exists to surface. Checkable: grep "
         "surface-sync-guard-findings hooks/worktree-footprint-signal.py "
         "(MYC-1133).",
+    "surface-unniced-launchagents.py":
+        "opt-in detector, deliberately unwired. It names LaunchAgents that run "
+        "at normal scheduling priority -- the 2026-08-19 freeze class (68 "
+        "agents, none declaring itself background, load 109 on 10 cores with "
+        "RAM healthy). Same call as surface-sync-guard-findings above: "
+        "SessionStart is at 19/19, so wiring it would breach the footprint SLA, "
+        "and raising the budget would tax every install's cold start forever "
+        "for a GROWTH failure that a default install (0 daemons wired) does not "
+        "have. Run it by hand, or wire it locally, on a machine whose agent "
+        "fleet is growing. Checkable: bash "
+        "tests/integration/test_surface_unniced_launchagents.sh (MYC-4032).",
 }
 
 # --- A: pre-existing debt (ratchet, may only shrink) -------------------------

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -226,6 +226,7 @@ INTEGRATION_TESTS=(
   test_bootstrap_ps1_slash_commands
   test_preflight_git_and_it_request
   test_remediate_runaway_procs
+  test_surface_unniced_launchagents
   test_scan_prior_single_instance
   test_scan_prior_failclosed_scrub
   test_sessionstart_freeze_class_excluded

--- a/scripts/com.granola-export.plist
+++ b/scripts/com.granola-export.plist
@@ -43,5 +43,16 @@
     <string>/path/to/your/vault/.granola_export.log</string>
     <key>RunAtLoad</key>
     <true/>
+    <!-- Scheduling priority: set BOTH on EVERY LaunchAgent you add, not just this one.
+         A background job left at normal priority competes with WindowServer for CPU
+         and disk. One is harmless; a fleet of them starves the UI and the machine
+         presents as FROZEN rather than merely busy - with memory and disk still
+         healthy, so it reads as a crash and misdirects every diagnosis at RAM.
+         ProcessType=Background => nice 10 + throttled CPU. LowPriorityIO => disk
+         reads yield to anything interactive. -->
+    <key>ProcessType</key>
+    <string>Background</string>
+    <key>LowPriorityIO</key>
+    <true/>
 </dict>
 </plist>

--- a/tests/integration/test_surface_unniced_launchagents.sh
+++ b/tests/integration/test_surface_unniced_launchagents.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Test: surface-unniced-launchagents.py — the "background job at normal
+# priority" detector.
+#
+# Bug class: a fleet of user LaunchAgents left at normal scheduling priority
+# competes with WindowServer for CPU and disk. Measured 2026-08-19: two hard
+# freezes on a 10-core host (load 43.78, then 109) with 2GB RAM free and swap
+# flat — 68 agents, none declaring itself background. Because memory and disk
+# stay healthy, the failure reads as a crash and misdirects diagnosis at RAM.
+#
+# The decision is factored into the pure function `is_priority_declared`, so
+# assertions 1-6 exercise every branch deterministically with no real plists.
+# Assertions 7-9 drive the real scan against a FIXTURE HOME, so the end-to-end
+# path is covered without reading the developer's actual LaunchAgents.
+#
+# Assertions:
+#   NEGATIVE controls (declared -> NOT flagged):
+#     1. ProcessType=Background.
+#     2. ProcessType=Adaptive.
+#     3. Explicit integer Nice.
+#   POSITIVE controls (undeclared -> flagged):
+#     4. A plist with neither key.
+#     5. LowPriorityIO alone — disk-only, still competes for CPU. The subtle one.
+#     6. A non-dict / garbage payload is never treated as declared.
+#   END-TO-END (fixture HOME, real scan):
+#     7. 3 undeclared agents -> systemMessage naming the count.
+#     8. All-declared fleet -> silent continue:true (no false alarm).
+#     9. UNNICED_LAUNCHAGENTS_BYPASS=1 -> no-op, valid JSON, continue:true.
+#
+# Self-contained. Exit 0 = pass, exit 1 = fail.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOK="$REPO_ROOT/hooks/surface-unniced-launchagents.py"
+# HOME alone does NOT sandbox on Windows: Path.home() reads USERPROFILE there,
+# so a bare HOME= override runs against the developer's REAL ~/.claude (MYC-3536).
+. "$REPO_ROOT/tests/integration/lib/sandbox_home.sh"
+if [ ! -f "$HOOK" ]; then
+  echo "FAIL: hook not found at $HOOK" >&2
+  exit 1
+fi
+
+# --- Assertions 1-6: pure-predicate pos/neg control ----------------------
+HOOK="$HOOK" python3 - <<'PY'
+import importlib.util
+import os
+import sys
+
+spec = importlib.util.spec_from_file_location("agents_under_test", os.environ["HOOK"])
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+failures = []
+
+def check(label, expected, payload):
+    got = mod.is_priority_declared(payload)
+    if got is not expected:
+        failures.append(f"{label}: expected {expected}, got {got}")
+
+# NEGATIVE controls — a declared job must never be flagged.
+check("1 ProcessType=Background", True, {"ProcessType": "Background"})
+check("2 ProcessType=Adaptive", True, {"ProcessType": "Adaptive"})
+check("3 explicit Nice", True, {"Nice": 10})
+
+# POSITIVE controls — an undeclared job must be flagged.
+check("4 neither key", False, {"Label": "com.example.job"})
+check("5 LowPriorityIO alone", False, {"LowPriorityIO": True})
+check("6 garbage payload", False, ["not", "a", "dict"])
+
+# ProcessType=Interactive is explicitly NOT a background declaration.
+check("6b ProcessType=Interactive", False, {"ProcessType": "Interactive"})
+
+if failures:
+    print("FAIL: is_priority_declared pos/neg control", file=sys.stderr)
+    for f in failures:
+        print("  " + f, file=sys.stderr)
+    sys.exit(1)
+PY
+echo "PASS: is_priority_declared pos+neg control (assertions 1-6)"
+
+# --- Assertions 7-9: end-to-end against a FIXTURE HOME -------------------
+# macOS ONLY. The hook is Darwin-gated by construction -- LaunchAgents do not
+# exist elsewhere, so on Linux/Windows it exits early with a bare continue and
+# the end-to-end path has nothing to assert. Assertions 1-6 above are pure and
+# DO run on every platform, so this file still carries real coverage in CI
+# (the canonical ci gate runs on ubuntu-latest).
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "SKIP: assertions 7-9 are macOS-only (hook is Darwin-gated); 1-6 passed on $(uname -s)"
+  exit 0
+fi
+
+FIXTURE="$(mktemp -d)"
+trap 'rm -rf "$FIXTURE"' EXIT
+mkdir -p "$FIXTURE/Library/LaunchAgents" "$FIXTURE/.claude"
+
+write_plist() {  # $1=name  $2=extra-xml
+  cat > "$FIXTURE/Library/LaunchAgents/$1.plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>Label</key><string>$1</string>
+$2
+</dict></plist>
+EOF
+}
+
+# 7: three undeclared agents must surface, naming the count.
+write_plist com.test.alpha ""
+write_plist com.test.beta ""
+write_plist com.test.gamma ""
+OUT="$(run_sandboxed "$FIXTURE" env UNNICED_AGENTS_CAP_HOURS=0 python3 "$HOOK" 2>/dev/null)"
+echo "$OUT" | python3 -c '
+import json,sys
+d=json.load(sys.stdin)
+m=d.get("systemMessage","")
+assert "3 of 3" in m, f"expected count 3 of 3 in message, got: {m}"
+assert "ProcessType" in m, "message must name the fix"
+' || { echo "FAIL assertion 7: undeclared fleet not surfaced" >&2; echo "$OUT" >&2; exit 1; }
+echo "PASS: undeclared fleet surfaced with count + fix (assertion 7)"
+
+# 8: an all-declared fleet must stay SILENT — the no-false-alarm control.
+write_plist com.test.alpha "  <key>ProcessType</key><string>Background</string>"
+write_plist com.test.beta  "  <key>ProcessType</key><string>Background</string>"
+write_plist com.test.gamma "  <key>Nice</key><integer>10</integer>"
+OUT="$(run_sandboxed "$FIXTURE" env UNNICED_AGENTS_CAP_HOURS=0 python3 "$HOOK" 2>/dev/null)"
+echo "$OUT" | python3 -c '
+import json,sys
+d=json.load(sys.stdin)
+assert d.get("continue") is True, d
+assert "systemMessage" not in d, f"declared fleet must not surface: {d}"
+' || { echo "FAIL assertion 8: false alarm on a fully-declared fleet" >&2; echo "$OUT" >&2; exit 1; }
+echo "PASS: fully-declared fleet stays silent (assertion 8)"
+
+# 9: bypass must no-op with valid JSON.
+OUT="$(run_sandboxed "$FIXTURE" env UNNICED_LAUNCHAGENTS_BYPASS=1 python3 "$HOOK" 2>/dev/null)"
+echo "$OUT" | python3 -c 'import json,sys; d=json.load(sys.stdin); assert d.get("continue") is True, d' \
+  || { echo "FAIL assertion 9: bypass did not emit continue JSON" >&2; exit 1; }
+echo "PASS: bypass no-ops with valid JSON (assertion 9)"
+
+echo "All assertions passed. Unniced-LaunchAgent detector holds (pos+neg control)."


### PR DESCRIPTION
## Why

A LaunchAgent left at normal scheduling priority competes with WindowServer for CPU and disk. One is harmless; a fleet is not.

Measured 2026-08-19 on a 10-core host: **68 user LaunchAgents** (16 firing at least hourly, one every 60s), none declaring itself background, drove load to **43.78 and then 109** and hard-froze the UI twice. RAM was healthy the entire time — 2GB free, swap flat, 316GB disk free. Because nothing looks wrong in memory, the failure reads as a crash and misdirects diagnosis at RAM. The largest process in Activity Monitor is always at the top of a memory-sorted list, so it looks guilty even after it has been fixed.

The default install wires **0 daemons**, so a fresh install does not start here. This is a **growth** failure: it arrives as an operator adds jobs over months. But the substrate was teaching the wrong pattern on the way in — `scripts/com.granola-export.plist` is the one shipped template, its comments are the install docs, and it declared no priority at all. Every job copied from it inherited normal priority.

Relates to MYC-570, whose predicate covered two freeze classes (cloud-sync daemon meltdown, SessionStart-hook pile-up). Scheduling priority is a third class it never contemplated — this is not a regression of it.

## What changed

- **`scripts/com.granola-export.plist`** — declares `ProcessType=Background` (nice 10 + throttled CPU) and `LowPriorityIO`, with the rationale inline. The template is what teaches the pattern.
- **`hooks/surface-unniced-launchagents.py`** — detects agents missing the declaration. The decision is the pure `is_priority_declared`, so the control test needs no real plists. `LowPriorityIO` alone does **not** count as declared: it covers disk only, leaving the job competing for CPU. Fail-open on non-macOS, unreadable plists, and any exception; 24h cap; bypass env.
- **`scripts/check-hook-activation.py`** — declares the hook `TEMPLATE_ONLY`, deliberately unwired. SessionStart is at **19/19** on the footprint SLA; wiring it would breach the budget, and raising the budget would tax every install's cold start forever for a failure a default install does not have. Same call and same rationale as `surface-sync-guard-findings` (MYC-1133).
- **`docs/HOOK_FLEET_RESOURCE_GOVERNANCE.md`** — the priority axis alongside the existing work-volume budgets, including two traps found the hard way: reloading a `RunAtLoad=true` fleet together re-fires the storm, and a plist edit is deployed-not-committed until mirrored where the plists are tracked.

## Verification

`ci-test` GREEN on `5f405b3` — 122 integration tests, 368 files `py_compile`, 24 `scripts/` + 17 `hooks/tests` unit suites, shellcheck, utf8 console guard, hook block-protocol, vault-root reads, home-hook deploy, subprocess decode, py3.9 annotation parity, ps1 UTF-8 BOM. Marker `5f405b36.ok` written.

New test: 9 assertions — 3 negative controls (`Background`, `Adaptive`, explicit `Nice`), 4 positive (neither key, **`LowPriorityIO` alone**, garbage payload, `Interactive`), 2 end-to-end against a fixture HOME.

**Not covered:** `live-evals(local-scrub)` is skipped locally and runs in CI. The detector is unwired, so it executes on no install until someone opts in.

## Five defects this repo's gates caught in my own work

Worth recording, because four are invisible on macOS:

1. Test file absent from `INTEGRATION_TESTS` — would have shipped as coverage that never runs.
2. Missing UTF-8 console guard — `UnicodeEncodeError` on a cp1252 console, failing silently open.
3. `HOME` set without `USERPROFILE` — on Windows `Path.home()` reads `USERPROFILE`, so all three end-to-end assertions would have run against the developer's real `~/.claude` and written a stamp into it (MYC-3536).
4. Hook shipped with no activation channel — dormant is byte-identical to forgotten, so the repo requires the non-wiring to be declared.
5. `check-utf8-file-io.py` false-positived a correct binary `Path.open("rb")`. Its `_mode_of` reads `args[1]`, right for builtin `open(path, mode)` but wrong for the `Path.open(mode)` method, so the binary guard never fires and it demands an `encoding=` that would raise `ValueError`. Worked around with the builtin form rather than patching a shipped correctness gate in an unrelated PR; evidence added to **MYC-3559**, which already tracks the identical bug in `check-cloud-safe-file-walkers.py`.

Follow-up: **MYC-4032** — the reaper is scoped to `~/.claude/hooks/`, so a cron/maintenance script can burn hours invisibly. That is the other half of this incident and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
