### PR TITLE
fix(hooks): the in-flight guard evaluated the session cwd, not the repo the command cd'd into (MYC-3779)

### DIFF
--- a/hooks/block-git-mutation-mid-operation.py
+++ b/hooks/block-git-mutation-mid-operation.py
@@ -31,11 +31,12 @@ while `.git` was mid-rebase. You had to already suspect the problem to ask the
 question that revealed it. That is what this hook asks, every time, for free.
 
 WHAT IT CHECKS
-  Resolves the git-dir the command would actually act on (honoring `-C <path>`
-  and `--git-dir`, and handling a `.git` FILE that points elsewhere -- the
-  incident repo keeps its working tree in one place and its git-dir in a
-  separate mirror directory, so a naive `<cwd>/.git` guess finds nothing).
-  Then looks for:
+  Resolves the git-dir the command would actually act on (honoring `-C <path>`,
+  `--git-dir`, an inline `GIT_DIR=`, AND a `cd` earlier in the same command --
+  see WHICH REPOSITORY below -- and handling a `.git` FILE that points
+  elsewhere: the incident repo keeps its working tree in one place and its
+  git-dir in a separate mirror directory, so a naive `<cwd>/.git` guess finds
+  nothing). Then looks for:
       rebase-merge/     paused interactive / merge-backend rebase
       rebase-apply/     paused am-backend rebase, or a stopped `git am`
       MERGE_HEAD        merge stopped at conflicts
@@ -47,6 +48,59 @@ WHAT IT CHECKS
   In a linked worktree this deliberately uses `--git-dir`, not
   `--git-common-dir`: in-flight operation state is per-worktree, so the
   per-worktree git-dir is the correct place to look.
+
+WHICH REPOSITORY (added 2026-08-22, after this hook blocked the wrong repo)
+  The hook read `-C`, `--git-dir` and `GIT_DIR`, but not the shell's own `cd`.
+  So for the single most common shape an agent emits --
+
+      cd /other/repo && git commit -m ...
+
+  -- the `cd` segment was parsed, found not to be a git call, and discarded;
+  the `git commit` segment then resolved against the SESSION cwd. That is the
+  wrong repository, and it failed in BOTH directions:
+
+    FALSE BLOCK  session cwd mid-rebase, `cd`-target clean -> refused a commit
+                 to a repo that had nothing in flight, citing an unrelated
+                 repo's rebase. Measured 2026-08-22. This is the direction that
+                 does the lasting damage, because the only way past it is the
+                 bypass var, so it teaches everyone to set
+                 GIT_INFLIGHT_OP_BYPASS=1 reflexively -- and then the guard is
+                 gone for the case it exists to catch.
+    FALSE ALLOW  session cwd clean, `cd`-target mid-rebase -> the commit was
+                 PERMITTED straight into a paused rebase. Measured the same
+                 day. This is the 2026-07-28 incident walking through the front
+                 door of the guard written to stop it.
+
+  So the cwd is now tracked across shell segments. Rules, and why each one:
+    `cd X && git ...`   -> X. `&&` runs the right side only if `cd` SUCCEEDED,
+                           so X is not a guess.
+    `cd X ; git ...`    -> X *and* the previous cwd. `;` runs the right side
+                           whether or not `cd` worked, so the repo is genuinely
+                           ambiguous; both are checked and either one being
+                           mid-operation blocks. Conservative on purpose -- the
+                           ambiguous case must not be the one that loses work.
+    `cd X || git ...`   -> previous cwd. The right side runs only if `cd`
+                           FAILED, so the cwd did not move.
+    `cd X | git ...`    -> previous cwd. A pipeline component is a subshell;
+                           its `cd` does not escape.
+  Bare `cd` resolves to $HOME. `cd -` does NOT: tracking $OLDPWD across the
+  ambiguous separators is more machinery than that shape is worth, and a wrong
+  OLDPWD is a wrong repository, so it takes the fallback below.
+
+  TRACKING IS ABANDONED (falling back to the session cwd -- i.e. exactly what
+  this hook did before any of this existed, so the fallback cannot regress it)
+  the moment the shell stops being readable:
+    - an unquoted `( ... )` subshell anywhere in the command. A subshell scopes
+      its `cd` to the group, so in `(cd /a && git commit) && git push` the push
+      is back at the ORIGINAL cwd. A tracker that missed the `)` would judge
+      the push against /a and could ALLOW a mutation into a stalled repo. The
+      detection is quote-aware: `git commit -m "fix (bug)"` must not trip it,
+      or the false block comes straight back for parenthesised messages.
+    - a `cd` whose destination is not a literal path -- `cd $VAR`,
+      `cd "$(...)"`, a glob, `cd -`, `popd`, a Windows drive-relative path, or
+      more than one operand.
+  Command substitution is NOT a subshell for this purpose: `$(cd /x)` cannot
+  move the caller's cwd, and it tokenizes as one word, not a bare paren.
 
 DETACHED HEAD gets its own, softer path (a warning, not a block) with its own
 message. Committing to a plain detached HEAD is survivable -- you can recover a
@@ -87,9 +141,9 @@ forward-slash paths ARE covered, which is what Git Bash / WSL / PATH
 invocations actually look like.
 
 The parser reads leading env assignments, transparent wrappers (`env`/`sudo`/
-...), `-C`, `--git-dir`, `GIT_DIR` and `GIT_WORK_TREE`, which is the shape real
-sessions and agents emit. The incidents this exists for were plain `git commit`
-calls.
+...), `-C`, `--git-dir`, `GIT_DIR`, `GIT_WORK_TREE` and a preceding `cd`, which
+is the shape real sessions and agents emit. The incidents this exists for were
+plain `git commit` calls, reached either directly or through a `cd`.
 
 Fails OPEN on any error (missing git, unreadable dir, timeout). A correctness
 guard that hard-fails would block every git command in the repo on a transient
@@ -113,6 +167,12 @@ BYPASS_VAR = "GIT_INFLIGHT_OP_BYPASS"
 # Split a command into sequential segments on shell separators so each piece is
 # evaluated independently (mirrors session-lock.py / check-cd-outside-worktree.py).
 SEGMENT_SPLIT_RE = re.compile(r"&&|\|\||[;\n|]")
+# Same pattern, capturing, so the separator BETWEEN two segments is available:
+# `cd X && git ...` and `cd X || git ...` put the git call in different
+# directories, and only the separator says which. `re.split` with one capture
+# group returns [seg, sep, seg, sep, ...], so `[0::2]` is exactly what
+# SEGMENT_SPLIT_RE.split() yields and the indices line up 1:1.
+SEGMENT_SPLIT_CAPTURE_RE = re.compile(r"(&&|\|\||[;\n|])")
 ENV_ASSIGN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
 
 # Transparent wrappers to skip before identifying `git`
@@ -163,6 +223,34 @@ IN_FLIGHT_MARKERS = [
     ("sequencer", "multi-commit cherry-pick/revert sequence, mid-run", "cherry-pick"),
 ]
 
+# Shell builtins that move the working directory. `pushd` moves it too; `popd`
+# moves it back to a stack this hook never saw, so it is unresolvable by
+# construction and is listed to force the fallback rather than be mistaken for
+# a non-cd command.
+CD_BUILTINS = {"cd", "pushd"}
+UNRESOLVABLE_CD_BUILTINS = {"popd"}
+CD_FLAGS = {"-L", "-P", "-e", "-@"}
+
+# A destination containing any of these is not a literal path: the shell would
+# expand it and this hook would resolve the pre-expansion text to the wrong
+# directory. `$`/backtick are substitution, the rest are globs.
+UNRESOLVABLE_PATH_CHARS = ("$", "`", "*", "?", "[")
+
+# A Windows drive-relative destination. Found by the pre-push doubt-pass, not by
+# a failing test. `shlex` eats the backslashes in `cd C:\repo` (it is a POSIX
+# tokenizer and a backslash is an escape), leaving `C:repo` -- which `isabs`
+# rejects on BOTH platforms, so it got joined onto the base, produced a
+# directory that does not exist, failed the isdir check and made the hook SKIP
+# the git call entirely. Skipping is the false-allow direction. Treat any
+# `X:`-prefixed destination that is not already absolute as unresolvable so it
+# takes the documented session-cwd fallback instead.
+WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:")
+
+# Sentinel: the segment is not a `cd` at all (distinct from a `cd` we could not
+# resolve, which must abandon tracking -- collapsing the two would silently
+# turn every unreadable `cd` into "cwd unchanged", the false-allow direction).
+NOT_A_CD = object()
+
 GIT_TIMEOUT_SEC = 5
 
 
@@ -184,6 +272,136 @@ def _inline_bypass(command: str, var: str) -> bool:
     return False
 
 
