### PR TITLE
fix(bootstrap): install git with no admin rights on Windows (MYC-3895)

### DIFF
--- a/.github/workflows/windows-install.yml
+++ b/.github/workflows/windows-install.yml
@@ -124,6 +124,135 @@ jobs:
           }
           exit 0
 
+      # THE NO-GIT PATH (MYC-3895)
+      # --------------------------
+      # The install's first command was `git clone`, and git was the one
+      # prerequisite bootstrap.ps1 never installed - while calling `git clone`,
+      # `git fetch` and `git pull` itself. A 2026-08-12 cohort install session
+      # lost five participants to exactly that, verbatim: "Git and Node.js CLI
+      # installs require administrator rights."
+      #
+      # The end-to-end run further down CANNOT cover this: windows-latest ships
+      # git, so the no-git branch is unreachable there. This step seals every
+      # directory holding a git.exe out of PATH and proves the two halves on the
+      # real platform:
+      #   1. the README's PowerShell fetch snippet - EXTRACTED from the shipped
+      #      README rather than retyped, so a README that regresses fails here -
+      #      completes with no git anywhere on PATH;
+      #   2. the real PortableGit fallback downloads the official asset, passes
+      #      the Authenticode publisher check, unpacks, and leaves a RUNNABLE
+      #      git. This is the positive control for Test-TrustedGitArchive; the
+      #      unit suite below covers its reject paths.
+      #
+      # Verify the premise before arming the leg: if the runner's git survived
+      # the seal, every assertion here would be vacuous, so that fails loudly.
+      #
+      # Seconds plus one ~60MB download, on this job's already-paid runner - no
+      # second windows-latest job floor at the 2x multiplier (see the cost note
+      # at the top of this file). Runs BEFORE the seed/e2e steps so nothing it
+      # does can colour them: it writes only into RUNNER_TEMP and never touches
+      # the user PATH (Add-UserPathEntry lives in bootstrap's driver, not in the
+      # function this exercises).
+      - name: git absent from PATH - README fetch + PortableGit fallback (MYC-3895)
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          if ($PSVersionTable.PSEdition -ne "Desktop") {
+            Write-Host "::error::Expected Windows PowerShell 5.1 (Desktop edition); got $($PSVersionTable.PSEdition) $($PSVersionTable.PSVersion)."
+            exit 1
+          }
+
+          # --- seal git off PATH ------------------------------------------------
+          $before = (Get-Command git -ErrorAction SilentlyContinue)
+          if (-not $before) {
+            Write-Host "::error::This runner has NO git to begin with - the seal below would prove nothing. Investigate the image before trusting this gate."
+            exit 1
+          }
+          Write-Host "runner git before the seal: $($before.Source)"
+          $kept = @()
+          foreach ($p in ($env:PATH -split ';')) {
+            if (-not $p) { continue }
+            $hit = $false
+            foreach ($n in @("git.exe", "git.cmd", "git.bat")) {
+              if (Test-Path -LiteralPath (Join-Path $p $n)) { $hit = $true }
+            }
+            if (-not $hit) { $kept += $p }
+          }
+          $env:PATH = ($kept -join ';')
+          if (Get-Command git -ErrorAction SilentlyContinue) {
+            Write-Host "::error::git survived the PATH seal at $((Get-Command git).Source) - every assertion in this step would be vacuous."
+            exit 1
+          }
+          Write-Host "git sealed off PATH (kept $($kept.Count) entries)."
+
+          # --- 1. the SHIPPED README fetch snippet, with no git ------------------
+          # Invoke-Expression on a line from this repo's own README is the point:
+          # the claim under test is that the text a participant pastes works.
+          $readme = Join-Path $env:GITHUB_WORKSPACE "README.md"
+          $line = @(Get-Content -LiteralPath $readme | Where-Object { $_ -match 'Expand-Archive \$z \$t -Force' })[0]
+          if (-not $line) {
+            Write-Host "::error::Could not find the Windows fetch snippet in README.md (looked for the Expand-Archive line). If the install command moved, this gate must move with it."
+            exit 1
+          }
+          $snippet = $line -replace '^\s*>\s?', ''
+          $D = Join-Path $env:RUNNER_TEMP ("abs-fetch-" + [guid]::NewGuid().ToString("N"))
+          Write-Host "running the README fetch into $D"
+          Invoke-Expression $snippet
+          if (-not (Test-Path -LiteralPath (Join-Path $D "bootstrap.ps1"))) {
+            Write-Host "::error::The README's Windows fetch did NOT land bootstrap.ps1 with git absent. This is the exact block that stranded the cohort."
+            exit 1
+          }
+          Write-Host "README fetch OK with no git on PATH (bootstrap.ps1 present in $D)."
+
+          # --- 2. the real PortableGit fallback ---------------------------------
+          $src = [System.IO.File]::ReadAllText((Join-Path $env:GITHUB_WORKSPACE "bootstrap.ps1"))
+          $si = $src.IndexOf("# ai-brain:install-git:start")
+          $ei = $src.IndexOf("# ai-brain:install-git:end")
+          if ($si -lt 0 -or $ei -le $si) {
+            Write-Host "::error::bootstrap.ps1 is missing its ai-brain:install-git markers; cannot exercise the git install."
+            exit 1
+          }
+          $blockFile = Join-Path $env:RUNNER_TEMP "gitblock.ps1"
+          [System.IO.File]::WriteAllText($blockFile, $src.Substring($si, $ei - $si), (New-Object System.Text.UTF8Encoding($false)))
+          . $blockFile
+
+          if (Test-WorkingGit) {
+            Write-Host "::error::Test-WorkingGit says git works while PATH is sealed - the shipped probe disagrees with the seal."
+            exit 1
+          }
+
+          $uri  = Get-PortableGitUri
+          $dest = Join-Path $env:RUNNER_TEMP ("PortableGit-" + [guid]::NewGuid().ToString("N"))
+          Write-Host "fetching $uri"
+          $cmdDir = Install-PortableGit -Uri $uri -DestDir $dest -TempDir $env:RUNNER_TEMP
+          if (-not $cmdDir) {
+            Write-Host "::error::The no-admin PortableGit fallback produced no runnable git from $uri. Causes: the pinned asset moved, the download was blocked, or the Authenticode publisher check rejected it."
+            exit 1
+          }
+          $env:PATH = "$cmdDir;$env:PATH"
+          if (-not (Test-WorkingGit)) {
+            Write-Host "::error::PortableGit unpacked to $cmdDir but git still does not run from there."
+            exit 1
+          }
+          Write-Host "no-admin git works: $((& git --version) -join ' ') from $cmdDir"
+          exit 0
+
+      # The unit half of the same suite: the capability probe, the release-asset
+      # URI, and - only meaningful here, because Get-AuthenticodeSignature does
+      # not exist off Windows - the publisher check's REJECT paths. scripts/ci.sh
+      # runs this same file on ubuntu under pwsh 7, where those two cases are
+      # trivially true. Neither runner alone is the gate.
+      - name: bootstrap.ps1 git install suite (Windows PowerShell 5.1)
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          powershell -NoProfile -ExecutionPolicy Bypass -File "$env:GITHUB_WORKSPACE\tests\integration\test_bootstrap_ps1_git_install.ps1"
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "::error::bootstrap.ps1 git install suite failed (exit $LASTEXITCODE)"
+            exit $LASTEXITCODE
+          }
+          exit 0
+
       # Prove the premise the .ps1 BOM rule rests on, on the platform it
       # protects. Every other gate enforces "must start with EF BB BF" and takes
       # the REASON on trust. The parse step in lint.yml runs on ubuntu under

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Bootstrap touches your `~/.claude/` directory and registers third-party content.
 
 **MCP servers wired in `~/.claude/.mcp.json`:** `granola` (meeting transcription), `chatprd` (PRD drafting). Existing MCPs you wired yourself are preserved.
 
