### PR TITLE
launchd: detect a job that never ran, and give the shipped daemons a PATH

### DIFF
--- a/hooks/surface-stale-automation-failures.py
+++ b/hooks/surface-stale-automation-failures.py
@@ -182,16 +182,77 @@ def user_launchd_labels() -> set[str]:
         return set()
 
 
+def _launchd_print_liveness(label: str, uid: int, timeout: float = 3.0) -> tuple[int, str] | None:
+    """Probe `launchctl print gui/<uid>/<label>` for the job's run count.
+
+    Disambiguates the case `launchd_failures()` cannot resolve from
+    `launchctl list` alone: last-exit-status 0 means both "ran and exited
+    clean" and "has never run at all" (see that function's docstring).
+    `launchctl print`'s `runs` field tells the two apart — 0 means the job
+    has never executed since it was loaded.
+
+    Returns `(runs, last_exit_text)` on a clean parse. Returns None on ANY
+    failure — binary missing, non-zero return, timeout, or output that does
+    not contain a parseable `runs = N` line — so the caller can degrade to
+    the pre-probe reading (silence) instead of raising. This hook runs at
+    every session start and must never crash or hang on a probe that a given
+    macOS version, sandbox, or permission set does not support.
+
+    `launchctl print` is slower per-label than the one-shot `list` table, so
+    callers should only reach this for labels already narrowed down to
+    "mine, loaded, ambiguous" — see MAX_LAUNCHD_PRINT_PROBES.
+    """
+    try:
+        result = subprocess.run(
+            ["launchctl", "print", f"gui/{uid}/{label}"],
+            capture_output=True, text=True, encoding="utf-8",
+            errors="replace", timeout=timeout, check=False,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    runs_match = re.search(r"^\s*runs\s*=\s*(\d+)\s*$", result.stdout, re.MULTILINE)
+    if not runs_match:
+        return None
+    exit_match = re.search(r"^\s*last exit code\s*=\s*(.+?)\s*$", result.stdout, re.MULTILINE)
+    last_exit = exit_match.group(1) if exit_match else ""
+    return int(runs_match.group(1)), last_exit
+
+
 def launchd_failures() -> list[str]:
-    """Flag the user's own launchd jobs whose last run exited non-zero.
+    """Flag the user's own launchd jobs that are failing OR that are HOLLOW.
 
     `launchctl list` column 2 is the last exit status: 0 = clean, a positive
-    int = non-zero exit, a negative int = killed by signal, '-' = never run.
-    This auto-covers every job — including ones not in RUNNERS, the gap that
-    let a health-check and a reconcile job fail unnoticed.
+    int = non-zero exit, a negative int = killed by signal, '-' in the PID
+    column = not currently running (irrelevant to this check). Measured
+    2026-08-20: a job launchd has REGISTERED but has NEVER EXECUTED also
+    reads 0 in this column — byte-identical to a genuinely healthy job. That
+    blind spot let a dead job sit unnoticed for days with real downstream
+    damage — this function used to treat status 0 as simply "clean", which
+    is exactly the misread.
 
-    Restricted to labels the user installed (see user_launchd_labels), so the
-    machine's Apple and third-party agents stay out of the report.
+    So status 0 is now AMBIGUOUS, not clean, and is disambiguated by a
+    second, slower probe: `_launchd_print_liveness()`, whose `runs` field is
+    0 only when the job has truly never run. That is reported as a DISTINCT
+    "hollow" finding, because the remedy differs — a hollow job needs
+    `bootout` + `bootstrap` (reload it), a failing job needs its error log
+    read. A non-zero status is unambiguous already (you cannot have a real
+    exit code without having executed) and is flagged directly, exactly as
+    before, with no extra probe.
+
+    The print probe is bounded three ways so this stays fast at every
+    session start: (1) only reached for labels the cheap `list` pass already
+    narrowed to "mine, loaded, status==0"; (2) capped at
+    MAX_LAUNCHD_PRINT_PROBES total calls per run; (3) each call carries its
+    own short timeout. Any failure of the probe itself — `launchctl print`
+    unavailable, non-zero exit, timeout, unparseable output, no UID — silently
+    degrades that label to the pre-probe reading (not flagged), never raises.
+
+    This auto-covers every job — including ones not in RUNNERS, the gap that
+    let a health-check and a reconcile job fail unnoticed. Restricted to
+    labels the user installed (see user_launchd_labels), so the machine's
+    Apple and third-party agents stay out of the report.
     """
     try:
         result = subprocess.run(
@@ -204,7 +265,12 @@ def launchd_failures() -> list[str]:
     mine = user_launchd_labels()
     if not mine:
         return []
+    try:
+        uid = os.getuid()  # type: ignore[attr-defined]
+    except AttributeError:
+        uid = None  # no os.getuid on Windows — the print probe degrades below
     out: list[str] = []
+    probes_used = 0
     for line in result.stdout.splitlines():
         parts = line.split("\t")
         if len(parts) != 3:
@@ -217,11 +283,32 @@ def launchd_failures() -> list[str]:
         try:
             code = int(status)
         except ValueError:
-            continue  # '-' — job has never run this boot
+            continue  # not a documented `launchctl list` status column value
         if code != 0:
             out.append(
                 f"  - {label}: last run exited {code} (launchctl status) — "
                 f"check the job's log / plist"
+            )
+            continue
+        # code == 0 is ambiguous (see docstring above) — disambiguate via the
+        # slower print probe, bounded so a large fleet can't slow down every
+        # session start.
+        if uid is None or probes_used >= MAX_LAUNCHD_PRINT_PROBES:
+            continue
+        probes_used += 1
+        liveness = _launchd_print_liveness(label, uid)
+        if liveness is None:
+            continue  # probe unavailable/erroring — degrade to pre-probe silence
+        runs, last_exit = liveness
+        if runs == 0:
+            plist_path = HOME / "Library" / "LaunchAgents" / f"{label}.plist"
+            exit_note = f", last exit code {last_exit}" if last_exit else ""
+            out.append(
+                f"  - {label}: loaded but has NEVER RUN (runs=0{exit_note}, "
+                f"launchctl print) — a hollow job, not a healthy one; "
+                f"`launchctl list` alone cannot tell the two apart. Reload it: "
+                f"launchctl bootout gui/{uid}/{label}; "
+                f"launchctl bootstrap gui/{uid} {plist_path}"
             )
     return out
 
@@ -272,6 +359,11 @@ def receipts_reconcile_findings(vault: Path | None) -> list[str]:
 # (`com.<whoever>.team-broadcast-daily`). These jobs have a dedicated finder
 # below that gives better recovery guidance than the generic launchd pass.
 BESPOKE_LAUNCHD_SUFFIXES = (".team-broadcast-daily",)
+
+# `launchctl print` is slow enough per-label that an unbounded fleet could slow
+# down every session start. This caps total probes per run regardless of how
+# many "mine, loaded, status==0" candidates exist.
+MAX_LAUNCHD_PRINT_PROBES = 25
 
 
 def team_broadcast_findings(log_path: Path | None = None) -> list[str]:

--- a/hooks/surface-stale-automation-failures.py
+++ b/hooks/surface-stale-automation-failures.py
@@ -140,7 +140,7 @@ def fail_count_in_window(
         return 0
 
     try:
-        text = log_path.read_text(errors="replace")
+        text = log_path.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return 0
 
@@ -343,7 +343,7 @@ def receipts_reconcile_findings(vault: Path | None) -> list[str]:
             f"({newest.name}) — the daily reconcile job may have stopped"
         )
     try:
-        text = newest.read_text(errors="replace")
+        text = newest.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return out
     m = re.search(r"^hard_violations:\s*(\d+)", text, re.MULTILINE)
@@ -386,7 +386,7 @@ def team_broadcast_findings(log_path: Path | None = None) -> list[str]:
     if not log_path.exists():
         return []
     try:
-        text = log_path.read_text(errors="replace")
+        text = log_path.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return []
 

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -336,6 +336,22 @@ INTEGRATION_TESTS=(
   # every test ran against the vault the env var already named, which makes
   # "resolve from the env" and "resolve from the target" indistinguishable.
   test_hook_vault_root_per_target
+  # That same hook's launchd pass read `launchctl list`'s exit-status column
+  # only, which reads 0 for BOTH a healthy job and one that has never run at
+  # all -- a hollow job was indistinguishable from a clean one and stayed
+  # silently unflagged. Proves the blind spot on a frozen, independent
+  # reimplementation of the old rule (not a git-history diff, which would stop
+  # meaning anything once this fix lands on main), then proves the shipped fix
+  # (a second `launchctl print` probe, only for the ambiguous status==0 case)
+  # closes it -- with regression + false-positive + probe-failure controls.
+  test_launchd_hollow_job_detection
+  # The three shipped launchd plist templates carried no PATH, so a client
+  # script that shells out to a brew-installed tool failed with "not found"
+  # under launchd while working fine in every interactive shell. Validates the
+  # added EnvironmentVariables/PATH key with two independent parsers (plutil
+  # -lint where available, portable plistlib everywhere else) against both the
+  # raw template and a simulated real installer render.
+  test_launchd_template_path_env
   # The rm -rf rule in that same hook, which MYC-3529 left alone: its regex
   # spelled the vault root `$HOME/vault` -- a SHELL string in a PYTHON regex,
   # where `$` is an end-of-line anchor, so the branch was dead and the vault

--- a/scripts/utf8-file-io-baseline.txt
+++ b/scripts/utf8-file-io-baseline.txt
@@ -63,7 +63,7 @@ a29f6c2b98ccf874e4c818e2487ce74f32248ecbbce73a11c91a738561f3aa84 SEV-A-write ski
 03d3f290e244d9ab0ae72af71ee51ed71be2e4f2aea62f6cf705d34ddcdeef69 SEV-A-write skills/graphify/scripts/graphify_stage_finish.py
 52d758fe570f834711cc82f5f0870678755325a30280625e1213b2882e036f6d SEV-A-write skills/graphify/scripts/graphify_stage_select.py
 
-# ---- SEV-B-read-only  (32 file(s)) ----
+# ---- SEV-B-read-only  (31 file(s)) ----
 b266f20ff920feeb950d48705939568f13e71e844707b90876c179c76d013da9 SEV-B-read-only hooks/_lib/dev_repo_scan.py
 3f7a1805473134ddb49cd1957cc4f94c8e84a1ccb4e8f875e6765b3dac33f289 SEV-B-read-only hooks/_lib/safe_read.py
 52c331ed8a99a90e12e347215144e6799dbe1d278024432dfc46639a4de68405 SEV-B-read-only hooks/_lib/worktree_safety.py
@@ -72,7 +72,6 @@ b647243fdf0a358d46a6a79b0bf7f817ee121f68d5d685fabe4b0ee2a93af94d SEV-B-read-only
 2050c962d8ba4b38910d207c75e786f4b4831406ba3d8e799fe9f475623c8bff SEV-B-read-only hooks/detect-secrets-in-bash-output.py
 3599a56754108272a15a2c879a23a52c0e844edf2991932118ecf16b24706af9 SEV-B-read-only hooks/dev-hub-refresh-on-session-start.py
 383b879b07fd9dce4a66c6a9beb449e2c7ec378b7f94d393b2bf486cf26531fb SEV-B-read-only hooks/observe-tool-calls.py
-226c80ed7d310efa5e94d3ed2324bbaa5f1a4503d0055295db5b0d4583393048 SEV-B-read-only hooks/surface-stale-automation-failures.py
 9ac734ab62df2f6176c7aabad09b72768fe553c93ef15a876ddae32e9a830ca4 SEV-B-read-only hooks/surface-sync-guard-findings.py
 328fa4ceb9777bf7600821fd6a31c4cfe7b97db233c59a1fa4d830f882cfd9f6 SEV-B-read-only hooks/test_check_fabricated_verification.py
 2b14fd8dbb3f827ca22270bee60bdacf598984bd28f2221856702b7791ba71b2 SEV-B-read-only hooks/test_footprint_aggregate_bloat.py

--- a/templates/launchd/com.abs.closed-loop-daemon.plist.template
+++ b/templates/launchd/com.abs.closed-loop-daemon.plist.template
@@ -38,6 +38,16 @@
         <string>{{VAULT_ROOT}}</string>
     </array>
 
+    <!-- launchd hands a job a minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin) with
+         no Homebrew prefix, so anything this daemon shells out to that was
+         installed via brew (gh, uv, node, a brew git...) fails with "not
+         found" here even though it works in every interactive shell. -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/home/linuxbrew/.linuxbrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+
     <key>KeepAlive</key>
     <true/>
 

--- a/templates/launchd/com.abs.dev-hub-refresh.plist.template
+++ b/templates/launchd/com.abs.dev-hub-refresh.plist.template
@@ -39,6 +39,16 @@
         <string>--quiet</string>
     </array>
 
+    <!-- launchd hands a job a minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin) with
+         no Homebrew prefix, so anything this daemon shells out to that was
+         installed via brew (gh, uv, node, a brew git...) fails with "not
+         found" here even though it works in every interactive shell. -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/home/linuxbrew/.linuxbrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+
     <key>StartInterval</key>
     <integer>21600</integer>
 

--- a/templates/launchd/com.abs.vault-daily-maintenance.plist.template
+++ b/templates/launchd/com.abs.vault-daily-maintenance.plist.template
@@ -46,6 +46,16 @@
         <string>{{VAULT_ROOT}}</string>
     </array>
 
+    <!-- launchd hands a job a minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin) with
+         no Homebrew prefix, so anything this script shells out to that was
+         installed via brew (gh, uv, node, a brew git...) fails with "not
+         found" here even though it works in every interactive shell. -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/home/linuxbrew/.linuxbrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+
     <key>StartCalendarInterval</key>
     <dict>
         <key>Hour</key>

--- a/tests/integration/test_launchd_hollow_job_detection.sh
+++ b/tests/integration/test_launchd_hollow_job_detection.sh
@@ -186,8 +186,12 @@ fi
 # Assertions 2-5: END-TO-END against the real (post-fix) hook.
 # --------------------------------------------------------------------------
 run_hook() {  # <stdin-json> -> sets RC, writes $OUT / $ERR
-  printf '%s' "$1" | env -u VAULT_ROOT -u SURFACE_STALE_AUTOMATION_BYPASS -u CLAUDE_CWD \
-    HOME="$FIXTURE" USERPROFILE="$(_sandbox_native_path "$FIXTURE")" HOMEDRIVE="" HOMEPATH="" \
+  # Routed through run_sandboxed (tests/integration/lib/sandbox_home.sh) rather
+  # than a hand-rolled HOME=/USERPROFILE= pair: that helper is what
+  # test_home_sandbox_hermeticity.sh recognizes as "paired by construction",
+  # and it is also just less duplication for the same guarantee.
+  printf '%s' "$1" | run_sandboxed "$FIXTURE" \
+    env -u VAULT_ROOT -u SURFACE_STALE_AUTOMATION_BYPASS -u CLAUDE_CWD \
     PATH="$STUB:$PATH" \
     python3 "$HOOK" >"$OUT" 2>"$ERR"
   RC=$?

--- a/tests/integration/test_launchd_hollow_job_detection.sh
+++ b/tests/integration/test_launchd_hollow_job_detection.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+# Test: surface-stale-automation-failures.py -- launchd HOLLOW-job detection.
+#
+# Bug class: `launchctl list` column 2 (the last exit status) reads "0" for
+# BOTH a genuinely healthy job (ran, exited clean) AND a job launchd has
+# REGISTERED but has NEVER EXECUTED. Measured 2026-08-20 on a real install:
+#
+#     launchctl list        ->  -   0   <label>      # reads as CLEAN
+#     launchctl print ...   ->  state = not running | runs = 0 | last exit code = (never exited)
+#
+# The pre-fix `launchd_failures()` read ONLY `launchctl list`, so a hollow job
+# was indistinguishable from a healthy one and was never flagged -- a real job
+# sat dead, unnoticed, for days behind exactly this blind spot. The fix adds a
+# second, slower probe (`launchctl print gui/<uid>/<label>`) for the AMBIGUOUS
+# status==0 case only, and reports a hollow job as a finding DISTINCT from a
+# failing one, because the remedy differs: bootout+bootstrap (reload it) vs.
+# reading the error log.
+#
+# `launchctl` is stubbed on PATH -- the real binary is never touched, and this
+# suite must never load/bootstrap/kickstart/unload any real launchd job. One
+# stub handles both subcommands the hook calls:
+#   `launchctl list`                    -> a fixed PID/status/label table
+#   `launchctl print gui/<uid>/<label>` -> per-label canned output, branching
+#                                          on the label suffix so the uid
+#                                          launchd_failures() computes at
+#                                          runtime never has to be known here
+# Same PATH-stub convention as test_hook_vault_root_per_target.sh case 8.
+#
+# Assertions:
+#   1. PRE-FIX PROOF (the negative control that proves the fix). An
+#      independent, literal reimplementation of the OLD decision rule --
+#      "read only the `list` status column; flag iff it parses as a non-zero
+#      int" -- applied to the SAME raw `launchctl list` stub rows, does NOT
+#      flag the hollow-job label. This is deliberately NOT a diff against git
+#      history: after this fix lands on main, "before" and "after" would be
+#      the same file and a history-based comparison would stop proving
+#      anything. A frozen, independent reimplementation keeps meaning the
+#      same thing forever.
+#   2-5. END-TO-END, one real hook invocation, four labels in one fixture:
+#      2. hollow job      (list status 0, print runs=0)     -> flagged, distinctly
+#      3. failing job     (list status 9)                   -> still flagged (no regression)
+#      4. healthy job     (list status 0, print runs=42)    -> NOT flagged (no false positive)
+#      5. flaky-print job (list status 0, print errors out) -> NOT flagged, hook does not crash
+#
+# Self-contained. Exit 0 = pass, exit 1 = fail.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOK="$REPO_ROOT/hooks/surface-stale-automation-failures.py"
+# HOME alone does NOT sandbox on Windows: Path.home() reads USERPROFILE there,
+# so a bare HOME= override runs against the developer's REAL ~/.claude (MYC-3536).
+. "$REPO_ROOT/tests/integration/lib/sandbox_home.sh"
+if [ ! -f "$HOOK" ]; then
+  echo "FAIL: hook not found at $HOOK" >&2
+  exit 1
+fi
+
+FAILURES=0
+pass() { echo "PASS: $1"; }
+fail() { echo "FAIL: $1" >&2; FAILURES=$((FAILURES + 1)); }
+show_streams() {
+  echo "  --- stdout ---" >&2; sed 's/^/  /' "$OUT" >&2
+  echo "  --- stderr ---" >&2; sed 's/^/  /' "$ERR" >&2
+}
+
+TMP="$(python3 -c 'import os,tempfile; print(os.path.realpath(tempfile.mkdtemp(prefix="abs-launchd-hollow-")).replace(chr(92), "/"))')"
+if [ -z "$TMP" ] || [ ! -d "$TMP" ]; then
+  echo "FAIL: could not create a tmpdir python and the shell both agree on" >&2
+  exit 1
+fi
+trap 'rm -rf "$TMP"' EXIT
+FIXTURE="$TMP/home"
+STUB="$TMP/stub"
+OUT="$TMP/out.txt"
+ERR="$TMP/err.txt"
+mkdir -p "$FIXTURE/Library/LaunchAgents" "$FIXTURE/.claude" "$STUB"
+
+# --------------------------------------------------------------------------
+# Fixture: four labels, one story each. `user_launchd_labels()` only reports
+# labels with a matching plist in LaunchAgents/, so every label needs one --
+# content is irrelevant, the glob only reads the filename stem.
+# --------------------------------------------------------------------------
+for label in com.example.hollow-job com.example.failing-job com.example.healthy-job com.example.flaky-print-job; do
+  printf '<plist/>\n' > "$FIXTURE/Library/LaunchAgents/$label.plist"
+done
+
+# The fake `launchctl`. Quoted heredoc delimiter -- the $1/$2/case syntax below
+# must reach the stub file literally, not be expanded by THIS shell.
+cat > "$STUB/launchctl" <<'LAUNCHCTL_STUB'
+#!/bin/sh
+case "$1" in
+  list)
+    printf -- '-\t0\tcom.example.hollow-job\n'
+    printf -- '-\t9\tcom.example.failing-job\n'
+    printf -- '12345\t0\tcom.example.healthy-job\n'
+    printf -- '-\t0\tcom.example.flaky-print-job\n'
+    ;;
+  print)
+    case "$2" in
+      */com.example.hollow-job)
+        printf 'com.example.hollow-job = {\n'
+        printf '\tactive count = 0\n'
+        printf '\tstate = not running\n'
+        printf '\truns = 0\n'
+        printf '\tlast exit code = (never exited)\n'
+        printf '}\n'
+        ;;
+      */com.example.healthy-job)
+        printf 'com.example.healthy-job = {\n'
+        printf '\tstate = not running\n'
+        printf '\truns = 42\n'
+        printf '\tlast exit code = 0\n'
+        printf '}\n'
+        ;;
+      *)
+        # com.example.failing-job never reaches `print` (its list status is
+        # already unambiguous); com.example.flaky-print-job lands here on
+        # purpose -- this is the probe-errors-out case.
+        echo "Could not find service" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+LAUNCHCTL_STUB
+chmod +x "$STUB/launchctl"
+
+# --------------------------------------------------------------------------
+# Assertion 1: PRE-FIX PROOF. See the file header for why this is a frozen,
+# independent reimplementation rather than a git-history diff.
+# --------------------------------------------------------------------------
+python3 - <<'PY'
+import sys
+
+ROWS = [
+    ("-", "0", "com.example.hollow-job"),
+    ("-", "9", "com.example.failing-job"),
+    ("12345", "0", "com.example.healthy-job"),
+    ("-", "0", "com.example.flaky-print-job"),
+]
+
+
+def pre_fix_flagged(rows):
+    """The OLD decision rule, frozen: read ONLY the `launchctl list` status
+    column, flag iff it parses as a non-zero int. Verbatim shape of what
+    launchd_failures() did before the hollow-job probe existed."""
+    flagged = set()
+    for _pid, status, label in rows:
+        try:
+            code = int(status)
+        except ValueError:
+            continue
+        if code != 0:
+            flagged.add(label)
+    return flagged
+
+
+flagged = pre_fix_flagged(ROWS)
+failures = []
+if "com.example.hollow-job" in flagged:
+    failures.append(
+        "fixture bug: the pre-fix rule already flags the hollow job "
+        f"({flagged}) -- this control would be vacuous"
+    )
+if "com.example.failing-job" not in flagged:
+    failures.append(
+        "fixture bug: the pre-fix rule does not flag the failing job either "
+        "-- check the ROWS fixture"
+    )
+if failures:
+    for f in failures:
+        print("FAIL: " + f, file=sys.stderr)
+    sys.exit(1)
+PY
+if [ $? -eq 0 ]; then
+  pass "pre-fix proof: reading only launchctl-list status reads the hollow job as clean (the blind spot the fix closes)"
+else
+  fail "pre-fix proof control did not hold -- see stderr above"
+fi
+
+# --------------------------------------------------------------------------
+# Assertions 2-5: END-TO-END against the real (post-fix) hook.
+# --------------------------------------------------------------------------
+run_hook() {  # <stdin-json> -> sets RC, writes $OUT / $ERR
+  printf '%s' "$1" | env -u VAULT_ROOT -u SURFACE_STALE_AUTOMATION_BYPASS -u CLAUDE_CWD \
+    HOME="$FIXTURE" USERPROFILE="$(_sandbox_native_path "$FIXTURE")" HOMEDRIVE="" HOMEPATH="" \
+    PATH="$STUB:$PATH" \
+    python3 "$HOOK" >"$OUT" 2>"$ERR"
+  RC=$?
+}
+
+verdict() {  # <out-file> -> prints the systemMessage text, or EMPTY/UNPARSEABLE(...)
+  python3 - "$1" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+raw = Path(sys.argv[1]).read_text(encoding="utf-8").strip()
+if not raw:
+    print("EMPTY")
+    raise SystemExit(0)
+try:
+    msg = json.loads(raw).get("systemMessage", "")
+except Exception as exc:
+    print(f"UNPARSEABLE({exc})")
+    raise SystemExit(0)
+print(msg)
+PY
+}
+
+PAYLOAD="$(python3 -c 'import json,sys; print(json.dumps({"cwd":sys.argv[1]}))' "$TMP")"
+run_hook "$PAYLOAD"
+MSG="$(verdict "$OUT")"
+
+if [ "$RC" -ne 0 ]; then
+  fail "hook exited $RC (expected 0 -- this hook is fail-open by design on every path)"
+  show_streams
+else
+  pass "hook exits 0 across all four fixture labels"
+fi
+
+if grep -qi "Traceback" "$ERR"; then
+  fail "hook printed a Python traceback to stderr -- the print-probe is not fail-open"
+  sed 's/^/  /' "$ERR" >&2
+else
+  pass "no crash / traceback across all four fixture labels (fail-open holds end to end)"
+fi
+
+if printf '%s' "$MSG" | grep -q "com.example.hollow-job" && printf '%s' "$MSG" | grep -q "NEVER RUN"; then
+  pass "hollow job (runs=0) is flagged as hollow -- the fix's core claim"
+else
+  fail "hollow job (runs=0) was not flagged as hollow"
+  echo "  systemMessage=[$MSG]" >&2
+fi
+
+if printf '%s' "$MSG" | grep -q "com.example.failing-job" && printf '%s' "$MSG" | grep -q "exited 9"; then
+  pass "a genuinely failing job (non-zero exit) is still flagged -- no regression"
+else
+  fail "the failing job's non-zero-exit finding regressed"
+  echo "  systemMessage=[$MSG]" >&2
+fi
+
+# The hollow and failing findings must read as DISTINCT states -- that's the
+# whole point of the fix (different remedies). Only the plain non-zero-exit
+# finding uses the "(launchctl status)" suffix; the hollow finding legitimately
+# says "never exited" as diagnostic detail, so the bare word "exited" is not a
+# safe discriminator -- the literal "(launchctl status)" suffix is.
+if printf '%s' "$MSG" | grep -F "com.example.hollow-job" | grep -qF "(launchctl status)"; then
+  fail "the hollow-job finding uses the plain-failure '(launchctl status)' phrasing -- not distinct"
+  echo "  systemMessage=[$MSG]" >&2
+else
+  pass "the hollow finding is worded distinctly from a generic exit-status failure"
+fi
+
+if printf '%s' "$MSG" | grep -q "com.example.healthy-job"; then
+  fail "a healthy job (runs>=1, exit 0) was flagged -- false positive"
+  echo "  systemMessage=[$MSG]" >&2
+else
+  pass "a healthy job (runs>=1, exit 0) is not flagged -- no false positive"
+fi
+
+if printf '%s' "$MSG" | grep -q "com.example.flaky-print-job"; then
+  fail "a label whose print probe errors out was flagged -- should degrade silently"
+  echo "  systemMessage=[$MSG]" >&2
+else
+  pass "a label whose print probe errors out degrades silently (not flagged, no crash)"
+fi
+
+if [ "$FAILURES" -eq 0 ]; then
+  echo "All assertions passed. Launchd hollow-job detection holds (pos+neg control)."
+  exit 0
+else
+  echo "$FAILURES assertion(s) failed." >&2
+  exit 1
+fi

--- a/tests/integration/test_launchd_template_path_env.sh
+++ b/tests/integration/test_launchd_template_path_env.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Test: templates/launchd/*.plist.template -- EnvironmentVariables/PATH key.
+#
+# Bug class: launchd hands a job a minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin)
+# with no Homebrew prefix. A client script that shells out to a brew-installed
+# tool (gh, uv, node, a brew git) fails with "not found" under launchd even
+# though it works in every interactive shell -- the exact failure took a daily
+# job down here, invisibly, for days, because nothing distinguished "job
+# crashed" from "job's PATH doesn't have what it needs" until someone read its
+# own stderr log.
+#
+# The fix adds an explicit EnvironmentVariables/PATH key to all three shipped
+# templates, prefixing the Homebrew locations (Apple Silicon, Intel,
+# Linuxbrew) ahead of the launchd-default system directories.
+#
+# Validation deliberately does NOT regex-eyeball the XML text -- a regex can
+# match a key that is commented out, malformed, or sitting in the wrong dict.
+# Two independent parsers are used instead:
+#   - plutil -lint: Apple's own tool (macOS only), the closest thing to "does
+#     launchd itself accept this file". Skipped, not failed, off macOS.
+#   - Python's plistlib: portable, so this control has REAL teeth on the
+#     canonical ubuntu-latest CI gate, not just on a developer's Mac. Each
+#     template's leading documentation comment is stripped before parsing:
+#     two of the three templates' PRE-EXISTING header prose contain a literal
+#     "--" inside a CLI-flag example (e.g. "--apply"), which XML forbids
+#     inside comment text -- plutil tolerates it (confirmed: `plutil -lint`
+#     reports OK on all three, unmodified), Python's strict expat parser does
+#     not. Comments carry zero plist DATA, so stripping them before parsing
+#     changes nothing about what a rendered, installed copy actually
+#     contains -- this is normalization for the test, not a workaround for
+#     anything the fix itself touches.
+#
+# Per template, two assertions:
+#   1. plutil -lint accepts it (macOS only; SKIP elsewhere, noted above)
+#   2. one Python check covering all of:
+#      (a) plistlib parses the raw template (comments stripped)
+#      (b) EnvironmentVariables/PATH exists and matches the required value
+#          exactly -- Homebrew locations ahead of the launchd-default system
+#          directories, in the specified order
+#      (c) the template's own placeholder tokens ({{REPO_ROOT}} etc.) are
+#          still present verbatim -- the fix must not disturb the installers'
+#          sed-substitution contract
+#      (d) a REAL sed substitution -- replicating byte-for-byte what
+#          scripts/install-*.sh actually runs -- still parses afterward, with
+#          the PATH key intact and zero leftover {{...}} tokens. This proves
+#          the fix survives the actual installer rendering path, not just the
+#          raw template.
+#
+# Static file validation only -- no real launchctl load/bootstrap anywhere in
+# this file. Self-contained. Exit 0 = pass, exit 1 = fail.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEMPLATES_DIR="$REPO_ROOT/templates/launchd"
+
+FAILURES=0
+pass() { echo "PASS: $1"; }
+fail() { echo "FAIL: $1" >&2; FAILURES=$((FAILURES + 1)); }
+
+EXPECTED_PATH="/opt/homebrew/bin:/usr/local/bin:/home/linuxbrew/.linuxbrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+# name -> space-separated placeholder tokens that template uses (matches each
+# scripts/install-*.sh's own `sed -e "s|{{X}}|...|g"` invocations verbatim).
+TEMPLATE_NAMES=(
+  "com.abs.closed-loop-daemon.plist.template"
+  "com.abs.dev-hub-refresh.plist.template"
+  "com.abs.vault-daily-maintenance.plist.template"
+)
+TEMPLATE_PLACEHOLDERS=(
+  "REPO_ROOT VAULT_ROOT LOG_DIR"
+  "REPO_ROOT LOG_DIR"
+  "REPO_ROOT VAULT_ROOT LOG_DIR"
+)
+
+i=0
+while [ "$i" -lt "${#TEMPLATE_NAMES[@]}" ]; do
+  name="${TEMPLATE_NAMES[$i]}"
+  placeholders="${TEMPLATE_PLACEHOLDERS[$i]}"
+  path="$TEMPLATES_DIR/$name"
+  i=$((i + 1))
+
+  if [ ! -f "$path" ]; then
+    fail "$name: template file not found at $path"
+    continue
+  fi
+
+  # --- assertion 1: plutil -lint (macOS only) ------------------------------
+  if command -v plutil >/dev/null 2>&1; then
+    if plutil -lint "$path" >/dev/null 2>&1; then
+      pass "$name: plutil -lint accepts the template"
+    else
+      fail "$name: plutil -lint rejected the template"
+      plutil -lint "$path" >&2 || true
+    fi
+  else
+    echo "SKIP: $name: plutil not available on this platform (non-macOS) -- assertion 2 (plistlib) still gives real coverage"
+  fi
+
+  # --- assertion 2: parse + PATH content + placeholders + real-render ------
+  if python3 - "$path" "$placeholders" "$EXPECTED_PATH" <<'PY'
+import plistlib
+import re
+import sys
+from pathlib import Path
+
+template_path = Path(sys.argv[1])
+placeholders = sys.argv[2].split()
+expected_path = sys.argv[3]
+
+COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+raw = template_path.read_text(encoding="utf-8")
+errors = []
+
+# (a) + (b): raw template parses (comments stripped) and PATH is correct.
+try:
+    data = plistlib.loads(COMMENT_RE.sub("", raw).encode("utf-8"))
+except Exception as exc:
+    print(f"FAIL: {template_path.name}: does not parse as plist (comments stripped): {exc}", file=sys.stderr)
+    sys.exit(1)
+
+env = data.get("EnvironmentVariables")
+if not isinstance(env, dict) or "PATH" not in env:
+    errors.append("no EnvironmentVariables/PATH key in the parsed plist")
+elif env["PATH"] != expected_path:
+    errors.append(f"PATH = {env['PATH']!r}, expected {expected_path!r}")
+
+# (c): every placeholder this template is supposed to carry is still there,
+# verbatim, in the RAW (unstripped) text -- the installers' sed step depends
+# on these tokens surviving byte-for-byte.
+for ph in placeholders:
+    token = "{{%s}}" % ph
+    if token not in raw:
+        errors.append(f"placeholder {token} missing from the raw template")
+
+# (d): replicate the installers' OWN substitution exactly (a literal global
+# string replace -- sed's `s|{{X}}|...|g` treats these tokens literally, no
+# BRE metacharacters in play), then re-parse. Proves the fix survives the
+# real rendering path, not just the pristine template.
+FAKE_VALUES = {
+    "REPO_ROOT": "/Users/tester/ai-brain-starter",
+    "VAULT_ROOT": "/Users/tester/MyVault",
+    "LOG_DIR": "/Users/tester/.local/state/ai-brain-starter",
+}
+rendered = raw
+for ph in placeholders:
+    rendered = rendered.replace("{{%s}}" % ph, FAKE_VALUES[ph])
+
+if "{{" in rendered:
+    errors.append("a {{...}} token survives after simulated sed substitution")
+
+try:
+    rendered_data = plistlib.loads(COMMENT_RE.sub("", rendered).encode("utf-8"))
+except Exception as exc:
+    errors.append(f"rendered (post-substitution) file does not parse as plist: {exc}")
+else:
+    r_env = rendered_data.get("EnvironmentVariables")
+    if not isinstance(r_env, dict) or r_env.get("PATH") != expected_path:
+        errors.append("PATH key did not survive simulated sed substitution intact")
+    # And the substituted values actually landed where they should have.
+    args = rendered_data.get("ProgramArguments") or []
+    joined = " ".join(str(a) for a in args) + " " + str(rendered_data.get("StandardOutPath", ""))
+    for ph, val in FAKE_VALUES.items():
+        if ph in placeholders and val not in joined and val not in str(rendered_data):
+            errors.append(f"substituted {ph} value never appears anywhere in the rendered plist")
+
+if errors:
+    for e in errors:
+        print(f"FAIL: {template_path.name}: {e}", file=sys.stderr)
+    sys.exit(1)
+print(f"{template_path.name}: parses, PATH correct, placeholders intact, survives real substitution")
+PY
+  then
+    pass "$name: parses (comments stripped) + PATH exact + placeholders survive real sed substitution"
+  else
+    fail "$name: one or more plist/PATH/placeholder/render checks failed -- see stderr above"
+  fi
+done
+
+if [ "$FAILURES" -eq 0 ]; then
+  echo "All assertions passed. Launchd template PATH env holds across all three templates."
+  exit 0
+else
+  echo "$FAILURES assertion(s) failed." >&2
+  exit 1
+fi


### PR DESCRIPTION

---

Drafted with Claude Code; every gate result above was re-run and read directly rather than taken from an agent report.
