### PR TITLE
docs: resolve the two deferred doc-promise tokens by removing the promise

### DIFF
--- a/phases/phase-19-23-finish.md
+++ b/phases/phase-19-23-finish.md
@@ -434,9 +434,9 @@ Leave graphify **off by default**. User decides when.
 
 ### Step 6: Weekly cadence
 
-If they use `/plan week`, their week-plan already checks graph freshness and proposes a run if stale (>7 days).
+Recommend a Monday 10am calendar block for `/second-brain-mapping --metadata-only`. Takes under a minute. Zero tokens. Keeps Claude's context layer fresh.
 
-If not: recommend a Monday 10am calendar block for `/second-brain-mapping --metadata-only`. Takes under a minute. Zero tokens. Keeps Claude's context layer fresh.
+Skip the block only if they already run a weekly planning routine of their own that checks graph freshness and proposes a run when the graph is stale.
 
 ### Step 7: Confirm CRM auto-log
 

--- a/scripts/check-doc-promises.py
+++ b/scripts/check-doc-promises.py
@@ -164,15 +164,29 @@ NON_COMMAND_TOKENS = {
 }
 
 # Confirmed references to something this repo does NOT resolve, found by
-# this script but left unfixed because they are outside MYC-4121's eight
-# findings. Listed here (never silently folded into NON_COMMAND_TOKENS,
-# which is reserved for tokens confirmed NOT to be commands) so a future
-# pass can grep this exact name and decide: ship it, or remove the promise.
-#   /plan (phases/phase-19-23-finish.md) -- "If they use `/plan week`...";
-#     no skill in this repo resolves /plan.
-#   /code-security (skills/sunday-review/SKILL.md) -- escalation target in
-#     the security-cadence model; no skill in this repo resolves it.
-DEFERRED_UNRESOLVED_TOKENS = {"plan", "code-security"}
+# this script but not yet decided. Listed here (never silently folded into
+# NON_COMMAND_TOKENS, which is reserved for tokens confirmed NOT to be
+# commands) so a future pass can grep this exact name and decide: ship it,
+# or remove the promise. EMPTY IS THE CORRECT STEADY STATE -- an entry here
+# is a debt with a name, not an exemption, and it is never the way to
+# silence a finding.
+#
+# Both original entries were resolved by removing the promise (2026-08-24):
+#   /plan (phases/phase-19-23-finish.md) and /code-security
+#   (skills/sunday-review/SKILL.md) are both paid-tier capabilities that live
+#   in a private repo -- not part of the free substrate.
+#   Neither was ever planned or built here (no file on any ref, zero mentions
+#   across CHANGELOG.md), and neither is an externally installable tool like
+#   the obra/superpowers bundle POWER_TOOLS.md documents, so there is no
+#   "install from X" note to write: X is private. The prose was rewritten to
+#   drop the command and keep the advice. Layer 3 of the security-cadence
+#   model now states plainly that this repo does not ship that layer --
+#   security-snapshot (passive, external-only) and secret-warn (edit-time
+#   guardrails) both explicitly disclaim deep review, so neither could stand
+#   in for it. The "removed in v" convention deliberately does NOT apply:
+#   nothing was removed from this repo, and writing it would both fabricate
+#   history and buy a green via REMOVED_MARKER instead of earning one.
+DEFERRED_UNRESOLVED_TOKENS: set[str] = set()
 
 HTTP_VERBS = ("GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS")
 

--- a/skills/sunday-review/SKILL.md
+++ b/skills/sunday-review/SKILL.md
@@ -166,11 +166,11 @@ After the script lands the report, inline a 5-minute Claude pass answering the 6
 5. Has the threat landscape shifted since last check? (Read 2-3 CISA + OWASP + vendor advisories — does any layer need a new pattern?)
 6. Any new public repo / endpoint / agentic surface shipped this week not classified into the 4-layer detection model? (CI-publish workflow-injection / post-publish Dependabot / outbound SSRF / endpoint-installed-state inventory)
 
-The Claude pass surfaces signals INTO the /sunday-review synthesis under a "Security cadence" subsection. If any question's answer is non-trivial → escalate to `/code-security` as event-driven, NOT calendar-driven. The three-layer cadence model:
+The Claude pass surfaces signals INTO the /sunday-review synthesis under a "Security cadence" subsection. If any question's answer is non-trivial → escalate to a full code-security review as event-driven, NOT calendar-driven. The three-layer cadence model:
 
 - **Layer 1** — daily cron (gh-harden + workflow-injection scan + endpoint inventory + Dependabot + hookify family). Auto, no skill invocation.
 - **Layer 2** — weekly meta-audit (this Step 4g via security-cadence-report.py).
