### PR TITLE
fix(secrets): the guard could not see the key its own auth docs tell you to use

### DIFF
--- a/hooks/_lib/secret_patterns.py
+++ b/hooks/_lib/secret_patterns.py
@@ -24,6 +24,7 @@ auto-scrub layer were the structural fix.
 from __future__ import annotations
 
 import re
+import sys
 from dataclasses import dataclass
 
 
@@ -52,6 +53,18 @@ _PROVIDER = [
         regex=re.compile(r"sk-ant-api\d{2}-[\w\-]{40,}", re.ASCII),
         redaction="[REDACTED-anthropic-api-key]",
         description="Anthropic API key, format sk-ant-api{NN}-{token}.",
+    ),
+    SecretPattern(
+        # NVIDIA build-API key. Added after a real leak: a live key reached a
+        # session transcript via a process listing, then turned up in 8+ files
+        # including backups. The shape had been written into a prose checklist
+        # a human reads, never into executable code -- so every guard reported
+        # a confident CLEAN over it. If an auth path is documented as supported,
+        # its credential shape belongs here, in code, not only in a checklist.
+        name="nvidia-api-key",
+        regex=re.compile(r"nvapi-[A-Za-z0-9_\-]{40,}", re.ASCII),
+        redaction="[REDACTED-nvidia-api-key]",
+        description="NVIDIA build/NIM API key, format nvapi-{token}.",
     ),
     SecretPattern(
         # Tightened after early audits: original `{20,}` matched
@@ -408,6 +421,16 @@ def filter_tool_output_false_positives(
 
 # Self-test (run `python3 -m hooks._lib.secret_patterns`)
 if __name__ == "__main__":
+    # This module's self-test prints pattern names and redaction markers. On a
+    # Windows cp1252 console any non-ASCII byte in that output raises
+    # UnicodeEncodeError and the self-test dies with no legible cause
+    # (ai-brain-starter#313). Idempotent; a no-op on an already-UTF-8 console.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
+
     SAMPLES = {
         "anthropic-api-key": "sk-ant-api03-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
         "hubspot-pat": "pat-na1-AAAAAAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA",
@@ -415,6 +438,7 @@ if __name__ == "__main__":
         "redis-url": "rediss://:p123abc456def@redis.example.com:6379",
         "jwt": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
         "github-pat": "github_pat_AAAAAAAAAAAAAAAAAAAAAA_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN",
+        "nvidia-api-key": "nvapi-" + "Xy7Zq2Lm9Rt4Bv6Nc8Ka1Pd3Wf5Hj0Gs7Ue2Yi4Ao6Bn1Cm",
         "hex-256": "a" * 64,
         "clean": "no secrets here just regular text and code",
     }

--- a/hooks/test_secret_patterns_nvidia.py
+++ b/hooks/test_secret_patterns_nvidia.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Regression tests for the NVIDIA build-API key pattern (`nvapi-`).
+
+Why this file exists
+--------------------
+A live NVIDIA key reached a session transcript through a process listing,
+and was then found sitting in 8+ transcript files including backup copies.
+Every secret guard reported a confident CLEAN over all of them.
+
+The cause was not a weak regex. The shape had been written into a prose
+checklist a human reads, and never into executable code -- so the one
+credential type the auth guidance tells you to use was the one shape no
+scanner could see. A guard cannot catch what was only ever documented.
+
+These tests pin the executable half of that contract.
+
+Design note: each positive case varies the ENCODING/CONTEXT, not just the
+token. A regression test that constructs a single spelling is
+byte-indistinguishable from one that merely pins the defence -- green,
+named for the property, and false. The token travels differently in a
+shell assignment, a `ps` line, JSON, and a quoted value, and the pattern
+must survive all of them.
+
+Run: python3 hooks/test_secret_patterns_nvidia.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+HOOKS = Path(__file__).resolve().parent
+sys.path.insert(0, str(HOOKS))
+
+from _lib.secret_patterns import PATTERNS, redact, scan  # noqa: E402
+
+PATTERN_NAME = "nvidia-api-key"
+
+# Real-shaped, non-live. NVIDIA build keys are `nvapi-` + a long token.
+KEY = "nvapi-" + "Xy7Zq2Lm9Rt4Bv6Nc8Ka1Pd3Wf5Hj0Gs7Ue2Yi4Ao6Bn1Cm"
+
+failures: list[str] = []
+
+
+def check(label: str, condition: bool, detail: str = "") -> None:
+    if condition:
+        print(f"  PASS {label}")
+    else:
+        print(f"  FAIL {label} {detail}")
+        failures.append(label)
+
+
+print("pattern is registered:")
+check(
+    "nvidia-api-key present in PATTERNS",
+    any(p.name == PATTERN_NAME for p in PATTERNS),
+    "-- the pattern was removed; every nvapi- guard is blind again",
+)
+
+print("\npositive cases (encoding varies, token is constant):")
+# Each entry is a DIFFERENT way the same credential actually travels.
+POSITIVE = {
+    "bare token": KEY,
+    "shell export": f"export NVIDIA_API_KEY={KEY}",
+    "process listing (the shape that leaked)": f"5123 python nvidia.sh --key {KEY}",
+    "json value": f'{{"nvidia_api_key": "{KEY}"}}',
+    "single-quoted header value": f"REQUEST_HEADER='Authorization: Bearer {KEY}'",
+    "env-file line": f"NVIDIA_API_KEY={KEY}\n",
+    "followed by shell delimiter": f"KEY={KEY};echo done",
+    "inside a longer log line": f"2026-08-23 INFO auth ok key={KEY} tier=2",
+}
+for label, text in POSITIVE.items():
+    hits = scan(text)
+    check(
+        f"caught in {label}",
+        any(name == PATTERN_NAME for name, _ in hits),
+        f"-- scan returned {hits}",
+    )
+
+print("\nnegative cases (must NOT fire -- these are not credentials):")
+NEGATIVE = {
+    "placeholder": "NVIDIA_API_KEY=nvapi-YOUR_KEY_HERE",
+    "bare prefix": "keys start with nvapi- and are long",
+    "too short": "nvapi-abc123",
+    "near-miss prefix": "navapi-" + "a" * 50,
+    "prose mentioning the shape": "The scrub list covers nvapi- tokens.",
+}
+for label, text in NEGATIVE.items():
+    hits = [h for h in scan(text) if h[0] == PATTERN_NAME]
+    check(f"no false positive on {label}", not hits, f"-- got {hits}")
+
+print("\nredaction:")
+redacted, hits = redact(f"export NVIDIA_API_KEY={KEY}")
+check("key does not survive redaction", KEY not in redacted, f"-- got {redacted!r}")
+check("redaction is labelled", "REDACTED-nvidia-api-key" in redacted, f"-- got {redacted!r}")
+
+# Idempotency: re-redacting redacted text must be a no-op. A marker that
+# itself matches a pattern would loop or corrupt on a second scrub pass.
+twice, hits2 = redact(redacted)
+check("redaction is idempotent", twice == redacted and hits2 == [], f"-- got {hits2}")
+
+print()
+if failures:
+    print(f"FAILED: {len(failures)} check(s): {', '.join(failures)}")
+    sys.exit(1)
+print("All nvidia-api-key pattern checks passed.")

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1139,6 +1139,7 @@ PY_DIRECT=(
   hooks/test_live_session_reap.py
   hooks/test_relocation_orphan_reclaim.py
   hooks/test_secret_patterns_fp_filter.py
+  hooks/test_secret_patterns_nvidia.py
   hooks/test_check_fabricated_verification.py
   hooks/test_warn_chained_state_command.py
   hooks/test_footprint_aggregate_bloat.py

--- a/scripts/utf8-stdout-baseline.txt
+++ b/scripts/utf8-stdout-baseline.txt
@@ -95,8 +95,7 @@
 # to trust a hand-written count; `python3 scripts/check-utf8-stdout.py` prints
 # the live split.)
 
-# ---- SEV-3-doc-only  (3 file(s)) ----
-028b9d634e09a6515f64176895cb35fc1415eae2ab1b74692aefa4a96da27e4f SEV-3-doc-only hooks/_lib/secret_patterns.py
+# ---- SEV-3-doc-only  (2 file(s)) ----
 ed1d68dba02ab76c99907e8efc27ac0aac8c98a14dad261da73fa5d8e1610369 SEV-3-doc-only hooks/_lib/template_purity.py
 8dea18caf79e387a2fbeddca90403ef8af0d0ff1e6395e3b1f00e1b396491a4b SEV-3-doc-only hooks/inject-instinct-context.py
 


### PR DESCRIPTION
## The gap

A live NVIDIA build-API key reached a session transcript through a process listing. A follow-up sweep found the same key already sitting in 8+ transcript files from earlier sessions, including `.bak` copies. Every secret guard reported a confident CLEAN over all of them.

The cause was not a weak regex. The `nvapi-` shape had been written into a prose checklist a human reads, and never into executable code. NVIDIA is a documented auth path, so **the one credential type the routing guidance tells you to reach for was the one shape no scanner could match.**

## Blast radius

`secret_patterns` is imported by seven shipped hooks: `detect-secrets-in-bash-output`, `scrub-session-jsonl-secrets`, `scan-prior-sessions-for-secrets`, `block-secret-in-note`, `block-claude-mcp-inline-secret`, `block-mcp-config-inline-secret`, and the `secret-warn` skill. All seven were blind to this shape.

## Changes

- `secret_patterns` gains `nvidia-api-key`. The detection set now covers a supported auth path rather than only the providers that happened to get written down twice.
- A new `test_secret_patterns_nvidia` suite pins it. Each positive case varies the **encoding and context** rather than the token — shell assignment, a `ps` line, JSON, a quoted header, an env-file line, a longer log line. A regression test that constructs one spelling of a leak is byte-indistinguishable from one that merely pins the defence: green, named for the property, and false. Negatives cover placeholders, a bare prefix, a too-short token, a near-miss prefix, and prose that only mentions the shape. Redaction is checked for labelling and idempotence.
- `ci.sh` runs the new suite in `PY_DIRECT`. A test the gate never enumerates passes locally forever and never runs in CI.
- `secret_patterns` gains the real UTF-8 console guard and drops off the `SEV-3-doc-only` tier of the utf8-stdout baseline (now 2 files). Editing the module made its content-pinned row stale, and the lint is explicit that re-pinning edited content turns a backlog into a permanent exemption — so this pays the row down instead of extending it.

## Review-risky areas

The baseline edit is the one worth a second look: it removes an exemption row and corrects a section header count. Both are burn-down ledger state that a human reads to judge whether the backlog is shrinking, so a wrong count there is quietly misleading rather than loud.

## Verification

- New suite green: 1 registration check, 8 positive encodings, 5 negatives, 3 redaction properties.
- **Mutation control:** neutering the pattern turns 10 checks red; restoring it returns green. The test fails on the thing it exists to catch.
- Module self-test green, including idempotence.
- Full `ci.sh` green — `py_compile` across 376 files, 129 integration tests, 27 `scripts/` suites, 19 hook suites, shellcheck, utf8 console guard, dormancy invariant clean.

Related: MYC-844, which tracks unifying the divergent pattern copies. This is that ticket's backfill step for one shape, not the unification itself.

Drafted with Claude Code; gate run and mutation control verified before merge.
