### PR TITLE
graphify: flag the Step 3 questions as provisional

### DIFF
--- a/skills/graphify/SKILL.md
+++ b/skills/graphify/SKILL.md
@@ -506,6 +506,7 @@ from graphify_seed_labels import seed_labels
 # Provisional names from each community's highest-degree member ('Money', 'Fear'),
 # never 'Community 412'. Step 5 replaces these with semantic labels.
 labels = seed_labels(G, communities)
+# Placeholder questions - regenerated with real labels in Step 5
 questions = suggest_questions(G, communities, labels)
 
 report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', suggested_questions=questions)


### PR DESCRIPTION
One-line comment so a reader of the graphify snippets knows the questions generated in Step 3 are provisional and get regenerated in Step 5.

**Why:** Step 5 already has `# Regenerate questions with real community labels (labels affect question phrasing)` at its `suggest_questions()` call. Step 3 calls the same function with seed labels and had no comment, so following the snippets top-to-bottom gives no signal that the first result is throwaway. This adds the mirror comment at the first call.

Comment-only — no behavior change, so no `docs/CHANGELOG.md` entry (nothing user-facing changed). Happy to add one if you'd rather have it.

**Heads-up on the CI gate:** `bash scripts/ci.sh` fails locally with `FAIL: E: ask must be framed optional` (`test_post_update_email_ask`). I verified this reproduces on a clean `upstream/main` with my change stashed, so it is pre-existing and unrelated to this PR — flagging it in case it is news to you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)