-- **Layer 3** — event-driven `/code-security` (new endpoint, new agentic surface, new CVE class, drift escalation from Layer 2). Not calendar.
+- **Layer 3** — event-driven full code-security review (new endpoint, new agentic surface, new CVE class, drift escalation from Layer 2). Not calendar. Not shipped here: `/security-snapshot` is passive and external-only, `/secret-warn` is edit-time guardrails, and both disclaim deep review. Bring your own reviewer.
 
 Source: panel synthesis (Schneier + Charity Majors + Patrick Collison + DHH-dissent, 2026-05-27) on cadence-vs-event-driven security. Bug class prevented: `ARTIFACT-WITH-OVER-STRICT-VERIFICATION` applied to time — over-scheduled verification trains a bypass habit; real fires get ignored. Skip silently if the script is missing.
 


### PR DESCRIPTION
Follow-up to #592, which shipped the doc-promises guard with two confirmed-unresolved slash commands parked in `DEFERRED_UNRESOLVED_TOKENS`: `/plan` and `/code-security`. That comment asked a future pass to grep the names and decide — ship it, or remove the promise. This is that pass. Both are removed and the set is now empty, which is its correct steady state.

## What they turned out to be

Both are paid-tier capabilities living in a private repo, not part of the free substrate.

- **Never planned or built here.** `git log --all --diff-filter=A` for `skills/plan/`, `commands/plan.md`, `skills/code-security/`, `commands/code-security.md` returns nothing on any ref. Positive control: the same query returns `skills/sunday-review/SKILL.md`.
- **Never announced.** Zero mentions across a 3,311-line `CHANGELOG.md`. Positive control: `sunday-review` returns 6 hits through the same engine.
- **Not externally installable.** Unlike the obra/superpowers bundle that `POWER_TOOLS.md` documents as an external MIT clone, there is no URL a public reader can install these from. So there is no "install from X" note to write: X is private.

Provenance also argues against them ever having been a plan here. `/plan` entered as incidental prose inside an unrelated commit (`bee9f3a`, second-brain-mapping cold-install hardening). `/code-security` entered with `cc1e377`, a single-file doc commit whose own message treats it as an already-existing escalation target.

## Why not the "removed in vX.Y.Z" convention

`docs/RELEASES.md` uses that convention for things that existed here and were taken out. Nothing was removed from this repo, so writing it would fabricate history. It would also be a green bought rather than earned: the guard exempts any line carrying `removed in v`, so the tokens would slip through `REMOVED_MARKER` instead of actually resolving.

## What changed instead — keep the advice, drop the command

- **`phases/phase-19-23-finish.md`** now leads with the Monday `/second-brain-mapping --metadata-only` block, the right default for the brand-new user this phase doc is speaking to, and keeps the exception as a generic weekly-planning routine. The old sentence also cited a >7-day staleness threshold that is the private skill's number; this repo's own `scripts/graph-liveness-check.py` uses `DEFAULT_MAX_AGE_DAYS = 45`.
- **`skills/sunday-review/SKILL.md`** keeps the three-layer cadence model intact and now states plainly that this repo does not ship Layer 3. I checked whether a shipped skill could stand in: `security-snapshot` says "NOT for ... application-layer vulnerability assessment" and `secret-warn` says "Not for full security audits, pen testing". Both explicitly disclaim deep review, so naming either would have been a different false promise. The doc discloses the gap and tells the reader to bring their own reviewer.

## Verification

| Gate | Result |
|---|---|
| `--self-test` (14 negative controls) | pass |
| `--fixture-test` (the third CI invocation) | pass |
| Real run | clean, exit 0 |
| `ci-test` (canonical local gate) | GREEN, marker `2333c6f2.ok`, incl. `py3.9 annotation parity` |
| Personal-data scrub | clean; 19 gated + 16 markdown patterns each proven against a planted specimen first |

**The green is earned, not bought.** With the set emptied, re-planting each token turns the guard RED again (exit 1, both files flagged by name and line); restoring returns it to green. Nothing else exempts them now.

The only behavioural change to the guard is that it got strictly stricter: `DEFERRED_UNRESOLVED_TOKENS` is referenced at exactly one site, a membership test. No regex, no exception handler, and no workflow file was touched.

Does **not** close MYC-4121 — its `Done =` predicate carries a third item (`/health-doctor` green on a clean stock install) and these two tokens were never among its eight findings. The branch name deliberately omits the ID so the merge cannot auto-close it.