-**System tools (skipped if already present):** Homebrew, Python 3.10+, Node, npm, pipx, gh, fastmcp, graphify (via pipx), skill-seekers (via pipx), Obsidian.
+**System tools (skipped if already present):** git, Homebrew, Python 3.10+, Node, npm, pipx, gh, fastmcp, graphify (via pipx), skill-seekers (via pipx), Obsidian. On Windows with no administrator rights, git and Node are unpacked into your own user folder rather than machine-wide.
 
 **Settings + backups:** every edit to `~/.claude/settings.json` and `~/.claude/.mcp.json` writes a `.bak-YYYY-MM-DD-HHMM` backup first. Existing custom marketplaces, plugins, hooks, env vars, and permissions are preserved (`setdefault` semantics, never overwrites).
 

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -423,6 +423,198 @@ if (Have winget) {
     $UseWinget = $false
 }
 
+# ─── git ──────────────────────────────────────────────────────────────────────
+# WHY THIS SECTION EXISTS (MYC-3895)
+# ----------------------------------
+# This installer calls git itself - `git clone` for the skill, `git fetch` /
+# `git pull` for the self-update, `git clone` for humanizer - and git was the
+# one prerequisite it never installed. A 2026-08-12 cohort install session
+# recorded the wall verbatim: "Git and Node.js CLI installs require
+# administrator rights." Several people finished a paid session un-installed,
+# because every no-admin recovery path further down this file was unreachable:
+# the script holding them could not be fetched.
+#
+# The entry command in the README already falls back to a zip, so bootstrap.ps1
+# now STARTS without git. This section is what lets the rest of the run recover:
+#   1. winget install -e --id Git.Git - correct whenever it is allowed.
+#   2. The official PortableGit self-extracting archive, unpacked under
+#      LOCALAPPDATA with the USER PATH wired. No elevation anywhere - the same
+#      shape as the Node ZIP fallback a few sections below, which exists for
+#      exactly the same reason.
+#
+# NOTHING on this path may call Err. git is NOT required for the rest of the
+# install; only auto-update depends on it. A git we cannot install DEGRADES the
+# run and is reported as Skipped, never as a red actionable failure - a scary
+# red line on a locked-down laptop is the experience this ticket exists to
+# remove. tests/integration/test_bootstrap_ps1_git_install.ps1 asserts that
+# structurally, so it cannot regress into an Err later.
+#
+# Placed BEFORE Python/Node so a git installed here is on PATH by the time the
+# clone/self-update section runs. Installing it any later cannot help the run
+# that needed it.
+
+# ai-brain:install-git:start
+# Test-WorkingGit - PRESENCE IS NOT CAPABILITY. `Get-Command git` answers true
+# for a git that cannot run: a half-removed Git for Windows leaves git.exe on
+# PATH pointing into a deleted install, and a PortableGit left behind by an
+# interrupted run sits there without a usable libexec. Same class as the macOS
+# Command Line Tools stub that bootstrap.sh's have_working_git guards against.
+# Probe by EXECUTION.
+#
+# Neutralises $ErrorActionPreference exactly as Run-Native does: under "Stop" a
+# native command writing ANY stderr can surface as a terminating
+# NativeCommandError even when it succeeded, and git is chatty on stderr.
+# Success is the exit code, never stderr.
+function Test-WorkingGit {
+    if (-not (Get-Command git -ErrorAction SilentlyContinue)) { return $false }
+    $eapSaved = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    $global:LASTEXITCODE = 0
+    try { & git --version 2>&1 | Out-Null }
+    catch { $global:LASTEXITCODE = 1 }
+    finally { $ErrorActionPreference = $eapSaved }
+    return ($LASTEXITCODE -eq 0)
+}
+
+# Get-PortableGitUri - the official git-for-windows release asset.
+#
+# Version-pinned the way the Node fallback pins v20.18.0: a pin is reviewable,
+# reproducible, and what the corporate profile's manifest promises. ARM is a
+# real Windows laptop now and an x64 PortableGit runs only under emulation
+# there, so the architecture is read rather than assumed.
+# PROCESSOR_ARCHITEW6432 is where an x86/x64 PowerShell on an ARM64 machine
+# reports the machine's REAL architecture; PROCESSOR_ARCHITECTURE would say
+# AMD64 and quietly hand that laptop the wrong build.
+function Get-PortableGitUri {
+    param(
+        [string]$Arch    = "",
+        [string]$Tag     = "v2.55.0.windows.5",
+        [string]$Version = "2.55.0.5"
+    )
+    if (-not $Arch) { $Arch = $env:PROCESSOR_ARCHITEW6432 }
+    if (-not $Arch) { $Arch = $env:PROCESSOR_ARCHITECTURE }
+    $asset = "PortableGit-$Version-64-bit.7z.exe"
+    if ($Arch -match "ARM64") { $asset = "PortableGit-$Version-arm64.7z.exe" }
+    return "https://github.com/git-for-windows/git/releases/download/$Tag/$asset"
+}
+
+# Test-TrustedGitArchive - this fallback DOWNLOADS AND RUNS an executable, which
+# the Node fallback (a plain zip) never does, so the trust question is real and
+# gets answered before anything is executed.
+#
+# Authenticode rather than a pinned SHA-256: a hash rots at every version bump
+# and would silently disable the fallback on exactly the machines that need it,
+# while the signature keeps verifying whatever Git for Windows actually signed.
+# BOTH halves are required - Status alone accepts any validly signed binary, so
+# the publisher is checked too.
+function Test-TrustedGitArchive([string]$Path) {
+    if (-not (Get-Command Get-AuthenticodeSignature -ErrorAction SilentlyContinue)) { return $false }
+    $sig = $null
+    try { $sig = Get-AuthenticodeSignature -LiteralPath $Path } catch { return $false }
+    if ($null -eq $sig) { return $false }
+    if ($sig.Status -ne "Valid") { return $false }
+    $subject = ""
+    if ($sig.SignerCertificate) { $subject = [string]$sig.SignerCertificate.Subject }
+    return ($subject -match "Schindelin" -or $subject -match "Git for Windows")
+}
+
+# Install-PortableGit - unpack git for THIS USER, no elevation. Returns the
+# directory to put on PATH, or $null on any failure. Never throws: the caller
+# reads a $null as "git stays unavailable", which is a degraded run, not a
+# failed one.
+function Install-PortableGit {
+    param(
+        [Parameter(Mandatory=$true)][string]$Uri,
+        [Parameter(Mandatory=$true)][string]$DestDir,
+        [Parameter(Mandatory=$true)][string]$TempDir
+    )
+    $exe = Join-Path $TempDir ("PortableGit-" + [System.Guid]::NewGuid().ToString("N") + ".7z.exe")
+    try { Invoke-WebRequest -Uri $Uri -OutFile $exe -UseBasicParsing } catch { return $null }
+    if (-not (Test-TrustedGitArchive $exe)) {
+        Remove-Item -LiteralPath $exe -Force -ErrorAction SilentlyContinue
+        return $null
+    }
+    # Move an existing folder aside rather than deleting it - the same
+    # .bak-<stamp> convention the Node fallback and the rest of this installer
+    # use. We only get here because git does not work, so whatever is there is
+    # broken or stale, but it is still the user's.
+    if (Test-Path -LiteralPath $DestDir) {
+        $shelved = "$DestDir.bak-$(Get-Date -Format 'yyyy-MM-dd-HHmm')"
+        Move-Item -LiteralPath $DestDir -Destination $shelved -ErrorAction SilentlyContinue
+        if (Test-Path -LiteralPath $DestDir) {
+            Remove-Item -LiteralPath $exe -Force -ErrorAction SilentlyContinue
+            return $null
+        }
+    }
+    New-Item -ItemType Directory -Force -Path $DestDir | Out-Null
+    # 7-Zip self-extractor: -o<dir> -y, silent, no elevation. -ArgumentList is
+    # passed as ONE string so the quoting around a path with spaces
+    # (C:\Users\First Last\AppData\Local\...) is ours, and is not rebuilt by the
+    # array-to-command-line joiner.
+    $exitCode = 1
+    try {
+        $proc = Start-Process -FilePath $exe -ArgumentList ('-o"' + $DestDir + '" -y') `
+                              -Wait -PassThru -WindowStyle Hidden
+        $exitCode = $proc.ExitCode
+    } catch { $exitCode = 1 }
+    Remove-Item -LiteralPath $exe -Force -ErrorAction SilentlyContinue
+    if ($exitCode -ne 0) { return $null }
+    # cmd\git.exe is PortableGit's self-locating launcher - the one directory
+    # that belongs on PATH. Verify the payload actually landed rather than
+    # trusting the extractor's exit code alone.
+    $cmdDir = Join-Path $DestDir "cmd"
+    if (-not (Test-Path -LiteralPath (Join-Path $cmdDir "git.exe"))) { return $null }
+    return $cmdDir
+}
+# ai-brain:install-git:end
+
+if (-not (Test-WorkingGit) -and $CorporateProfile) {
+    Warn (T "Corporate profile: git not found - NOT auto-installing (user-space, pinned-version policy)." `
+            "Perfil corporativo: no se encontro git - NO se instala automaticamente (espacio de usuario, version fija).")
+    Warn (T "Provision git via your IT-approved channel, then re-run. Automatic updates stay off until then." `
+            "Instala git por tu canal aprobado de IT y volve a correr. Las actualizaciones automaticas quedan apagadas hasta entonces.")
+    Warn (T "The exact command for IT to approve/run: winget install -e --id Git.Git" `
+            "El comando exacto para que IT apruebe/corra: winget install -e --id Git.Git")
+} elseif (-not (Test-WorkingGit) -and $DryRun) {
+    Dry "would: winget install -e --id Git.Git (or a no-admin PortableGit unpack into LOCALAPPDATA)"
+} elseif (-not (Test-WorkingGit)) {
+    Hdr (T "Installing git" "Instalando git")
+    Log (T "git is how this install keeps itself up to date." `
+          "git es como esta instalacion se mantiene actualizada.")
+    if ($UseWinget) {
+        [void](Run-Native { winget install -e --id Git.Git --accept-source-agreements --accept-package-agreements })
+        $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+    }
+    if (-not (Test-WorkingGit)) {
+        # winget's Git package is per-machine, so an unelevated run walks into
+        # the denied-elevation wall the cohort session reported. The PortableGit
+        # archive needs no privileges at all.
+        Log (T "Installing git for this user only (no Administrator needed)." `
+              "Instalando git solo para este usuario (sin Administrador).")
+        $gitHome   = "$env:LOCALAPPDATA\Programs\PortableGit"
+        $gitCmdDir = Install-PortableGit -Uri (Get-PortableGitUri) -DestDir $gitHome -TempDir $env:TEMP
+        if ($gitCmdDir) {
+            Add-UserPathEntry $gitCmdDir
+            $script:Installed += "git (user-scoped, $gitHome)"
+            Ok (T "git installed at $gitHome (user-scoped)." `
+                  "git instalado en $gitHome (solo para este usuario).")
+        }
+    }
+}
+if (Test-WorkingGit) {
+    $gitVersion = ""
+    try { $gitVersion = ((& git --version) -join " ").Trim() } catch { $gitVersion = "" }
+    if ($gitVersion) { Ok $gitVersion } else { Ok "git available" }
+} elseif (-not $DryRun -and -not $CorporateProfile) {
+    # DELIBERATELY NOT Err - see the section header. The archive entry path
+    # means the install completes without git; only auto-update waits on it.
+    Warn (T "git isn't available yet - everything else continues, only automatic updates wait on it." `
+            "git todavia no esta disponible - todo lo demas sigue, solo las actualizaciones automaticas dependen de eso.")
+    Warn (T "  Ask IT to approve: winget install -e --id Git.Git" `
+            "  Pedile a IT que apruebe: winget install -e --id Git.Git")
+    $script:Skipped += "git (install blocked; automatic updates stay off)"
+}
+
 # ─── Python 3.10+ ─────────────────────────────────────────────────────────────
 # Windows offers three separate ways to be wrong about "is Python here?", and
 # testing the single name `python` walked into all three:
@@ -1043,7 +1235,11 @@ if (Test-Path "$SkillDir\.git") {
     # fetched a zip because git was unavailable. `git clone` into a non-empty
     # directory FAILS, and that failure used to land in the red actionable list -
     # trading a missing-git block for a scary-looking one. Adopt instead.
-    if (-not (Have git)) {
+    #
+    # Gated on Test-WorkingGit, not `Have git`: a PortableGit left half-unpacked
+    # by an interrupted earlier run answers a PRESENCE check and then fails
+    # every git call Adopt-ArchiveInstall makes. Presence is not capability.
+    if (-not (Test-WorkingGit)) {
         Warn (T "Installed from an archive, and git isn't available yet - automatic updates stay off until git is installed." `
                 "Instalado desde un archivo, y git todavia no esta disponible - las actualizaciones automaticas quedan apagadas hasta instalar git.")
         $script:Skipped += "ai-brain-starter clone (archive install, git unavailable)"

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -227,6 +227,10 @@ INTEGRATION_TESTS=(
   # Windows leg of ARTIFACT-WITHOUT-ACTIVATION: bootstrap.ps1 installed the
   # skills but never commands/*.md, so no slash command existed on Windows.
   test_bootstrap_ps1_slash_commands
+  # Windows half of MYC-3895: bootstrap.ps1 called `git clone` itself and never
+  # installed git, so the one prerequisite a locked-down laptop cannot get was
+  # also the one nothing provided.
+  test_bootstrap_ps1_git_install
   test_preflight_git_and_it_request
   test_remediate_runaway_procs
   test_surface_unniced_launchagents

--- a/tests/integration/test_bootstrap_ps1_git_install.ps1
+++ b/tests/integration/test_bootstrap_ps1_git_install.ps1
@@ -1,0 +1,280 @@
+﻿#!/usr/bin/env pwsh
+# Test bootstrap.ps1's git install (Windows half of MYC-3895).
+#
+# Bug (2026-08-12 cohort install session): the install's FIRST command was
+# `git clone`, and git is the one prerequisite neither bootstrap installed. The
+# session transcript records the wall verbatim: "Git and Node.js CLI installs
+# require administrator rights." Five participants ended a paid session still
+# un-installed, because every no-admin recovery path already built into
+# bootstrap.ps1 was unreachable: the script containing them could not be
+# fetched.
+#
+# PR #488 fixed the FETCH (the entry command falls back to a zip, so
+# bootstrap.ps1 now starts with no git). PR #502 fixed the macOS/Linux side of
+# the same gap in bootstrap.sh. bootstrap.ps1 was still the half with NO git
+# install at all: it calls `git clone` / `git pull` / `git fetch` itself, and
+# `winget install -e --id Git.Git` never appeared anywhere in it. On a locked
+# down laptop winget's Git package is a per-machine install an unelevated run
+# cannot complete, which is exactly the reported wall.
+#
+# Fix: winget first (correct when it is allowed), then the official PortableGit
+# self-extracting archive unpacked under LOCALAPPDATA with the USER PATH wired,
+# needing no elevation at all - the same shape as the Node ZIP fallback that
+# already ships a few sections below.
+#
+# Covered here:
+#   A. The git block ships in bootstrap.ps1 between its markers and is
+#      extractable, so this suite cannot drift from the shipped source.
+#   B. Test-WorkingGit: PRESENCE IS NOT CAPABILITY. A `git` that EXISTS on PATH
+#      and exits non-zero (a half-removed Git for Windows leaves exactly that,
+#      and it is the same class as the macOS CLT stub bootstrap.sh guards) must
+#      read ABSENT. Paired with a NEGATIVE CONTROL asserting a runnable git
+#      reads WORKING, so this cannot pass by always answering false.
+#   C. Sealed, empty PATH -> ABSENT. Doubles as the PATH-seal positive control:
+#      if the runner's own real git leaked past the seal, this case fails.
+#   D. Get-PortableGitUri points at the OFFICIAL git-for-windows release asset
+#      and switches on architecture, with a control proving the arch argument
+#      actually changes the answer (a hardcoded x64 URL would silently ship an
+#      emulated git to every Windows-on-ARM laptop).
+#   E. Test-TrustedGitArchive: the fallback DOWNLOADS AND RUNS an executable, so
+#      the publisher check must bite. An unsigned file is rejected, and - on
+#      Windows, where the check is real - a VALIDLY SIGNED binary from the wrong
+#      publisher is rejected too. That second one is the control proving the
+#      Status check is not the whole test. The positive half (a real PortableGit
+#      accepted) cannot be proven here without a 60MB download; it lives in the
+#      windows-install job, which fetches the real asset.
+#   F. STRUCTURAL, over the shipped bootstrap.ps1:
+#      F1 the git section runs BEFORE the clone/self-update section (a git
+#         installed after the clone cannot help the run that needed it);
+#      F2 the git path calls Err NOWHERE - the Done predicate for this ticket is
+#         "0 entries in the red FAILED list", and git is not required for the
+#         rest of the install, so a blocked git DEGRADES the run (auto-update
+#         off) and must never be reported as a failure;
+#      F3 the winget package id is named (the preferred path);
+#      F4 the fallback wires the user PATH (a git unpacked where nothing looks
+#         is invisible - the exact bug the Node ZIP fallback had to fix);
+#      F5 nothing on the git path asks for elevation;
+#      F6 the signature is verified BEFORE the downloaded binary is executed.
+#
+# PATH is sealed to a stub directory alone, so the runner's own git cannot
+# decide any outcome. Runs on Windows PowerShell 5.1 and on pwsh 7
+# (macOS/Linux); stubs are .cmd on Windows and /bin/sh scripts elsewhere.
+#
+# Self-contained; no network; never writes outside its own temp dir.
+
+$ErrorActionPreference = "Stop"
+
+$RepoRoot  = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$Bootstrap = Join-Path $RepoRoot "bootstrap.ps1"
+if (-not (Test-Path -LiteralPath $Bootstrap)) {
+    Write-Host "ERROR: $Bootstrap not found" -ForegroundColor Red
+    exit 1
+}
+
+$OnWindows = ($PSVersionTable.PSEdition -eq "Desktop") -or ($env:OS -eq "Windows_NT")
+$script:Failures = @()
+
+# Structural checks must read CODE, not prose. Without this, a comment
+# EXPLAINING why a banned construct is absent ("gated on X, not on Y") matches
+# the ban on Y and fails the very change it documents - which is exactly what
+# happened while writing this suite.
+function Remove-PsComments([string]$Text) {
+    $keep = @()
+    foreach ($line in ($Text -split "`n")) {
+        if ($line -match '^\s*#') { continue }
+        $keep += $line
+    }
+    return ($keep -join "`n")
+}
+
+function Check([bool]$Ok, [string]$Msg) {
+    if ($Ok) {
+        Write-Host "  ok    $Msg"
+    } else {
+        Write-Host "  FAIL  $Msg" -ForegroundColor Red
+        $script:Failures += $Msg
+    }
+}
+
+# A git stub: prints one line and exits with a fixed code. Test-WorkingGit only
+# reads the exit code, so no stub has to imitate git's output format.
+function New-GitStub([string]$Dir, [int]$ExitCode, [string]$EchoLine, [string]$StderrLine) {
+    if ($OnWindows) {
+        $p = Join-Path $Dir "git.cmd"
+        $body = "@echo off`r`n"
+        if ($EchoLine)   { $body += "echo $EchoLine`r`n" }
+        if ($StderrLine) { $body += "echo $StderrLine 1>&2`r`n" }
+        $body += "exit /b $ExitCode`r`n"
+        [System.IO.File]::WriteAllText($p, $body, [System.Text.Encoding]::ASCII)
+    } else {
+        $p = Join-Path $Dir "git"
+        $body = "#!/bin/sh`n"
+        if ($EchoLine)   { $body += "echo '$EchoLine'`n" }
+        if ($StderrLine) { $body += "echo '$StderrLine' >&2`n" }
+        $body += "exit $ExitCode`n"
+        [System.IO.File]::WriteAllText($p, $body, [System.Text.Encoding]::ASCII)
+        & /bin/chmod "+x" $p
+    }
+    return $p
+}
+
+$TmpRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("abs-ps1-git-" + [System.Guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Force -Path $TmpRoot | Out-Null
+$PathSaved = $env:PATH
+
+function New-Case([string]$Name) {
+    $d = Join-Path $TmpRoot $Name
+    New-Item -ItemType Directory -Force -Path $d | Out-Null
+    $env:PATH = $d                 # sealed: nothing but this directory
+    return $d
+}
+
+try {
+    # --- A. the block ships in bootstrap.ps1 and is extractable ---------------
+    Write-Host "A. git block is present and extractable"
+    $src = [System.IO.File]::ReadAllText($Bootstrap)
+    $startMark = "# ai-brain:install-git:start"
+    $endMark   = "# ai-brain:install-git:end"
+    $si = $src.IndexOf($startMark)
+    $ei = $src.IndexOf($endMark)
+    Check ($si -ge 0) "bootstrap.ps1 carries the $startMark marker"
+    Check ($ei -gt $si) "bootstrap.ps1 carries the $endMark marker after it"
+    if ($si -lt 0 -or $ei -le $si) {
+        Write-Host "ERROR: cannot extract the git block; the rest of this test would be vacuous." -ForegroundColor Red
+        exit 1
+    }
+    $block = $src.Substring($si, $ei - $si)
+    Check ($block -match "function Test-WorkingGit")       "extracted block defines Test-WorkingGit"
+    Check ($block -match "function Get-PortableGitUri")    "extracted block defines Get-PortableGitUri"
+    Check ($block -match "function Test-TrustedGitArchive") "extracted block defines Test-TrustedGitArchive"
+    Check ($block -match "function Install-PortableGit")   "extracted block defines Install-PortableGit"
+    # Dot-sourced in isolation, so a bootstrap-only helper leaking in would make
+    # this suite pass while the shipped script throws.
+    Check ($block -notmatch "(?m)^\s*(Warn|Log|Ok|Err|Hdr|Dry)\s") "extracted block calls no bootstrap-only helper"
+
+    $blockFile = Join-Path $TmpRoot "gitblock.ps1"
+    [System.IO.File]::WriteAllText($blockFile, $block, (New-Object System.Text.UTF8Encoding($false)))
+    . $blockFile
+
+    # --- B. presence is not capability ---------------------------------------
+    Write-Host "B. a git that exists on PATH but cannot run"
+    $d = New-Case "b"
+    # Writes to STDERR and exits non-zero, like a git.exe shim left behind by a
+    # half-removed install. The stderr half matters: under
+    # $ErrorActionPreference = "Stop" a native command writing to stderr is what
+    # crashed this bootstrap before (Bug 1 in windows-install.yml), so this
+    # doubles as a regression control on the probe surviving a noisy candidate.
+    $null = New-GitStub $d 1 "" "fatal: not a git repository (or any of the parent directories)"
+    Check (-not (Test-WorkingGit)) "a git that exits non-zero reads ABSENT"
+
+    Write-Host "B2. NEGATIVE CONTROL: a runnable git reads WORKING"
+    $d = New-Case "b2"
+    $null = New-GitStub $d 0 "git version 2.99.0" ""
+    Check (Test-WorkingGit) "control: a runnable git reads WORKING (the probe is not always-false)"
+
+    # --- C. sealed empty PATH (also the seal control) ------------------------
+    Write-Host "C. nothing named git anywhere on PATH"
+    $null = New-Case "c"
+    Check (-not (Test-WorkingGit)) "reports ABSENT (seal control: no real git leaked in)"
+
+    # --- D. the official asset, per architecture ------------------------------
+    Write-Host "D. Get-PortableGitUri"
+    $x64   = Get-PortableGitUri -Arch "AMD64"
+    $arm   = Get-PortableGitUri -Arch "ARM64"
+    Check ($x64 -like "https://github.com/git-for-windows/git/releases/download/*") "x64 URI is an official git-for-windows release asset (got '$x64')"
+    Check ($arm -like "https://github.com/git-for-windows/git/releases/download/*") "arm64 URI is an official git-for-windows release asset (got '$arm')"
+    Check ($x64 -match "PortableGit-.*64-bit\.7z\.exe$") "x64 URI names the PortableGit 64-bit self-extracting archive"
+    Check ($arm -match "PortableGit-.*arm64\.7z\.exe$")  "arm64 URI names the PortableGit arm64 self-extracting archive"
+    # CONTROL: the parameter is actually consulted. A hardcoded URL would pass
+    # every check above and still hand an emulated x64 git to every ARM laptop.
+    Check ($x64 -ne $arm) "control: architecture changes the answer (not a hardcoded URL)"
+
+    # --- E. the publisher check bites ----------------------------------------
+    Write-Host "E. Test-TrustedGitArchive"
+    $unsigned = Join-Path $TmpRoot "not-really-git.exe"
+    [System.IO.File]::WriteAllText($unsigned, "this is not a signed binary", [System.Text.Encoding]::ASCII)
+    Check (-not (Test-TrustedGitArchive $unsigned)) "an unsigned file is REJECTED"
+    if ($OnWindows) {
+        Check ([bool](Get-Command Get-AuthenticodeSignature -ErrorAction SilentlyContinue)) "control: Get-AuthenticodeSignature exists here, so the check above was real"
+        # A binary Windows itself signed: Status is Valid, publisher is wrong.
+        # Rejecting it is what proves the publisher half is not decoration.
+        $msSigned = Join-Path $env:WINDIR "System32\notepad.exe"
+        if (Test-Path -LiteralPath $msSigned) {
+            Check (-not (Test-TrustedGitArchive $msSigned)) "control: a VALIDLY SIGNED binary from the wrong publisher is REJECTED"
+        } else {
+            Write-Host "  note  $msSigned absent; skipped the wrong-publisher control"
+        }
+    } else {
+        Write-Host "  note  not Windows: Get-AuthenticodeSignature does not exist, so the reject above is trivially true here."
+        Write-Host "        windows-install.yml runs this same suite under PS 5.1, where it is the real check."
+    }
+
+    # --- F. structural, over the shipped bootstrap.ps1 -----------------------
+    Write-Host "F. structural checks over the shipped bootstrap.ps1"
+    $env:PATH = $PathSaved
+
+    # F1: ordering. The git section must come before anything that USES git.
+    $cloneIdx = $src.IndexOf('Test-Path "$SkillDir\.git"')
+    Check ($cloneIdx -gt 0) "found the clone/self-update section to order against"
+    Check ($si -lt $cloneIdx) "the git section runs BEFORE the clone/self-update section"
+
+    # The git driver region: from the block start to the next section header.
+    $pyIdx = $src.IndexOf("# ai-brain:pick-python:start")
+    Check ($pyIdx -gt $si) "the Python section follows the git section"
+    $gitRegion = Remove-PsComments $src.Substring($si, $pyIdx - $si)
+
+    # F2: THE DONE PREDICATE. git is optional for everything except auto-update,
+    # so a blocked git must never land in the red actionable-failures list.
+    $errCalls = [regex]::Matches($gitRegion, "(?m)^\s*Err\s")
+    Check ($errCalls.Count -eq 0) "the git path calls Err nowhere (found $($errCalls.Count)) - a blocked git degrades, never fails"
+
+    # F3: winget first - it is the correct install whenever it is allowed.
+    # Asserted on the INVOCATION, not on the package id appearing somewhere: the
+    # id also appears in the IT-facing guidance text, so a bare id match stayed
+    # green with the winget call itself mutated away (caught by this suite's own
+    # mutation controls while it was being written).
+    Check ($gitRegion -match "Run-Native \{ winget install -e --id Git\.Git") "winget install -e --id Git.Git is actually invoked"
+    # And the same id reaches the human, so a blocked machine can hand IT the
+    # exact command instead of a description of it.
+    Check ($gitRegion -match "approve.*winget install -e --id Git\.Git") "the IT-facing guidance names the exact winget command"
+
+    # F4: unpacking git where nothing looks for it installs nothing.
+    Check ($gitRegion -match "Add-UserPathEntry") "the fallback wires the user PATH"
+
+    # F5: the whole point is that this works without an admin password.
+    Check ($gitRegion -notmatch "msiexec") "the git path never shells out to msiexec"
+    Check ($gitRegion -notmatch "Invoke-Installer") "the git path never uses the elevation-requiring installer helper"
+    Check ($gitRegion -notmatch "Test-Elevated") "the git path does not branch on elevation (the fallback needs none)"
+
+    # F7: the archive-adopt branch must ask the CAPABILITY question too. A
+    # PortableGit left half-unpacked by an interrupted run answers `Have git`
+    # and then fails every git call Adopt-ArchiveInstall makes.
+    $adoptIdx = $src.IndexOf("Adopt-ArchiveInstall -Dir")
+    Check ($adoptIdx -gt 0) "found the archive-adopt branch"
+    $adoptRegion = Remove-PsComments $src.Substring($cloneIdx, $adoptIdx - $cloneIdx)
+    Check ($adoptRegion -match "Test-WorkingGit") "the archive-adopt branch gates on Test-WorkingGit"
+    Check ($adoptRegion -notmatch "Have git") "the archive-adopt branch no longer gates on presence alone"
+
+    # F6: verify before you execute. Ordering inside Install-PortableGit.
+    $fnIdx = $block.IndexOf("function Install-PortableGit")
+    Check ($fnIdx -ge 0) "found Install-PortableGit to order inside"
+    $fnBody   = $block.Substring($fnIdx)
+    $trustIdx = $fnBody.IndexOf("Test-TrustedGitArchive")
+    $runIdx   = $fnBody.IndexOf("Start-Process")
+    Check ($trustIdx -ge 0) "Install-PortableGit consults the publisher check"
+    Check ($runIdx -ge 0)   "Install-PortableGit runs the self-extracting archive"
+    Check ($trustIdx -lt $runIdx) "the signature is verified BEFORE the downloaded binary is executed"
+}
+finally {
+    $env:PATH = $PathSaved
+    Remove-Item -Recurse -Force -LiteralPath $TmpRoot -ErrorAction SilentlyContinue
+}
+
+Write-Host ""
+if ($script:Failures.Count -gt 0) {
+    Write-Host "FAILED - bootstrap.ps1 git install ($($script:Failures.Count) check(s)):" -ForegroundColor Red
+    foreach ($f in $script:Failures) { Write-Host "  x $f" -ForegroundColor Red }
+    exit 1
+}
+Write-Host "PASSED - bootstrap.ps1 git install" -ForegroundColor Green
+exit 0

--- a/tests/integration/test_bootstrap_ps1_git_install.sh
+++ b/tests/integration/test_bootstrap_ps1_git_install.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# CI integration wrapper - runs the PowerShell bootstrap git-install suite
+# (tests/integration/test_bootstrap_ps1_git_install.ps1, MYC-3895) as part of
+# scripts/ci.sh. Same pattern as test_bootstrap_ps1_python_discovery.sh: pwsh is
+# preinstalled on GitHub's ubuntu-latest runner, so CI always exercises it; if
+# pwsh is absent locally we LOUDLY skip rather than block a contributor's other
+# gates.
+#
+# NOTE ON COVERAGE: this run proves the LOGIC on pwsh 7 - the capability probe,
+# the release-asset URI, the publisher check's reject path, and the structural
+# claims about the shipped bootstrap.ps1. It structurally cannot prove the two
+# Windows-only halves: Authenticode verification of a real signed binary (the
+# cmdlet does not exist off Windows) and a PortableGit that actually unpacks and
+# runs. windows-install.yml covers both, on a real windows-latest runner with
+# git sealed off PATH. Neither runner alone is the gate.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+
+if ! command -v pwsh >/dev/null 2>&1; then
+  echo "SKIP: pwsh not installed here; CI's ubuntu + windows runners enforce this suite."
+  echo "      install: brew install --cask powershell (macOS) / https://aka.ms/powershell (other)"
+  exit 0
+fi
+
+pwsh -NoProfile -File "$ROOT/tests/integration/test_bootstrap_ps1_git_install.ps1"


### PR DESCRIPTION
Closes the last blocking piece of MYC-3895: **bootstrap.ps1 called `git clone`, `git fetch` and `git pull` itself, and never installed git.**

## Re-verification of the ticket's cited claims (read 2026-08-14, re-read against `origin/main` today)

The ticket cites code as claims to confirm. Three of the four are now **stale** - items 1, 3 and 4 already landed in #488, #502 and #516:

| Claim | Verdict | Evidence |
|---|---|---|
| `bootstrap.ps1` calls `git clone` at L852 | **STALE (line), TRUE (fact)** | Now L1069, behind an archive-adopt branch added by #488. It still calls git. |
| `bootstrap.ps1` never installs `Git.Git` | **TRUE** | `grep -n 'Git\.Git\|PortableGit\|MinGit\|git-for-windows' bootstrap.ps1` -> exit 1. The only hit repo-wide was a `diagnose.ps1` message telling the user to run it themselves. **This PR is that gap.** |
| `bootstrap.sh` never installs git | **STALE** | bootstrap.sh L1170-1205 installs git (brew on Mac, apt/dnf/pacman on Linux) with the CLT step framed explicitly. Landed in #502. |
| `xcode-select` appears nowhere in the repo | **STALE** | 9 hits across `bootstrap.sh`, `scripts/preflight.sh`, and two integration tests. |
| `bootstrap.sh` has no user-space Node/Python fallback | **STALE** | `install_*_userspace()` + `tests/integration/test_bootstrap_userspace_fallback.sh`, landed in #502. |

So items 1, 3 and 4 of the ticket are built. **Item 2's Windows half was the only one still open**, and it is the one that blocks: bootstrap.ps1 is the installer for the OS the cohort session's blocked participants were on.

## What this changes

New git section in `bootstrap.ps1`, placed **before** Python/Node so a git installed here is on PATH by the time the clone/self-update section runs:

1. `winget install -e --id Git.Git` - correct whenever it is allowed.
2. Fallback: the official **PortableGit** self-extracting archive unpacked under `LOCALAPPDATA` with the user PATH wired. No elevation anywhere, mirroring the Node ZIP fallback that already exists a few sections below for the same reason.

The download is **Authenticode-verified against the Git for Windows publisher before it is executed**. Authenticode rather than a pinned SHA-256: a hash rots at every version bump and would silently disable the fallback on exactly the machines that need it.

**Nothing on the git path calls `Err`.** git is not required for the rest of the install - only auto-update depends on it - so a git we cannot install *degrades* the run and is reported as `Skipped`, never as a red actionable failure. A test asserts that structurally so it cannot regress into an `Err` later.

Also gates the archive-adopt branch on `Test-WorkingGit` instead of `Have git`: a PortableGit left half-unpacked by an interrupted run answers a presence check and then fails every git call `Adopt-ArchiveInstall` makes.

## Evidence per Done clause

**(a) the README paste command completes the fetch with no git on PATH, on macOS and Windows**

- macOS/Linux: already proven by `tests/integration/test_bootstrap_archive_entry.sh` (landed #488). Re-run here, PASS.
- Windows: **newly proven.** The `windows-install` job now extracts the PowerShell fetch snippet *from the shipped README* (not retyped - a README regression fails the gate), seals git off PATH, and asserts `bootstrap.ps1` lands. Not runnable from a macOS host; it runs in CI.

**(b) `bootstrap.ps1` with git absent leaves a working git on the user PATH, and 0 entries in the red FAILED list**

- *Working git*: the `windows-install` job seals every directory holding a `git.exe` out of PATH, fails loudly if git survives the seal (a vacuous gate is worse than none), then runs the **real** `Install-PortableGit` - real download, real Authenticode check, real extraction - and asserts `git --version` runs from the result. That download is also the positive control for `Test-TrustedGitArchive`.
- *0 red FAILED entries*: proven **structurally** - `Err` appears nowhere on the git path, asserted over the shipped source, mutation-controlled. See the honest limit below.

**(c) `bootstrap.sh` with brew absent and no sudo lands node + python3 in user space** - already proven by `tests/integration/test_bootstrap_userspace_fallback.sh` (landed #502). Not re-implemented here.

**(d) preflight prints the missing-prerequisite list and emits the IT request text** - already proven by `tests/integration/test_preflight_git_and_it_request.sh` (landed #502, reachability #516), ES + EN.

## RED / GREEN

RED, the new suite against `origin/main`'s `bootstrap.ps1` in a detached worktree:

```
A. git block is present and extractable
  FAIL  bootstrap.ps1 carries the # ai-brain:install-git:start marker
  FAIL  bootstrap.ps1 carries the # ai-brain:install-git:end marker after it
ERROR: cannot extract the git block; the rest of this test would be vacuous.
EXIT=1
```

GREEN, same suite against this branch: 30 checks, `PASSED - bootstrap.ps1 git install`.

**Mutation controls - a new guard's first number measures the guard.** Eight mutants, eight killed:

| Mutant | Killed by |
|---|---|
| winget install call removed | `winget install -e --id Git.Git is actually invoked` |
| a blocked git becomes an `Err` | `the git path calls Err nowhere (found 1)` |
| PATH never wired | `the fallback wires the user PATH` |
| presence-only git probe | `a git that exits non-zero reads ABSENT` |
| execute before verifying the signature | `Install-PortableGit consults the publisher check` |
| git section moved after the clone | marker extraction aborts |
| hardcoded x64 URL | `control: architecture changes the answer` |
| adopt reverted to a presence check | `the archive-adopt branch gates on Test-WorkingGit` |

The first pass of the mutation set **caught a real hole in my own assertion**: matching the bare package id stayed green with the winget call mutated away, because the same id also appears in the IT-facing guidance text. The assertion now pins the invocation and the guidance separately. A second self-inflicted catch: a structural check matched my own *comment* explaining why a construct was absent, so the checks now strip comments and read code.

## What I could NOT prove, and why

- **I cannot run the Windows path from a macOS host.** Everything Windows-specific here - Windows PowerShell 5.1 semantics, `Get-AuthenticodeSignature`, a PortableGit that actually unpacks - is proven only by the `windows-install` job. The unit suite ran locally under **pwsh 7.6.5**, where the publisher check is trivially true because the cmdlet does not exist; the suite says so in its own output rather than implying coverage.
- **"0 entries in the red FAILED list" is proven structurally, not by a full no-git end-to-end run.** A second full `bootstrap.ps1` run would double this repo's most expensive job, which MYC-3419 deliberated and deliberately declined. The structural guard (no `Err` on the git path, mutation-controlled) plus the scoped real-Windows leg is what I chose instead.
- **User-PATH persistence** is asserted structurally (the driver calls `Add-UserPathEntry`), not by reading the persisted user PATH back: doing that on the runner mutates state later steps read.

## Public-repo gates

- **Personal-data scrub:** clean. No participant names, emails, phone numbers, internal URLs, tenant ids or secrets in code, comments, tests, docs or the commit message. Scanned the full diff.
- **Open-core boundary:** `tests/integration/test_open_core_boundary.sh` PASS. No workflow content, connectors, or audit analytics added.
- `scripts/check-ps1-encoding.sh` + `--self-test`: PASS (16 files, BOM + no em dash).
- `scripts/shellcheck.sh`: PASS, 212 files, no findings at `-S warning`.
- Every `.ps1` parses clean under `[Parser]::ParseFile`.
- `test_bootstrap_ps1_python_discovery`, `test_bootstrap_ps1_slash_commands`, `test_bootstrap_archive_entry`, `test_bootstrap_dry_run`, `test_bootstrap_corporate_profile`, `test_open_core_boundary`: PASS.
- `test_dry_run_purity`, `test_template_purity`, `test_preflight_git_and_it_request` fail **identically on `origin/main`** on this host - a local `python3` -> `uv run python3` shim, not a regression from this change. Baselined in a detached `origin/main` worktree.

## Scope

Does not touch MYC-2348 (post-install footprint), MYC-3706 (git-config hardening), MYC-2571 (Windows uninstall), or MYC-1501 (broken-but-present classification - its `probe_command` classifier is not in the tree yet; `Test-WorkingGit` here is the PowerShell twin of `bootstrap.sh`'s existing `have_working_git`, not a second copy of 1501's work).

**Not merging.** An adversarial reviewer gates this first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
