### PR TITLE
fix(bootstrap): wire three shipped skills into the install lists, on both platforms

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -1277,7 +1277,7 @@ if ((Test-Path "$SkillDir\SKILL.md") -or $DryRun) { Ok "ai-brain-starter at $Ski
 Hdr "Installing bundled sub-skills (with safety checks)"
 $stamp = Get-Date -Format "yyyy-MM-dd-HHmm"
 
-foreach ($sub in @("graphify", "cierre-de-llamada", "meeting-todos", "patterns", "insights", "deconstruct", "daily-journal", "rise", "repurpose-talk", "nano-banana", "second-brain-mapping", "setup-vault-types", "diagnose", "note-todos", "sunday-review", "coach", "coaching", "backfill-journal-body-context", "longitudinal", "resolver-query", "for-my-team", "health-context", "health-doctor", "health-setup", "ingest-github", "ingest-health", "ingest-youtube", "evolve", "instinct-export", "instinct-import", "interview-me", "doubt-driven-development", "secret-warn")) {
+foreach ($sub in @("graphify", "cierre-de-llamada", "meeting-todos", "patterns", "insights", "deconstruct", "daily-journal", "rise", "repurpose-talk", "nano-banana", "second-brain-mapping", "setup-vault-types", "diagnose", "note-todos", "sunday-review", "coach", "coaching", "backfill-journal-body-context", "longitudinal", "resolver-query", "for-my-team", "health-context", "health-doctor", "health-setup", "ingest-github", "ingest-health", "ingest-youtube", "evolve", "instinct-export", "instinct-import", "interview-me", "doubt-driven-development", "secret-warn", "optimize-brain", "security-snapshot", "vault-system", "skillify-meta-loop")) {
     $src = "$SkillDir\skills\$sub"
     $dst = "$env:USERPROFILE\.claude\skills\$sub"
 
@@ -1503,7 +1503,7 @@ if ($DryRun) {
 foreach ($pair in @(@("graphify","graphify"), @("node","node"), @("npm","npm"), @("pipx","pipx"), @("gh","gh"))) {
     if (Have $pair[1]) { Ok $pair[0] } else { Err "$($pair[0]) not callable" }
 }
-foreach ($sub in @("graphify","cierre-de-llamada","meeting-todos","patterns","insights","deconstruct","daily-journal","rise","repurpose-talk","nano-banana","humanizer","ai-brain-starter","diagnose","second-brain-mapping","setup-vault-types","note-todos","sunday-review","coach","coaching","backfill-journal-body-context","longitudinal","resolver-query","for-my-team","health-context","health-doctor","health-setup","ingest-github","ingest-health","ingest-youtube","evolve","instinct-export","instinct-import","interview-me","doubt-driven-development","secret-warn")) {
+foreach ($sub in @("graphify","cierre-de-llamada","meeting-todos","patterns","insights","deconstruct","daily-journal","rise","repurpose-talk","nano-banana","humanizer","ai-brain-starter","diagnose","second-brain-mapping","setup-vault-types","note-todos","sunday-review","coach","coaching","backfill-journal-body-context","longitudinal","resolver-query","for-my-team","health-context","health-doctor","health-setup","ingest-github","ingest-health","ingest-youtube","evolve","instinct-export","instinct-import","interview-me","doubt-driven-development","secret-warn","optimize-brain","security-snapshot","vault-system","skillify-meta-loop")) {
     if (Test-Path "$env:USERPROFILE\.claude\skills\$sub") { Ok "skill: $sub" } else { Err "skill missing: $sub" }
 }
 if (Test-Path "$env:USERPROFILE\.claude\skills\graphify\scripts") { Ok "graphify scripts" } else { Err "graphify scripts missing" }

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1572,7 +1572,7 @@ SKILL_FORKS=()
 SKILL_SYMLINKS=()
 SKILLS_TO_SYNC=()
 
-for sub in graphify cierre-de-llamada meeting-todos patterns insights deconstruct daily-journal rise repurpose-talk nano-banana second-brain-mapping setup-vault-types diagnose note-todos sunday-review coach coaching backfill-journal-body-context longitudinal resolver-query for-my-team health-context health-doctor health-setup ingest-github ingest-health ingest-youtube evolve instinct-export instinct-import interview-me longitudinal doubt-driven-development secret-warn optimize-brain; do
+for sub in graphify cierre-de-llamada meeting-todos patterns insights deconstruct daily-journal rise repurpose-talk nano-banana second-brain-mapping setup-vault-types diagnose note-todos sunday-review coach coaching backfill-journal-body-context longitudinal resolver-query for-my-team health-context health-doctor health-setup ingest-github ingest-health ingest-youtube evolve instinct-export instinct-import interview-me longitudinal doubt-driven-development secret-warn optimize-brain security-snapshot vault-system skillify-meta-loop; do
   dst="$HOME/.claude/skills/$sub"
 
   if [[ -L "$dst" ]]; then
@@ -2079,7 +2079,7 @@ for check in "${CHECKS[@]}"; do
   fi
 done
 # Skill folders (full bundled set + humanizer + ai-brain-starter itself)
-for sub in graphify cierre-de-llamada meeting-todos patterns insights deconstruct daily-journal rise repurpose-talk nano-banana humanizer ai-brain-starter diagnose second-brain-mapping setup-vault-types note-todos sunday-review coach coaching backfill-journal-body-context longitudinal resolver-query for-my-team health-context health-doctor health-setup ingest-github ingest-health ingest-youtube evolve instinct-export instinct-import interview-me doubt-driven-development secret-warn optimize-brain; do
+for sub in graphify cierre-de-llamada meeting-todos patterns insights deconstruct daily-journal rise repurpose-talk nano-banana humanizer ai-brain-starter diagnose second-brain-mapping setup-vault-types note-todos sunday-review coach coaching backfill-journal-body-context longitudinal resolver-query for-my-team health-context health-doctor health-setup ingest-github ingest-health ingest-youtube evolve instinct-export instinct-import interview-me doubt-driven-development secret-warn optimize-brain security-snapshot vault-system skillify-meta-loop; do
   if [[ -d "$HOME/.claude/skills/$sub" ]]; then
     ok "skill: $sub"
   else


### PR DESCRIPTION
## What

`security-snapshot`, `vault-system` and `skillify-meta-loop` ship as complete skills under `skills/` but are named in **none** of bootstrap's four hardcoded skill lists. The install loop copies only what its list names, so a fresh clone installs them on no platform.

While fixing that, `bootstrap.ps1` turned out to also be missing `optimize-brain`. That name was added to `bootstrap.sh` earlier today by #592, so **that fix is currently macOS/Linux-only** — `/optimize-brain`, the last instruction the installer gives a new client and the headline defect #592 exists to fix, is still broken on Windows. Fixed here so the two installers don't ship the same class of gap twice.

## Evidence

Measured against `git ls-tree origin/main skills/` (37 skill dirs + `_shared`):

| list | before | after |
|---|---|---|
| `bootstrap.sh:1575` (install → `SKILLS_TO_SYNC`) | missing 3 | complete |
| `bootstrap.sh:2082` (verify) | missing 3 | complete |
| `bootstrap.ps1:1280` (install) | missing 4 | complete |
| `bootstrap.ps1:1506` (verify) | missing 4 | complete |

`docs/RELEASES.md` (2026-06-20) records `security-snapshot` as a deliberately restored free asset, and MYC-1339 restored the files without ever wiring the installer — so this is a wiring gap, not a ship decision.

After this change the sh and ps1 lists are set-equal. `humanizer` and `ai-brain-starter` remain verify-only in both files by design (installed by other paths).

## Verification

- `bash -n bootstrap.sh` → clean
- PowerShell `Parser::ParseFile` on `bootstrap.ps1` → clean (pwsh present locally)
- The **shipped sync loop, extracted verbatim**, run against a sandboxed `HOME`: all four names appear in the `would run sync-skills.sh for:` output
- `.ps1` BOM preserved (gate (e7) checks encoding); edits applied by line number on bytes, not global replace
- Public-repo personal-data scrub: **clean**, via `pii-scrub-local.sh`, which proves each of its 19 gated + 16 markdown patterns against a planted specimen before scanning

`bootstrap.sh` was **not** run for real, and not even with `--dry-run`: `--dry-run` is not fully no-op — it unconditionally writes `~/.claude/commands` (tracked, still open, on MYC-1480) — and this machine's `~/.claude` is a live deployed install.

The local `scripts/ci.sh` run exceeded a 10-minute window inside gate (f) and is still finishing; it had cleared gates (a)–(e). CI here is the authoritative verdict.

## Not in this PR

No guard yet. The existing parity guard on `claude/myc-bootstrap-parity-guard` compares `.claude/<dest>` destination *tokens* — both installers write to `.claude/skills/`, so it cannot see a missing skill *name* inside a list. A check that every `skills/*/` dir appears in all four lists (with a negative control) is the durable half, tracked on MYC-4139 and best folded into `scripts/test_bootstrap_install_parity.py` once that branch lands.

Also spotted, left alone: `bootstrap.sh`'s install list contains `longitudinal` twice. Harmless, worth deleting when the guard lands.

Refs MYC-4139