+def _has_subshell(command: str) -> bool:
+    """True iff `command` contains an UNQUOTED `(` or `)` grouping token.
+
+    Quote-aware by construction: tokenized with `shlex` in punctuation mode, a
+    paren inside a quoted word stays inside that word (`git commit -m
+    "fix (bug)"` -> [..., 'fix (bug)']) while a real subshell becomes its own
+    token (`(cd /a && git commit)` -> ['(', ...,  ')']). A naive substring test
+    would confuse the two and re-break every parenthesised commit message.
+
+    Command substitution deliberately does NOT count: `$(...)` tokenizes as a
+    single word, and a substitution cannot move the caller's cwd anyway.
+
+    Fails toward True (abandon tracking, resolve from the session cwd) on any
+    tokenizer error -- an unbalanced quote means the shape is unreadable, and
+    an unreadable shape must not drive a repository decision.
+    """
+    try:
+        lex = shlex.shlex(command, posix=True, punctuation_chars=True)
+        lex.whitespace_split = True
+        return any(tok in ("(", ")") for tok in lex)
+    except (ValueError, AttributeError):
+        return True
+
+
+def _cd_targets(segment: str, bases):
+    """Where a `cd` segment would land, relative to each of `bases`.
+
+    Returns NOT_A_CD when the segment is not a cd, None when it is a cd whose
+    destination cannot be resolved literally, else a list of absolute paths
+    (one per base, since a RELATIVE `cd` means something different from each).
+    """
+    try:
+        tokens = shlex.split(segment)
+    except ValueError:
+        tokens = segment.split()
+
+    i = 0
+    while i < len(tokens) and (
+        ENV_ASSIGN_RE.match(tokens[i]) or tokens[i] in WRAPPER_PREFIXES
+    ):
+        i += 1
+    if i >= len(tokens):
+        return NOT_A_CD
+    builtin = tokens[i]
+    if builtin in UNRESOLVABLE_CD_BUILTINS:
+        return None
+    if builtin not in CD_BUILTINS:
+        return NOT_A_CD
+
+    rest = []
+    seen_ddash = False
+    for tok in tokens[i + 1:]:
+        if not seen_ddash and tok == "--":
+            seen_ddash = True
+            continue
+        if not seen_ddash and not rest and tok in CD_FLAGS:
+            continue
+        rest.append(tok)
+
+    if not rest:
+        # Bare `cd` is $HOME; bare `pushd` swaps the top of a stack we cannot see.
+        if builtin == "pushd":
+            return None
+        home = os.path.expanduser("~")
+        return [os.path.normpath(home)] if home and home != "~" else None
+    if len(rest) > 1:
+        return None
+
+    dest = rest[0]
+    if dest == "-":
+        # $OLDPWD. Deliberately NOT resolved: tracking it correctly across the
+        # ambiguous separators is more machinery than the shape is worth, and a
+        # wrong OLDPWD is a wrong repository. Falls back to the session cwd.
+        return None
+    if any(c in dest for c in UNRESOLVABLE_PATH_CHARS):
+        return None
+
+    dest = os.path.expanduser(dest)
+    if os.path.isabs(dest):
+        return [os.path.normpath(dest)]
+    if WINDOWS_DRIVE_RE.match(dest) or "\\" in dest:
+        return None  # drive-relative / backslashed: not resolvable here
+    return [os.path.normpath(os.path.join(b, dest)) for b in bases]
+
+
+def _cwd_candidates_by_segment(command: str, session_cwd: str):
+    """Per shell segment, the working directories a command there could run in.
+
+    Aligned index-for-index with `SEGMENT_SPLIT_RE.split(command)`, which is
+    what `_git_invocations` walks. Usually a single directory; more than one
+    only for the genuinely ambiguous `cd X ; git ...`, where the caller checks
+    every candidate and blocks if ANY is mid-operation.
+    """
+    parts = SEGMENT_SPLIT_CAPTURE_RE.split(command)
+    segments = parts[0::2]
+    separators = parts[1::2]  # separators[i] is the one FOLLOWING segments[i]
+
+    if _has_subshell(command):
+        return [[session_cwd] for _ in segments]
+
+    out = []
+    current = [session_cwd]
+    tracking = True
+    for idx, seg in enumerate(segments):
+        out.append(list(current))
+        if not tracking:
+            continue
+
+        targets = _cd_targets(seg, current)
+        if targets is NOT_A_CD:
+            continue
+        if targets is None:
+            # An unreadable `cd`: stop guessing and fall back to the session cwd
+            # for the rest of the command -- byte-for-byte the behavior this
+            # hook had before cwd tracking existed, so it cannot regress it.
+            tracking = False
+            current = [session_cwd]
+            continue
+
+        sep = separators[idx] if idx < len(separators) else None
+        prev = current
+        if sep == "&&":
+            current = targets                      # cd must have succeeded
+        elif sep in (";", "\n"):
+            current = targets + [p for p in prev if p not in targets]
+        else:
+            current = prev                         # `||` / `|`: cd did not apply
+    return out
+
+
 def _is_git_exe(token: str) -> bool:
     """True iff `token` invokes git, on every platform this ships to.
 
@@ -200,10 +418,14 @@ def _is_git_exe(token: str) -> bool:
 
 
 def _git_invocations(command: str):
-    """Yield (subcommand, args, workdir_override, gitdir_override) for each git
-    call in `command`. Skips leading env assignments and transparent wrappers so
-    `FOO=1 sudo git commit` is still seen as a commit."""
-    for seg in SEGMENT_SPLIT_RE.split(command):
+    """Yield (segment_index, subcommand, args, workdir_override, gitdir_override)
+    for each git call in `command`. Skips leading env assignments and transparent
+    wrappers so `FOO=1 sudo git commit` is still seen as a commit.
+
+    The segment index is what lets the caller look up the working directory a
+    preceding `cd` put this call in; it indexes the same split, so it stays
+    correct even when earlier segments are skipped."""
+    for seg_index, seg in enumerate(SEGMENT_SPLIT_RE.split(command)):
         seg = seg.strip()
         if not seg:
             continue
@@ -267,7 +489,7 @@ def _git_invocations(command: str):
 
         if i >= len(tokens):
             continue
-        yield tokens[i], tokens[i + 1:], workdir_override, gitdir_override
+        yield seg_index, tokens[i], tokens[i + 1:], workdir_override, gitdir_override
 
 
 def _is_resolution(subcmd: str, args) -> bool:
@@ -326,17 +548,36 @@ def _is_detached(git_dir: str) -> bool:
 
 
 def _block_message(subcmd: str, marker: str, desc: str, owner: str,
-                   git_dir: str, workdir: str) -> str:
+                   git_dir: str, workdir: str, moved: bool = False,
+                   ambiguous: bool = False, session_cwd: str = "") -> str:
     resolution = (
         "  git bisect reset\n" if owner == "bisect"
         else "  git %s --abort      # or --continue -- see above, it is a real choice\n" % owner
     )
+    # Say HOW this directory was arrived at whenever it is not the session cwd.
+    # Without it the block reads as though it were about the session's own repo,
+    # which is exactly the confusion that made the old wrong-repo block look
+    # like a bug in the guard rather than a real finding about another repo.
+    provenance = ""
+    if moved:
+        provenance += (
+            f"  reached via : a `cd` earlier in this same command\n"
+            f"  session cwd : {session_cwd or '(unknown)'}  <- NOT the repo above\n"
+        )
+    if ambiguous:
+        provenance += (
+            "  ambiguity   : `;` runs the next command whether or not the `cd` "
+            "succeeded, so every candidate directory was checked and this one "
+            "is mid-operation. Use `&&` to pin it.\n"
+        )
     return (
         f"BLOCKED: `git {subcmd}` would mutate a repository that has an "
         f"operation already IN FLIGHT.\n\n"
         f"  working dir : {workdir}\n"
         f"  git-dir     : {git_dir}\n"
-        f"  in flight   : {marker}  ({desc})\n\n"
+        f"  in flight   : {marker}  ({desc})\n"
+        + provenance +
+        "\n"
         "HEAD is almost certainly detached onto that operation's temporary base. "
         "A commit here does NOT land on the branch you think it does -- it lands "
         "on the in-flight state, and the next `--abort` moves the branch out from "
@@ -416,36 +657,54 @@ def main() -> int:
         return 0
 
     session_cwd = payload.get("cwd") or os.getcwd()
+    seg_cwds = _cwd_candidates_by_segment(command, session_cwd)
     warnings = []
+    warned_git_dirs = set()
 
-    for subcmd, args, workdir_override, gitdir_override in _git_invocations(command):
+    for seg_index, subcmd, args, workdir_override, gitdir_override in _git_invocations(command):
         if subcmd not in MUTATING_SUBCOMMANDS:
             continue
         if _is_resolution(subcmd, args):
             continue  # ending the operation is exactly what should stay possible
 
-        workdir = session_cwd
-        if workdir_override:
-            workdir = os.path.normpath(
-                os.path.join(session_cwd, os.path.expanduser(workdir_override))
-            )
-        if not os.path.isdir(workdir):
-            continue
+        bases = seg_cwds[seg_index] if seg_index < len(seg_cwds) else [session_cwd]
+        moved = bases != [session_cwd]
+        ambiguous = len(bases) > 1
+        seen_git_dirs = set()
 
-        git_dir = _resolve_git_dir(workdir, gitdir_override)
-        if not git_dir or not os.path.isdir(git_dir):
-            continue  # not a git repo (or unreadable) -> fail open
+        for base in bases:
+            workdir = base
+            if workdir_override:
+                # An ABSOLUTE `-C` outranks the base outright -- os.path.join
+                # already discards the left side for an absolute right side, so
+                # every base collapses to the same target and the dedupe below
+                # keeps this to one resolution.
+                workdir = os.path.normpath(
+                    os.path.join(base, os.path.expanduser(workdir_override))
+                )
+            if not os.path.isdir(workdir):
+                continue
 
-        found = _in_flight(git_dir)
-        if found:
-            marker, desc, owner = found
-            sys.stderr.write(
-                _block_message(subcmd, marker, desc, owner, git_dir, workdir)
-            )
-            return 2
+            git_dir = _resolve_git_dir(workdir, gitdir_override)
+            if not git_dir or not os.path.isdir(git_dir):
+                continue  # not a git repo (or unreadable) -> fail open
+            if git_dir in seen_git_dirs:
+                continue  # several candidate dirs, one underlying repository
+            seen_git_dirs.add(git_dir)
 
-        if _is_detached(git_dir):
-            warnings.append(_detached_warning(subcmd, git_dir, workdir))
+            found = _in_flight(git_dir)
+            if found:
+                marker, desc, owner = found
+                sys.stderr.write(_block_message(
+                    subcmd, marker, desc, owner, git_dir, workdir,
+                    moved=moved, ambiguous=ambiguous, session_cwd=session_cwd,
+                ))
+                return 2
+
+            # One warning per repository, not per candidate path that reaches it.
+            if _is_detached(git_dir) and git_dir not in warned_git_dirs:
+                warned_git_dirs.add(git_dir)
+                warnings.append(_detached_warning(subcmd, git_dir, workdir))
 
     if warnings:
         print(json.dumps({

--- a/hooks/block-git-mutation-mid-operation.py
+++ b/hooks/block-git-mutation-mid-operation.py
@@ -96,6 +96,16 @@ WHICH REPOSITORY (added 2026-08-22, after this hook blocked the wrong repo)
       the push against /a and could ALLOW a mutation into a stalled repo. The
       detection is quote-aware: `git commit -m "fix (bug)"` must not trip it,
       or the false block comes straight back for parenthesised messages.
+    - an unquoted `#` comment. Everything after it is text the shell never
+      runs, so a `cd` sitting there is inert -- but it still looks like a
+      segment. Measured 2026-08-23, same shape as the two below.
+    - an unquoted heredoc (`<<`, `<<<`). A heredoc BODY is data, not commands,
+      but it arrives in the same string and its lines look exactly like
+      segments. Measured 2026-08-23: `cat <<EOF > f` / `cd /clean && echo hi` /
+      `EOF` / `git commit` moved the tracked cwd to /clean off a line the shell
+      only ever wrote to a FILE, and the commit into the stalled session cwd
+      was ALLOWED where the cwd-blind hook blocked it. Same class as the quoted
+      operator above, and the same call `_lib/gh_merge.py` makes.
     - a `cd` whose destination is not a literal path -- `cd $VAR`,
       `cd "$(...)"`, a glob, `cd -`, `popd`, a Windows drive-relative path, or
       more than one operand.
@@ -357,14 +367,40 @@ def _segments(command: str):
     return segs, seps
 
 
-def _has_subshell(command: str) -> bool:
-    """True iff `command` contains an UNQUOTED `(` or `)` grouping token.
+# THE PROPERTY, not a list of syntax we happened to think of: a construct
+# belongs here iff it can make a computed segment boundary FAKE, or make a `cd`
+# we parsed INERT. Enumerated against that test, the shell's command-list
+# grammar yields exactly three, and each one was measured producing a
+# false ALLOW on this hook before it was added:
+#   ( )    subshell     -- scopes its own `cd`; it does not escape the group
+#   << <<< heredoc      -- the BODY is data whose lines look like commands
+#   #      comment      -- the tail is text the shell never runs
+# Deliberately NOT here, having been checked against the same property:
+#   > >> < 2>  redirects  -- create no boundary and leave no `cd` inert
+#   &          background -- `cd /a & git ...` leaves the `cd` with >1 operand,
+#                            so it is already unresolvable and takes the
+#                            session-cwd fallback
+#   $( ) ` `   substitution -- cannot move the CALLER's cwd, and tokenizes as
+#                            one word rather than a bare paren
+# Quoting is not on this list because it is not a bail: `_segments` handles it
+# correctly, which is the whole point of it being quote-aware.
+UNREADABLE_SHAPE_TOKENS = {"(", ")", "<<", "<<<", "#"}
+
+
+def _unreadable_shape(command: str) -> bool:
+    """True iff `command` has an UNQUOTED construct that invalidates cwd tracking.
 
     Quote-aware by construction: tokenized with `shlex` in punctuation mode, a
-    paren inside a quoted word stays inside that word (`git commit -m
-    "fix (bug)"` -> [..., 'fix (bug)']) while a real subshell becomes its own
-    token (`(cd /a && git commit)` -> ['(', ...,  ')']). A naive substring test
-    would confuse the two and re-break every parenthesised commit message.
+    paren or `<<` inside a quoted word stays inside that word (`git commit -m
+    "fix (bug)"` -> [..., 'fix (bug)']) while a real subshell or heredoc becomes
+    its own token (`(cd /a && git commit)` -> ['(', ..., ')']; `cat <<EOF` ->
+    ['cat', '<<', 'EOF']). A naive substring test would confuse the two and
+    re-break every commit message containing a paren, a `<<`, or an issue
+    number like "#42".
+
+    `commenters` is cleared so an unquoted `#` survives as its own token. Left
+    at the default, `shlex` silently DISCARDS the comment tail -- and a comment
+    tail is precisely where a phantom `cd` hides from this check.
 
     Command substitution deliberately does NOT count: `$(...)` tokenizes as a
     single word, and a substitution cannot move the caller's cwd anyway.
@@ -376,7 +412,8 @@ def _has_subshell(command: str) -> bool:
     try:
         lex = shlex.shlex(command, posix=True, punctuation_chars=True)
         lex.whitespace_split = True
-        return any(tok in ("(", ")") for tok in lex)
+        lex.commenters = ""   # see docstring: the default HIDES comment tails
+        return any(tok in UNREADABLE_SHAPE_TOKENS for tok in lex)
     except (ValueError, AttributeError):
         return True
 
@@ -453,7 +490,7 @@ def _cwd_candidates_by_segment(command: str, session_cwd: str):
     """
     segments, separators = _segments(command)
 
