### PR TITLE
docs(encoding): the em-dash rule's comment promised more than the rule delivers

### DIFF
--- a/scripts/check-ps1-encoding.sh
+++ b/scripts/check-ps1-encoding.sh
@@ -20,11 +20,21 @@
 # non-ASCII byte decodes wrong and the parser dies on a file that is valid UTF-8
 # everywhere else. The BOM is how 5.1 is told the encoding.
 #
-# The em-dash rule is the same failure from the other side. U+2014 is the
-# character most likely to be introduced by an editor or a paste, and it was the
-# exact byte sequence that crashed the 5.1 parser before the BOM fix. With a BOM
-# present it parses fine, so this rule is defense in depth: keeping every .ps1
-# ASCII-clean makes losing a BOM recoverable rather than a crash.
+# The em-dash rule is the same failure from the other side. U+2014 was the exact
+# byte sequence that crashed the 5.1 parser before the BOM fix, and it is the
+# non-ASCII character most likely to arrive by accident - an editor's autocorrect
+# or a paste from a doc - in a file where a plain hyphen was meant.
+#
+# Be precise about what this buys, because it is easy to overstate. If the BOM is
+# present, non-ASCII parses fine and this rule is style. If the BOM is ever lost,
+# ANY non-ASCII byte breaks the file, and U+2014 is not special among them. So
+# this is NOT an ASCII-cleanliness guarantee: 4 of the 14 *.ps1 files here carry
+# deliberate non-ASCII (box-drawing rules in section headers, a middle dot in the
+# log prefix, the enye in "Espanol", a gear and an arrow) and are intentionally
+# untouched. What the rule actually does is close the one hole that opens by
+# accident rather than by choice. Widening it to all non-ASCII behind a pinned
+# baseline - the pattern utf8-stdout-baseline.txt already uses here - is tracked
+# separately (MYC-4040); it is a real decision about those four files, not a bug fix.
 #
 # ONE implementation, THREE callers, so the rule cannot drift between them:
 #


### PR DESCRIPTION
Follow-up to #564. No behaviour change — this corrects a comment that promised more than the code delivers.

## What the comment claimed

> keeping every .ps1 ASCII-clean makes losing a BOM recoverable rather than a crash

## What the rule does

Bans one codepoint, U+2014.

Measured on `257f4c2` — **4 of the 14 `*.ps1` files carry deliberate non-ASCII that is not an em dash**:

| File | Characters |
|---|---|
| `bootstrap.ps1` | `·` log prefix, `─` section rules |
| `scripts/preflight.ps1` | `ñ` in "Español", `─` box-drawing |
| `scripts/drift-check.ps1` | `⚙️`, `→`, `─` |
| `scripts/sync-vault-scripts.ps1` | `⚙️` |

If a BOM were lost, every one of those breaks under cp1252 exactly like an em dash would. So the rule closes about a fourteenth of the space its comment described.

## Why the rule still earns its place

U+2014 is the one that arrives **by accident** — an editor's autocorrect, a paste from a doc — in a file where a plain hyphen was meant. The others are deliberate: bilingual Spanish text and terminal UI decoration. Banning them outright would be a product regression, not a fix.

That distinction is the useful thing, and it was not written down. A future contributor reading the old comment would reasonably trust an ASCII guarantee that is not enforced.

## The real widening is tracked

MYC-4040 carries it: any non-ASCII byte, behind a content-pinned baseline for those four files — the pattern `utf8-stdout-baseline.txt` already uses here.

It also inherits MYC-3544's standing rule: **pin newline-normalized content, never raw bytes.** `.ps1` files are the ones most likely to sit CRLF on a Windows contributor's clone, so a raw-byte baseline would mark every row STALE there, make `bash scripts/ci.sh` unpassable on Windows, and tell the operator to re-pin — which inverts the breakage onto Linux. That has already happened three times in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
