### PR TITLE
fix(guards): close two checks that reported OK without checking, and make hook parity argument-aware (MYC-3879)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -235,6 +235,33 @@ jobs:
       - name: no shipped hook lacks a test surface
         run: python3 scripts/check-hook-negative-control.py
 
+      # The check above asks whether a hook is wired AT ALL. This asks whether it
+      # is wired on BOTH PLATFORMS - a question nothing in this repo used to ask.
+      #
+      # hooks.json is POSIX shell. On native Windows the installer rewrites every
+      # command through hook_runner.py, and anything it cannot rewrite - anything
+      # that runs `bash` - is DROPPED. Four hooks are dropped today and three of
+      # them (write-hook.sh, session-end-hook.sh, graph-context-hook.sh) have NO
+      # Windows equivalent, so meeting-todos extraction, the session-close
+      # finalizer and graph-context routing are POSIX-only features. Every existing
+      # check stayed green through that: the installer exits 0 because it installed
+      # what it could, --verify verifies what is WIRED (not what went missing), and
+      # CI asserts the install SUCCEEDS. A Windows job and a macOS job could differ
+      # by three whole features and both pass.
+      #
+      # The gate diffs the two legs by running the installer's OWN pipeline twice
+      # (never a private copy of the drop rule, which would agree today and drift
+      # silently), and fails on any difference not carrying a written reason in
+      # scripts/hook-parity-allowlist.json. The allowlist is the deliverable: it
+      # turns a silent drop into a reviewed decision, and a stale entry fails too,
+      # so it cannot rot into excuses for problems already fixed.
+      # Self-test first (cheap, and proves the gate bites a synthetic mismatch).
+      - name: hook-parity negative controls (a silent platform drop must go RED)
+        run: python3 scripts/check-hook-parity.py --self-test
+
+      - name: every hook is wired on both POSIX and Windows, or reviewed as not
+        run: python3 scripts/check-hook-parity.py
+
       # The READ half of the UTF-8 console guard below. That one fails a CLI that
       # PRINTS non-ASCII without reconfiguring stdout; this fails one that READS a
       # child's output with text=True and no encoding=, so the decode uses the

--- a/scripts/audit-sessionstart-boundedness.py
+++ b/scripts/audit-sessionstart-boundedness.py
@@ -46,11 +46,14 @@ or runs a bounded subprocess - needs none of this. It is bounded by construction
 and passes clean.
 
 Modes:
-  --all [--hooks-json P] [--hooks-dir D]
+  --all [--hooks-json P] [--hooks-dir D [D ...]]
                     Audit the canonical SessionStart set (default: the SessionStart
-                    block of <repo>/hooks.json, resolved against <repo>/hooks/).
-                    Exit 1 if any wired hook is an unguarded, unexempt corpus
-                    walker. This is the CI gate.
+                    block of <repo>/hooks.json, resolved against <repo>/hooks/ AND
+                    <repo>/scripts/ — a SessionStart hook may ship in either, and
+                    heal-journal-guard.py ships in scripts/, so a hooks/-only
+                    resolver skipped it silently). Exit 1 if any wired hook is an
+                    unguarded, unexempt corpus walker; exit 2 if any wired hook
+                    could not be resolved and read. This is the CI gate.
   --check FILE      Add-time gate for ONE candidate SessionStart hook script: exit
                     1 if it recursive-walks without the guards or the exemption.
                     Advisory - fails OPEN (exit 0) on its own read error. Used by
@@ -69,7 +72,22 @@ Stdlib only. Reads are bounded (1 MB cap, binary skip) - cloud-safe-walk
 compliant. --all / --selftest fail LOUD (exit 2) on an internal error so a broken
 detector can never silently pass CI; --check fails OPEN (it is advisory).
 