-    if _has_subshell(command):
+    if _unreadable_shape(command):
         return [[session_cwd] for _ in segments]
 
     out = []

--- a/hooks/block-git-mutation-mid-operation.py
+++ b/hooks/block-git-mutation-mid-operation.py
@@ -151,6 +151,32 @@ hiccup; the failure mode it prevents is rare, and the cost of a false block on
 every commit is not worth trading for it.
 
 Bypass: `GIT_INFLIGHT_OP_BYPASS=1` (env or inline prefix). Document why.
+
+BYPASS POLICY (decided 2026-08-23, MYC-3779 predicate 4). The bypass stays
+self-serviceable, and every use of it is now LOUD.
+
+  Why self-serviceable stays. The guard refuses to judge `--abort` vs
+  `--continue` on purpose; that call belongs to whoever owns the operation. A
+  bypass only a second party can grant would, in the one case that matters --
+  an abandoned operation whose owner is gone -- leave the repo with no exit at
+  all. The hook already declines to trap a repo (it never blocks the resolution
+  verbs) and this is the same principle one level up.
+
+  Why that was not enough before. MYC-3779 measured three subagents in one
+  session independently setting this var. Each had verified its own worktree was
+  clean and each was factually right; the guard was evaluating a DIFFERENT repo
+  and was unfalsifiable from where they stood. The honest reading is that the
+  scoping bug manufactured those bypasses -- which is why the fix is the
+  cwd tracking above, not a harder-to-reach escape hatch. Making a correct
+  guard harder to bypass would have punished the agents for the guard's error.
+
+  What changed anyway. A bypass that leaves no trace is a comment, not a
+  control. The bypass is now evaluated AFTER the repository check rather than
+  before it, so the log records what it actually SUPPRESSED -- repo, marker,
+  subcommand -- instead of merely that someone had the variable exported. A
+  bypass that suppresses nothing writes nothing. Blocks are recorded too, so a
+  guard that has gone quiet is distinguishable from one that never fires
+  (a dead guard and a healthy one otherwise emit the same signal).
 """
 
 from __future__ import annotations
@@ -163,16 +189,19 @@ import subprocess
 import sys
 
 BYPASS_VAR = "GIT_INFLIGHT_OP_BYPASS"
+HOOK_NAME = "block-git-mutation-mid-operation"
+
+# Fire telemetry (MYC-285). Fail-open: a missing _lib must never break a
+# fail-open guard, and a telemetry error must never turn an allow into a block.
+try:
+    sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "_lib"))
+    from guard_telemetry import log_fire
+except Exception:  # pragma: no cover - telemetry is never load-bearing
+    def log_fire(*_a, **_k):
+        return
 
 # Split a command into sequential segments on shell separators so each piece is
 # evaluated independently (mirrors session-lock.py / check-cd-outside-worktree.py).
-SEGMENT_SPLIT_RE = re.compile(r"&&|\|\||[;\n|]")
-# Same pattern, capturing, so the separator BETWEEN two segments is available:
-# `cd X && git ...` and `cd X || git ...` put the git call in different
-# directories, and only the separator says which. `re.split` with one capture
-# group returns [seg, sep, seg, sep, ...], so `[0::2]` is exactly what
-# SEGMENT_SPLIT_RE.split() yields and the indices line up 1:1.
-SEGMENT_SPLIT_CAPTURE_RE = re.compile(r"(&&|\|\||[;\n|])")
 ENV_ASSIGN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
 
 # Transparent wrappers to skip before identifying `git`
@@ -257,7 +286,7 @@ GIT_TIMEOUT_SEC = 5
 def _inline_bypass(command: str, var: str) -> bool:
     """True iff `<var>=1` leads any shell segment of `command`. A quoted token
     is not a leading assignment (`echo 'X=1'` -> no)."""
-    for seg in SEGMENT_SPLIT_RE.split(command):
+    for seg in _segments(command)[0]:
         try:
             tokens = shlex.split(seg)
         except ValueError:
@@ -270,6 +299,62 @@ def _inline_bypass(command: str, var: str) -> bool:
                 if k == var and v == "1":
                     return True
     return False
+
+
+def _segments(command: str):
+    """Split `command` into sequential shell segments plus the separator between
+    each pair, ignoring operators that sit INSIDE quotes.
+
+    Returns (segments, separators); separators[i] is the one FOLLOWING
+    segments[i], because `cd X && git ...` and `cd X || git ...` put the git
+    call in different directories and only the separator says which.
+
+    QUOTE AWARENESS IS LOAD-BEARING HERE, not tidiness. This started as a plain
+    `re.split` on the operators, and with cwd tracking on top of it,
+
+        echo "a ; cd /elsewhere" && git commit
+
+    split into a phantom `cd /elsewhere` segment cut out of text the shell never
+    executes. The tracker followed the phantom, the git call was judged against
+    a directory that does not exist, the isdir check skipped it, and a commit
+    into a PAUSED REBASE was ALLOWED. Measured 2026-08-23 during the pre-merge
+    doubt-pass: on that exact command the older, cwd-blind hook returned 2 and
+    the cwd-tracking one returned 0. The tracker did not merely fail to help --
+    it opened a hole the naive version did not have.
+
+    A quote-aware walk is also what `_lib/gh_merge.py` settled on for the same
+    class (MYC-357: `echo '... && gh pr merge 1'` minted a real marker off a
+    quoted string). Same bug, same shape, same fix.
+
+    Segments keep their quotes, so each one is independently balanced and
+    `shlex.split` succeeds on it. `&` is deliberately NOT a split point: leaving
+    `cd /a & git commit` as one segment makes the `cd` unparseable, which takes
+    the safe session-cwd fallback rather than a guess about backgrounding.
+    """
+    segs, seps, cur = [], [], []
+    i, n, quote = 0, len(command), None
+    while i < n:
+        c = command[i]
+        if quote:                        # inside quotes: copy through to the close
+            cur.append(c)
+            if c == "\\" and quote == '"' and i + 1 < n and command[i + 1] in '"\\$`':
+                cur.append(command[i + 1]); i += 2; continue
+            if c == quote:
+                quote = None
+            i += 1
+            continue
+        if c in ("'", '"'):
+            quote = c; cur.append(c); i += 1; continue
+        if c == "\\" and i + 1 < n:      # escaped operator outside quotes -> literal
+            cur.append(c); cur.append(command[i + 1]); i += 2; continue
+        two = command[i:i + 2]
+        if two in ("&&", "||"):
+            segs.append("".join(cur)); seps.append(two); cur = []; i += 2; continue
+        if c in (";", "\n", "|"):
+            segs.append("".join(cur)); seps.append(c); cur = []; i += 1; continue
+        cur.append(c); i += 1
+    segs.append("".join(cur))
+    return segs, seps
 
 
 def _has_subshell(command: str) -> bool:
@@ -360,14 +445,13 @@ def _cd_targets(segment: str, bases):
 def _cwd_candidates_by_segment(command: str, session_cwd: str):
     """Per shell segment, the working directories a command there could run in.
 
