### PR TITLE
fix(daily-journal): rebuild the journal index when an entry is written

### DIFF
--- a/skills/daily-journal/SKILL.md
+++ b/skills/daily-journal/SKILL.md
@@ -803,6 +803,33 @@ If no clear action items came up, skip silently — don't force it.
 
 ### Step 9: After saving
 
+**FIRST, before you tell them anything: rebuild the journal index.**
+
+The entry you just saved does not exist for `/weekly`, `/monthly` or `/sunday-review` until this
+runs. Nothing else rebuilds it — there is no hook and no scheduled task, and those skills only
+*read* the index.
+
+```bash
+python3 "[VAULT_PATH]/Meta/scripts/build-journal-index.py" --vault-root "[VAULT_PATH]" --journal-dir "[JOURNAL_FOLDER]"
+```
+
+Pass `--vault-root` and `--journal-dir` explicitly whenever the vault uses localized or
+emoji-prefixed folder names (`⚙️ Meta`, `📓 Journals`) — the script cannot infer those, and on
+Windows use `python`, not `/usr/bin/python3`.
+
+Expected output: `Indexed N entries → ...`, where N equals the number of journals on disk. **If it
+fails, say so** — never continue silently. A report built on a stale index looks successful and is
+wrong.
+
+> **Why this belongs here and not in the insights skills.** `/weekly` and `/monthly` guard the index
+> with a staleness check ("rebuild if missing or more than 7 days old"). That check measures *age,
+> not completeness*: a one-day-old index passes it while still missing every entry written since it
+> was built. Observed in the field: one vault sat at 21 indexed entries against 26 on disk, and went
+> **seven weeks without generating a single weekly or monthly report** — silently, because the index
+> was never "old", just incomplete. The index is derived from the journals, so it has to be refreshed
+> when one is *written*, not when someone remembers to check.
+
+
 Tell them the file name and floor. If relevant, connect it to a pattern from their data:
 - "This is your 3rd Courage entry this month — you're on a streak."
 - "Last time that person triggered you, you stayed on Anger for 3 entries. This time you moved to Acceptance same day. That's growth."

--- a/skills/insights/SKILL.md
+++ b/skills/insights/SKILL.md
@@ -26,7 +26,7 @@ Journal entries are in: `[VAULT_PATH]/Journals/`
 ### Step 0: Load the journal index
 Read `[VAULT_PATH]/⚙️ Meta/journal-index.json` (or `[VAULT_PATH]/Meta/journal-index.json` on vaults without an emoji-prefixed Meta — the same folder `build-journal-index.py` writes to). Structure: `{"total": N, "last_updated": "YYYY-MM-DD", "entries": [{file, date, floor, floor_level}, ...]}`. Access entries via `idx["entries"]`, then filter by `entry["date"]`.
 
-If the index doesn't exist or is more than 7 days old, rebuild it first:
+If the index doesn't exist or is more than 7 days old, rebuild it first. **Note this check measures age, not completeness** — a freshly built index can still be missing entries written after it. The daily-journal skill rebuilds the index every time it writes an entry, which is what keeps this guard honest; if entries are missing here, that step is the first thing to check:
 ```bash
 /usr/bin/python3 "[VAULT_PATH]/Meta/scripts/build-journal-index.py"
 ```


### PR DESCRIPTION
## The problem

`/weekly`, `/monthly` and `/sunday-review` all read `journal-index.json`. **Nothing rebuilds it when a journal is written** — there is no hook and no scheduled task.

The insights skills guard the index with a staleness check:

> If the index doesn't exist or is more than 7 days old, rebuild it first

That check measures **age, not completeness**. A one-day-old index passes it while still missing every entry written since it was built.

## What this looked like in practice

In one vault the index sat at **21 indexed entries against 26 on disk**, and the vault went **seven weeks without generating a single weekly or monthly report**. Nothing surfaced the failure: the index was never "old", just incomplete, so the guard never fired and the reports silently had nothing to work from.

## The fix

The index is *derived* from the journals, so it should be refreshed when one is **written**, not when someone remembers to check.

- **`skills/daily-journal/SKILL.md`** — adds the rebuild to the top of Step 9 (after saving), with the expected output and an explicit instruction not to continue silently if it fails. Notes that `--vault-root` / `--journal-dir` are required for localized or emoji-prefixed folder names, and that Windows needs `python`, not `/usr/bin/python3`.
- **`skills/insights/SKILL.md`** — one line so the 7-day guard is not mistaken for a completeness check, and points at the write-time rebuild as the first thing to check when entries are missing.

Docs only — no script or behavior changes.