### PR TITLE
fix(vault-root): a stray .session-close-root dotfile could capture a folder

### DIFF
--- a/docs/SESSION_CLOSE.md
+++ b/docs/SESSION_CLOSE.md
@@ -89,7 +89,9 @@ Session-adjacent headings like `## Session Protocol` deliberately do **not** cou
 - an empty `.session-close-root` file in the folder, or
 - `sessionCloseRoot: true` in the frontmatter of its `CLAUDE.md`.
 
-The marker wins over the heading, and unlike the heading it does not require a `Meta` directory — an explicit declaration is an instruction, so the cascade honors it and then tells you plainly if there is nowhere to write yet.
+Either marker replaces the heading, but **both routes still require a `Meta` (or `⚙️ Meta`) directory** — a folder has to have somewhere to write before it can claim your session artifacts.
+
+That requirement is deliberate. `.session-close-root` is a dotfile, and dotfiles travel by accident in ways a heading never does: committed to a repo and cloned, swept up by `cp -r`, baked into a template, invisible in `ls`. If a stray marker could claim a folder on its own, your session notes would land inside it — inside a cloned client repo, that means your private notes in someone else's tree. Requiring a `Meta` directory keeps a stray marker inert until a person deliberately creates one.
 
 To make an existing folder own its cascade:
 

--- a/hooks/_lib/vault_root.py
+++ b/hooks/_lib/vault_root.py
@@ -159,12 +159,26 @@ def _frontmatter(text: str) -> str:
 def _declares_session_root_explicitly(candidate: Path) -> bool:
     """True iff `candidate` carries the prose-independent opt-in marker.
 
-    Unlike the heading path this does NOT require a Meta dir. An explicit
-    declaration is an instruction, not a hint: honoring it and then failing
-    loudly about the missing Meta dir (see detect-closing-signal's
-    unscaffolded-vault notice) tells the operator exactly what to fix. Falling
-    back to some other vault because the folder is half-built is the silent
-    cross-vault write this whole resolver exists to prevent.
+    Marker OR frontmatter key. The caller pairs this with the same Meta-dir
+    requirement the heading path carries — see _declares_own_session_close_cascade.
+
+    Why the marker does NOT get to skip the Meta check (reversed 2026-08-22;
+    it originally did): `.session-close-root` is a DOTFILE, and dotfiles
+    propagate by accident in ways a prose heading never does — committed to a
+    repo and cloned, swept up by `cp -r`, baked into a scaffold or template,
+    invisible in `ls`. A stray marker that captures a folder as a vault root
+    sends the operator's session artifacts INTO that folder — for a cloned
+    client repo, that means private notes landing in someone else's tree,
+    potentially committed and pushed.
+
+    Requiring a Meta dir makes a stray marker INERT until a human also creates
+    somewhere to write, which is a far higher bar to clear by accident. The
+    earlier argument for skipping it was that honoring the declaration and then
+    failing loudly beats a silent fallback — but that premise was wrong: the
+    fallback is not silent either. The offsite warning added alongside the
+    unscaffolded-vault notice already announces when resolution lands outside
+    the working folder. Both paths are loud, so loudness cannot break the tie;
+    accidental-capture risk does.
     """
     if (candidate / _SESSION_ROOT_SENTINEL).is_file():
         return True
@@ -182,10 +196,15 @@ def _declares_own_session_close_cascade(candidate: Path) -> bool:
     """True iff `candidate` is a self-contained vault for session-close purposes.
 
     Precedence (MYC-2457):
-      1. The explicit marker wins outright — see _declares_session_root_explicitly.
-      2. Otherwise the zero-config heading path, which needs BOTH signals:
-         a CLAUDE.md whose heading declares its OWN close cascade (en/es/pt,
-         case-insensitive), AND an existing Meta folder to write into.
+      Both paths require an existing Meta folder to write into. They differ
+      only in how the folder DECLARES itself:
+      1. The explicit marker — a `.session-close-root` file or a
+         `sessionCloseRoot: true` frontmatter key. Prose-independent, so it
+         survives translation and rewording. See
+         _declares_session_root_explicitly for why it does not get to skip
+         the Meta requirement.
+      2. The zero-config heading path — a CLAUDE.md whose heading declares its
+         OWN close cascade (en/es/pt, case-insensitive).
     Either heading signal alone is too weak: a CLAUDE.md can mention sessions
     without owning a cascade for this purpose (a default vault's own CLAUDE.md
     may use a different heading — e.g. "Session Protocol" — precisely so it
@@ -193,7 +212,7 @@ def _declares_own_session_close_cascade(candidate: Path) -> bool:
     folder can exist without any CLAUDE.md ever declaring it canonical.
     """
     if _declares_session_root_explicitly(candidate):
-        return True
+        return _has_meta_dir(candidate)
     claude_md = candidate / "CLAUDE.md"
     if not claude_md.is_file():
         return False

--- a/tests/integration/test_detect_closing_signal_trilingual_vault_root.sh
+++ b/tests/integration/test_detect_closing_signal_trilingual_vault_root.sh
@@ -30,6 +30,19 @@
 #      every default vault would start false-winning the walk-up.
 #   8. NEGATIVE CONTROL — a Spanish heading about something else
 #      ("## Cierre de trimestre") must NOT declare a root.