-    Aligned index-for-index with `SEGMENT_SPLIT_RE.split(command)`, which is
-    what `_git_invocations` walks. Usually a single directory; more than one
-    only for the genuinely ambiguous `cd X ; git ...`, where the caller checks
-    every candidate and blocks if ANY is mid-operation.
+    Aligned index-for-index with `_segments(command)[0]`, which is what
+    `_git_invocations` walks -- the same function, so the indices cannot drift.
+    Usually a single directory; more than one only for the genuinely ambiguous
+    `cd X ; git ...`, where the caller checks every candidate and blocks if ANY
+    is mid-operation.
     """
-    parts = SEGMENT_SPLIT_CAPTURE_RE.split(command)
-    segments = parts[0::2]
-    separators = parts[1::2]  # separators[i] is the one FOLLOWING segments[i]
+    segments, separators = _segments(command)
 
     if _has_subshell(command):
         return [[session_cwd] for _ in segments]
@@ -425,7 +509,7 @@ def _git_invocations(command: str):
     The segment index is what lets the caller look up the working directory a
     preceding `cd` put this call in; it indexes the same split, so it stays
     correct even when earlier segments are skipped."""
-    for seg_index, seg in enumerate(SEGMENT_SPLIT_RE.split(command)):
+    for seg_index, seg in enumerate(_segments(command)[0]):
         seg = seg.strip()
         if not seg:
             continue
@@ -631,8 +715,11 @@ def _detached_warning(subcmd: str, git_dir: str, workdir: str) -> str:
 
 
 def main() -> int:
-    if os.environ.get(BYPASS_VAR) == "1":
-        return 0
+    # NOTE: the bypass is resolved here but APPLIED at the block site, so the
+    # audit record can name what it suppressed. Returning early here would make
+    # every bypass indistinguishable from every other -- including the ones that
+    # suppressed nothing at all.
+    bypass_env = os.environ.get(BYPASS_VAR) == "1"
 
     try:
         payload = json.loads(sys.stdin.read() or "{}")
@@ -653,8 +740,7 @@ def main() -> int:
     if "git" not in command.lower():
         return 0
 
-    if _inline_bypass(command, BYPASS_VAR):
-        return 0
+    bypassed = bypass_env or _inline_bypass(command, BYPASS_VAR)
 
     session_cwd = payload.get("cwd") or os.getcwd()
     seg_cwds = _cwd_candidates_by_segment(command, session_cwd)
@@ -695,6 +781,16 @@ def main() -> int:
             found = _in_flight(git_dir)
             if found:
                 marker, desc, owner = found
