### PR TITLE
fix(vault-backup): verify refused the .tar.gz snapshots the sh half writes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,28 @@ description: What's new in AI Brain Starter — plain English, no jargon
 
 ---
 
+## 2026-08-24: on Windows, "your backup is not a supported format" was the opener, not the backup
+
+**Who this affects:** Windows users who set their backup up with the `bash ... vault-backup.sh setup` command — which is the one the install walks you through.
+
+There are two halves to the backup feature, one written in bash and one in PowerShell, and they share a settings file and a destination folder. What they do not share is the kind of file they write: the bash half writes `.tar.gz`, the PowerShell half writes `.zip`. That was fine as long as nobody crossed the streams.
+
+They cross on Windows, routinely. The install hands you the bash command, and it runs perfectly well there under Git Bash. But the reminder that appears at the start of a session — the one that says *prove your backup restores* — hands Windows users the PowerShell command. Run it, and you got this:
+
+```
+.gpg is not a supported archive file format. .zip is the only supported archive file format.
+```
+
+Which reads like the backup is corrupt. It was not. Every one of those snapshots was fine and would have restored perfectly. The tool that was supposed to reassure you was holding the wrong opener and blaming the file.
+
+That is the part worth fixing carefully, because of *when* it happens. Nobody runs a restore drill on a good day. You run it the morning you are worried, and that morning it told you the one thing you did not want to hear, incorrectly.
+
+**Now `verify` looks at what the file actually is** and picks the matching opener — `.zip` or `.tar.gz`, encrypted or not. Everything that already worked keeps working, and a file that is genuinely neither now says so in a sentence you can read, instead of an exception about a `.zip` you never had.
+
+**One related trap, also closed.** The two halves store the encryption passphrase in files with the *same name* and different formats. When the PowerShell half met the bash half's passphrase, it threw a raw cryptography error that reads as a damaged secret. It now recognises the situation and hands you the bash command that works.
+
+**What you should do:** nothing. If you ever saw that "not a supported archive file format" message, your backups were never the problem — check them once more after updating and you should see the file count come back.
+
 ## 2026-08-19: the privacy checker no longer publishes the private word list it checks for
 
 **Who this affects:** anyone who publishes repos with this starter installed, and anyone who forked one of ours.

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -243,6 +243,7 @@ INTEGRATION_TESTS=(
   test_footprint_sla
   test_vault_safety_guards
   test_vault_backup_conf_bom
+  test_vault_backup_ps1_archive_dispatch
   test_backup_staleness_surfaces
   test_home_fingerprint_noise
   test_scheduled_task_registration

--- a/scripts/vault-backup.ps1
+++ b/scripts/vault-backup.ps1
@@ -100,7 +100,22 @@ function Store-Passphrase { param([string]$slug, [string]$plain)
 function Get-Passphrase { param([string]$slug)
   $pf = Join-Path $env:USERPROFILE ".claude\.vault-backup-pass-$slug"
   if (-not (Test-Path -LiteralPath $pf)) { return $null }
-  $secure = ((Get-Content -Raw -LiteralPath $pf) -replace '[^0-9A-Fa-f]', '') | ConvertTo-SecureString
+  # Same file name, two formats. This script writes a DPAPI blob here;
+  # vault-backup.sh writes the passphrase itself to the identically-named file.
+  # When the .sh half set this vault up, ConvertTo-SecureString throws a raw
+  # CryptographicException ("El parametro no es correcto" / "Key not valid"),
+  # which reads as a damaged secret. Name the real cause and hand over the
+  # command that works instead.
+  try {
+    $secure = ((Get-Content -Raw -LiteralPath $pf) -replace '[^0-9A-Fa-f]', '') | ConvertTo-SecureString -ErrorAction Stop
+  } catch {
+    $shPath = Join-Path $PSScriptRoot "vault-backup.sh"
+    if (Test-Path -LiteralPath $shPath) {
+      Die ("this vault was set up by vault-backup.sh, whose passphrase store this script cannot read.`n" +
+           "     Use:  bash `"$shPath`" $Command --vault `"$(Resolve-Vault $Vault)`"")
+    }
+    Die "cannot read the stored passphrase at $pf (not a DPAPI blob written by this script)"
+  }
   $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secure)
   try { return [Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr) }
   finally { [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr) }
@@ -314,22 +329,64 @@ function Cmd-Verify {
   New-Item -ItemType Directory -Force -Path $tmp | Out-Null
   Say "Restoring $($newest.FullName) to a temp dir to prove it works..."
   try {
-    if ($newest.Name -like "*.zip.gpg") {
+    # DISPATCH ON THE ARCHIVE THAT IS ACTUALLY THERE, not on the one this script
+    # would have written. Both halves of the product write into the same
+    # destination folder and share ~/.claude/.vault-backup.conf: vault-backup.ps1
+    # writes .zip/.zip.gpg, vault-backup.sh writes .tar.gz/.tar.gz.gpg. The
+    # install phases hand every user the .sh setup command (phases/phase-01 and
+    # phase-12-17), and it runs fine on Windows under Git Bash, so a Windows
+    # vault very often holds .tar.gz.gpg snapshots. Verifying only zip fed the
+    # .gpg straight to Expand-Archive:
+    #     ".gpg is not a supported archive file format. .zip is the only
+    #      supported archive file format."
+    # which reads as a CORRUPT BACKUP. The backup was fine; the opener was wrong.
+    # That is the worst possible error to get wrong: the one moment a user goes
+    # looking for reassurance is the one moment this told them they had none.
+    $archive = $newest.FullName
+    if ($newest.Name -like "*.gpg") {
       $gpg = Get-Command gpg -ErrorAction SilentlyContinue
       if (-not $gpg) { Die "cannot decrypt: gpg not found" }
       $slug = if ($e.keychain_account) { $e.keychain_account } else { Slug-For $v }
       $pass = Get-Passphrase $slug
-      $zip = Join-Path $tmp "restore.zip"
+      # Keep the inner extension (foo.tar.gz.gpg -> restore.tar.gz) so the
+      # extractor below can still tell what kind of archive it is.
+      $inner = [IO.Path]::GetFileNameWithoutExtension($newest.Name)
+      if ($inner -like "*.tar.gz") {
+        $plain = Join-Path $tmp "restore.tar.gz"
+      } else {
+        $plain = Join-Path $tmp ("restore" + [IO.Path]::GetExtension($inner))
+      }
       $prevEAP = $ErrorActionPreference; $ErrorActionPreference = 'Continue'
-      & $gpg.Source --batch --yes --pinentry-mode loopback --passphrase $pass -o $zip -d $newest.FullName 2>$null
+      & $gpg.Source --batch --yes --pinentry-mode loopback --passphrase $pass -o $plain -d $newest.FullName 2>$null
       $gpgCode = $LASTEXITCODE
       $ErrorActionPreference = $prevEAP
-      if ($gpgCode -ne 0 -or -not (Test-Path -LiteralPath $zip)) { Die "gpg decryption failed (exit $gpgCode)" }
-      Expand-Archive -LiteralPath $zip -DestinationPath $tmp -Force
-      Remove-Item -LiteralPath $zip -Force
-    } else {
-      Expand-Archive -LiteralPath $newest.FullName -DestinationPath $tmp -Force
+      if ($gpgCode -ne 0 -or -not (Test-Path -LiteralPath $plain)) { Die "gpg decryption failed (exit $gpgCode)" }
+      $archive = $plain
     }
+    if ($archive -like "*.tar.gz" -or $archive -like "*.tgz") {
+      # Prefer the tar Windows ships in System32 (bsdtar): GNU tar, which is what
+      # Git for Windows puts on PATH, reads the colon in C:\... as a remote host
+      # and refuses the path outright.
+      $sysTar = Join-Path $env:SystemRoot "System32\tar.exe"
+      if ($env:SystemRoot -and (Test-Path -LiteralPath $sysTar)) {
+        $tarExe = $sysTar
+      } else {
+        $tarCmd = Get-Command tar -ErrorAction SilentlyContinue
+        if (-not $tarCmd) { Die "cannot open $([IO.Path]::GetFileName($archive)): tar not found on PATH" }
+        $tarExe = $tarCmd.Source
+      }
+      $prevEAP = $ErrorActionPreference; $ErrorActionPreference = 'Continue'
+      & $tarExe -xzf $archive -C $tmp 2>$null
+      $tarCode = $LASTEXITCODE
+      $ErrorActionPreference = $prevEAP
+      if ($tarCode -ne 0) { Die "tar could not extract $([IO.Path]::GetFileName($archive)) (exit $tarCode)" }
+    } elseif ($archive -like "*.zip") {
+      Expand-Archive -LiteralPath $archive -DestinationPath $tmp -Force
+    } else {
+      Die "don't know how to open $($newest.Name) - expected .zip, .tar.gz, or either with .gpg"
+    }
+    # Drop the decrypted copy before counting, so it cannot pad the file count.
+    if ($archive -ne $newest.FullName) { Remove-Item -LiteralPath $archive -Force -ErrorAction SilentlyContinue }
     $count = (Get-ChildItem -Recurse -File -LiteralPath $tmp -ErrorAction SilentlyContinue).Count
     if ($count -lt 1) { Die "restore produced ZERO files - the backup is empty/broken" }
     $sentinel = if (Test-Path -LiteralPath (Join-Path $tmp "CLAUDE.md")) { ", CLAUDE.md present" } else { "" }

--- a/scripts/vault-backup.ps1
+++ b/scripts/vault-backup.ps1
@@ -367,10 +367,15 @@ function Cmd-Verify {
       # Prefer the tar Windows ships in System32 (bsdtar): GNU tar, which is what
       # Git for Windows puts on PATH, reads the colon in C:\... as a remote host
       # and refuses the path outright.
-      $sysTar = Join-Path $env:SystemRoot "System32\tar.exe"
-      if ($env:SystemRoot -and (Test-Path -LiteralPath $sysTar)) {
-        $tarExe = $sysTar
-      } else {
+      # $env:SystemRoot is null off Windows, and Join-Path throws on a null
+      # -Path, so the lookup itself has to sit inside the guard -- not just the
+      # Test-Path. (Caught by this file's own suite on the Linux runner.)
+      $tarExe = $null
+      if ($env:SystemRoot) {
+        $sysTar = Join-Path $env:SystemRoot "System32\tar.exe"
+        if (Test-Path -LiteralPath $sysTar) { $tarExe = $sysTar }
+      }
+      if (-not $tarExe) {
         $tarCmd = Get-Command tar -ErrorAction SilentlyContinue
         if (-not $tarCmd) { Die "cannot open $([IO.Path]::GetFileName($archive)): tar not found on PATH" }
         $tarExe = $tarCmd.Source

--- a/tests/integration/test_vault_backup_ps1_archive_dispatch.ps1
+++ b/tests/integration/test_vault_backup_ps1_archive_dispatch.ps1
@@ -1,0 +1,228 @@
+﻿#!/usr/bin/env pwsh
+# Test that `vault-backup.ps1 verify` opens the archive that is ACTUALLY there.
+#
+# THE BUG
+# -------
+# Both halves of the backup feature write into the same destination folder and
+# share ~/.claude/.vault-backup.conf, but they do not write the same kind of
+# archive: vault-backup.ps1 writes .zip/.zip.gpg, vault-backup.sh writes
+# .tar.gz/.tar.gz.gpg. Verify only ever handled zip, so a vault whose snapshots
+# came from the .sh half fed the archive straight to Expand-Archive and got:
+#
+#     ".gpg is not a supported archive file format. .zip is the only supported
+#      archive file format."
+#
+# That is not an obscure combination. The install phases hand every user the
+# .sh setup command (phases/phase-01-welcome.md, phases/phase-12-17-imports-
+# rules.md), it runs fine on Windows under Git Bash, and surface-backup-status.py
+# then hands that same user the .ps1 command on Windows. Nothing warns them the
+# two do not interoperate.
+#
+# The failure mode is what makes it worth a test: the backup is FINE and the
+# tool says it is broken, at the one moment a user goes looking for reassurance.
+#
+# COVERED HERE
+#   A. .tar.gz snapshot verifies. THE REPORTED CASE. Paired with a NEGATIVE
+#      CONTROL that Expand-Archive really does refuse that same file, so this
+#      cannot pass because the fixture forgot to model the bug.
+#   B. .zip snapshot still verifies. The "changes nothing that worked" claim.
+#   C. An extension neither half writes fails with a sentence that names the
+#      problem, instead of an archive-format exception about a .zip nobody asked
+#      for.
+#   D. An EMPTY .tar.gz still reports ZERO files. The whole point of verify is
+#      opening the archive; teaching it a new format must not cost that.
+#   E. A .gpg snapshot whose passphrase store was written by the .sh half points
+#      at the command that works, instead of throwing a raw
+#      CryptographicException that reads as a damaged secret.
+#      SKIPPED (loudly) where gpg is absent: verify checks for gpg first.
+#
+# Runs on Windows PowerShell 5.1 and on pwsh 7 (macOS/Linux).
+# Self-contained; no network; never writes outside its own temp dir, and never
+# touches the real ~/.claude/.vault-backup.conf (VAULT_BACKUP_CONF is redirected).
+
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$Script   = Join-Path (Join-Path $RepoRoot "scripts") "vault-backup.ps1"
+if (-not (Test-Path -LiteralPath $Script)) {
+    Write-Host "ERROR: $Script not found" -ForegroundColor Red
+    exit 1
+}
+
+$PSExe = [System.Diagnostics.Process]::GetCurrentProcess().MainModule.FileName
+$IsWin = ($env:OS -eq "Windows_NT")
+
+$Failures = 0
+$Root = Join-Path ([IO.Path]::GetTempPath()) ("vbk-dispatch-" + [Guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Force -Path $Root | Out-Null
+
+function Fail($m) { $script:Failures++; Write-Host "FAIL $m" -ForegroundColor Red }
+function Pass($m) { Write-Host "PASS $m" -ForegroundColor Green }
+function Skip($m) { Write-Host "SKIP $m" -ForegroundColor Yellow }
+
+function Find-Tar {
+    if ($IsWin) {
+        $sys = Join-Path $env:SystemRoot "System32\tar.exe"
+        if (Test-Path -LiteralPath $sys) { return $sys }
+    }
+    $c = Get-Command tar -ErrorAction SilentlyContinue
+    if ($c) { return $c.Source }
+    return $null
+}
+
+# One disposable vault + destination + conf per case, so no case can inherit
+# another's state (a stale last_verify would make a broken case look fine).
+function New-Case {
+    param([string]$name, [bool]$withContent = $true)
+    $case  = Join-Path $Root $name
+    $vault = Join-Path $case "vault"
+    $dest  = Join-Path $case "dest"
+    New-Item -ItemType Directory -Force -Path $vault | Out-Null
+    New-Item -ItemType Directory -Force -Path $dest  | Out-Null
+    if ($withContent) {
+        Set-Content -LiteralPath (Join-Path $vault "CLAUDE.md") -Value "# test vault" -Encoding UTF8
+        Set-Content -LiteralPath (Join-Path $vault "note.md")   -Value "hello"        -Encoding UTF8
+    }
+    $conf = Join-Path $case "conf.json"
+    $key  = (Resolve-Path -LiteralPath $vault).Path
+    $obj  = [pscustomobject]@{ vaults = [pscustomobject]@{} }
+    $obj.vaults | Add-Member -NotePropertyName $key -NotePropertyValue ([pscustomobject]@{
+        dest = $dest; encrypt = $false; keep = 7; last = "2026-01-01T00:00:00Z"
+    }) -Force
+    $obj | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $conf -Encoding UTF8
+    return [pscustomobject]@{ Vault = $key; Dest = $dest; Conf = $conf }
+}
+
+function Invoke-Verify {
+    param([pscustomobject]$c)
+    $env:VAULT_BACKUP_CONF = $c.Conf
+    $args = @("-NoProfile")
+    if ($IsWin) { $args += @("-ExecutionPolicy", "Bypass") }
+    $args += @("-File", $Script, "verify", "-Vault", $c.Vault)
+    # EAP must drop to Continue around the child. Under 'Stop', Windows
+    # PowerShell 5.1 turns a native command's stderr into a TERMINATING
+    # NativeCommandError, so the first case whose script writes to stderr would
+    # abort the whole suite instead of being reported as one FAIL -- which is
+    # exactly what a regression looks like, and exactly when the other cases
+    # matter most.
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        $out = & $PSExe @args 2>&1 | Out-String
+        $code = $LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $prevEAP
+    }
+    return [pscustomobject]@{ Code = $code; Out = $out }
+}
+
+$Tar = Find-Tar
+if (-not $Tar) {
+    Write-Host "ERROR: no tar on PATH; this suite cannot build its fixtures" -ForegroundColor Red
+    exit 1
+}
+
+# ---------------------------------------------------------------- A: .tar.gz --
+$c = New-Case "a-targz"
+$snap = Join-Path $c.Dest "vault-backup-20260101-120000.tar.gz"
+& $Tar -czf $snap -C $c.Vault "CLAUDE.md" "note.md"
+if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $snap)) {
+    Fail "A: could not build the .tar.gz fixture"
+} else {
+    # NEGATIVE CONTROL FIRST: prove Expand-Archive really refuses this file. If
+    # some future PowerShell learns tar, this control fails and tells us the
+    # test stopped modelling the bug -- rather than passing for a stale reason.
+    $ctl = Join-Path $Root "a-control"
+    New-Item -ItemType Directory -Force -Path $ctl | Out-Null
+    $refused = $false
+    try { Expand-Archive -LiteralPath $snap -DestinationPath $ctl -Force } catch { $refused = $true }
+    if (-not $refused) {
+        Fail "A(control): Expand-Archive accepted a .tar.gz, so this case no longer models the bug"
+    } else {
+        Pass "A(control): Expand-Archive refuses a .tar.gz, as the bug requires"
+    }
+
+    $r = Invoke-Verify $c
+    if ($r.Code -eq 0 -and $r.Out -match "Restore verified" -and $r.Out -match "CLAUDE\.md present") {
+        Pass "A: a .tar.gz snapshot verifies"
+    } else {
+        Fail "A: .tar.gz did not verify (exit $($r.Code)): $($r.Out.Trim())"
+    }
+}
+
+# ------------------------------------------------------------------- B: .zip --
+$c = New-Case "b-zip"
+$snap = Join-Path $c.Dest "vault-backup-20260101-120000.zip"
+Compress-Archive -Path (Join-Path $c.Vault "*") -DestinationPath $snap -Force
+$r = Invoke-Verify $c
+if ($r.Code -eq 0 -and $r.Out -match "Restore verified") {
+    Pass "B: a .zip snapshot still verifies"
+} else {
+    Fail "B: .zip regressed (exit $($r.Code)): $($r.Out.Trim())"
+}
+
+# ------------------------------------------------------- C: unknown extension --
+$c = New-Case "c-unknown"
+$snap = Join-Path $c.Dest "vault-backup-20260101-120000.rar"
+Set-Content -LiteralPath $snap -Value "not really an archive" -Encoding UTF8
+$r = Invoke-Verify $c
+if ($r.Code -ne 0 -and $r.Out -match "don't know how to open") {
+    Pass "C: an unknown extension says so plainly"
+} else {
+    Fail "C: expected a plain 'don't know how to open' (exit $($r.Code)): $($r.Out.Trim())"
+}
+
+# ---------------------------------------------------------- D: empty .tar.gz --
+$c = New-Case "d-empty" $false
+$empty = Join-Path $Root "d-empty-src"
+New-Item -ItemType Directory -Force -Path $empty | Out-Null
+$snap = Join-Path $c.Dest "vault-backup-20260101-120000.tar.gz"
+& $Tar -czf $snap -C $empty "."
+if ($LASTEXITCODE -ne 0) {
+    Fail "D: could not build the empty .tar.gz fixture"
+} else {
+    $r = Invoke-Verify $c
+    if ($r.Code -ne 0 -and $r.Out -match "ZERO files") {
+        Pass "D: an empty .tar.gz is still reported as empty"
+    } else {
+        Fail "D: an empty archive passed as a good backup (exit $($r.Code)): $($r.Out.Trim())"
+    }
+}
+
+# ------------------------------------------- E: .sh-written passphrase store --
+if (-not (Get-Command gpg -ErrorAction SilentlyContinue)) {
+    Skip "E: gpg not installed here; verify stops at its own gpg check before reaching the passphrase"
+} else {
+    $c = New-Case "e-shpass"
+    $snap = Join-Path $c.Dest "vault-backup-20260101-120000.tar.gz.gpg"
+    Set-Content -LiteralPath $snap -Value "encrypted bytes" -Encoding UTF8
+    # Point the passphrase lookup at a disposable home and plant the .sh half's
+    # format there: the passphrase itself, not a DPAPI blob.
+    $home2 = Join-Path $Root "e-home"
+    New-Item -ItemType Directory -Force -Path (Join-Path $home2 ".claude") | Out-Null
+    Set-Content -LiteralPath (Join-Path $home2 ".claude\.vault-backup-pass-testslug") `
+        -Value "s3cr3t-passphrase-not-a-dpapi-blob" -Encoding UTF8
+    $conf = Get-Content -Raw -LiteralPath $c.Conf | ConvertFrom-Json
+    $conf.vaults.($c.Vault) | Add-Member -NotePropertyName keychain_account -NotePropertyValue "testslug" -Force
+    $conf.vaults.($c.Vault) | Add-Member -NotePropertyName encrypt -NotePropertyValue $true -Force
+    $conf | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $c.Conf -Encoding UTF8
+
+    $savedProfile = $env:USERPROFILE
+    $env:USERPROFILE = $home2
+    try { $r = Invoke-Verify $c } finally { $env:USERPROFILE = $savedProfile }
+
+    if ($r.Code -ne 0 -and $r.Out -match "vault-backup\.sh" -and $r.Out -notmatch "CryptographicException") {
+        Pass "E: a .sh-written passphrase store points at the command that works"
+    } else {
+        Fail "E: expected a pointer to vault-backup.sh (exit $($r.Code)): $($r.Out.Trim())"
+    }
+}
+
+Remove-Item -Recurse -Force -LiteralPath $Root -ErrorAction SilentlyContinue
+
+if ($Failures -gt 0) {
+    Write-Host "$Failures case(s) failed" -ForegroundColor Red
+    exit 1
+}
+Write-Host "all cases passed" -ForegroundColor Green
+exit 0

--- a/tests/integration/test_vault_backup_ps1_archive_dispatch.sh
+++ b/tests/integration/test_vault_backup_ps1_archive_dispatch.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# CI integration wrapper - runs the PowerShell archive-dispatch suite
+# (tests/integration/test_vault_backup_ps1_archive_dispatch.ps1) as part of
+# scripts/ci.sh. Same pattern as test_bootstrap_ps1_python_discovery.sh: pwsh is
+# preinstalled on GitHub's ubuntu-latest runner, so CI always exercises it; if
+# pwsh is absent locally we LOUDLY skip rather than block a contributor's other
+# gates.
+#
+# NOTE ON COVERAGE: on a Linux runner this proves the DISPATCH logic - which
+# opener gets chosen for which archive, and that the empty-archive guard still
+# bites. It cannot prove the Windows-only halves: Windows PowerShell 5.1
+# semantics, and the System32 bsdtar preference that exists because Git for
+# Windows puts GNU tar on PATH and GNU tar reads C:\... as a remote host.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+
+if ! command -v pwsh >/dev/null 2>&1; then
+  echo "SKIP: pwsh not installed here; CI's ubuntu runner enforces this suite."
+  echo "      install: brew install --cask powershell (macOS) / https://aka.ms/powershell (other)"
+  exit 0
+fi
+
+pwsh -NoProfile -File "$ROOT/tests/integration/test_vault_backup_ps1_archive_dispatch.ps1"


### PR DESCRIPTION
`vault-backup.ps1 verify` only ever opened `.zip`, so on Windows it refused the `.tar.gz` snapshots the bash half writes — and the refusal reads as a corrupt backup.

## What happens

```
> powershell -File vault-backup.ps1 verify
Restoring ...\vault-backup-20260823-130002.tar.gz.gpg to a temp dir to prove it works...
Expand-Archive : .gpg is not a supported archive file format. .zip is the only
supported archive file format.
```

The backup was fine. It restores, with everything in it. The opener was wrong.

## Why this is a normal path, not an exotic one

The two halves share `~/.claude/.vault-backup.conf` and the destination folder, but not the archive format: `vault-backup.sh` writes `.tar.gz[.gpg]`, `vault-backup.ps1` writes `.zip[.gpg]`. Three things bring a Windows user to the crossing:

1. The install hands out the **bash** setup command — `phases/phase-01-welcome.md:291` and `phases/phase-12-17-imports-rules.md:114` — and it works fine on Windows under Git Bash. So the snapshots on disk are `.tar.gz.gpg`.
2. `hooks/surface-backup-status.py:58-62` picks its commands by platform, so on Windows that same user is told to verify with **`vault-backup.ps1`**.
3. `Cmd-Verify` matched only `*.zip.gpg` and sent everything else to `Expand-Archive`.

Nothing warns that the two do not interoperate, and `status` does not notice either — it reads names and timestamps, which are perfectly fine on a `.tar.gz`.

The reason I think this one is worth the diff: nobody runs a restore drill on a good day. They run it the morning they are worried — and that morning the product told them, incorrectly, that their backup was unreadable. It is the same "the check is broken, not the thing" class as the 2026-08-15 empty-archive entry, one layer up.

## The change

**`scripts/vault-backup.ps1`**

- `Cmd-Verify` now dispatches on the extension that is actually there: `.zip`, `.tar.gz`, either with `.gpg`. Decryption is split from extraction, so `foo.tar.gz.gpg` decrypts to `restore.tar.gz` and the extractor can still tell what it is. Anything genuinely unknown gets one readable sentence instead of an exception about a `.zip` the user never had.
- For tar it prefers `%SystemRoot%\System32\tar.exe` (bsdtar). Git for Windows puts **GNU** tar on PATH, and GNU tar reads the colon in `C:\...` as a remote host and refuses the path — so picking whatever `tar` resolves to would have swapped one confusing failure for another.
- `Get-Passphrase`: the two halves write the passphrase to files with the **same name** and different formats (DPAPI blob vs. the passphrase itself). Meeting the other half's file threw a raw `CryptographicException`, which reads as a damaged secret. It now says which half owns the vault and prints the `bash ... vault-backup.sh` command that works.

**Tests** — `tests/integration/test_vault_backup_ps1_archive_dispatch.{ps1,sh}`, wired into `scripts/ci.sh`, same wrapper pattern as `test_bootstrap_ps1_python_discovery.sh` (pwsh on the ubuntu runner, loud skip locally without it).

| | case |
|---|---|
| A | `.tar.gz` verifies — the reported case, with a **negative control** asserting `Expand-Archive` really does refuse that same file, so it cannot pass for a stale reason |
| B | `.zip` still verifies |
| C | an unknown extension says so plainly |
| D | an **empty** `.tar.gz` still reports ZERO files — teaching it a format must not cost the guard that is the whole point of `verify` |
| E | a `.sh`-written passphrase store points at the working command instead of throwing (loud skip where gpg is absent, since `verify` checks for gpg first) |

Against unpatched `main` on Windows PowerShell 5.1: **A, C, D, E fail, B passes, control passes.** With the patch: all six pass. Also run under the same 5.1 host that CI's `windows-install` job uses.

One thing found while writing it, worth mentioning because it bites any `.ps1` suite here: under `$ErrorActionPreference = 'Stop'`, 5.1 turns a child process's stderr into a terminating `NativeCommandError`, so the first failing case aborted the whole run instead of being reported. The harness drops to `Continue` around the child and restores it after — noted in the test.

## Not done here, on purpose

`surface-backup-status.py` still picks its command by platform alone, so on Windows it names the `.ps1` half regardless of which half owns the vault. With this PR that is no longer a dead end — the user gets pointed at the right command — but the honest fix is to choose by evidence (which archives and which passphrase format exist) rather than by `os.name`. Happy to do it in a follow-up if you want it; it seemed like a separate decision from making `verify` work.

`docs/RELEASES.md` untouched: it is versioned per release and the recent fixes I looked at land in `CHANGELOG.md` only. Say the word if you would rather have an entry there too.

## Checks

`bash scripts/ci.sh` locally, plus `scripts/check-ps1-encoding.sh` (BOM + no em dash) and `[Parser]::ParseFile` on both `.ps1` files.
