### PR TITLE
fix(hooks): a registered daily broadcast that has NEVER run read as healthy (MYC-4130)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -116,6 +116,8 @@ If your session start mentions "background helpers not active", this is what it 
 
 **If you never set up team-broadcast, you will not hear about this at all.** This starter does not install that skill, so a missing one is the normal state for most people, and a warning about a component you never asked for is just noise that teaches you to ignore the rest. The check only speaks up when there is evidence you did set it up here and it since broke: a scheduled job that refers to it, a log from a previous run, or a half-present skill folder.
 
+**And a scheduled job that exists but has never actually run now gets caught too.** macOS reports the same status for a job that ran and finished cleanly as for one that was registered and never fired, so "the schedule is there" was being read as "it is working". The daily summary is the one job where that distinction is the entire point: the failure people actually hit is a broadcast that has never been sent. It now says so and gives you the two commands that reload it.
+
 **Also:** this file's non-ASCII console output (the warning emoji, some em dashes) was carried over from before the UTF-8 console-crash lint was widened to cover `hooks/`. It's provably safe — the only print is `json.dumps(...)`, which escapes non-ASCII before it reaches stdout — so it's now marked `# utf8-stdout-ok` and dropped from the legacy pin list instead of staying silently grandfathered in.
 
 ## 2026-08-05: on Mac and Linux, "daily backup scheduled" now means it really is

--- a/hooks/surface-stale-automation-failures.py
+++ b/hooks/surface-stale-automation-failures.py
@@ -470,6 +470,35 @@ def team_broadcast_install_gap() -> str | None:
             "summary cron will never fire. (Session-close broadcasts, "
             "triggered live by Claude rather than this cron, are unaffected.)"
         )
+    # Registered is NOT the same as running. `launchctl list` reports status 0
+    # both for a job that ran and exited clean and for one that has never
+    # executed at all, and launchd_failures() SKIPS this label by suffix
+    # precisely because this finder owns it — so silence here means silence
+    # everywhere. A hollow daily broadcast is the exact shape this finder
+    # exists to catch: the job is present, nothing looks wrong, and the
+    # summary has never once been sent.
+    #
+    # Bounded by construction: registered_bespoke_label() returns at most one
+    # label, so this adds at most ONE `launchctl print` per run, well inside
+    # the budget MAX_LAUNCHD_PRINT_PROBES exists to protect.
+    try:
+        uid = os.getuid()  # type: ignore[attr-defined]
+    except AttributeError:
+        return None  # no os.getuid (Windows) — cannot probe; stay silent
+    liveness = _launchd_print_liveness(label, uid)
+    if liveness is None:
+        return None  # probe unavailable/erroring — degrade to pre-probe silence
+    runs, last_exit = liveness
+    if runs == 0:
+        plist_path = HOME / "Library" / "LaunchAgents" / f"{label}.plist"
+        exit_note = f", last exit code {last_exit}" if last_exit else ""
+        return (
+            f"  - {label}: registered but has NEVER RUN (runs=0{exit_note}, "
+            "launchctl print) — a hollow job, so the daily summary has never "
+            "been sent from this machine and nothing else reports it. Reload "
+            f"it: launchctl bootout gui/{uid}/{label}; "
+            f"launchctl bootstrap gui/{uid} {plist_path}"
+        )
     return None
 
 

--- a/tests/integration/test_team_broadcast_install_gap.sh
+++ b/tests/integration/test_team_broadcast_install_gap.sh
@@ -29,6 +29,9 @@
 #   3. NEG-CONTROL: script present, job registered under one namespace -> SILENT.
 #   4. ANY-OPERATOR: same, under a completely different namespace -> SILENT.
 #      Case 3 alone would still pass if the suffix match were secretly a literal.
+#   4b. HOLLOW: registered but runs=0 -> FIRES. `launchctl list` shows status 0
+#      for a job that never ran, identical to a healthy one, and the generic
+#      launchd pass skips this label by suffix — so only this finder can see it.
 #   5. END-TO-END: the finding reaches the real SessionStart entrypoint
 #      (main()'s systemMessage), not just the helper function in isolation.
 #
@@ -68,12 +71,15 @@ opt_in_but_broken() {  # <home> -- skill dir present, auto-send.py MISSING
   mkdir -p "$1/.claude/skills/team-broadcast"
 }
 
