### PR TITLE
fix(lint): the private-context gate blamed a stale branch for main's own lines

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -434,46 +434,24 @@ jobs:
         if: github.event_name == 'pull_request'
         env:
           BASE_REF: ${{ github.base_ref }}
-        run: git fetch origin "$BASE_REF" --depth=50
+        # NO --depth here. checkout above uses fetch-depth: 0, and a depth-limited
+        # fetch re-introduces a shallow boundary: on a PR older than that many
+        # commits the merge base falls outside it and `git diff BASE...HEAD`
+        # cannot be computed at all.
+        run: git fetch origin "$BASE_REF"
+
+      # The scan itself lives in scripts/check-private-context.sh so this
+      # enforcing gate and a local run cannot drift, and so its negative control
+      # is runnable. Same reasoning as check-ps1-encoding.sh above.
+      - name: private-context negative controls (the guard must still bite)
+        if: github.event_name == 'pull_request'
+        run: bash scripts/check-private-context.sh --self-test
 
       - name: private-context tokens (PR-scoped)
         if: github.event_name == 'pull_request'
         env:
           BASE_REF: ${{ github.base_ref }}
-        run: |
-          set -e
-          P='\b[A]delaida\b|\b[O]nde\b|\b[D]iaz.Roa\b|\b[B]ogot[aá]\b|\b[S]ergio Perez\b|\b[N]atalia\b|\b[P]aola\b|\b[A]ccenture\b|\b[H]igh.Rise Series\b|\b[S]hark Tank\b'
-          BASE="origin/$BASE_REF"
-          fail=0
-          while IFS= read -r f; do
-            [ -z "$f" ] && continue
-            [ ! -f "$f" ] && continue
-            case "$f" in
-              */.venv/*|*/node_modules/*|*/__pycache__/*) continue ;;
-            esac
-            case "$f" in
-              *.md|*.sh|*.ps1|*.py|*.json|*.yml|*.yaml|*.txt|.env.example) ;;
-              *) continue ;;
-            esac
-            # Scan ONLY lines this PR adds (diff lines starting with `+`,
-            # excluding the `+++ b/path` file header). Pre-existing committed
-            # content is intentionally ignored: CI gates net-new private-context
-            # additions, not legacy text in files this PR happens to touch.
-            added_lines=$(git diff "$BASE"..HEAD -- "$f" | grep -E '^\+' | grep -vE '^\+\+\+' || true)
-            if [ -z "$added_lines" ]; then
-              continue
-            fi
-            if matches=$(echo "$added_lines" | grep -nE "$P" 2>/dev/null); then
-              echo "::error file=$f::private-context token added in this PR"
-              echo "$matches" | head -3 | sed 's|^|  |'
-              fail=1
-            fi
-          done < <(git diff --name-only "$BASE"..HEAD)
-          if [ "$fail" = "1" ]; then
-            echo "::error::Private-context scan failed. Use placeholders or fictional names instead."
-            exit 1
-          fi
-          echo "Private-context scan passed (added lines only)."
+        run: bash scripts/check-private-context.sh "origin/$BASE_REF"
 
       # ---- last: the only step that installs anything ------------------------
 

--- a/scripts/check-private-context.sh
+++ b/scripts/check-private-context.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Private-context token scan, PR-scoped.
+#
+# Lives here rather than inline in .github/workflows/lint.yml for the same
+# reason check-ps1-encoding.sh does: an inline copy is unreachable locally, so
+# it can only be exercised by pushing, and the enforcing gate and any local
+# equivalent drift apart silently.
+#
+# Contract: fail (exit 1) if THIS BRANCH ADDS a line carrying a private-context
+# token. Pre-existing committed content is intentionally ignored -- the gate is
+# about net-new additions, not legacy text in a file the branch happens to touch.
+#
+# THE TRAP THIS SCRIPT EXISTS TO NOT FALL INTO: `git diff A..B` (two dots)
+# compares the two TIPS. Every line the base changed since the branch forked
+# comes back as a `+` on the branch side and gets blamed on the branch. Only
+# `git diff A...B` (three dots) diffs from the MERGE BASE, which is the only
+# thing that means "what this branch added".
+#
+# Measured 2026-08-23 on PR #519: two-dot reported 165 files and 10 token hits
+# on a PR that touches 3 files and adds none. That false positive stranded ~15
+# PRs for weeks -- the over-strict-verification failure mode that teaches people
+# to bypass a security gate.
+set -euo pipefail
+
+P='\b[A]delaida\b|\b[O]nde\b|\b[D]iaz.Roa\b|\b[B]ogot[aá]\b|\b[S]ergio Perez\b|\b[N]atalia\b|\b[P]aola\b|\b[A]ccenture\b|\b[H]igh.Rise Series\b|\b[S]hark Tank\b'
+
+scan() {
+  local BASE="$1" fail=0 f added_lines matches merge_base
+
+  # Fail LOUD if the merge base is unreachable. A shallow clone that cannot
+  # reach the fork point would make `git diff BASE...HEAD` empty, and an empty
+  # diff is indistinguishable from a clean one -- a silent fail-open on the
+  # exact gate that must never fail open.
+  if ! merge_base="$(git merge-base "$BASE" HEAD 2>/dev/null)" || [ -z "$merge_base" ]; then
+    echo "::error::cannot compute merge base against $BASE -- the checkout is too shallow to scan. Fetch the base branch with full history (no --depth)." >&2
+    return 1
+  fi
+
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    [ ! -f "$f" ] && continue
+    case "$f" in
+      */.venv/*|*/node_modules/*|*/__pycache__/*) continue ;;
+    esac
+    case "$f" in
+      *.md|*.sh|*.ps1|*.py|*.json|*.yml|*.yaml|*.txt|.env.example) ;;
+      *) continue ;;
+    esac
+    added_lines="$(git diff "$BASE"...HEAD -- "$f" | grep -E '^\+' | grep -vE '^\+\+\+' || true)"
+    [ -z "$added_lines" ] && continue
+    if matches="$(echo "$added_lines" | grep -nE "$P" 2>/dev/null)"; then
+      echo "::error file=$f::private-context token added in this PR"
+      echo "$matches" | head -3 | sed 's|^|  |'
+      fail=1
+    fi
+  done < <(git diff --name-only "$BASE"...HEAD)
+
+  if [ "$fail" = "1" ]; then
+    echo "::error::Private-context scan failed. Use placeholders or fictional names instead."
+    return 1
+  fi
+  echo "Private-context scan passed (added lines only, merge-base scoped)."
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# --self-test: the negative control. A gate that has never been observed to
+# FAIL on the thing it catches is not known to work.
+# ---------------------------------------------------------------------------
+self_test() {
+  local pass=0 fail=0 work
+  work="$(mktemp -d)"
+  trap 'rm -rf "$work"' RETURN
+  local SELF; SELF="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+
+  ok()  { echo "  PASS: $1"; pass=$((pass + 1)); }
+  bad() { echo "  FAIL: $1"; fail=$((fail + 1)); }
+
+  git -C "$work" init -q -b main
+  git -C "$work" config user.email t@t.local
+  git -C "$work" config user.name t
+
+  mkdir -p "$work/docs" "$work/templates"
+  # Legacy file that ALREADY contains a private token on both sides.
+  printf 'legacy line mentioning Adelaida here\n' > "$work/docs/legacy.md"
+  printf '{"a":1}\n' > "$work/templates/x.json"
+  git -C "$work" add -A && git -C "$work" commit -qm base
+
+  # Branch forks here.
+  git -C "$work" branch pr
+  # main advances, MODIFYING the legacy file (this is what makes two-dot lie).
+  printf 'legacy line mentioning Adelaida here\nmain added this later\n' > "$work/docs/legacy.md"
+  git -C "$work" add -A && git -C "$work" commit -qm main-advances
+
+  # The PR touches ONLY an innocent file.
+  git -C "$work" checkout -q pr
+  printf '{"a":1,"b":2}\n' > "$work/templates/x.json"
+  git -C "$work" add -A && git -C "$work" commit -qm pr-innocent
+
+  # CASE 1: the real-world false positive. Stale branch, innocent change.
+  if ( cd "$work" && bash "$SELF" main >/dev/null 2>&1 ); then
+    ok "stale branch with an innocent change PASSES (no false positive)"
+  else
+    bad "stale branch with an innocent change was flagged -- the two-dot bug is back"
+  fi
+
+  # CASE 2 (NEGATIVE CONTROL): a genuinely added token MUST still fail.
+  printf 'brand new line naming Accenture\n' >> "$work/templates/x.json"
+  git -C "$work" add -A && git -C "$work" commit -qm pr-adds-token
+  if ( cd "$work" && bash "$SELF" main >/dev/null 2>&1 ); then
+    bad "a NET-NEW private token was NOT caught -- the gate is vacuous"
+  else
+    ok "a NET-NEW private token is still caught (guard bites)"
+  fi
+
+  # CASE 3: fail LOUD, never silently clean, when the base is unreachable.
+  if ( cd "$work" && bash "$SELF" refs/heads/does-not-exist >/dev/null 2>&1 ); then
+    bad "an unreachable base returned CLEAN -- silent fail-open"
+  else
+    ok "an unreachable base fails loudly rather than reporting clean"
+  fi
+
+  echo "=== private-context selftest: $pass passed, $fail failed ==="
+  [ "$fail" -eq 0 ]
+}
+
+if [ "${1:-}" = "--self-test" ]; then
+  self_test
+else
+  scan "${1:?usage: check-private-context.sh <BASE_REF> | --self-test}"
+fi

--- a/scripts/check-private-context.sh
+++ b/scripts/check-private-context.sh
@@ -81,15 +81,24 @@ self_test() {
   git -C "$work" config user.name t
 
   mkdir -p "$work/docs" "$work/templates"
+  # The fixtures need REAL tokens inside the temp repo, but this file must not
+  # contain them as contiguous literals -- the repo-wide scrub and this very
+  # scanner both read this source, and a literal here is a genuine hit. Split
+  # across a quote boundary: the shell concatenates at runtime, while the text
+  # on disk never matches \bAdelaida\b. Same reason the P pattern above writes
+  # the bracketed form rather than the bare name.
+  local TOK_A TOK_B
+  TOK_A="A""delaida"
+  TOK_B="A""ccenture"
   # Legacy file that ALREADY contains a private token on both sides.
-  printf 'legacy line mentioning Adelaida here\n' > "$work/docs/legacy.md"
+  printf 'legacy line mentioning %s here\n' "$TOK_A" > "$work/docs/legacy.md"
   printf '{"a":1}\n' > "$work/templates/x.json"
   git -C "$work" add -A && git -C "$work" commit -qm base
 
   # Branch forks here.
   git -C "$work" branch pr
   # main advances, MODIFYING the legacy file (this is what makes two-dot lie).
-  printf 'legacy line mentioning Adelaida here\nmain added this later\n' > "$work/docs/legacy.md"
+  printf 'legacy line mentioning %s here\nmain added this later\n' "$TOK_A" > "$work/docs/legacy.md"
   git -C "$work" add -A && git -C "$work" commit -qm main-advances
 
   # The PR touches ONLY an innocent file.
@@ -105,7 +114,7 @@ self_test() {
   fi
 
   # CASE 2 (NEGATIVE CONTROL): a genuinely added token MUST still fail.
-  printf 'brand new line naming Accenture\n' >> "$work/templates/x.json"
+  printf 'brand new line naming %s\n' "$TOK_B" >> "$work/templates/x.json"
   git -C "$work" add -A && git -C "$work" commit -qm pr-adds-token
   if ( cd "$work" && bash "$SELF" main >/dev/null 2>&1 ); then
     bad "a NET-NEW private token was NOT caught -- the gate is vacuous"

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -289,6 +289,7 @@ INTEGRATION_TESTS=(
   test_meeting_todos_step0_create_if_absent
   test_meeting_workflow_trigger_hook
   test_personal_brain_not_optional
+  test_private_context_scan_merge_base
   test_phase11_writes_to_vault_rule_file
   test_post_commit_ff_worktrees
   test_write_hook_meeting_folder_i18n

--- a/tests/integration/test_private_context_scan_merge_base.sh
+++ b/tests/integration/test_private_context_scan_merge_base.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Pins the private-context gate to a MERGE-BASE diff and to its delegation.
+#
+# The bug this exists to prevent (measured 2026-08-23, PR #519): lint.yml scanned
+# `git diff origin/main..HEAD` -- two dots, which compares TIPS. On a branch 52
+# commits behind, every line main had changed came back as a `+` on the PR side.
+# The gate reported 165 files and 10 private-token hits on a PR that touches 3
+# files and adds none. ~15 PRs sat blocked on that false positive for weeks.
+#
+# A false positive on a SECURITY gate is not a cosmetic bug: it is the failure
+# mode that teaches an operator to reach for --admin.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SCANNER="$ROOT/scripts/check-private-context.sh"
+WF="$ROOT/.github/workflows/lint.yml"
+PASS=0 FAIL=0
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+echo "== the scanner exists and its own negative controls hold =="
+[ -f "$SCANNER" ] && pass "scripts/check-private-context.sh present" \
+  || fail "scripts/check-private-context.sh missing"
+if bash "$SCANNER" --self-test >/dev/null 2>&1; then
+  pass "scanner self-test green (catches a real token, ignores a stale base)"
+else
+  echo "--- scanner self-test output ---"; bash "$SCANNER" --self-test || true
+  fail "scanner self-test FAILED"
+fi
+
+echo "== the workflow delegates instead of re-inlining a private copy =="
+if grep -q 'bash scripts/check-private-context.sh "origin/\$BASE_REF"' "$WF"; then
+  pass "lint.yml calls the shared scanner"
+else
+  fail "lint.yml no longer delegates to scripts/check-private-context.sh"
+fi
+if grep -q 'check-private-context.sh --self-test' "$WF"; then
+  pass "lint.yml runs the negative control in CI"
+else
+  fail "lint.yml dropped the negative-control step"
+fi
+
+echo "== no two-dot diff against the base survives anywhere in the gate =="
+# `"$BASE"..HEAD` is the exact defect. `...` must never regress to `..`.
+if grep -nE '"\$BASE"\.\.[^.]' "$SCANNER" "$WF" 2>/dev/null; then
+  fail "a TWO-DOT diff against the base is back -- stale branches will false-positive again"
+else
+  pass "no two-dot base diff in the scanner or the workflow"
+fi
+
+echo "== the base fetch stays deep enough to HAVE a merge base =="
+# A depth-limited fetch re-shallows the checkout; on a PR older than that many
+# commits the merge base falls outside the boundary and the diff cannot compute.
+if grep -nE 'git fetch origin "\$BASE_REF".*--depth' "$WF" 2>/dev/null; then
+  fail "base fetch is depth-limited again -- old PRs will lose their merge base"
+else
+  pass "base fetch is unbounded (merge base always reachable)"
+fi
+
+echo "=== $(basename "$0"): $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## The bug

The PR-scoped private-context scan diffed `origin/main..HEAD` -- **two dots**, which compares the two TIPS. On a branch behind main, every line main had changed since the fork comes back as a `+` on the PR side and is reported as "private-context token added in this PR".

Measured on **#519**, a PR that touches 3 files and adds no tokens:

| diff form | files scanned | token hits | verdict |
| --- | --- | --- | --- |
| `origin/main..HEAD` (what CI ran) | 165 | 10 | FAIL |
| `origin/main...HEAD` (merge base) | 3 | 0 | PASS |

Around **15 open PRs** were sitting on this false positive, several for weeks. It reported `CLAUDE.md` and `.github/workflows/personal-pii-scrub.yml` as things #519 had edited. It never touched either.

A false positive on the personal-data gate is not cosmetic. It is the over-strict-verification failure that teaches an operator to reach for `--admin`, and it strands finished work behind a red check that looks like a leak.

## What changed

- **Three-dot diff.** The scan is now scoped to the merge base, so it means "what this PR added" rather than "how the two tips differ".
- **The base fetch drops `--depth=50`.** A depth-limited fetch re-shallows an already-complete checkout; on a PR older than that boundary the merge base falls outside it entirely and the diff cannot be computed at all.
- **The scan moves out of the workflow YAML** into `scripts/check-private-context.sh`, for the same reason `check-ps1-encoding.sh` already lives there: an inline copy is unreachable locally, so it can only be exercised by pushing, and it drifts from any local equivalent. CI now runs the same script a developer can.
- **An unreachable merge base fails LOUD.** Previously a too-shallow checkout produced an empty diff, and an empty diff is indistinguishable from a clean one -- a silent fail-open on the one gate that must never fail open.

## Why this is not a weakening of the gate

Three-dot is *stricter*, not looser. Two-dot has a real blind spot: if main independently adds the same line the PR adds, the net diff shows nothing and the addition goes unreported. Three-dot still attributes it to the PR.

Negative controls ship with the change and run in CI, so the guard is observed failing on the thing it catches:

- a net-new private token **must still be caught**
- a stale base **must not** false-positive
- an unreachable base **must not** report clean

## Verification

- `scripts/check-private-context.sh --self-test` -- 3/3
- `tests/integration/test_private_context_scan_merge_base.sh` -- 6/6, wired into `INTEGRATION_TESTS` (confirmed the enumeration gate flags it when unlisted)
- `ci-test` full local gate GREEN: `py_compile` (375 files) + 130 integration tests + 27 `scripts/` + 18 `hooks/tests` suites + shellcheck + phase-doc python + utf8 console guard + hook block-protocol + ps1 encoding

🤖 Generated with [Claude Code](https://claude.com/claude-code)
