### PR TITLE
docs(graphify): mark Step 4 questions as placeholders

### DIFF
--- a/skills/graphify/SKILL.md
+++ b/skills/graphify/SKILL.md
@@ -506,6 +506,7 @@ from graphify_seed_labels import seed_labels
 # Provisional names from each community's highest-degree member ('Money', 'Fear'),
 # never 'Community 412'. Step 5 replaces these with semantic labels.
 labels = seed_labels(G, communities)
+# Placeholder questions - regenerated with real labels in Step 5
 questions = suggest_questions(G, communities, labels)
 
 report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', suggested_questions=questions)


### PR DESCRIPTION
## What

One comment line in `skills/graphify/SKILL.md`, in the Step 4 code block.

```diff
 labels = seed_labels(G, communities)
+# Placeholder questions - regenerated with real labels in Step 5
 questions = suggest_questions(G, communities, labels)
```

## Why

`suggest_questions` runs in Step 4 against **seed** labels. Step 5 replaces those labels with semantic ones and regenerates the questions — so anything Step 4 produces is provisional.

The block already flags `seed_labels` as provisional two lines above, but says nothing about the questions that derive from them. Reading it as-is, the Step 4 questions look final, which makes it easy to carry provisional questions ("What connects Money and Fear?" built off a highest-degree-member label) straight into the report.

This just makes the existing intent explicit and matches the comment style already there.

## Notes

Documentation only — no behavior change, no script touched. Surfaced by the skill-content drift check, which flagged this line as living only in a local install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)