-Provenance: MYC-571 (parent incident MYC-570, the 2026-06-05 Mac-freeze).
+Exit codes (--all / --settings):
+  0  every wired SessionStart hook was READ and is bounded or declared-bounded
+  1  at least one hook is an unguarded, unexempt corpus walker
+  2  UNEVALUATED - a hook was skipped (unresolvable command, missing file,
+     unreadable source), or an internal error. NEVER 0: an audit is only as
+     strong as the fraction of the set it actually opened, and "6 of 25 read,
+     0 unguarded" is not "the fleet is bounded". This mirrors
+     scripts/audit-guard-activation-roots.py, which already refuses to call an
+     empty comparison a pass ("Nothing was compared - that is not the same as
+     everything matching"). MYC-3879: run against a live settings.json this
+     printed "6 resolved - 6 clean, 0 unguarded; 19 unresolved" followed by a
+     bare OK and exit 0. Nineteen wired commands were never opened and the
+     verdict said PASS.
+
+Provenance: MYC-571 (parent incident MYC-570, the 2026-06-05 Mac-freeze);
+verdict + resolution-root fixes MYC-3879.
 Canonical guarded example: hooks/scan-prior-sessions-for-secrets.py.
 """
 from __future__ import annotations
@@ -308,15 +326,35 @@ def _cite() -> str:
 
 
 # ---- modes --------------------------------------------------------------------
-def cmd_all(hooks_json: Path, hooks_dir: Path, as_json: bool) -> int:
+def _resolve_in_dirs(bn: str, dirs: list[Path]) -> Path | None:
+    """First existing <dir>/<basename> across the resolution roots, else None.
+
+    Why a LIST and not one hooks/ directory (MYC-3879): SessionStart hooks ship
+    from two places. heal-journal-guard.py is wired on SessionStart and lives in
+    <repo>/scripts, so a hooks/-only resolver could not open it and dropped it
+    into the "not found - skipped" bucket, where the old verdict ignored it."""
+    for d in dirs:
+        f = d / bn
+        if f.exists():
+            return f
+    return None
+
+
+def cmd_all(hooks_json: Path, hooks_dirs: list[Path], as_json: bool) -> int:
     names = sessionstart_basenames(hooks_json)
     rows, reds, exempts, unresolved = [], [], [], []
     for bn in names:
-        f = hooks_dir / bn
-        if not f.exists():
+        f = _resolve_in_dirs(bn, hooks_dirs)
+        if f is None:
             unresolved.append(bn)
             continue
         src = _read_bounded(f)
+        if not src:
+            # Unreadable / binary / oversize. Previously indistinguishable from
+            # "clean" because evaluate("") returns ok=True with no walk. An
+            # unread file is UNEVALUATED, not bounded.
+            unresolved.append(bn)
+            continue
         v = evaluate(src, _detect_lang(bn, src))
         rows.append((bn, v))
         if v["walk"] and not v["ok"] and not v["exempt"]:
@@ -327,19 +365,23 @@ def cmd_all(hooks_json: Path, hooks_dir: Path, as_json: bool) -> int:
     if as_json:
         print(json.dumps(dict(
             hooks_json=str(hooks_json),
+            hooks_dirs=[str(d) for d in hooks_dirs],
             audited=[bn for bn, _ in rows],
             unresolved=unresolved,
+            verdict=("FAIL" if reds else "UNEVALUATED" if unresolved else "PASS"),
             red=[dict(hook=bn, walks=v["walks"], missing=v["missing"]) for bn, v in reds],
             exempt=[dict(hook=bn, reason=v["exempt_reason"]) for bn, v in exempts],
         ), indent=2))
-        return 1 if reds else 0
+        return 1 if reds else (2 if unresolved else 0)
 
     print("=" * 78)
     print("SessionStart boundedness audit (MYC-571) - corpus walks need the 3 guards")
     print("=" * 78)
     print(f"hooks.json: {hooks_json}")
-    print(f"{len(rows)} SessionStart hook(s) audited; "
-          f"{len(reds)} unguarded corpus walk(s); {len(exempts)} declared-bounded.\n")
+    print(f"resolution roots: {', '.join(str(d) for d in hooks_dirs)}")
+    print(f"{len(rows)} of {len(names)} SessionStart hook(s) audited; "
+          f"{len(reds)} unguarded corpus walk(s); {len(exempts)} declared-bounded; "
+          f"{len(unresolved)} NOT EVALUATED.\n")
     for bn, v in rows:
         if v["walk"] and not v["ok"] and not v["exempt"]:
             mark = "RED "
@@ -357,12 +399,22 @@ def cmd_all(hooks_json: Path, hooks_dir: Path, as_json: bool) -> int:
         if v["walk"] and not v["ok"] and not v["exempt"]:
             detail += f"  MISSING: {', '.join(v['missing'])}"
         print(f"  [{mark}] {bn}{detail}")
-    if unresolved:
-        print(f"\n  (note: {len(unresolved)} wired hook(s) not found under {hooks_dir} - "
-              f"user-level only, skipped: {', '.join(unresolved)})")
     if reds:
         print("\n" + _cite())
         return 1
+    if unresolved:
+        # NOT a note, and NOT exit 0. This used to print "user-level only,
+        # skipped" and pass — an assumption about hooks nothing had opened.
+        print(f"\nUNEVALUATED: {len(unresolved)} wired SessionStart hook(s) could not be "
+              f"resolved and read under {', '.join(str(d) for d in hooks_dirs)}:")
+        for bn in unresolved:
+            print(f"    - {bn}")
+        print("Nothing was checked for those - that is not the same as them being\n"
+              "bounded. Ship the hook into a resolution root, or pass the root that\n"
+              "holds it with --hooks-dir. (heal-journal-guard.py is exactly this\n"
+              "class: SessionStart-wired, shipped in scripts/, invisible to a\n"
+              "hooks/-only audit that then reported OK.)")
+        return 2
     print("\nAll SessionStart corpus walks are guarded or declared-bounded. OK.")
     return 0
 
@@ -490,8 +542,16 @@ def cmd_settings(settings_path: Path, porcelain: bool) -> int:
     template that --all checks (MYC-1113). Resolves each hook by its full command
     path.
 
-    Exit: 0 = every resolved hook is bounded/declared; 1 = >=1 unguarded corpus
-    walker; 2 = settings.json missing / unparseable (fail LOUD, never silent)."""
+    Exit: 0 = every wired command was READ and is bounded/declared; 1 = >=1
+    unguarded corpus walker; 2 = UNEVALUATED — settings.json missing /
+    unparseable, OR at least one wired command was never opened (MYC-3879).
+
+    That last case used to exit 0. On a live Windows settings.json it printed
+    "6 resolved hook(s) — 6 clean, 0 unguarded; 19 unresolved" and then "OK."
+    Nineteen SessionStart commands went unread and the verdict was PASS, so a
+    freeze-class hook among them could never have been reported. The skip count
+    was already on screen; only the EXIT CODE decides what CI and diagnose.sh
+    believe, and it said everything was fine."""
     p = Path(settings_path)
     if not p.exists():
         print("ERROR:not-found" if porcelain else f"ERROR: settings.json not found: {p}")
@@ -501,22 +561,26 @@ def cmd_settings(settings_path: Path, porcelain: bool) -> int:
     except Exception as e:
         print("ERROR:unparseable" if porcelain else f"ERROR: settings.json unparseable: {e}")
         return 2
-    reds, exempts, clean, unresolved = [], 0, 0, 0
+    reds, exempts, clean = [], 0, 0
+    # (why-it-was-skipped, what-was-skipped). Kept as a list, not a bare count:
+    # "19 unresolved" is unactionable, and an unactionable number is what let
+    # this stay at 19 for months.
+    skipped: list[tuple[str, str]] = []
     seen: set[str] = set()
     for c in sessionstart_commands(p):
         rp = resolve_command_path(c)
         if rp is None:
-            unresolved += 1
+            skipped.append(("no absolute script path in the command", c[:96]))
             continue
         if str(rp) in seen:
             continue
         seen.add(str(rp))
         if not rp.exists():
-            unresolved += 1
+            skipped.append(("script not on disk", str(rp)))
             continue
         src = _read_bounded(rp)
         if not src:
-            unresolved += 1
+            skipped.append(("source unreadable / binary / over 1 MB", str(rp)))
             continue
         v = evaluate(src, _detect_lang(rp.name, src))
         if v["walk"] and not v["ok"] and not v["exempt"]:
@@ -526,20 +590,35 @@ def cmd_settings(settings_path: Path, porcelain: bool) -> int:
         else:
             clean += 1
     if porcelain:
+        # A found freeze-class hook outranks an incomplete audit: UNGUARDED is
+        # a fact, PARTIAL is an absence of facts.
         if reds:
             print("UNGUARDED:" + str(len(reds)) + ":" + ",".join(n for n, _ in reds))
             return 1
-        print(f"OK:{clean}:{exempts}:{unresolved}")
+        if skipped:
+            print(f"PARTIAL:{clean}:{exempts}:{len(skipped)}")
+            return 2
+        print(f"OK:{clean}:{exempts}:0")
         return 0
     total = clean + exempts + len(reds)
     print(f"Effective SessionStart set ({p}): {total} resolved hook(s) — "
           f"{clean} clean, {exempts} declared-bounded, {len(reds)} unguarded; "
-          f"{unresolved} unresolved.")
+          f"{len(skipped)} NOT EVALUATED.")
     for n, v in reds:
         print(f"  RED  {n}: walk={'+'.join(v['walks'])}  MISSING: {', '.join(v['missing'])}")
     if reds:
         print("\n" + _cite())
         return 1
+    if skipped:
+        print(f"\nUNEVALUATED: {len(skipped)} wired SessionStart command(s) were never "
+              f"opened, so nothing is known about them:")
+        for why, what in skipped:
+            print(f"    - {what}\n        ({why})")
+        print("A verdict over the fraction that happened to resolve is not a verdict\n"
+              "over the fleet. Every line above could be a corpus walker and this\n"
+              "audit would look identical. Fix the wiring (absolute paths), install\n"
+              "the missing scripts, then re-run - do NOT read this as bounded.")
+        return 2
     print("All resolved SessionStart corpus walks are guarded or declared-bounded. OK.")
     return 0
 
@@ -749,7 +828,15 @@ def main() -> int:
     ap.add_argument("--json", action="store_true")
     ap.add_argument("--porcelain", action="store_true", help="one-line verdict (with --settings)")
     ap.add_argument("--hooks-json", default=str(repo / "hooks.json"))
-    ap.add_argument("--hooks-dir", default=str(repo / "hooks"))
+    # nargs="+": a SessionStart hook may ship from hooks/ OR scripts/, so the
+    # default is BOTH. A single-value `--hooks-dir X` still parses exactly as
+    # before (existing callers and tests are unaffected) and REPLACES the
+    # default pair, which keeps a hermetic fixture run from silently reaching
+    # into the real repo.
+    ap.add_argument("--hooks-dir", nargs="+", default=[str(repo / "hooks"),
+                                                       str(repo / "scripts")],
+                    help="one or more roots to resolve wired hook basenames "
+                         "against (default: <repo>/hooks <repo>/scripts)")
     a = ap.parse_args()
 
     # --check is advisory: fail OPEN on its own error.
@@ -768,7 +855,8 @@ def main() -> int:
         if a.settings:
             return cmd_settings(Path(a.settings), a.porcelain)
         if a.all:
-            return cmd_all(Path(a.hooks_json), Path(a.hooks_dir), a.json)
+            dirs = [a.hooks_dir] if isinstance(a.hooks_dir, str) else list(a.hooks_dir)
+            return cmd_all(Path(a.hooks_json), [Path(d) for d in dirs], a.json)
     except Exception as e:
         print(f"[sessionstart-boundedness] FATAL: {e}", file=sys.stderr)
         return 2

--- a/scripts/check-hook-parity.py
+++ b/scripts/check-hook-parity.py
@@ -23,8 +23,22 @@ so out loud until this file existed.
 
 WHAT THIS DOES. Runs the installer's OWN pipeline twice over hooks.json - once
 as POSIX, once forced to the Windows leg - and diffs the resulting (event, hook
-basename) sets. Any difference not present in scripts/hook-parity-allowlist.json
-FAILS. Every allowlist entry must carry a non-empty reason.
+basename, arguments) sets. Any difference not present in
+scripts/hook-parity-allowlist.json FAILS. Every allowlist entry must carry a
+non-empty reason.
+
+WHY ARGUMENTS ARE PART OF THE IDENTITY. A hook is not a script; it is a script
+plus what it is invoked with. hooks.json wires lint-claude-settings.py TWICE on
+SessionStart - once plain, once `--test` for the self-test that asserts its
+guards still bite - and until #504 the Windows rewrite discarded everything after
+the script path, so both became the same argument-less command and the
+installer's dedup collapsed the pair. The linter ran; its negative control
+silently did not, on every Windows install, for as long as the rewrite existed.
+Keyed on (event, basename) alone that is invisible: a SET puts both entries on
+one element, so both legs agree and this gate reports parity whether the --test
+registration survived or not. With arguments in the key the POSIX leg has two
+elements and the Windows leg one, and the difference is named for what it is - a
+registration present on one platform and absent on the other.
 
 Why the installer's own functions and not a reimplementation: a private copy of
 the drop rule would agree with the installer on the day it was written and
@@ -118,28 +132,54 @@ def _load_installer():
             f"{INSTALLER.name} no longer exports: {', '.join(missing)}. This gate "
             "compares the installer's REAL behaviour, so it cannot run against a "
             "renamed pipeline - re-point it rather than deleting it.")
+    # Deliberately not in REQUIRED_ATTRS: this one is NEWER than the gate's other
+    # needs, so a base predating it deserves a message that says so rather than
+    # the misleading "no longer exports".
+    if not hasattr(mod, "_hook_script_args"):
+        raise Unevaluated(
+            f"{INSTALLER.name} does not export _hook_script_args (added in #504). "
+            "This gate compares hook ARGUMENTS, not just script names, so it "
+            "cannot run against a base that predates it - rebase onto main.")
     return mod
 
 
-def _pairs(template: dict, drop_basenames: set[str]) -> set[tuple[str, str]]:
-    """{(event, hook basename)} wired by this template.
+def _pairs(template: dict, drop_basenames: set[str],
+           hook_args) -> set[tuple[str, str, tuple[str, ...]]]:
+    """{(event, hook basename, arguments)} wired by this template.
 
     Per EVENT, not a flat basename set: the same hook wired on SessionStart on
     one platform and on Stop on the other is a real behavioural difference, and
-    a flat set would call it parity."""
-    out: set[tuple[str, str]] = set()
+    a flat set would call it parity.
+
+    With ARGUMENTS, not the basename alone: one script wired twice on one event
+    under different arguments is two registrations, and a basename-keyed set
+    collapses them onto a single element that both legs then always agree on
+    (see WHY ARGUMENTS ARE PART OF THE IDENTITY above).
+
+    `hook_args` is the installer's OWN extractor, passed in for the same reason
+    the rest of this gate imports rather than reimplements: a private copy of the
+    argument rule would agree on the day it was written and drift silently after.
+
+    Arguments belong to the COMMAND, so every basename a command names carries
+    that command's arguments. A fallback chain naming one basename twice still
+    collapses to one element, exactly as before."""
+    out: set[tuple[str, str, tuple[str, ...]]] = set()
     for event, blocks in (template.get("hooks") or {}).items():
         for block in blocks or []:
             for hook in (block.get("hooks") or []):
-                for match in _SCRIPT_RE.findall(hook.get("command", "") or ""):
+                command = hook.get("command", "") or ""
+                args = tuple(hook_args(command))
+                for match in _SCRIPT_RE.findall(command):
                     basename = os.path.basename(match)
                     if basename in drop_basenames:
                         continue
-                    out.add((event, basename))
+                    out.add((event, basename, args))
     return out
 
 
-def wired_sets(mod, hooks_json: Path) -> tuple[set[tuple[str, str]], set[tuple[str, str]], list[str]]:
+def wired_sets(mod, hooks_json: Path) -> tuple[
+        set[tuple[str, str, tuple[str, ...]]],
+        set[tuple[str, str, tuple[str, ...]]], list[str]]:
     """(posix_pairs, windows_pairs, installer-reported skips).
 
     Runs the installer's real pipeline in both directions. `_is_windows` is
@@ -170,8 +210,8 @@ def wired_sets(mod, hooks_json: Path) -> tuple[set[tuple[str, str]], set[tuple[s
         template = mod.substitute_python_interpreter(template)
         if force_windows:
             template, skipped = mod.platformize_template_for_windows(template)
-            return _pairs(template, launcher_only), list(skipped)
-        return _pairs(template, set()), []
+            return _pairs(template, launcher_only, mod._hook_script_args), list(skipped)
+        return _pairs(template, set(), mod._hook_script_args), []
 
     try:
         posix, _ = leg(False)
@@ -224,7 +264,7 @@ def load_allowlist(path: Path) -> tuple[dict[tuple[str, str], str], dict[tuple[s
     return section("posix_only"), section("windows_only")
 
 
-def compare(posix: set[tuple[str, str]], windows: set[tuple[str, str]],
+def compare(posix: set[tuple], windows: set[tuple],
             allow_posix: dict[tuple[str, str], str],
             allow_windows: dict[tuple[str, str], str]) -> dict:
     """Pure verdict. Separated from the installer plumbing so --self-test can
@@ -233,24 +273,33 @@ def compare(posix: set[tuple[str, str]], windows: set[tuple[str, str]],
     windows_only = windows - posix
 
     unreviewed, reasonless, stale = [], [], []
+    # Allowlist keys stay (event, hook): ONE reviewed decision covers every
+    # argument variant of that hook on that event. So adding arguments to the
+    # comparison invalidates not a single committed allowlist entry - the
+    # reviewed-asymmetry file keeps its exact meaning, and only the DIFF gets
+    # sharper. (`pair[:2]` also lets --self-test keep driving compare() with
+    # plain (event, hook) fixtures, which is why those controls still read the
+    # same below.)
     for pair in sorted(posix_only):
-        if pair not in allow_posix:
+        if pair[:2] not in allow_posix:
             unreviewed.append(("posix_only", pair))
-        elif not allow_posix[pair]:
+        elif not allow_posix[pair[:2]]:
             reasonless.append(("posix_only", pair))
     for pair in sorted(windows_only):
-        if pair not in allow_windows:
+        if pair[:2] not in allow_windows:
             unreviewed.append(("windows_only", pair))
-        elif not allow_windows[pair]:
+        elif not allow_windows[pair[:2]]:
             reasonless.append(("windows_only", pair))
     # A stale entry is a fixed drop whose excuse survived. Left alone, the
     # allowlist decays into a list nobody re-reads, which is how a reviewed
     # decision quietly becomes an unreviewed one again.
+    posix_only_keys = {p[:2] for p in posix_only}
+    windows_only_keys = {p[:2] for p in windows_only}
     for pair in sorted(allow_posix):
-        if pair not in posix_only:
+        if pair not in posix_only_keys:
             stale.append(("posix_only", pair))
     for pair in sorted(allow_windows):
-        if pair not in windows_only:
+        if pair not in windows_only_keys:
             stale.append(("windows_only", pair))
 
     return {
@@ -304,6 +353,39 @@ def _selftest_compare_cases() -> list[str]:
 
     check("stale allowlist entry (the drop was fixed, the excuse stayed)",
           compare(base, set(base), {("PreToolUse", "b.py"): "obsolete"}, {}), False)
+
+    # ---- arguments are part of the identity (the #504 class) ----------------
+    # One script, one event, wired twice under DIFFERENT arguments - the shape
+    # hooks.json actually ships for lint-claude-settings.py. The Windows leg
+    # keeps only the argument-less registration, which is precisely what the
+    # pre-#504 rewrite produced.
+    two_variants = {("SessionStart", "lint.py", ()),
+                    ("SessionStart", "lint.py", ("--test",))}
+    collapsed = {("SessionStart", "lint.py", ())}
+
+    # PREMISE, asserted rather than asserted-in-a-comment: with arguments
+    # stripped these two fixtures are the SAME set. So the old (event, basename)
+    # key could not have caught this, and the control below is not a duplicate
+    # of the drop controls above. If this ever stops holding, the fixture has
+    # drifted into testing something easier than the bug it stands for.
+    if {q[:2] for q in two_variants} != {q[:2] for q in collapsed}:
+        fails.append("arg-collapse fixture is distinguishable WITHOUT arguments; "
+                     "it no longer exercises the #504 class")
+
+    check("same script+event, one ARGUMENT variant dropped on Windows",
+          compare(two_variants, collapsed, {}, {}), False)
+    check("both argument variants survive on both platforms",
+          compare(two_variants, set(two_variants), {}, {}), True)
+    check("an argument variant dropped, allowlisted by (event, hook)",
+          compare(two_variants, collapsed,
+                  {("SessionStart", "lint.py"): "no Windows port for the self-test"},
+                  {}), True)
+    check("an argument variant dropped, allowlisted with an EMPTY reason",
+          compare(two_variants, collapsed, {("SessionStart", "lint.py"): ""}, {}), False)
+    # A Windows-only ARGUMENT is a difference in the other direction: the same
+    # script gaining a flag no POSIX install passes is not parity either.
+    check("Windows-only argument variant, NOT allowlisted",
+          compare(collapsed, two_variants, {}, {}), False)
     return fails
 
 
@@ -327,11 +409,12 @@ def _selftest_endtoend(mod) -> list[str]:
         except Unevaluated as e:
             return [f"end-to-end fixture could not be evaluated: {e}"]
         result = compare(posix, windows, {}, {})
-        if ("Stop", "synthetic-drop.sh") not in result["posix_only"]:
+        if ("Stop", "synthetic-drop.sh", ()) not in result["posix_only"]:
             fails.append("end-to-end: a bash-only Stop hook was NOT reported as "
                          f"dropped on Windows (posix_only={result['posix_only']}). "
                          "The gate would not see a real drop either.")
-        if ("Stop", "survivor.py") not in posix or ("Stop", "survivor.py") not in windows:
+        if (("Stop", "survivor.py", ()) not in posix
+                or ("Stop", "survivor.py", ()) not in windows):
             fails.append("end-to-end: the .py hook that SHOULD survive both legs "
                          f"did not (posix={sorted(posix)}, windows={sorted(windows)}). "
                          "A gate that drops everything would pass this file vacuously.")
@@ -354,50 +437,65 @@ def cmd_selftest() -> int:
             print("  - " + f)
         return 1
     print("SELF-TEST PASS: the gate bites an unreviewed drop, a Windows-only extra, "
-          "a reasonless allowlist entry, a wrong-event entry, a per-event move and a "
-          "stale entry; and it still detects a real bash-hook drop end-to-end.")
+          "a reasonless allowlist entry, a wrong-event entry, a per-event move, a "
+          "stale entry, and a dropped ARGUMENT variant of a script that survives "
+          "under its other arguments; and it still detects a real bash-hook drop "
+          "end-to-end.")
     return 0
 
 
+def _fmt(pair) -> str:
+    """'SessionStart: lint-claude-settings.py --test'. The arguments are part of
+    the identity, so they have to be part of what a failure NAMES - otherwise the
+    report says one hook differs and shows two lines that look identical."""
+    args = pair[2] if len(pair) > 2 else ()
+    return f"{pair[0]}: {pair[1]}" + (" " + " ".join(args) if args else "")
+
+
+def _jpair(pair) -> list:
+    """(event, hook, args) as JSON. Tolerates a 2-tuple allowlist key."""
+    return [pair[0], pair[1], list(pair[2]) if len(pair) > 2 else []]
+
+
 def _print_report(result: dict, allow_posix: dict, allow_windows: dict) -> None:
-    print(f"POSIX wires {result['posix_hooks']} (event, hook) pair(s); "
-          f"Windows wires {result['windows_hooks']}.")
+    print(f"POSIX wires {result['posix_hooks']} (event, hook, args) "
+          f"registration(s); Windows wires {result['windows_hooks']}.")
     if result["posix_only"]:
         print("\nDropped on Windows (wired on POSIX only):")
-        for event, hook in result["posix_only"]:
-            reason = allow_posix.get((event, hook))
+        for pair in result["posix_only"]:
+            reason = allow_posix.get(pair[:2])
             tag = "reviewed" if reason else "UNREVIEWED"
-            print(f"  [{tag}] {event}: {hook}")
+            print(f"  [{tag}] {_fmt(pair)}")
             if reason:
                 print(f"            {reason}")
     if result["windows_only"]:
         print("\nWired on Windows only:")
-        for event, hook in result["windows_only"]:
-            reason = allow_windows.get((event, hook))
+        for pair in result["windows_only"]:
+            reason = allow_windows.get(pair[:2])
             tag = "reviewed" if reason else "UNREVIEWED"
-            print(f"  [{tag}] {event}: {hook}")
+            print(f"  [{tag}] {_fmt(pair)}")
             if reason:
                 print(f"            {reason}")
 
     if result["unreviewed"]:
         print(f"\nFAIL: {len(result['unreviewed'])} platform difference(s) are not in "
               f"{ALLOWLIST.name}:")
-        for side, (event, hook) in result["unreviewed"]:
-            print(f"  {side}  {event}: {hook}")
+        for side, pair in result["unreviewed"]:
+            print(f"  {side}  {_fmt(pair)}")
         print("\nA hook wired on one platform and not the other is a FEATURE that\n"
               "only some users have. Either wire it on both, or add it to\n"
               f"{ALLOWLIST.name} with a reason and the consequence the users on\n"
               "the losing platform will live with. The allowlist is the review.")
     if result["reasonless"]:
         print(f"\nFAIL: {len(result['reasonless'])} allowlist entry/entries carry no reason:")
-        for side, (event, hook) in result["reasonless"]:
-            print(f"  {side}  {event}: {hook}")
+        for side, pair in result["reasonless"]:
+            print(f"  {side}  {_fmt(pair)}")
         print("A bare entry records that someone noticed, not that anyone decided.")
     if result["stale"]:
         print(f"\nFAIL: {len(result['stale'])} allowlist entry/entries no longer "
               f"describe a real difference:")
-        for side, (event, hook) in result["stale"]:
-            print(f"  {side}  {event}: {hook}")
+        for side, pair in result["stale"]:
+            print(f"  {side}  {_fmt(pair)}")
         print("The platforms now agree here. Delete the entry - a list of excuses\n"
               "for problems that were fixed is how the next real drop hides.")
     if result["ok"]:
@@ -436,11 +534,11 @@ def main() -> int:
             "verdict": "PASS" if result["ok"] else "FAIL",
             "posix_hooks": result["posix_hooks"],
             "windows_hooks": result["windows_hooks"],
-            "posix_only": [list(p) for p in result["posix_only"]],
-            "windows_only": [list(p) for p in result["windows_only"]],
-            "unreviewed": [[s, e, h] for s, (e, h) in result["unreviewed"]],
-            "reasonless": [[s, e, h] for s, (e, h) in result["reasonless"]],
-            "stale": [[s, e, h] for s, (e, h) in result["stale"]],
+            "posix_only": [_jpair(p) for p in result["posix_only"]],
+            "windows_only": [_jpair(p) for p in result["windows_only"]],
+            "unreviewed": [[s] + _jpair(p) for s, p in result["unreviewed"]],
+            "reasonless": [[s] + _jpair(p) for s, p in result["reasonless"]],
+            "stale": [[s] + _jpair(p) for s, p in result["stale"]],
             "installer_reported_skips": skipped,
         }, indent=2))
         return 0 if result["ok"] else 1

--- a/scripts/check-hook-parity.py
+++ b/scripts/check-hook-parity.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+"""check-hook-parity.py - a hook dropped on one platform must be a REVIEWED
+decision, never a silent one.
+
+THE BUG CLASS. hooks.json is written in POSIX shell. On native Windows the
+installer rewrites every command through hook_runner.py
+(platformize_template_for_windows), and any command it cannot rewrite - anything
+that runs a `bash` script - is DROPPED. Not warned about at install time in a way
+anyone reads, not recorded, not compared. The Windows user simply never has that
+feature, and every check still passes:
+
+  * the installer exits 0 (it installed what it could)
+  * `--verify` passes (it verifies what is WIRED, and the dropped hook is not)
+  * check-hook-activation.py passes (it reads hooks.json, the POSIX source)
+  * CI passes (the Windows job asserts the install SUCCEEDS)
+
+So a Windows job and a macOS job can differ by three whole features and both
+stay green. Today that is exactly what happens: four bash hooks are dropped, and
+three of them - write-hook.sh, session-end-hook.sh, graph-context-hook.sh - have
+NO Windows equivalent at all. Meeting-note extraction, the entire session-close
+cascade, and graph-context routing are POSIX-only, and nothing in the repo said
+so out loud until this file existed.
+
+WHAT THIS DOES. Runs the installer's OWN pipeline twice over hooks.json - once
+as POSIX, once forced to the Windows leg - and diffs the resulting (event, hook
+basename) sets. Any difference not present in scripts/hook-parity-allowlist.json
+FAILS. Every allowlist entry must carry a non-empty reason.
+
+Why the installer's own functions and not a reimplementation: a private copy of
+the drop rule would agree with the installer on the day it was written and
+diverge silently after. This gate imports platformize_template_for_windows and
+asks it what it actually does. If the installer stops exporting what this needs,
+the gate exits 2 (UNEVALUATED) rather than passing on an empty comparison - the
+same rule scripts/audit-guard-activation-roots.py applies.
+
+WHAT THE ALLOWLIST IS FOR. It is not an exception mechanism; it IS the point.
+Seeded green with today's four drops, each carrying a written reason and its
+user-visible consequence. The gate converts "a bash hook silently vanished on
+Windows" into "someone had to add a line to a committed file saying which
+platform loses which feature, and why". A new drop cannot land unreviewed; a
+drop that gets FIXED must have its entry removed (a stale entry also fails), so
+the file cannot rot into a list of excuses nobody re-reads.
+
+WHAT THIS DELIBERATELY DOES NOT DO. It does not require the sets to be equal and
+it does not try to port anything. Genuine platform asymmetry is legitimate; an
+UNRECORDED asymmetry is not.
+
+Usage:
+    python3 scripts/check-hook-parity.py            # the gate
+    python3 scripts/check-hook-parity.py --json     # machine-readable
+    python3 scripts/check-hook-parity.py --self-test  # negative controls
+
+Exit codes:
+    0  the POSIX and Windows wired sets differ only where the allowlist says so
+    1  an unreviewed difference, a stale allowlist entry, or a reasonless entry
+    2  UNEVALUATED - the installer/hooks.json/allowlist could not be loaded, or
+       a leg produced no hooks at all. Never 0: nothing compared is not parity.
+
+Provenance: MYC-3879. Sibling gate: scripts/check-hook-activation.py (which
+asks whether a hook is wired AT ALL; this asks whether it is wired on BOTH
+platforms).
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+INSTALLER = REPO / "scripts" / "install-hooks-user-level.py"
+HOOKS_JSON = REPO / "hooks.json"
+ALLOWLIST = REPO / "scripts" / "hook-parity-allowlist.json"
+
+# Hermetic pins for the installer's environment probes. Without these the two
+# legs would depend on what happens to be on PATH, so the same tree could pass
+# on one machine and fail on another.
+FAKE_VAULT = "/abs-hook-parity-vault"
+FAKE_POSIX_PYTHON = "/usr/bin/python3"
+FAKE_WIN_LAUNCHER = "py -3"
+
+# Every function this gate calls on the installer. Named up front so a rename
+# there produces "UNEVALUATED: installer no longer exports X" instead of an
+# AttributeError traceback or, worse, a skipped comparison that reads as pass.
+REQUIRED_ATTRS = (
+    "load_hooks_template",
+    "normalize_path_substitutions",
+    "substitute_python_interpreter",
+    "platformize_template_for_windows",
+    "_is_windows",
+)
+
+_SCRIPT_RE = re.compile(r"([\w.\-]+\.(?:py|sh|bash))")
+
+
+class Unevaluated(Exception):
+    """The comparison could not be performed. Distinct from "no differences"."""
+
+
+def _load_installer():
+    if not INSTALLER.is_file():
+        raise Unevaluated(f"installer not found: {INSTALLER}")
+    spec = importlib.util.spec_from_file_location("abs_installer_for_parity", INSTALLER)
+    if spec is None or spec.loader is None:
+        raise Unevaluated(f"could not build an import spec for {INSTALLER}")
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)
+    except Exception as e:  # noqa: BLE001 - any import failure is UNEVALUATED
+        raise Unevaluated(f"importing {INSTALLER.name} failed: {e}") from e
+    missing = [a for a in REQUIRED_ATTRS if not hasattr(mod, a)]
+    if missing:
+        raise Unevaluated(
+            f"{INSTALLER.name} no longer exports: {', '.join(missing)}. This gate "
+            "compares the installer's REAL behaviour, so it cannot run against a "
+            "renamed pipeline - re-point it rather than deleting it.")
+    return mod
+
+
+def _pairs(template: dict, drop_basenames: set[str]) -> set[tuple[str, str]]:
+    """{(event, hook basename)} wired by this template.
+
+    Per EVENT, not a flat basename set: the same hook wired on SessionStart on
+    one platform and on Stop on the other is a real behavioural difference, and
+    a flat set would call it parity."""
+    out: set[tuple[str, str]] = set()
+    for event, blocks in (template.get("hooks") or {}).items():
+        for block in blocks or []:
+            for hook in (block.get("hooks") or []):
+                for match in _SCRIPT_RE.findall(hook.get("command", "") or ""):
+                    basename = os.path.basename(match)
+                    if basename in drop_basenames:
+                        continue
+                    out.add((event, basename))
+    return out
+
+
+def wired_sets(mod, hooks_json: Path) -> tuple[set[tuple[str, str]], set[tuple[str, str]], list[str]]:
+    """(posix_pairs, windows_pairs, installer-reported skips).
+
+    Runs the installer's real pipeline in both directions. `_is_windows` is
+    patched rather than driven through ABS_FORCE_WINDOWS because this process
+    must produce BOTH legs, and on a native-Windows checkout os.name=='nt'
+    makes the POSIX leg otherwise unreachable."""
+    if not hooks_json.is_file():
+        raise Unevaluated(f"hooks template not found: {hooks_json}")
+
+    runner = str(REPO / "scripts" / "hook_runner.py")
+    pins = {"ABS_POSIX_PYTHON": FAKE_POSIX_PYTHON,
+            "ABS_WIN_LAUNCHER": FAKE_WIN_LAUNCHER,
+            "ABS_HOOK_RUNNER": runner}
+    saved = {k: os.environ.get(k) for k in pins}
+    os.environ.update(pins)
+    # hook_runner.py is the Windows LAUNCHER shim, not a hook: every rewritten
+    # command names it, so leaving it in would report it as a Windows-only
+    # "extra" on every event. Derived from the installer's own runner path so a
+    # rename follows automatically instead of silently re-appearing as a diff.
+    launcher_only = {Path(runner).name}
+
+    original_is_windows = mod._is_windows
+
+    def leg(force_windows: bool):
+        mod._is_windows = (lambda: True) if force_windows else (lambda: False)
+        template = mod.load_hooks_template(hooks_json)
+        template = mod.normalize_path_substitutions(template, FAKE_VAULT)
+        template = mod.substitute_python_interpreter(template)
+        if force_windows:
+            template, skipped = mod.platformize_template_for_windows(template)
+            return _pairs(template, launcher_only), list(skipped)
+        return _pairs(template, set()), []
+
+    try:
+        posix, _ = leg(False)
+        windows, skipped = leg(True)
+    finally:
+        # Leave the module and the environment exactly as found: this function
+        # is called twice by --self-test, and a leaked pin would make the second
+        # call depend on the first.
+        mod._is_windows = original_is_windows
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    # PREMISE. An empty leg means the pipeline broke, not that the platforms
+    # agree - and an empty-vs-empty comparison would otherwise pass silently.
+    if not posix:
+        raise Unevaluated("the POSIX leg wired ZERO hooks; the template or the "
+                          "installer pipeline is broken, so nothing was compared")
+    if not windows:
+        raise Unevaluated("the Windows leg wired ZERO hooks; platformize dropped "
+                          "everything (no launcher resolved?), so nothing was compared")
+    return posix, windows, skipped
+
+
+def load_allowlist(path: Path) -> tuple[dict[tuple[str, str], str], dict[tuple[str, str], str]]:
+    """(posix_only, windows_only) -> {(event, hook): reason}. Raises Unevaluated
+    if the file is missing or malformed: an unreadable allowlist must never be
+    treated as an empty one, because an empty one makes the gate MORE strict and
+    would look like it is working."""
+    if not path.is_file():
+        raise Unevaluated(f"allowlist not found: {path}")
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as e:
+        raise Unevaluated(f"allowlist unreadable/invalid JSON: {e}") from e
+
+    def section(key: str) -> dict[tuple[str, str], str]:
+        out: dict[tuple[str, str], str] = {}
+        for entry in (data.get(key) or []):
+            if not isinstance(entry, dict):
+                raise Unevaluated(f"allowlist {key}: entries must be objects, got {entry!r}")
+            event, hook = entry.get("event"), entry.get("hook")
+            if not event or not hook:
+                raise Unevaluated(f"allowlist {key}: entry missing event/hook: {entry!r}")
+            out[(event, hook)] = (entry.get("reason") or "").strip()
+        return out
+
+    return section("posix_only"), section("windows_only")
+
+
+def compare(posix: set[tuple[str, str]], windows: set[tuple[str, str]],
+            allow_posix: dict[tuple[str, str], str],
+            allow_windows: dict[tuple[str, str], str]) -> dict:
+    """Pure verdict. Separated from the installer plumbing so --self-test can
+    drive it with synthetic sets and prove it BITES."""
+    posix_only = posix - windows
+    windows_only = windows - posix
+
+    unreviewed, reasonless, stale = [], [], []
+    for pair in sorted(posix_only):
+        if pair not in allow_posix:
+            unreviewed.append(("posix_only", pair))
+        elif not allow_posix[pair]:
+            reasonless.append(("posix_only", pair))
+    for pair in sorted(windows_only):
+        if pair not in allow_windows:
+            unreviewed.append(("windows_only", pair))
+        elif not allow_windows[pair]:
+            reasonless.append(("windows_only", pair))
+    # A stale entry is a fixed drop whose excuse survived. Left alone, the
+    # allowlist decays into a list nobody re-reads, which is how a reviewed
+    # decision quietly becomes an unreviewed one again.
+    for pair in sorted(allow_posix):
+        if pair not in posix_only:
+            stale.append(("posix_only", pair))
+    for pair in sorted(allow_windows):
+        if pair not in windows_only:
+            stale.append(("windows_only", pair))
+
+    return {
+        "posix_hooks": len(posix),
+        "windows_hooks": len(windows),
+        "posix_only": sorted(posix_only),
+        "windows_only": sorted(windows_only),
+        "unreviewed": unreviewed,
+        "reasonless": reasonless,
+        "stale": stale,
+        "ok": not (unreviewed or reasonless or stale),
+    }
+
+
+# ---- self-test (negative controls: the gate must BITE) ------------------------
+def _selftest_compare_cases() -> list[str]:
+    fails: list[str] = []
+    base = {("Stop", "a.py"), ("PreToolUse", "b.py")}
+
+    def check(label: str, result: dict, want_ok: bool) -> None:
+        if result["ok"] != want_ok:
+            fails.append(f"{label}: wanted {'PASS' if want_ok else 'BITE'}, got "
+                         f"{'PASS' if result['ok'] else 'BITE'} "
+                         f"(unreviewed={result['unreviewed']}, "
+                         f"reasonless={result['reasonless']}, stale={result['stale']})")
+
+    check("identical sets, empty allowlist",
+          compare(base, set(base), {}, {}), True)
+
+    dropped = {("Stop", "a.py")}
+    check("hook dropped on Windows, NOT allowlisted",
+          compare(base, dropped, {}, {}), False)
+    check("hook dropped on Windows, allowlisted WITH a reason",
+          compare(base, dropped, {("PreToolUse", "b.py"): "bash-only, no port"}, {}), True)
+    check("hook dropped on Windows, allowlisted with an EMPTY reason",
+          compare(base, dropped, {("PreToolUse", "b.py"): ""}, {}), False)
+    check("hook dropped on Windows, allowlisted under the WRONG event",
+          compare(base, dropped, {("Stop", "b.py"): "wrong event"}, {}), False)
+
+    extra = set(base) | {("SessionStart", "win-only.py")}
+    check("Windows-only extra, NOT allowlisted",
+          compare(base, extra, {}, {}), False)
+    check("Windows-only extra, allowlisted WITH a reason",
+          compare(base, extra, {}, {("SessionStart", "win-only.py"): "windows shim"}), True)
+
+    # Same basename, different event: a flat basename comparison would call
+    # this parity. It is not.
+    moved = {("Stop", "a.py"), ("SessionStart", "b.py")}
+    check("same hook wired on a DIFFERENT event per platform",
+          compare(base, moved, {}, {}), False)
+
+    check("stale allowlist entry (the drop was fixed, the excuse stayed)",
+          compare(base, set(base), {("PreToolUse", "b.py"): "obsolete"}, {}), False)
+    return fails
+
+
+def _selftest_endtoend(mod) -> list[str]:
+    """Prove the EXTRACTION bites too, not just the set math: a synthetic
+    hooks.json whose only Stop hook is a bash script must come out as a
+    posix_only difference after the real installer pipeline runs."""
+    import tempfile
+
+    fails: list[str] = []
+    with tempfile.TemporaryDirectory() as td:
+        j = Path(td) / "hooks.json"
+        j.write_text(json.dumps({"hooks": {
+            "Stop": [{"hooks": [
+                {"type": "command", "command": "bash '[VAULT_PATH]/synthetic-drop.sh'"},
+                {"type": "command", "command": "[PYTHON] ~/.claude/hooks/survivor.py"},
+            ]}],
+        }}), encoding="utf-8")
+        try:
+            posix, windows, _ = wired_sets(mod, j)
+        except Unevaluated as e:
+            return [f"end-to-end fixture could not be evaluated: {e}"]
+        result = compare(posix, windows, {}, {})
+        if ("Stop", "synthetic-drop.sh") not in result["posix_only"]:
+            fails.append("end-to-end: a bash-only Stop hook was NOT reported as "
+                         f"dropped on Windows (posix_only={result['posix_only']}). "
+                         "The gate would not see a real drop either.")
+        if ("Stop", "survivor.py") not in posix or ("Stop", "survivor.py") not in windows:
+            fails.append("end-to-end: the .py hook that SHOULD survive both legs "
+                         f"did not (posix={sorted(posix)}, windows={sorted(windows)}). "
+                         "A gate that drops everything would pass this file vacuously.")
+        if result["ok"]:
+            fails.append("end-to-end: an unallowlisted synthetic drop was reported OK")
+    return fails
+
+
+def cmd_selftest() -> int:
+    fails = _selftest_compare_cases()
+    try:
+        mod = _load_installer()
+    except Unevaluated as e:
+        print(f"SELF-TEST UNEVALUATED: {e}", file=sys.stderr)
+        return 2
+    fails += _selftest_endtoend(mod)
+    if fails:
+        print("SELF-TEST FAIL:")
+        for f in fails:
+            print("  - " + f)
+        return 1
+    print("SELF-TEST PASS: the gate bites an unreviewed drop, a Windows-only extra, "
+          "a reasonless allowlist entry, a wrong-event entry, a per-event move and a "
+          "stale entry; and it still detects a real bash-hook drop end-to-end.")
+    return 0
+
+
+def _print_report(result: dict, allow_posix: dict, allow_windows: dict) -> None:
+    print(f"POSIX wires {result['posix_hooks']} (event, hook) pair(s); "
+          f"Windows wires {result['windows_hooks']}.")
+    if result["posix_only"]:
+        print("\nDropped on Windows (wired on POSIX only):")
+        for event, hook in result["posix_only"]:
+            reason = allow_posix.get((event, hook))
+            tag = "reviewed" if reason else "UNREVIEWED"
+            print(f"  [{tag}] {event}: {hook}")
+            if reason:
+                print(f"            {reason}")
+    if result["windows_only"]:
+        print("\nWired on Windows only:")
+        for event, hook in result["windows_only"]:
+            reason = allow_windows.get((event, hook))
+            tag = "reviewed" if reason else "UNREVIEWED"
+            print(f"  [{tag}] {event}: {hook}")
+            if reason:
+                print(f"            {reason}")
+
+    if result["unreviewed"]:
+        print(f"\nFAIL: {len(result['unreviewed'])} platform difference(s) are not in "
+              f"{ALLOWLIST.name}:")
+        for side, (event, hook) in result["unreviewed"]:
+            print(f"  {side}  {event}: {hook}")
+        print("\nA hook wired on one platform and not the other is a FEATURE that\n"
+              "only some users have. Either wire it on both, or add it to\n"
+              f"{ALLOWLIST.name} with a reason and the consequence the users on\n"
+              "the losing platform will live with. The allowlist is the review.")
+    if result["reasonless"]:
+        print(f"\nFAIL: {len(result['reasonless'])} allowlist entry/entries carry no reason:")
+        for side, (event, hook) in result["reasonless"]:
+            print(f"  {side}  {event}: {hook}")
+        print("A bare entry records that someone noticed, not that anyone decided.")
+    if result["stale"]:
+        print(f"\nFAIL: {len(result['stale'])} allowlist entry/entries no longer "
+              f"describe a real difference:")
+        for side, (event, hook) in result["stale"]:
+            print(f"  {side}  {event}: {hook}")
+        print("The platforms now agree here. Delete the entry - a list of excuses\n"
+              "for problems that were fixed is how the next real drop hides.")
+    if result["ok"]:
+        print("\nEvery POSIX/Windows difference is reviewed and current. OK.")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--self-test", action="store_true",
+                    help="negative controls: prove the gate still bites")
+    ap.add_argument("--json", action="store_true")
+    ap.add_argument("--hooks-json", default=str(HOOKS_JSON))
+    ap.add_argument("--allowlist", default=str(ALLOWLIST))
+    a = ap.parse_args()
+
+    if a.self_test:
+        return cmd_selftest()
+
+    try:
+        mod = _load_installer()
+        allow_posix, allow_windows = load_allowlist(Path(a.allowlist))
+        posix, windows, skipped = wired_sets(mod, Path(a.hooks_json))
+    except Unevaluated as e:
+        msg = (f"UNEVALUATED: {e}\nNothing was compared - that is not the same as "
+               f"the platforms matching.")
+        if a.json:
+            print(json.dumps({"verdict": "UNEVALUATED", "error": str(e)}, indent=2))
+        else:
+            print(msg, file=sys.stderr)
+        return 2
+
+    result = compare(posix, windows, allow_posix, allow_windows)
+    if a.json:
+        print(json.dumps({
+            "verdict": "PASS" if result["ok"] else "FAIL",
+            "posix_hooks": result["posix_hooks"],
+            "windows_hooks": result["windows_hooks"],
+            "posix_only": [list(p) for p in result["posix_only"]],
+            "windows_only": [list(p) for p in result["windows_only"]],
+            "unreviewed": [[s, e, h] for s, (e, h) in result["unreviewed"]],
+            "reasonless": [[s, e, h] for s, (e, h) in result["reasonless"]],
+            "stale": [[s, e, h] for s, (e, h) in result["stale"]],
+            "installer_reported_skips": skipped,
+        }, indent=2))
+        return 0 if result["ok"] else 1
+
+    _print_report(result, allow_posix, allow_windows)
+    return 0 if result["ok"] else 1
+
+
+if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII hook path
+    # in a report cannot crash the gate before it prints its finding.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
+    sys.exit(main())

--- a/scripts/diagnose.sh
+++ b/scripts/diagnose.sh
@@ -573,7 +573,17 @@ else
   ssverdict="$(python3 "$AUDIT_SS" --settings "$SS_SETTINGS" --porcelain 2>/dev/null)"
   case "$ssverdict" in
     OK:*)
-      ok "Effective SessionStart fleet is bounded (${ssverdict#OK:} clean/declared/unresolved)" ;;
+      ok "Effective SessionStart fleet is bounded (${ssverdict#OK:} clean/declared/unevaluated)" ;;
+    PARTIAL:*)
+      # MYC-3879. The auditor resolves each wired command to a file and reads it;
+      # anything it cannot resolve is SKIPPED. This branch used to be folded into
+      # OK:, so a real machine printed "6 resolved - 6 clean, 0 unguarded; 19
+      # unresolved" and diagnose showed a green line. Nineteen SessionStart
+      # commands unread is not a bounded fleet - it is an unmeasured one, and a
+      # freeze-class hook sitting in any of them was structurally invisible.
+      _rest="${ssverdict#PARTIAL:}"; _skipped="${_rest##*:}"
+      warn "$_skipped SessionStart command(s) could not be evaluated for boundedness" \
+        "The auditor never opened them, so nothing is known about their work shape - this is NOT a clean bill of health. Run: python3 \"$AUDIT_SS\" --settings \"$SS_SETTINGS\" to see each skipped command and why (unresolvable command string, script not on disk, or unreadable source). Common cause on Windows: hook commands are wired in the 'py -3 \"<runner>\" --fallback silent \"<hook>\"' form, whose backslash paths the resolver does not match." ;;
     UNGUARDED:*)
       _rest="${ssverdict#UNGUARDED:}"; _n="${_rest%%:*}"; _hooks="${_rest#*:}"
       bad "$_n SessionStart hook(s) do an unguarded corpus walk: $_hooks" \

--- a/scripts/hook-parity-allowlist.json
+++ b/scripts/hook-parity-allowlist.json
@@ -1,0 +1,45 @@
+{
+  "_README": [
+    "Reviewed cross-platform hook asymmetries. Enforced by scripts/check-hook-parity.py.",
+    "",
+    "Every entry is a FEATURE that users on one platform do not have. This file is",
+    "not an exception mechanism to get CI green - it is the record that somebody",
+    "looked at a drop and accepted it. An entry with no reason fails the gate; an",
+    "entry describing a difference that no longer exists fails it too, so the list",
+    "cannot decay into excuses for problems that were already fixed.",
+    "",
+    "posix_only  = wired by hooks.json, NOT wired by the installer's Windows leg",
+    "              (platformize_template_for_windows drops it).",
+    "windows_only = wired only on Windows. hook_runner.py is NOT listed: it is the",
+    "              launcher shim every rewritten command names, and the gate",
+    "              excludes it by deriving its basename from the installer.",
+    "",
+    "Adding an entry: say WHAT is lost and WHO loses it, not just that bash is",
+    "involved. Removing a drop is always better than describing it.",
+    "",
+    "Provenance: MYC-3879."
+  ],
+  "posix_only": [
+    {
+      "event": "PostToolUse",
+      "hook": "write-hook.sh",
+      "reason": "Bash-only vault script; no Windows equivalent exists. Windows installs get NO PostToolUse(Write) hook at all, so automatic meeting-todos extraction never fires when a meeting note is saved - the user must invoke it by hand and is never told why. This is the largest of the four gaps: it is the only hook on its event, so platformize deletes the whole PostToolUse block. Fix is a port, not a longer reason."
+    },
+    {
+      "event": "Stop",
+      "hook": "session-end-hook.sh",
+      "reason": "Bash-only vault script; no Windows equivalent exists. It is Layer 3 of the session-close cascade (Haiku fallback when the model bails, Last Session / Decision Log aggregators, git snapshot, retention cleanup). On Windows Layers 1-2 still run - detect-closing-signal.py injects the cascade context and the model writes captures - but nothing finalizes them, so a close that LOOKS complete leaves the aggregators stale. Silent-partial-cascade, not a clean absence."
+    },
+    {
+      "event": "UserPromptSubmit",
+      "hook": "graph-context-hook.sh",
+      "reason": "Bash-only vault script; no Windows equivalent exists. Windows users with a /graphify knowledge graph get no per-prompt routing hint, so Claude re-reads source files instead of opening the right GRAPH_REPORT.md. Degrades answer quality and context cost rather than breaking anything, which is why it went unnoticed."
+    },
+    {
+      "event": "SessionStart",
+      "hook": "check-claude-code-version.sh",
+      "reason": "Bash-only, and the ONLY one of the four that is a deliberate documented choice: install-hooks-user-level.py keeps it out of ABS_OWNED_BASENAMES precisely because it is skipped on Windows, so hooks/surface-deployed-hooks-behind.py does not nag Windows users with drift no action can clear. Cost: Windows installs are never told the Claude Code CLI is behind, nor what changed in the releases they skipped. scripts/update-check.ps1 is NOT this hook's equivalent - it tracks the ai-brain-starter checkout, not the CLI."
+    }
+  ],
+  "windows_only": []
+}

--- a/scripts/test_hook_parity.py
+++ b/scripts/test_hook_parity.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""test_hook_parity.py - the cross-platform hook parity gate must bite.
+
+WHY THIS SUITE EXISTS. scripts/check-hook-parity.py is the only thing in the
+repo that compares WHICH hooks end up wired on POSIX against which end up wired
+on Windows. Before it, four bash hooks were dropped by
+platformize_template_for_windows on every Windows install and nothing anywhere
+failed: the installer exits 0, --verify passes, check-hook-activation.py reads
+the POSIX hooks.json, and CI only asserts the install SUCCEEDS. A Windows job
+and a macOS job could differ by three whole features and both stay green.
+
+A gate nobody tests is the same shape as the bug it was written for: it would
+keep printing OK after any edit that stopped it from detecting anything. So this
+suite drives it from the outside, against fixtures, and asserts it goes RED for
+each way a difference can hide:
+
+  * a new drop that is not in the allowlist          (the original bug)
+  * an allowlist entry with no written reason        (noticing != deciding)
+  * an allowlist entry for a difference that is gone (excuses outliving fixes)
+  * an unreadable or missing allowlist               (must be UNEVALUATED, not
+                                                      an empty allowlist, which
+                                                      would look like it works)
+  * a template that wires nothing on a leg           (nothing compared != parity)
+
+It also pins the gate against the installer's own accounting: the set the gate
+calls "dropped on Windows" must equal what platformize_template_for_windows
+itself reports skipping. Two independent readings of the same function; if they
+ever disagree, one of them is lying.
+
+PREMISE GUARDS. hooks.json must still contain at least one `bash <script>.sh`
+hook - if every hook became cross-platform, the four allowlisted drops would
+vanish, the gate would go red on stale entries, and this suite would be pinning
+a risk that no longer exists. That is a premise break, reported as such, not a
+silent pass over an empty fixture.
+
+Stdlib only, no pytest (repo convention). Hermetic: fixtures live in a tmpdir,
+nothing outside it is written. Exit non-zero on any failure.
+
+Provenance: MYC-3879. Sibling suite: scripts/test_sessionstart_audit_verdict.py.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+GATE = REPO / "scripts" / "check-hook-parity.py"
+ALLOWLIST = REPO / "scripts" / "hook-parity-allowlist.json"
+INSTALLER = REPO / "scripts" / "install-hooks-user-level.py"
+HOOKS_JSON = REPO / "hooks.json"
+
+PASSED = 0
+FAILED = 0
+
+
+def ok(msg: str) -> None:
+    global PASSED
+    PASSED += 1
+    print(f"PASS  {msg}")
+
+
+def bad(msg: str, detail: str) -> None:
+    global FAILED
+    FAILED += 1
+    print(f"FAIL  {msg}\n        {detail}")
+
+
+def premise(cond: bool, msg: str) -> None:
+    if cond:
+        print(f"premise  {msg}")
+        return
+    print(f"PREMISE BROKEN: {msg}")
+    print("This suite would be testing nothing. Fix the premise, not the assert.")
+    raise SystemExit(3)
+
+
+def run(args: list[str]) -> tuple[int, str]:
+    p = subprocess.run([sys.executable, str(GATE), *args], capture_output=True,
+                       text=True, encoding="utf-8", errors="replace")
+    return p.returncode, (p.stdout or "") + (p.stderr or "")
+
+
+def run_json(args: list[str]) -> tuple[int, dict]:
+    rc, out = run([*args, "--json"])
+    try:
+        return rc, json.loads(out[out.index("{"):out.rindex("}") + 1])
+    except (ValueError, json.JSONDecodeError):
+        return rc, {}
+
+
+def main() -> int:
+    print("=== premises ===")
+    premise(GATE.is_file(), f"parity gate present: {GATE}")
+    premise(ALLOWLIST.is_file(), f"committed allowlist present: {ALLOWLIST}")
+    premise(INSTALLER.is_file(), f"installer present: {INSTALLER}")
+    premise(HOOKS_JSON.is_file(), f"hooks.json present: {HOOKS_JSON}")
+
+    hooks_src = HOOKS_JSON.read_text(encoding="utf-8")
+    premise("bash " in hooks_src and ".sh" in hooks_src,
+            "hooks.json still wires at least one bash script (the drop risk is real)")
+
+    allow = json.loads(ALLOWLIST.read_text(encoding="utf-8"))
+    premise(bool(allow.get("posix_only")),
+            "the allowlist still records at least one reviewed platform drop")
+
+    print("\n=== 1. the gate's own negative controls ===")
+    rc, out = run(["--self-test"])
+    if rc == 0 and "SELF-TEST PASS" in out:
+        ok("--self-test passes (the gate proves it bites a synthetic mismatch)")
+    else:
+        bad("--self-test passes", f"rc={rc} out={out.strip()[:400]}")
+
+    print("\n=== 2. the gate is green on this tree ===")
+    rc, data = run_json([])
+    if rc == 0 and data.get("verdict") == "PASS":
+        ok("every current POSIX/Windows difference is reviewed")
+    else:
+        bad("gate green on main",
+            f"rc={rc} unreviewed={data.get('unreviewed')} "
+            f"reasonless={data.get('reasonless')} stale={data.get('stale')}")
+
+    print("\n=== 3. the gate agrees with the installer's own skip accounting ===")
+    # posix_only is derived from a SET DIFFERENCE of the two legs; the skip list
+    # comes from platformize_template_for_windows itself. They must name the
+    # same hooks, or one of the two readings is wrong.
+    dropped = {h for _e, h in [tuple(p) for p in (data.get("posix_only") or [])]}
+    reported = {s for s in (data.get("installer_reported_skips") or [])}
+    unaccounted = [h for h in dropped if not any(h in s for s in reported)]
+    if dropped and not unaccounted:
+        ok(f"all {len(dropped)} dropped hook(s) appear in the installer's skip list")
+    else:
+        bad("gate matches installer accounting",
+            f"dropped={sorted(dropped)} unaccounted={unaccounted} "
+            f"skips={sorted(reported)}")
+
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+
+        print("\n=== 4. a NEW unreviewed drop goes RED ===")
+        # Simulates exactly what happens when someone adds a bash hook: the
+        # difference exists and the allowlist does not mention it.
+        thinned = json.loads(json.dumps(allow))
+        removed = thinned["posix_only"].pop(0)
+        f = tmp / "allow_thinned.json"
+        f.write_text(json.dumps(thinned), encoding="utf-8")
+        rc, out = run(["--allowlist", str(f)])
+        if rc == 1 and "UNREVIEWED" in out and removed["hook"] in out:
+            ok(f"an unreviewed drop of {removed['hook']} fails the gate (exit 1)")
+        else:
+            bad("unreviewed drop fails",
+                f"rc={rc} - the gate would let a silent Windows feature loss land. "
+                f"out={out.strip()[:400]}")
+
+        print("\n=== 5. an allowlist entry with NO reason goes RED ===")
+        blank = json.loads(json.dumps(allow))
+        blank["posix_only"][0]["reason"] = "   "
+        f = tmp / "allow_blank.json"
+        f.write_text(json.dumps(blank), encoding="utf-8")
+        rc, out = run(["--allowlist", str(f)])
+        if rc == 1 and "no reason" in out:
+            ok("a reasonless entry fails (noticing is not deciding)")
+        else:
+            bad("reasonless entry fails",
+                f"rc={rc} - the allowlist would degrade to a mute skip list. "
+                f"out={out.strip()[:400]}")
+
+        print("\n=== 6. a STALE allowlist entry goes RED ===")
+        stale = json.loads(json.dumps(allow))
+        stale["posix_only"].append({
+            "event": "Stop", "hook": "already-fixed.sh",
+            "reason": "describes a difference that does not exist"})
+        f = tmp / "allow_stale.json"
+        f.write_text(json.dumps(stale), encoding="utf-8")
+        rc, out = run(["--allowlist", str(f)])
+        if rc == 1 and "already-fixed.sh" in out:
+            ok("an entry for a non-existent difference fails (excuses expire)")
+        else:
+            bad("stale entry fails",
+                f"rc={rc} - the allowlist could rot into a list nobody re-reads. "
+                f"out={out.strip()[:400]}")
+
+        print("\n=== 7. a missing / malformed allowlist is UNEVALUATED, not a pass ===")
+        rc, out = run(["--allowlist", str(tmp / "does-not-exist.json")])
+        if rc == 2 and "UNEVALUATED" in out:
+            ok("a missing allowlist exits 2 (never silently 'no exceptions')")
+        else:
+            bad("missing allowlist exits 2",
+                f"rc={rc} - an absent allowlist read as empty looks like a working "
+                f"strict gate. out={out.strip()[:300]}")
+
+        f = tmp / "allow_broken.json"
+        f.write_text("{ not json", encoding="utf-8")
+        rc, out = run(["--allowlist", str(f)])
+        if rc == 2 and "UNEVALUATED" in out:
+            ok("an unparseable allowlist exits 2")
+        else:
+            bad("unparseable allowlist exits 2", f"rc={rc} out={out.strip()[:300]}")
+
+        f = tmp / "allow_shape.json"
+        f.write_text(json.dumps({"posix_only": [{"hook": "x.sh", "reason": "no event"}]}),
+                     encoding="utf-8")
+        rc, out = run(["--allowlist", str(f)])
+        if rc == 2 and "UNEVALUATED" in out:
+            ok("an entry missing event/hook exits 2 (shape is not guessed at)")
+        else:
+            bad("malformed entry exits 2", f"rc={rc} out={out.strip()[:300]}")
+
+        print("\n=== 8. a template that wires nothing is UNEVALUATED, not parity ===")
+        empty = tmp / "hooks_empty.json"
+        empty.write_text(json.dumps({"hooks": {}}), encoding="utf-8")
+        rc, out = run(["--hooks-json", str(empty)])
+        if rc == 2 and "UNEVALUATED" in out:
+            ok("an empty template exits 2 (empty == empty is not agreement)")
+        else:
+            bad("empty template exits 2",
+                f"rc={rc} - two empty sets match perfectly and mean nothing. "
+                f"out={out.strip()[:300]}")
+
+        print("\n=== 9. a real synthetic bash hook is caught end-to-end ===")
+        synth = tmp / "hooks_synth.json"
+        synth.write_text(json.dumps({"hooks": {
+            "Stop": [{"hooks": [
+                {"type": "command", "command": "bash '[VAULT_PATH]/brand-new.sh'"},
+                {"type": "command", "command": "[PYTHON] ~/.claude/hooks/kept.py"},
+            ]}]}}), encoding="utf-8")
+        empty_allow = tmp / "allow_empty.json"
+        empty_allow.write_text(json.dumps({"posix_only": [], "windows_only": []}),
+                               encoding="utf-8")
+        rc, data2 = run_json(["--hooks-json", str(synth),
+                              "--allowlist", str(empty_allow)])
+        posix_only = {tuple(p) for p in (data2.get("posix_only") or [])}
+        if rc == 1 and ("Stop", "brand-new.sh") in posix_only:
+            ok("a newly added bash hook is reported as dropped on Windows")
+        else:
+            bad("new bash hook caught",
+                f"rc={rc} posix_only={sorted(posix_only)} - this is the exact "
+                f"shape of the four hooks already lost.")
+        if ("Stop", "kept.py") not in posix_only:
+            ok("the cross-platform .py hook beside it is NOT falsely reported")
+        else:
+            bad("no false positive on a .py hook",
+                "a gate that flags everything gets muted and then ignored")
+
+    print(f"\n=== summary: {PASSED} passed, {FAILED} failed ===")
+    return 1 if FAILED else 0
+
+
+if __name__ == "__main__":
+    # Windows cp1252-console safety (#313).
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
+    sys.exit(main())

--- a/scripts/test_hook_parity.py
+++ b/scripts/test_hook_parity.py
@@ -127,7 +127,10 @@ def main() -> int:
     # posix_only is derived from a SET DIFFERENCE of the two legs; the skip list
     # comes from platformize_template_for_windows itself. They must name the
     # same hooks, or one of the two readings is wrong.
-    dropped = {h for _e, h in [tuple(p) for p in (data.get("posix_only") or [])]}
+    # JSON pairs are [event, hook, args]: arguments joined the comparison key so
+    # a dropped ARGUMENT variant is a difference too. Index rather than unpack,
+    # so this reading survives the key gaining another dimension later.
+    dropped = {p[1] for p in (data.get("posix_only") or [])}
     reported = {s for s in (data.get("installer_reported_skips") or [])}
     unaccounted = [h for h in dropped if not any(h in s for s in reported)]
     if dropped and not unaccounted:
@@ -232,7 +235,10 @@ def main() -> int:
                                encoding="utf-8")
         rc, data2 = run_json(["--hooks-json", str(synth),
                               "--allowlist", str(empty_allow)])
-        posix_only = {tuple(p) for p in (data2.get("posix_only") or [])}
+        # (event, hook) only: this case is a WHOLE hook vanishing, not an
+        # argument variant. Pairs now carry args as a third element - a JSON
+        # list, so a raw tuple(p) would be unhashable as well as too specific.
+        posix_only = {(p[0], p[1]) for p in (data2.get("posix_only") or [])}
         if rc == 1 and ("Stop", "brand-new.sh") in posix_only:
             ok("a newly added bash hook is reported as dropped on Windows")
         else:

--- a/scripts/test_sessionstart_audit_verdict.py
+++ b/scripts/test_sessionstart_audit_verdict.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""test_sessionstart_audit_verdict.py - the SessionStart auditor must never
+report OK over a set it never looked at.
+
+THE BUG CLASS. scripts/audit-sessionstart-boundedness.py answers "is every
+SessionStart hook bounded?" by resolving each wired command to a file on disk
+and reading it. Every hook it CANNOT resolve is skipped. Both verdict paths then
+printed a bare OK and exited 0 over whatever survived:
+
+    Effective SessionStart set: 6 resolved hook(s) - 6 clean, 0 unguarded;
+                                19 unresolved.
+    All resolved SessionStart corpus walks are guarded or declared-bounded. OK.
+
+That is a real run against a real settings.json (Windows, 2026-08-13): 19 of 25
+wired commands were never opened, and the exit code said PASS. A freeze-class
+hook sitting in any of those 19 would have been invisible - the auditor would
+have kept printing OK forever. "Nothing was checked" is not "everything is
+bounded", and only the exit code decides whether CI or /diagnose believes it.
+
+Two independent holes produced that number, and this suite pins both:
+
+  A1  RESOLUTION. --all resolved a wired basename under <repo>/hooks only.
+      heal-journal-guard.py is wired on SessionStart and lives in
+      <repo>/scripts, so the canonical audit silently skipped it. Resolution now
+      walks every root given to --hooks-dir (default: hooks/ AND scripts/).
+
+  A2  VERDICT. Anything skipped now yields UNEVALUATED and exit 2, matching
+      scripts/audit-guard-activation-roots.py, which already refuses to call an
+      empty comparison a pass. Test 9 asserts the two auditors agree, so a
+      future edit cannot quietly re-split them.
+
+Also pinned: the detector itself must not be weakened to reach green. Test 1
+runs --selftest, whose positive/negative controls prove evaluate() still bites
+unguarded corpus walks. Deleting a detector rule would make every fixture below
+"clean" and this suite would still be green without it.
+
+PREMISE GUARDS. Every case that could pass vacuously asserts its own setup
+first: the auditors exist, --selftest passes, and heal-journal-guard.py really
+is wired on SessionStart, really is in scripts/, and really is NOT in hooks/. If
+the repo moves that file, this suite fails LOUD as a premise break instead of
+quietly testing nothing - which is the same failure mode it exists to prevent.
+
+Stdlib only, no pytest (repo convention). Hermetic: every fixture is built in a
+tmpdir, no file outside it is written, and the two real-repo cases only READ.
+Exit non-zero on any failure.
+
+Provenance: MYC-3879. Sibling guard: scripts/test_hook_parity.py.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+AUDIT = REPO / "scripts" / "audit-sessionstart-boundedness.py"
+ROOTS_AUDIT = REPO / "scripts" / "audit-guard-activation-roots.py"
+HOOKS_JSON = REPO / "hooks.json"
+
+# The hook that exposed A1: wired on SessionStart, shipped in scripts/, invisible
+# to a hooks/-only resolver.
+CROSS_DIR_HOOK = "heal-journal-guard.py"
+
+PASSED = 0
+FAILED = 0
+
+
+def ok(msg: str) -> None:
+    global PASSED
+    PASSED += 1
+    print(f"PASS  {msg}")
+
+
+def bad(msg: str, detail: str) -> None:
+    global FAILED
+    FAILED += 1
+    print(f"FAIL  {msg}\n        {detail}")
+
+
+def premise(cond: bool, msg: str) -> None:
+    """A premise break is not a soft failure: the suite cannot mean anything
+    without it, so say so and stop rather than report green."""
+    if cond:
+        print(f"premise  {msg}")
+        return
+    print(f"PREMISE BROKEN: {msg}")
+    print("This suite would be testing nothing. Fix the premise, not the assert.")
+    raise SystemExit(3)
+
+
+def run(args: list[str]) -> tuple[int, str]:
+    """Run the auditor. encoding pinned so a cp1252 console cannot eat output
+    (scripts/check-utf8-subprocess.py enforces this repo-wide)."""
+    p = subprocess.run([sys.executable, *args], capture_output=True,
+                       text=True, encoding="utf-8", errors="replace")
+    return p.returncode, (p.stdout or "") + (p.stderr or "")
+
+
+CLEAN_HOOK = """#!/usr/bin/env python3
+from pathlib import Path
+def main():
+    for _p in Path('~/.claude/state').expanduser().iterdir():  # one level: bounded
+        pass
+"""
+EVIL_HOOK = """#!/usr/bin/env python3
+import os
+def main():
+    for _r, _d, _f in os.walk(os.path.expanduser('~')):  # unbounded corpus walk
+        pass
+"""
+
+
+def wire(path: Path, commands: list[str]) -> None:
+    path.write_text(json.dumps(
+        {"hooks": {"SessionStart": [
+            {"hooks": [{"type": "command", "command": c} for c in commands]}]}}),
+        encoding="utf-8")
+
+
+def main() -> int:
+    print("=== premises ===")
+    premise(AUDIT.is_file(), f"auditor present: {AUDIT}")
+    premise(ROOTS_AUDIT.is_file(), f"sibling auditor present: {ROOTS_AUDIT}")
+    premise(HOOKS_JSON.is_file(), f"canonical hooks.json present: {HOOKS_JSON}")
+
+    wired = HOOKS_JSON.read_text(encoding="utf-8")
+    premise(CROSS_DIR_HOOK in wired,
+            f"{CROSS_DIR_HOOK} is still wired in hooks.json")
+    premise((REPO / "scripts" / CROSS_DIR_HOOK).is_file(),
+            f"{CROSS_DIR_HOOK} still lives in scripts/")
+    premise(not (REPO / "hooks" / CROSS_DIR_HOOK).exists(),
+            f"{CROSS_DIR_HOOK} is still ABSENT from hooks/ (otherwise A1 is moot)")
+
+    print("\n=== 1. the detector is not weakened (--selftest) ===")
+    rc, out = run([str(AUDIT), "--selftest"])
+    if rc == 0 and "SELFTEST PASS" in out:
+        ok("--selftest still prints SELFTEST PASS")
+    else:
+        bad("--selftest still passes",
+            f"rc={rc}; the fix must not soften evaluate(). out={out.strip()[:300]}")
+
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+
+        # ---- A1: resolution across MULTIPLE roots ---------------------------
+        print("\n=== 2. A1 hermetic: a wired hook resolves from the SECOND root ===")
+        root_a = tmp / "root_a"
+        root_b = tmp / "root_b"
+        root_a.mkdir()
+        root_b.mkdir()
+        (root_b / "only-in-b.py").write_text(CLEAN_HOOK, encoding="utf-8")
+        premise(not (root_a / "only-in-b.py").exists(),
+                "fixture hook is absent from the first resolution root")
+        j = tmp / "hooks_multiroot.json"
+        wire(j, ["python3 ~/.claude/hooks/only-in-b.py"])
+        rc, out = run([str(AUDIT), "--all", "--hooks-json", str(j),
+                       "--hooks-dir", str(root_a), str(root_b), "--json"])
+        try:
+            data = json.loads(out[out.index("{"):out.rindex("}") + 1])
+        except (ValueError, json.JSONDecodeError):
+            data = {}
+        if rc == 0 and data.get("audited") == ["only-in-b.py"] and not data.get("unresolved"):
+            ok("--hooks-dir accepts several roots and resolves from any of them")
+        else:
+            bad("multi-root resolution",
+                f"rc={rc} audited={data.get('audited')} "
+                f"unresolved={data.get('unresolved')}; out={out.strip()[:300]}")
+
+        print("\n=== 3. A1 live: the real SessionStart set resolves scripts/ hooks ===")
+        rc, out = run([str(AUDIT), "--all", "--json"])
+        try:
+            data = json.loads(out[out.index("{"):out.rindex("}") + 1])
+        except (ValueError, json.JSONDecodeError):
+            data = {}
+        if CROSS_DIR_HOOK in (data.get("audited") or []):
+            ok(f"{CROSS_DIR_HOOK} is actually audited, not skipped")
+        else:
+            bad(f"{CROSS_DIR_HOOK} is audited",
+                f"still unresolved={data.get('unresolved')}; a WIRED SessionStart "
+                f"hook in scripts/ is never opened. out={out.strip()[:300]}")
+        if rc == 0 and not (data.get("unresolved") or []):
+            ok("the shipped SessionStart set is fully resolved and exits 0")
+        else:
+            bad("shipped set fully resolved",
+                f"rc={rc} unresolved={data.get('unresolved')}")
+
+        # ---- A2: a skip must never read as a pass ---------------------------
+        print("\n=== 4. A2 --all: an unresolved hook yields UNEVALUATED, not OK ===")
+        gap = tmp / "gap"
+        gap.mkdir()
+        (gap / "present.py").write_text(CLEAN_HOOK, encoding="utf-8")
+        premise(not (gap / "ghost.py").exists(),
+                "the unresolvable fixture hook is genuinely absent from disk")
+        j = tmp / "hooks_gap.json"
+        wire(j, ["python3 ~/.claude/hooks/present.py",
+                 "python3 ~/.claude/hooks/ghost.py"])
+        rc, out = run([str(AUDIT), "--all", "--hooks-json", str(j),
+                       "--hooks-dir", str(gap)])
+        if rc == 2:
+            ok("--all exits 2 (UNEVALUATED) when a wired hook was skipped")
+        else:
+            bad("--all exits 2 on a skipped hook",
+                f"rc={rc} - a bare exit 0 over a partly-unread set IS the bug. "
+                f"out={out.strip()[:300]}")
+        if "UNEVALUATED" in out and "ghost.py" in out:
+            ok("--all names the skipped hook and says UNEVALUATED")
+        else:
+            bad("--all reports the skip",
+                f"expected UNEVALUATED + ghost.py; out={out.strip()[:400]}")
+        if not re.search(r"guarded or declared-bounded\. OK\.", out):
+            ok("--all does NOT print the clean-verdict line over a partial set")
+        else:
+            bad("--all suppresses the OK line",
+                "it still claims every corpus walk is guarded")
+
+        print("\n=== 5. A2 --all: a fully resolved clean set still exits 0 ===")
+        j = tmp / "hooks_full.json"
+        wire(j, ["python3 ~/.claude/hooks/present.py"])
+        rc, out = run([str(AUDIT), "--all", "--hooks-json", str(j),
+                       "--hooks-dir", str(gap)])
+        if rc == 0 and "OK." in out:
+            ok("--all still passes a set it fully evaluated")
+        else:
+            bad("--all passes a fully resolved set",
+                f"rc={rc} out={out.strip()[:300]} - the fix must not fail everything")
+
+        print("\n=== 6. A2 --all --json: the machine verdict agrees ===")
+        j = tmp / "hooks_gap2.json"
+        wire(j, ["python3 ~/.claude/hooks/ghost.py"])
+        rc, out = run([str(AUDIT), "--all", "--hooks-json", str(j),
+                       "--hooks-dir", str(gap), "--json"])
+        if rc == 2:
+            ok("--json exits 2 on an unresolved set (same verdict as text mode)")
+        else:
+            bad("--json exits 2 on an unresolved set",
+                f"rc={rc} - a machine consumer would read this as clean")
+
+        # ---- A2 on the effective-set mode (the shape seen on real hardware) --
+        print("\n=== 7. A2 --settings: an unevaluated command is not a pass ===")
+        good = tmp / "good-eff.py"
+        good.write_text(CLEAN_HOOK, encoding="utf-8")
+        missing_abs = tmp / "never-created.py"
+        premise(not missing_abs.exists(), "the absolute-but-missing hook is absent")
+        s_partial = tmp / "settings_partial.json"
+        s_partial.write_text(json.dumps({"hooks": {"SessionStart": [{"hooks": [
+            {"type": "command", "command": f'python3 "{good}"'},
+            {"type": "command", "command": f'python3 "{missing_abs}"'},
+            {"type": "command", "command": "python3 relative/cwd-dependent.py"},
+        ]}]}}), encoding="utf-8")
+        rc, out = run([str(AUDIT), "--settings", str(s_partial)])
+        if rc == 2:
+            ok("--settings exits 2 when commands were never evaluated")
+        else:
+            bad("--settings exits 2 on unevaluated commands",
+                f"rc={rc} - this is the exact real-hardware false OK. "
+                f"out={out.strip()[:400]}")
+        if "UNEVALUATED" in out:
+            ok("--settings says UNEVALUATED instead of OK")
+        else:
+            bad("--settings says UNEVALUATED", f"out={out.strip()[:400]}")
+        rc, out = run([str(AUDIT), "--settings", str(s_partial), "--porcelain"])
+        if rc == 2 and out.strip().startswith("PARTIAL:"):
+            ok("porcelain emits PARTIAL:<clean>:<bounded>:<skipped> for diagnose")
+        else:
+            bad("porcelain PARTIAL shape",
+                f"rc={rc} out={out.strip()[:200]} - diagnose.sh would print a "
+                f"green line over an unread fleet")
+
+        print("\n=== 8. A2 --settings: clean stays 0, unguarded stays 1 ===")
+        s_ok = tmp / "settings_ok.json"
+        s_ok.write_text(json.dumps({"hooks": {"SessionStart": [{"hooks": [
+            {"type": "command", "command": f'python3 "{good}"'},
+        ]}]}}), encoding="utf-8")
+        rc, out = run([str(AUDIT), "--settings", str(s_ok), "--porcelain"])
+        if rc == 0 and out.strip().startswith("OK:"):
+            ok("a fully evaluated clean effective set still exits 0 / OK:")
+        else:
+            bad("clean effective set exits 0", f"rc={rc} out={out.strip()[:200]}")
+
+        evil = tmp / "evil-eff.py"
+        evil.write_text(EVIL_HOOK, encoding="utf-8")
+        s_bad = tmp / "settings_bad.json"
+        s_bad.write_text(json.dumps({"hooks": {"SessionStart": [{"hooks": [
+            {"type": "command", "command": f'python3 "{evil}"'},
+            {"type": "command", "command": "python3 relative/cwd-dependent.py"},
+        ]}]}}), encoding="utf-8")
+        rc, out = run([str(AUDIT), "--settings", str(s_bad), "--porcelain"])
+        if rc == 1 and out.strip().startswith("UNGUARDED:"):
+            ok("a real unguarded walker still outranks the skip verdict (exit 1)")
+        else:
+            bad("unguarded outranks unevaluated",
+                f"rc={rc} out={out.strip()[:200]} - a found freeze-class hook must "
+                f"never be downgraded to 'could not evaluate'")
+
+        # ---- consistency with the auditor whose pattern this copies ---------
+        print("\n=== 9. both auditors treat 'nothing compared' the same way ===")
+        fake_root = tmp / "primary"
+        fake_root.mkdir()
+        (fake_root / "settings.json").write_text(json.dumps({"hooks": {"PreToolUse": [
+            {"hooks": [{"type": "command", "command": "python3 x.py"}]}]}}),
+            encoding="utf-8")
+        env = dict(os.environ)
+        env.pop("CLAUDE_CONFIG_DIR", None)  # else it discovers a real alternate root
+        p = subprocess.run(
+            [sys.executable, str(ROOTS_AUDIT), "--primary", str(fake_root)],
+            capture_output=True, text=True, encoding="utf-8",
+            errors="replace", env=env)
+        sibling = (p.returncode, (p.stdout or "") + (p.stderr or ""))
+        if sibling[0] == 2 and "UNEVALUATED" in sibling[1]:
+            ok("audit-guard-activation-roots.py: nothing compared -> exit 2")
+        else:
+            bad("sibling auditor exits 2 on an empty comparison",
+                f"rc={sibling[0]} out={sibling[1].strip()[:200]} - if THIS changed, "
+                f"the consistency this suite pins moved; re-derive, do not relax")
+
+    print(f"\n=== summary: {PASSED} passed, {FAILED} failed ===")
+    return 1 if FAILED else 0
+
+
+if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print
+    # cannot crash the suite before it reports.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
+    sys.exit(main())


### PR DESCRIPTION
Two commits. The first is @adelaidasofia's existing MYC-3879 work, cherry-picked onto current `main` unchanged. The second makes its parity gate see a class it was blind to.

## Commit 1 — close two checks that reported OK without checking

`check-hook-parity.py` (new): `hooks.json` is POSIX shell. On native Windows the installer rewrites every command through `hook_runner.py`, and anything it cannot rewrite — anything running `bash` — is **dropped**. Every existing check stayed green through that: the installer exits 0 because it installed what it could, `--verify` verifies what is *wired* rather than what went missing, and CI asserts the install *succeeds*. A Windows job and a macOS job could differ by three whole features and both pass.

The gate runs the installer's **own** pipeline twice — once POSIX, once forced down the Windows leg — and fails on any difference not carrying a written reason in `hook-parity-allowlist.json`. It exits **2 (UNEVALUATED)** rather than 0 if a leg wires nothing, because nothing-compared is not parity.

The allowlist is the deliverable, and it is uncomfortable reading: on Windows, `write-hook.sh` means meeting-todos extraction never fires, `session-end-hook.sh` means the session-close cascade finalizes nothing (a close that *looks* complete leaves the aggregators stale), and `graph-context-hook.sh` means no graph routing. Those were true before this PR; the difference is that they are now written down, and a stale entry fails too, so the file cannot rot into excuses for problems already fixed.

Also reworks `audit-sessionstart-boundedness.py` to the same discipline: a hook that could not be read is `UNEVALUATED`, not a pass.

**Conflict resolved on cherry-pick:** `main` added a `check-hook-negative-control.py` block to `lint.yml` in the interim. Both blocks are kept — they ask disjoint questions. The result is additive (+27, −0).

## Commit 2 — a hook is a script PLUS its arguments

The gate compared `(event, basename)` **sets**, so two registrations of one script on one event collapsed onto a single element both legs always agreed on.

That is not hypothetical. `hooks.json` wires `lint-claude-settings.py` twice on SessionStart — once plain, once `--test` for the self-test asserting its guards still bite. Until #504 the Windows rewrite discarded everything after the script path, both became the same argument-less command, and dedup collapsed the pair. **The linter ran; its negative control silently did not**, on every Windows install, for as long as the rewrite existed — and this gate reported parity throughout, because with arguments stripped there was nothing to see.

Now keyed on `(event, basename, arguments)` via the installer's own `_hook_script_args`, passed into `_pairs` rather than reimplemented — same reason the rest of the file imports the real pipeline instead of copying its rules.

**The allowlist stays keyed on `(event, hook)`**, so one reviewed decision still covers every argument variant. Not one committed entry changes meaning and the four recorded asymmetries need no edit — only the diff gets sharper. `compare()` accepts 2- and 3-tuples alike (`pair[:2]`), which is why every pre-existing self-test control reads unchanged below.

### Verification

- `--self-test` passes, including five new controls. One asserts the **premise** — that with arguments stripped the fixtures are the same set — so the control cannot quietly decay into testing something easier than the bug it stands for.
- `test_hook_parity.py` 12/12; `test_sessionstart_audit_verdict.py`, `test_hook_arg_forwarding.py`, `check-utf8-stdout.py`, `check-utf8-subprocess.py` all pass.
- The gate is **green on this tree** with the allowlist untouched: POSIX wires 61 registrations, Windows 57 — the four known bash drops, all reviewed.
- **It earns its place:** re-introducing the #504 bug in the installer turns the gate **red**, naming `posix_only -> SessionStart: lint-claude-settings.py --test`. Under the old key that scenario was invisible — verified both ways.

Also: `_hook_script_args` is required with a message naming #504 and saying "rebase onto main" rather than the misleading "no longer exports"; reports and `--json` render arguments, because a failure naming one hook and printing two identical-looking lines is not a report; `test_hook_parity.py` reads JSON pairs by index now that the shape has a third element.

## Note on branching

The original work lives on the local branch `fix/myc-3879-parity-gate` (commit `d18cd68`, never pushed), which is **checked out in another active worktree**. Committing there would have moved that session's HEAD out from under it, so this PR is a new branch carrying `d18cd68` cherry-picked onto current `main` with authorship preserved, plus the arg-aware commit. Rebasing was necessary regardless: `_hook_script_args` does not exist at the original base (#485), so the gate would exit UNEVALUATED there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