+#   9. A marker with NO Meta dir does NOT declare a root — it falls back.
+#  10. Same for the frontmatter key with no Meta dir.
+#
+# 9-10 pin the 2026-08-22 reversal: the marker originally skipped the Meta
+# requirement the heading path carries, on the reasoning that an explicit
+# declaration should be honored immediately and then fail loudly about the
+# missing dir. That premise did not hold — the fallback is not silent either
+# (the offsite warning announces it), so loudness could not break the tie.
+# Accidental-capture risk did: `.session-close-root` is a DOTFILE and dotfiles
+# propagate by accident, so a stray one would capture a folder and write the
+# operator's session notes into it — inside a cloned client repo, that is
+# private content landing in someone else's tree. Requiring Meta makes a stray
+# marker inert until a human creates somewhere to write.
 #
 # Controls 6-8 carry the weight: widening a regex is easy, and a widened regex
 # that matches everything would pass 1-5 while silently breaking the fallback
@@ -62,6 +75,17 @@ fails=0
 mkvault() {
   local d="$TMP/$1"
   mkdir -p "$d/⚙️ Meta"
+  [ -n "$2" ] && printf '%s\n' "$2" > "$d/CLAUDE.md"
+  [ "${3:-no}" = "yes" ] && : > "$d/.session-close-root"
+  echo "$d"
+}
+
+# Same, but with NO Meta dir — a folder that declares itself and has nowhere
+# to write. Reachable in production: a `.session-close-root` committed to a
+# repo and cloned, swept up by `cp -r`, or baked into a scaffold.
+mkvault_no_meta() {
+  local d="$TMP/$1"
+  mkdir -p "$d"
   [ -n "$2" ] && printf '%s\n' "$2" > "$d/CLAUDE.md"
   [ "${3:-no}" = "yes" ] && : > "$d/.session-close-root"
   echo "$d"
@@ -140,8 +164,16 @@ expect "es unrelated heading falls back" "$(mkvault esother '# Bóveda
 
 reporte financiero')"                  default
 
+# 9-10. A declared-but-unwritable folder must NOT capture the cascade.
+expect "marker with NO Meta dir falls back" "$(mkvault_no_meta straymarker '' yes)" default
+expect "frontmatter key with NO Meta dir falls back" "$(mkvault_no_meta strayfm '---
+sessionCloseRoot: true
+---
+
+# Whatever')" default
+
 if [ "$fails" -gt 0 ]; then
   echo "FAILED: $fails assertion(s)" >&2
   exit 1
 fi
-echo "PASS: vault-root detection is trilingual (en/es/pt) + declarative, fallback preserved"
+echo "PASS: vault-root detection is trilingual (en/es/pt) + declarative, Meta required on both paths, fallback preserved"


### PR DESCRIPTION
Reverses one deliberate asymmetry from #536, on review. The declarative marker skipped the `Meta`-dir requirement that the heading path carries; now both routes require it.

## Why the original reasoning failed

#536 argued: an explicit declaration is an instruction, so honor it immediately and then fail loudly about the missing `Meta` dir, rather than fall back *silently* to another vault.

The premise was false. **The fallback is not silent.** The offsite warning shipped in #534 already announces when resolution lands outside the working folder. Both paths are loud, so loudness could not break the tie — the decision rested on a distinction that does not exist.

## What actually breaks the tie

`.session-close-root` is a **dotfile**, and dotfiles propagate by accident in ways a prose heading never does:

- committed to a repo and cloned by someone else
- swept up by `cp -r`
- baked into a scaffold or template
- invisible in `ls`

A stray marker capturing a folder means session artifacts are written **into** that folder. Inside a cloned client repo, that is the operator's private notes landing in someone else's tree, potentially committed and pushed.

Requiring a `Meta` dir makes a stray marker **inert** until a human deliberately creates somewhere to write — a far higher bar to clear by accident. It costs the normal path nothing: the documented setup command creates `Meta/` and the marker in the same breath.

## What does not change

The marker keeps the property it was added for — it is prose-independent, surviving translation and rewording, which is what MYC-2457 needed. The heading path is untouched. **MYC-2457's Done= is unaffected**, and all four clauses were re-verified.

## Verification

- Two new cases pin the reversal (marker with no `Meta` → falls back; frontmatter key with no `Meta` → falls back). They **fail against the pre-symmetry resolver**; the other eight pass unchanged in both directions.
- The fixture occupies a state production actually reaches — a folder carrying a marker with no `Meta` dir is exactly what a clone or a `cp -r` produces, not a synthetic construction.
- `ci-test`: **GREEN**, sha-keyed marker `e739a4a4….ok` written. 375 py_compile, 126 integration tests, 27 scripts, 18 hooks/tests suites, all secondary gates.
- Personal-data scrub: exit 0.
- Docs corrected — `docs/SESSION_CLOSE.md` previously stated the opposite.

## One thing worth knowing about this repo

The worktree for this change was **deleted mid-run by `ci-test`** (the MYC-3391 failure mode). The gate then reported 7 phantom MISSes against README/SKILL.md strings that provably exist on `origin/main` — it was reading files as they vanished underneath it. The commit survived only because it had already been made. Anyone reading a `ci-test` failure on this repo should confirm the worktree still exists before believing the failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