-# fake_launchctl HOME REGISTERED_LABEL_OR_EMPTY -- puts a fake `launchctl` ahead
-# of the real one on PATH. The hook calls bare `launchctl list` and parses the
-# tab-separated PID/Status/Label table, so the stub prints that table: a header
-# plus one row for REGISTERED, or a header alone when nothing is registered.
+# fake_launchctl HOME REGISTERED_LABEL_OR_EMPTY [RUNS] -- puts a fake `launchctl`
+# ahead of the real one on PATH. Answers the two calls this hook makes:
+#   `launchctl list`                  -> the tab-separated PID/Status/Label table
+#   `launchctl print gui/<uid>/<lbl>` -> the `runs = N` liveness field
+# RUNS defaults to 7 (a job that has actually executed). Pass 0 to model a
+# HOLLOW job: registered, status 0, never once run — indistinguishable from
+# healthy in the `list` table alone, which is the whole reason for the probe.
 fake_launchctl() {
-  local home="$1" registered="$2" bin="$1/fakebin" row=""
+  local home="$1" registered="$2" runs="${3:-7}" bin="$1/fakebin" row=""
   mkdir -p "$bin"
   [ -n "$registered" ] && row="printf -- '-\t0\t%s\n' '$registered'"
   cat > "$bin/launchctl" <<EOF
@@ -82,6 +88,17 @@ if [ "\$1" = "list" ] && [ -z "\${2:-}" ]; then
   printf 'PID\tStatus\tLabel\n'
   $row
   exit 0
+fi
+if [ "\$1" = "print" ]; then
+  if [ -n "$registered" ]; then
+    case "\${2:-}" in
+      *"$registered")
+        printf '\tstate = waiting\n\truns = $runs\n\tlast exit code = 0\n'
+        exit 0
+        ;;
+    esac
+  fi
+  exit 1
 fi
 exit 0
 EOF
@@ -141,6 +158,18 @@ install_broadcast_script "$H4"
 fake_launchctl "$H4" "io.someone-else.team-broadcast-daily"
 run_hook "$H4"
 assert_silent "the suffix match is not secretly a literal: another operator's label also counts as installed"
+
+echo "=== 4b. HOLLOW: registered but runs=0 -> FIRES ==="
+# The case launchd_failures() cannot report: it skips this label by suffix
+# because THIS finder owns it. If the finder reads "registered" as healthy,
+# a daily broadcast that has never once fired is invisible everywhere.
+H4B="$(newhome)"
+install_broadcast_script "$H4B"
+fake_launchctl "$H4B" "com.example.team-broadcast-daily" 0
+run_hook "$H4B"
+assert_fires "fires when the job is registered but has never run"
+assert_has   "names the hollow state" "NEVER RUN"
+assert_has   "gives the reload remedy" "launchctl bootout"
 
 echo "=== 5. END-TO-END: reaches main()'s systemMessage, not just the helper ==="
 H5="$(newhome)"


### PR DESCRIPTION
Follow-up to #472, which merged minutes ago. Same file, one gap that PR could not have closed because the cause landed while it was being rebased.

## What is wrong

#582 measured that `launchctl list`'s exit-status column reads `0` for **two different things**: a job that ran and exited clean, and a job that has never executed at all. It added `_launchd_print_liveness()` to tell them apart, and wired it into the generic launchd pass.

The generic pass **skips** every label in `BESPOKE_LAUNCHD_SUFFIXES`, because `team_broadcast_install_gap()` owns those. That finder treated presence in the `launchctl list` table as health.

So a daily-broadcast job that is registered but has **never once fired** was reported by neither pass — skipped by one, called healthy by the other. Two passes, both silent, on the one job whose entire purpose is a summary that must go out every day. "The broadcast never fired" is the exact failure that finder was written for.

## What this does

Probes liveness on the resolved label and reports a hollow job distinctly, reusing #582's helper and matching the wording and `bootout`/`bootstrap` remedy the generic pass already emits.

**Bounded by construction.** `registered_bespoke_label()` resolves at most one label, so this adds at most **one** `launchctl print` per run — well inside the budget `MAX_LAUNCHD_PRINT_PROBES` exists to protect. Every probe failure mode (no `getuid` on Windows, probe unavailable, timeout, unparseable output) degrades to the pre-probe reading of silence, never a false alarm.

## Why the test is not vacuous

The two healthy-namespace controls run with `runs=7` and stay **silent**; the new case runs with `runs=0` and **fires**. A probe that always returned `None`, or one that fired unconditionally, fails one side or the other. 17 assertions, 0 failures.

## Verification

- `bash scripts/ci.sh` via `ci-test`: **GREEN**, marker `af437850.ok`
- personal-data scrub: **clean**, each pattern proven against a planted specimen before scanning

Closes MYC-4130.

---

Drafted with Claude Code; gated and reviewed before merge.