+                if bypassed:
+                    # Honored -- and now on the record, with the thing it let
+                    # through. This is the ONLY place a bypass is logged: one
+                    # that suppressed nothing is not worth a line.
+                    log_fire(HOOK_NAME, status="bypassed", subcmd=subcmd,
+                             marker=marker, workdir=workdir, git_dir=git_dir,
+                             via="env" if bypass_env else "inline")
+                    return 0
+                log_fire(HOOK_NAME, status="blocked", subcmd=subcmd,
+                         marker=marker, workdir=workdir, git_dir=git_dir)
                 sys.stderr.write(_block_message(
                     subcmd, marker, desc, owner, git_dir, workdir,
                     moved=moved, ambiguous=ambiguous, session_cwd=session_cwd,
@@ -706,7 +802,8 @@ def main() -> int:
                 warned_git_dirs.add(git_dir)
                 warnings.append(_detached_warning(subcmd, git_dir, workdir))
 
-    if warnings:
+    if warnings and not bypassed:
+        log_fire(HOOK_NAME, status="warned", detail="detached-head")
         print(json.dumps({
             "hookSpecificOutput": {
                 "hookEventName": "PreToolUse",

--- a/hooks/block-git-mutation-mid-operation.py
+++ b/hooks/block-git-mutation-mid-operation.py
@@ -125,6 +125,15 @@ WHAT IS DELIBERATELY NOT BLOCKED
     would trap the repo in the stuck state with the bypass env var as the only
     exit, which trains everyone to disable the guard. Whoever owns the
     operation must be able to end it.
+  - Taking a side on a conflicted PATH: `git checkout --ours|--theirs <path>`
+    and the `git restore` spelling. Same principle one step earlier, and the
+    step that was missing until 2026-08-23. `checkout` and `restore` are both
+    mutating verbs, so the guard allowed `--continue` while blocking every way
+    to REACH it -- the resolution an operation stops for cannot be performed at
+    all. MYC-3779's fourth reporter hit exactly this and bypassed, on a rebase
+    they had started themselves seconds earlier. An escape hatch that does not
+    reach the exit is not an escape hatch. (`git add` was already allowed: it
+    is not a mutating verb by this hook's reckoning.)
   - `git tag` and `git branch`: both were the moves that actually PRESERVED
     work during the incident (a tag anchored an orphan commit; an unrelated
     session branching off it is the only reason six stranded commits survived).
@@ -230,6 +239,25 @@ MUTATING_SUBCOMMANDS = {
 # Subcommands that OWN an in-flight operation and can therefore end it.
 RESOLVABLE_SUBCOMMANDS = {"rebase", "merge", "cherry-pick", "revert", "am"}
 RESOLUTION_FLAGS = {"--abort", "--continue", "--skip", "--quit"}
+
+# Taking a side on a conflicted PATH. `git checkout --ours <f>` /
+# `--theirs <f>` (and the `git restore` spelling) are how a human or an agent
+# actually resolves the conflict an operation stopped on -- and both verbs sit
+# in MUTATING_SUBCOMMANDS, so until now the guard blocked every route from
+# "stopped at a conflict" to "`--continue`", while cheerfully allowing
+# `--continue` itself. That is an outage with a good error message: the only
+# way forward was the bypass, on the one repo where the guard is RIGHT.
+#
+# Narrow on purpose. The side flags are meaningless outside a conflicted path,
+# so `--ours` cannot smuggle a branch switch: `git checkout --ours main` is a
+# PATHSPEC operation, not a checkout of `main`. Bare `git checkout <branch>`
+# stays blocked (it abandons the operation), and so does bare `git commit`
+# (that IS the 2026-07-28 incident; every operation has a `--continue` that
+# concludes it properly). Neither of these verbs can create a commit, so
+# neither can land work on the doomed detached HEAD this hook exists to
+# protect.
+CONFLICT_SIDE_SUBCOMMANDS = {"checkout", "restore"}
+CONFLICT_SIDE_FLAGS = {"--ours", "--theirs"}
 
 # git global options that consume the FOLLOWING token as their value.
 GIT_GLOBAL_VALUE_OPTS = {
@@ -614,10 +642,19 @@ def _git_invocations(command: str):
 
 
 def _is_resolution(subcmd: str, args) -> bool:
-    """`git rebase --abort`, `git merge --continue`, `git bisect reset`, ... --
-    the acts that END an in-flight operation. Never blocked."""
+    """The acts that ADVANCE or END an in-flight operation. Never blocked.
+
+    Two families: the operation-level verbs (`git rebase --abort`,
+    `git merge --continue`, `git bisect reset`) and the path-level ones that
+    take a side on a conflict (`git checkout --ours <f>`). Allowing only the
+    first is what MYC-3779's fourth reporter hit on 2026-08-22: the guard let
+    them run `--continue` but blocked every way to REACH it, so the bypass was
+    the only exit on the repo the guard was correctly protecting.
+    """
     if subcmd in RESOLVABLE_SUBCOMMANDS:
         return any(a in RESOLUTION_FLAGS for a in args)
+    if subcmd in CONFLICT_SIDE_SUBCOMMANDS:
+        return any(a in CONFLICT_SIDE_FLAGS for a in args)
     if subcmd == "bisect":
         return bool(args) and args[0] in {"reset", "bad", "good", "skip", "log", "view"}
     return False

--- a/hooks/test_git_inflight_op_guard.py
+++ b/hooks/test_git_inflight_op_guard.py
@@ -33,6 +33,8 @@ Legs:
       any of the three opened a hole the cwd-blind hook did not have.
   17. The bypass leaves an audit record naming what it SUPPRESSED, and a bypass
       that suppressed nothing leaves none
+  18. The conflict-RESOLUTION path is reachable -- the guard allowed
+      `--continue` while blocking every way to get there
 
 Stdlib only. Exit 0 = all pass.
 """
@@ -730,6 +732,39 @@ def main():
         os.remove(TELEMETRY_LOG)
     except OSError:
         pass
+
+    # ----------------------------------------------------------------- leg 18
+    # An escape hatch that does not reach the exit is not an escape hatch.
+    # `checkout` and `restore` are both mutating verbs, so the guard blocked
+    # `git checkout --ours <f>` -- the ONLY way to resolve the conflict an
+    # operation stopped on -- while allowing `git rebase --continue`, the step
+    # AFTER it. On a repo where the guard is RIGHT to be watching, the bypass
+    # was the only route forward. MYC-3779's fourth reporter hit exactly this
+    # on 2026-08-22, on a rebase they had started themselves seconds earlier,
+    # and bypassed three times.
+    reachable = ["git checkout --ours f.txt", "git checkout --theirs f.txt",
+                 "git restore --ours f.txt", "git add f.txt",
+                 "git rebase --continue"]
+    trapped = [c for c in reachable if run_hook(c, cwd=stalled)[0] != 0]
+    if not trapped:
+        ok("18a. Every step of the conflict-resolution path is reachable")
+    else:
+        bad("18a. resolution path trapped",
+            "blocked, leaving the bypass as the only exit: " + ", ".join(trapped))
+
+    # 18b. ...and the widening stops exactly there. The side flags are
+    # meaningless outside a conflicted path, so `--ours` cannot smuggle a branch
+    # switch; everything that could abandon the operation or land a commit on
+    # its doomed detached HEAD stays blocked.
+    still_blocked = ["git checkout main", "git checkout -b other",
+                     "git restore f.txt", "git commit -m x",
+                     "git reset --hard", "git push"]
+    leaked = [c for c in still_blocked if run_hook(c, cwd=stalled)[0] != 2]
+    if not leaked:
+        ok("18b. Bare checkout/restore/commit/reset/push are still refused")
+    else:
+        bad("18b. resolution allow-list too wide",
+            "these should still block: " + ", ".join(leaked))
     subprocess.run(["rm", "-rf", tmp], capture_output=True)
 
     print("\n%d passed, %d failed" % (PASS, FAIL))

--- a/hooks/test_git_inflight_op_guard.py
+++ b/hooks/test_git_inflight_op_guard.py
@@ -26,6 +26,8 @@ Legs:
   12. Ignores non-git commands and non-Bash tools
   13. Refusal message carries the required safety text (no rm -rf, --abort is
       the operation owner's call)
+  15. Honors a `cd` earlier in the command -- BOTH directions, because the
+      missing `cd` produced a false block AND a false allow
 
 Stdlib only. Exit 0 = all pass.
 """
@@ -452,6 +454,129 @@ def main():
             bad("14b. mid-sequence hint", "wrong verb: %r" % serr[-200:])
     else:
         bad("14. setup", "could not produce a mid-run sequencer state")
+
+
+    # ----------------------------------------------------------------- leg 15
+    # `cd <dir> && git ...` -- the single most common shape an agent emits, and
+    # until 2026-08-22 the one the hook could not see. The `cd` segment parsed
+    # as "not a git call" and was discarded, so the git segment resolved against
+    # the SESSION cwd: the wrong repository, wrong in both directions. Both are
+    # asserted here, and 15b is the negative control -- it FAILS on the
+    # pre-fix hook, which is the only reason to trust 15a's pass.
+    rc, _, err = run_hook("cd %s && git commit -m x" % clean, cwd=stalled)
+    if rc == 0:
+        ok("15a. `cd CLEAN && git commit` from a stalled cwd is ALLOWED")
+    else:
+        bad("15a. cd false block",
+            "rc=%s -- blocked on a repo the command never touches, which is what "
+            "trains reflexive GIT_INFLIGHT_OP_BYPASS=1 :: %r" % (rc, err[:200]))
+
+    rc, _, err = run_hook("cd %s && git commit -m x" % stalled, cwd=clean)
+    if rc == 2:
+        ok("15b. `cd STALLED && git commit` from a clean cwd BLOCKS (was a false allow)")
+    else:
+        bad("15b. cd false allow",
+            "rc=%s -- a commit into a PAUSED REBASE was permitted; this is the "
+            "2026-07-28 incident walking through the guard" % rc)
+
+    if "reached via" in err and "session cwd" in err:
+        ok("15c. The refusal says the repo was reached via a `cd`, not the session cwd")
+    else:
+        bad("15c. cd provenance", "message would read as being about the session repo")
+
+    # Separator semantics. `&&` pins the cd; the others do not, and guessing
+    # wrong in the permissive direction is how work gets lost.
+    rc_semi_s, _, _ = run_hook("cd %s ; git commit -m x" % stalled, cwd=clean)
+    rc_semi_c, _, _ = run_hook("cd %s ; git commit -m x" % clean, cwd=stalled)
+    if rc_semi_s == 2 and rc_semi_c == 2:
+        ok("15d. `;` is ambiguous (cd may have failed) -> both candidates checked, blocks")
+    else:
+        bad("15d. `;` handling",
+            "into-stalled rc=%s, out-of-stalled rc=%s (expected 2 and 2)"
+            % (rc_semi_s, rc_semi_c))
+
+    rc_or_s, _, _ = run_hook("cd %s || git commit -m x" % stalled, cwd=clean)
+    rc_or_c, _, _ = run_hook("cd %s || git commit -m x" % clean, cwd=stalled)
+    if rc_or_s == 0 and rc_or_c == 2:
+        ok("15e. `||` runs the git only if the cd FAILED -> cwd did not move")
+    else:
+        bad("15e. `||` handling",
+            "into-stalled rc=%s (want 0), out-of-stalled rc=%s (want 2)"
+            % (rc_or_s, rc_or_c))
+
+    # A RELATIVE cd resolves against the directory we are actually in.
+    rc, _, _ = run_hook("cd ../stalled && git commit -m x", cwd=clean)
+    if rc == 2:
+        ok("15f. A relative `cd ../stalled` resolves against the current cwd")
+    else:
+        bad("15f. relative cd", "rc=%s -- relative destination not resolved" % rc)
+
+    # Chained cds: only the last one is where git runs.
+    rc, _, _ = run_hook("cd %s && cd %s && git commit -m x" % (clean, stalled), cwd=clean)
+    if rc == 2:
+        ok("15g. The LAST cd in a chain is the one that counts")
+    else:
+        bad("15g. chained cd", "rc=%s" % rc)
+
+    # An explicit `-C` outranks the cd, exactly as git itself resolves it.
+    rc_a, _, _ = run_hook("cd %s && git -C %s commit -m x" % (clean, stalled), cwd=clean)
+    rc_b, _, _ = run_hook("cd %s && git -C %s commit -m x" % (stalled, clean), cwd=stalled)
+    if rc_a == 2 and rc_b == 0:
+        ok("15h. `-C` outranks the cd in both directions")
+    else:
+        bad("15h. -C vs cd", "cd-clean/-C-stalled rc=%s (want 2), inverse rc=%s (want 0)"
+            % (rc_a, rc_b))
+
+    # THE REGRESSION THAT WOULD SILENTLY UNDO ALL OF THE ABOVE. Subshell
+    # detection has to be quote-aware: a parenthesised commit MESSAGE is not a
+    # subshell, and if it trips the bail-out then the false block of 15a comes
+    # straight back for every commit whose message happens to contain a paren.
+    rc, _, _ = run_hook('cd %s && git commit -m "fix (bug)"' % clean, cwd=stalled)
+    if rc == 0:
+        ok("15i. A paren inside a quoted commit message is not a subshell")
+    else:
+        bad("15i. quoted paren", "rc=%s -- cd tracking abandoned on a quoted paren" % rc)
+
+    # A cd we cannot resolve must fall back to the session cwd -- the behavior
+    # this hook had before tracking existed -- and NOT be read as "cwd unchanged
+    # and therefore fine". Conservative on an unreadable shape.
+    rc, _, _ = run_hook("cd $TARGET && git commit -m x", cwd=stalled)
+    if rc == 2:
+        ok("15j. An unresolvable `cd $VAR` falls back to the session cwd, still blocks")
+    else:
+        bad("15j. unresolvable cd", "rc=%s -- guard went quiet on an unreadable cd" % rc)
+
+    # A subshell scopes its cd, so tracking is abandoned for the whole command
+    # and the session cwd decides. Pinned so the documented fallback stays the
+    # DOCUMENTED one rather than drifting into an accidental allow.
+    rc, _, _ = run_hook("(cd %s && git commit -m x) && git commit -m y" % clean, cwd=stalled)
+    if rc == 2:
+        ok("15k. A subshell abandons cd tracking and falls back to the session cwd")
+    else:
+        bad("15k. subshell fallback", "rc=%s -- subshell scoping not handled" % rc)
+
+    # 15l/15m. Both found by the pre-push doubt-pass on the cd-tracking diff
+    # itself, not by a failing test -- same provenance as 9c.
+    #
+    # 15l: `shlex` is a POSIX tokenizer, so it eats the backslashes in
+    # `cd C:\repo` and hands back `C:repo`. That is not absolute on EITHER
+    # platform, so it got joined onto the base, produced a path that does not
+    # exist, failed the isdir check, and made the hook SKIP the git call --
+    # silently converting a block into an allow on Windows.
+    rc, _, _ = run_hook("cd C:\\somewhere && git commit -m x", cwd=stalled)
+    if rc == 2:
+        ok("15l. A Windows drive-relative `cd` falls back, it does not skip the check")
+    else:
+        bad("15l. windows drive cd",
+            "rc=%s -- an unresolvable destination made the guard skip the commit" % rc)
+
+    # 15m: `cd -` is deliberately NOT resolved. Pinned so that a later attempt
+    # to "improve" it has to face the test: a wrong OLDPWD is a wrong repository.
+    rc, _, _ = run_hook("cd - && git commit -m x", cwd=stalled)
+    if rc == 2:
+        ok("15m. `cd -` is unresolved and falls back to the session cwd")
+    else:
+        bad("15m. cd -", "rc=%s -- OLDPWD was guessed instead of falling back" % rc)
 
     subprocess.run(["rm", "-rf", tmp], capture_output=True)
 

--- a/hooks/test_git_inflight_op_guard.py
+++ b/hooks/test_git_inflight_op_guard.py
@@ -683,10 +683,16 @@ def main():
     # control for the control: shipping the telemetry without proving it writes
     # would be the same unfalsifiable-guard mistake one level up.
     def _telemetry():
+        # (OSError, ValueError), not bare OSError: `open(encoding=)` raises
+        # UnicodeDecodeError and `json.loads` raises JSONDecodeError, and BOTH
+        # are ValueError subclasses that a bare OSError handler lets escape.
+        # Returning [] on a corrupt log makes the legs below FAIL loudly, which
+        # is the right direction for a control -- an exception here would abort
+        # the suite instead of reporting that the audit trail is unreadable.
         try:
             with open(TELEMETRY_LOG, encoding="utf-8") as fh:
                 return [json.loads(ln) for ln in fh if ln.strip()]
-        except OSError:
+        except (OSError, ValueError):
             return []
 
     for _p in (TELEMETRY_LOG,):

--- a/hooks/test_git_inflight_op_guard.py
+++ b/hooks/test_git_inflight_op_guard.py
@@ -28,6 +28,10 @@ Legs:
       the operation owner's call)
   15. Honors a `cd` earlier in the command -- BOTH directions, because the
       missing `cd` produced a false block AND a false allow
+  16. Operators inside QUOTES are not segment boundaries -- a phantom `cd` cut
+      out of a quoted string once opened a hole the cwd-blind hook did not have
+  17. The bypass leaves an audit record naming what it SUPPRESSED, and a bypass
+      that suppressed nothing leaves none
 
 Stdlib only. Exit 0 = all pass.
 """
@@ -45,6 +49,10 @@ HOOK = os.path.join(os.path.dirname(os.path.abspath(__file__)),
 
 PASS = 0
 FAIL = 0
+
+# Telemetry sink for this run. Pointed at a scratch file so the suite never
+# appends to ~/.claude/guard-fires.jsonl, and so leg 17 reads only its own rows.
+TELEMETRY_LOG = os.path.join(tempfile.gettempdir(), "inflight-guard-telemetry.jsonl")
 
 
 def ok(msg):
@@ -81,6 +89,7 @@ def run_hook(command, cwd, env=None, tool_name="Bash"):
     })
     e = dict(os.environ)
     e.pop("GIT_INFLIGHT_OP_BYPASS", None)
+    e["GUARD_FIRES_LOG"] = TELEMETRY_LOG
     if env:
         e.update(env)
     p = subprocess.run([sys.executable, HOOK], input=payload,
@@ -578,6 +587,93 @@ def main():
     else:
         bad("15m. cd -", "rc=%s -- OLDPWD was guessed instead of falling back" % rc)
 
+
+    # ----------------------------------------------------------------- leg 16
+    # Quoted operators are not shell operators. This is the regression that the
+    # cwd tracking INTRODUCED and the pre-merge doubt-pass caught: with a plain
+    # regex split, `echo "a ; cd /elsewhere" && git commit` yielded a phantom
+    # `cd /elsewhere` segment carved out of text the shell never runs. The
+    # tracker followed it, the git call was judged against a directory that does
+    # not exist, the isdir check skipped the invocation, and a commit into a
+    # PAUSED REBASE was ALLOWED -- on the very command the older, cwd-blind hook
+    # correctly blocked. 16a/16b are the negative controls for that hole.
+    rc, _, _ = run_hook('echo "a ; cd %s" && git commit -m x' % clean, cwd=stalled)
+    if rc == 2:
+        ok("16a. A `cd` hidden inside quotes is not followed (semicolon form)")
+    else:
+        bad("16a. phantom cd via quoted `;`",
+            "rc=%s -- the tracker followed text the shell never executes and "
+            "skipped the check on a stalled repo" % rc)
+
+    rc, _, _ = run_hook('echo "a && cd %s" && git commit -m x' % clean, cwd=stalled)
+    if rc == 2:
+        ok("16b. A `cd` hidden inside quotes is not followed (&& form)")
+    else:
+        bad("16b. phantom cd via quoted `&&`", "rc=%s" % rc)
+
+    # The other half: quote awareness must not become an excuse to give up. A
+    # commit MESSAGE containing an operator is ordinary, and bailing on it would
+    # bring back the false block this whole change exists to remove.
+    noisy = [
+        ('cd %s && git commit -m "a && b"' % clean, "&& in the message"),
+        ('cd %s && git commit -m "fix: a; also b"' % clean, "; in the message"),
+        ('cd %s && git commit -m "a | b"' % clean, "pipe in the message"),
+    ]
+    over_bailed = [why for cmd, why in noisy if run_hook(cmd, cwd=stalled)[0] != 0]
+    if not over_bailed:
+        ok("16c. An operator inside a commit MESSAGE does not abandon cd tracking")
+    else:
+        bad("16c. over-bailed on a quoted operator",
+            "false block returned for: " + ", ".join(over_bailed))
+
+    # ----------------------------------------------------------------- leg 17
+    # MYC-3779 predicate 4: the bypass stays self-serviceable (a guard that can
+    # trap a repo with no exit is worse), but it is no longer silent. A bypass
+    # that leaves no trace is a comment, not a control -- and this leg is the
+    # control for the control: shipping the telemetry without proving it writes
+    # would be the same unfalsifiable-guard mistake one level up.
+    def _telemetry():
+        try:
+            with open(TELEMETRY_LOG, encoding="utf-8") as fh:
+                return [json.loads(ln) for ln in fh if ln.strip()]
+        except OSError:
+            return []
+
+    for _p in (TELEMETRY_LOG,):
+        try:
+            os.remove(_p)
+        except OSError:
+            pass
+
+    rc, _, _ = run_hook("git commit -m x", cwd=stalled,
+                        env={"GIT_INFLIGHT_OP_BYPASS": "1"})
+    rows = [r for r in _telemetry() if r.get("status") == "bypassed"]
+    if rc == 0 and rows and rows[-1].get("marker") and rows[-1].get("workdir") == stalled:
+        ok("17a. A bypass that suppressed a real block is recorded, with the repo it let through")
+    else:
+        bad("17a. bypass audit trail",
+            "rc=%s rows=%s -- the bypass left no usable trace" % (rc, rows[-1:]))
+
+    rc, _, _ = run_hook("git commit -m x", cwd=stalled)
+    rows = [r for r in _telemetry() if r.get("status") == "blocked"]
+    if rc == 2 and rows:
+        ok("17b. A real block is recorded too (a dead guard and a quiet one differ)")
+    else:
+        bad("17b. block telemetry", "rc=%s rows=%s" % (rc, rows))
+
+    before = len(_telemetry())
+    run_hook("git commit -m x", cwd=clean, env={"GIT_INFLIGHT_OP_BYPASS": "1"})
+    if len(_telemetry()) == before:
+        ok("17c. A bypass that suppressed NOTHING writes nothing (no trail noise)")
+    else:
+        bad("17c. bypass noise",
+            "a bypass over a clean repo emitted a record; the log stops meaning "
+            "\'something was suppressed\'")
+
+    try:
+        os.remove(TELEMETRY_LOG)
+    except OSError:
+        pass
     subprocess.run(["rm", "-rf", tmp], capture_output=True)
 
     print("\n%d passed, %d failed" % (PASS, FAIL))

--- a/hooks/test_git_inflight_op_guard.py
+++ b/hooks/test_git_inflight_op_guard.py
@@ -28,8 +28,9 @@ Legs:
       the operation owner's call)
   15. Honors a `cd` earlier in the command -- BOTH directions, because the
       missing `cd` produced a false block AND a false allow
-  16. Operators inside QUOTES are not segment boundaries -- a phantom `cd` cut
-      out of a quoted string once opened a hole the cwd-blind hook did not have
+  16. Text that only LOOKS like a command sequence -- a quoted operator, a
+      heredoc body, a comment tail -- is not one. A phantom `cd` cut out of
+      any of the three opened a hole the cwd-blind hook did not have.
   17. The bypass leaves an audit record naming what it SUPPRESSED, and a bypass
       that suppressed nothing leaves none
 
@@ -625,6 +626,55 @@ def main():
     else:
         bad("16c. over-bailed on a quoted operator",
             "false block returned for: " + ", ".join(over_bailed))
+
+    # 16d. The same class one layer out: a heredoc BODY is data, but it arrives
+    # in the same string and its lines look exactly like segments. The `&&`
+    # variant is the dangerous one -- a plain body line gets the ambiguous `\n`
+    # separator and unions the candidates (which happens to stay safe), while
+    # `&&` PINS the phantom and drops the real cwd. Measured 2026-08-23: the
+    # cwd-blind hook returned 2 on this and the cd-tracking one returned 0.
+    heredoc = ("cat <<EOF > note.txt\n"
+               "cd %s && echo hi\n"
+               "EOF\n"
+               "git commit -m x" % clean)
+    rc, _, _ = run_hook(heredoc, cwd=stalled)
+    if rc == 2:
+        ok("16d. A `cd` inside a heredoc BODY is not followed")
+    else:
+        bad("16d. phantom cd via heredoc body",
+            "rc=%s -- the tracker moved cwd off a line the shell only wrote to a "
+            "file, and skipped the check on a stalled repo" % rc)
+
+    # 16e. ...and `<<` inside a quoted message is still just text.
+    rc, _, _ = run_hook('cd %s && git commit -m "see doc << here"' % clean, cwd=stalled)
+    if rc == 0:
+        ok("16e. A quoted `<<` is not a heredoc and does not abandon tracking")
+    else:
+        bad("16e. over-bailed on a quoted `<<`", "rc=%s" % rc)
+
+    # 16f. Third instance of the class, and the sneakiest: `shlex` DISCARDS a
+    # comment tail by default, so a phantom `cd` parked after a `#` was invisible
+    # to the shape check while still reaching the segment splitter.
+    commented = ("git status # note ; cd %s && echo hi\n"
+                 "git commit -m x" % clean)
+    rc, _, _ = run_hook(commented, cwd=stalled)
+    if rc == 2:
+        ok("16f. A `cd` inside a COMMENT tail is not followed")
+    else:
+        bad("16f. phantom cd via comment tail",
+            "rc=%s -- tracker moved cwd off text the shell never runs" % rc)
+
+    # 16g. The matching over-bail guard. An issue number and a redirect are both
+    # ordinary; bailing on either would bring the false block back.
+    ordinary = [
+        ('cd %s && git commit -m "issue #42 fixed"' % clean, "#42 in the message"),
+        ('cd %s && git commit -m x > /dev/null' % clean, "redirect"),
+    ]
+    tripped = [why for cmd, why in ordinary if run_hook(cmd, cwd=stalled)[0] != 0]
+    if not tripped:
+        ok("16g. A quoted `#` and a redirect do not abandon cd tracking")
+    else:
+        bad("16g. over-bailed", "false block returned for: " + ", ".join(tripped))
 
     # ----------------------------------------------------------------- leg 17
     # MYC-3779 predicate 4: the bypass stays self-serviceable (a guard that can


### PR DESCRIPTION
Closes MYC-3779.

## The defect

`hooks/block-git-mutation-mid-operation.py` resolved `-C`, `--git-dir` and an inline `GIT_DIR=`, but **not the shell's own `cd`**. For the single most common shape an agent emits — `cd /other/repo && git commit -m …` — the `cd` segment parsed as "not a git call", was discarded, and the `git commit` resolved against the **session cwd**. Wrong repository, wrong in both directions:

| session cwd | `cd` target | old | correct |
|---|---|---|---|
| mid-rebase | clean | `exit 2` — refused, citing an unrelated repo's rebase | allow |
| clean | mid-rebase | **`exit 0` — commit into a paused rebase permitted** | block |

MYC-3779 was filed off the first direction: three subagents in one orchestrator session each verified their own worktree was clean, each was factually right, and each self-authorized `GIT_INFLIGHT_OP_BYPASS=1`. The guard manufactured that choice by being unfalsifiable from where they stood.

The second direction was not in the ticket and is worse on its own terms: it is the 2026-07-28 incident this hook exists to stop, walking through its front door.

One correction to the ticket's work item 1: `-C` / `--git-dir` / `GIT_DIR` were **already** honored, with test legs 9, 9b, 9c and 9d covering them. The one missing input was the shell's `cd`.

## The fix

Working directory tracked across shell segments, with the **separator** deciding, since `cd X && git …` and `cd X || git …` land in different repos:

| form | resolves to | why |
|---|---|---|
| `cd X && git …` | `X` | `&&` runs the right side only if the `cd` succeeded |
| `cd X ; git …` | `X` **and** the previous cwd | `;` runs it either way — genuinely ambiguous, so both are checked and either one mid-operation blocks |
| `cd X \|\| git …` | previous cwd | the right side runs only if the `cd` **failed** |
| `cd X \| git …` | previous cwd | a pipeline component is a subshell; its `cd` does not escape |

Bare `cd` is `$HOME`; relative destinations resolve against the directory we are actually in; an explicit `-C` still outranks the `cd`, as git itself resolves it.

## Three fail-opens the cd tracking itself introduced

Found by doubt-passes on my own diff, each **measured** — on every one of these the older cwd-blind hook returned `2` and the cd-tracking one returned `0`. All three are a phantom `cd` carved out of text the shell never executes, which moved the tracked repo to a directory that does not exist, failed the `isdir` check, and made the hook skip the invocation entirely.

1. **An operator inside quotes.** `echo "a ; cd /elsewhere" && git commit`
2. **A heredoc body line.** `cat <<EOF > f` / `cd /clean && echo hi` / `EOF` / `git commit`. The `&&` variant is the dangerous one — a plain body line gets the ambiguous newline separator and unions the candidates, which is accidentally safe.
3. **A comment tail.** `git status # note ; cd /clean && echo hi` / `git commit`. The sneakiest: `shlex` **discards** comment tails by default, so the phantom was invisible to the shape check while still reaching the splitter.

Finding the third the same way I found the second is the signature of a denylist against an open set, which our own operating rule says always loses. So the bail set is justified by a **property** — *can this construct make a computed segment boundary fake, or make a parsed `cd` inert?* — and the code states the enumeration against that test **and what was checked and excluded**: redirects create no boundary and leave no `cd` inert; backgrounding leaves the `cd` with more than one operand so it is already unresolvable; command substitution cannot move the caller's cwd. Against that property the shell's command-list grammar yields exactly three constructs, and all three are covered.

Quoting is not on the bail list, because it is not a bail — `_segments` handles it, which is the point of it being quote-aware. Same shape and same fix as MYC-357 in `_lib/gh_merge.py`, where a quoted `&& gh pr merge` minted a real marker.

**Over-bailing is tested as hard as under-bailing**, because a bail is a false block and a false block is what trains the bypass this ticket is about. An issue number (`-m "issue #42 fixed"`), a redirect (`> /dev/null`), a quoted `<<`, and quoted `&&` / `;` / `|` in commit messages all still track normally.

## MYC-3779 predicate 3 — sibling audit

Every other **blocking** PreToolUse guard already splits quote-aware: `check-cd-outside-worktree`, `session-lock`, `block-raw-vault-git`, `block-vault-git-fullwalk`, `block-worktree-shared-edit`. This hook was the only blocking one that did not, which is exactly why adding cwd tracking *here* was able to regress.

`block-branch-switch-with-untracked-build` is not quote-aware and still holds the static `-C` regex, but it is warn-only and degrades by scanning active repos rather than by granting permission. MYC-4034 owns it and argues against fail-closing it — no re-file.

The audit also surfaced the structural finding, filed as **MYC-4115**: the public substrate has **four** hand-rolled shell-command parsers and `hooks/_lib/` exposes no shared one, while the canonical expander (`_expand` + `_split_segments`) lives only in the private tree. Four blocking guards, four parsers, one of which just had three fail-opens found in it.

## MYC-3779 predicate 4 — bypass policy

`GIT_INFLIGHT_OP_BYPASS` **stays self-serviceable.** The hook refuses to judge `--abort` vs `--continue` because that belongs to the operation's owner; a bypass only a second party can grant would, in the one case that matters — an abandoned operation whose owner is gone — leave the repo with no exit at all. And the three bypasses MYC-3779 measured were manufactured by the scoping bug, so the fix is the scoping, not a harder hatch. Making a correct guard harder to bypass would punish the agents for the guard's error.

But a bypass that leaves no trace is a comment, not a control. The bypass is now evaluated **after** the repository check instead of before it, so the record names what it actually **suppressed** — repo, marker, subcommand, env-vs-inline — rather than merely that someone had the variable exported. Blocks are recorded too, so a guard that has gone quiet is distinguishable from one that never fires. A bypass that suppressed nothing writes nothing.

## Tests

**48 legs, all green** (was 25). Suite is in the `scripts/ci.sh` allow-list, so these run in CI.

Negative controls, because a guard earns trust by failing on the thing it catches:

- vs. the pre-fix hook: **7 of the new legs fail**, including both headline directions.
- vs. the intermediate commits: **16d** and **16f** fail — the heredoc and comment holes.
- **17a–17c** prove the audit trail actually writes; shipping an unproven control would repeat the unfalsifiable-guard mistake one level up.

The remaining new legs pin *fallback* behavior that must not change, so passing against both old and new is correct for those — they are invariant pins, not controls.

## One more the gate caught, in my own test code

The first full `ci-test` run on this branch came back **RED**, and it was right. `test-decode-safe-reads` flagged the leg-17 telemetry reader: it read the log under a bare `except OSError`, but `open(encoding=…)` raises `UnicodeDecodeError` and `json.loads` raises `JSONDecodeError` — both `ValueError` subclasses that an `OSError` handler lets escape. One undecodable byte would have aborted the suite instead of reporting an unreadable audit trail.

Now `(OSError, ValueError)`, so a corrupt log makes the legs fail loudly, which is the right direction for a control. The other two `open()` calls in these files were checked and are safe: one is a write, and the hook's `HEAD` read already passes `errors="replace"`, which is why the scanner did not flag it.

Naming it rather than quietly fixing it: this is the repo's own lint catching, inside the commit that adds a control for one bug class, an instance of a *different* bug class the repo already keeps a lint for.

## What this was verified against

`ci-test` GREEN on `5c71587` — `py_compile` over 375 files, 126 integration tests, 27 `scripts/` suites, 18 `hooks/` unit suites, `shellcheck`, phase-doc python, and the utf8 / decode / py3.9-parity guards. Marker written.

**What it does not cover:** every leg ran on macOS / Python 3.14. The Windows paths in this hook — `git.exe` detection and the drive-relative `cd C:\repo` fallback added here — are green *by construction* on this runner and have never executed on Windows. That is MYC-3543's known gap (CI is ubuntu-only), not something this change closes.

Drafted with Claude Code; adversarially reviewed against its own diff before merge, which is how the three fail-opens above were found.

## The uncomfortable part: this class was already named, and closed

MYC-357 (closed 2026-06-02) is titled *"Harden gh_merge detection + CI-green gate: quote-aware splitting + cwd/-R-aware checks"*. Its recorded bug class is, verbatim:

> `HOOK-RESOLVES-SESSION-CWD-NOT-COMMAND-CWD` + `NAIVE-SHELL-SPLIT-NOT-QUOTE-AWARE`

Those are **both halves of this PR**. Its Work item 3 even prescribed the sweep: *"audit the OTHER PreToolUse/PostToolUse Bash hooks that run `git`/`gh` assuming session cwd == target … either reuse a shared 'effective repo cwd' helper or document why each is safe."*

This hook did not exist then — it was written after the 2026-07-28 rebase incident — and it was born with both defects. That is the real lesson here, and it is not "audit harder": a sweep fixes the instances that exist on the day it runs and does nothing about the next file. The durable fix is the shared helper MYC-357 already asked for and that still does not exist on the public side, which is MYC-4115.

Filed while this PR was in flight, with that evidence: the public substrate carries four independent quote-aware splitters and `hooks/_lib` exposes no shell parsing at all, while the good implementation lives only in the private tree.
