### PR TITLE
feat(ci): fail RED when a shipped skill is wired into no bootstrap install list

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1572,7 +1572,7 @@ SKILL_FORKS=()
 SKILL_SYMLINKS=()
 SKILLS_TO_SYNC=()
 
-for sub in graphify cierre-de-llamada meeting-todos patterns insights deconstruct daily-journal rise repurpose-talk nano-banana second-brain-mapping setup-vault-types diagnose note-todos sunday-review coach coaching backfill-journal-body-context longitudinal resolver-query for-my-team health-context health-doctor health-setup ingest-github ingest-health ingest-youtube evolve instinct-export instinct-import interview-me longitudinal doubt-driven-development secret-warn optimize-brain security-snapshot vault-system skillify-meta-loop; do
+for sub in graphify cierre-de-llamada meeting-todos patterns insights deconstruct daily-journal rise repurpose-talk nano-banana second-brain-mapping setup-vault-types diagnose note-todos sunday-review coach coaching backfill-journal-body-context longitudinal resolver-query for-my-team health-context health-doctor health-setup ingest-github ingest-health ingest-youtube evolve instinct-export instinct-import interview-me doubt-driven-development secret-warn optimize-brain security-snapshot vault-system skillify-meta-loop; do
   dst="$HOME/.claude/skills/$sub"
 
   if [[ -L "$dst" ]]; then

--- a/scripts/test_bootstrap_install_parity.py
+++ b/scripts/test_bootstrap_install_parity.py
@@ -120,8 +120,227 @@ def destinations(path: Path, pattern: re.Pattern[str]) -> set[str]:
     ]
     return {m for m in pattern.findall("\n".join(lines))} - IGNORE
 
+# ─────────────────────────────────────────────────────────────────────────────
+# SECOND CHECK: skill-list coverage.
+#
+# The destination check above deliberately IGNOREs "skills" (see IGNORE) --
+# both installers write under .claude/skills, so the destination token matches
+# on both sides and parity looks perfect. That is true and useless: WHICH
+# skills get written is decided by four hardcoded name lists, and a skill
+# missing from a list is invisible to a check that only compares destinations.
+#
+# Measured 2026-08-24 (MYC-4139): security-snapshot, vault-system and
+# skillify-meta-loop shipped as complete skills under skills/ while appearing
+# in none of the four lists, so a fresh clone installed them on no platform.
+# optimize-brain had been added to bootstrap.sh only, leaving the Windows
+# installer's own last instruction (/optimize-brain) broken. Both classes were
+# invisible to every guard in this repo, including the one in this file.
+#
+# A skill dir is the SOURCE OF TRUTH. Adding skills/<name>/SKILL.md and
+# forgetting the lists must fail RED here rather than ship an unreachable skill.
+# ─────────────────────────────────────────────────────────────────────────────
+
+SKILLS_DIR = REPO / "skills"
+
+# Names allowed in a VERIFY list without being in an INSTALL list, because
+# something other than the sub-skill sync puts them on disk. Rationale-tagged,
+# and ratcheted in both directions exactly like KNOWN_GAPS: a row that stops
+# being needed fails as STALE, so this cannot become a parking lot.
+VERIFY_ONLY: dict[str, str] = {
+    "humanizer": (
+        "installed from its own public fork repo, not from skills/ -- it has "
+        "no skills/humanizer dir here, so the install loop must not name it."
+    ),
+    "ai-brain-starter": (
+        "the starter itself, laid down at $SKILL_DIR before the sub-skill loop "
+        "runs; verifying it proves the parent install landed."
+    ),
+}
+
+# `for sub in a b c; do` (bootstrap.sh) and
+# `foreach ($sub in @("a", "b")) {` (bootstrap.ps1).
+SKILL_LIST_RE_SH = re.compile(r"^for sub in (.+?); do\s*$", re.MULTILINE)
+SKILL_LIST_RE_PS = re.compile(r"^foreach \(\$sub in @\((.+?)\)\)\s*\{", re.MULTILINE)
+
+
+def shipped_skills() -> set[str]:
+    """Every skills/<name>/ that carries a SKILL.md.
+
+    SKILL.md presence is the test, not directory presence: skills/_shared/ is
+    support material, not an installable skill, and a bare dir left by a failed
+    checkout must not be demanded of the installers.
+    """
+    if not SKILLS_DIR.is_dir():
+        print(f"FAIL: {SKILLS_DIR} not found - this guard cannot run", file=sys.stderr)
+        raise SystemExit(1)
+    return {
+        d.name for d in SKILLS_DIR.iterdir()
+        if d.is_dir() and (d / "SKILL.md").is_file()
+    }
+
+
+def skill_lists(text: str, kind: str) -> list[list[str]]:
+    """The skill-name lists in one installer, in file order, WITH duplicates.
+
+    Duplicates are preserved so the caller can report them; every other
+    comparison is done on sets.
+    """
+    if kind == "sh":
+        return [m.split() for m in SKILL_LIST_RE_SH.findall(text)]
+    return [re.findall(r'"([^"]+)"', m) for m in SKILL_LIST_RE_PS.findall(text)]
+
+
+def check_skill_lists(sh_text: str, ps_text: str, shipped: set[str]) -> list[str]:
+    """Pure over its inputs so the self-test can drive it with synthetic text."""
+    failures: list[str] = []
+    sh_lists = skill_lists(sh_text, "sh")
+    ps_lists = skill_lists(ps_text, "ps1")
+
+    # Positive control. Without this an extraction that quietly stops matching
+    # reports a perfect, entirely unmeasured pass -- the exact failure mode this
+    # file's other check guards against.
+    if len(sh_lists) != 2 or len(ps_lists) != 2:
+        failures.append(
+            f"  EXTRACTION BROKEN: expected 2 skill lists per installer, found "
+            f"bootstrap.sh={len(sh_lists)}, bootstrap.ps1={len(ps_lists)}.\n"
+            f"      The loop syntax changed and this guard is no longer reading the\n"
+            f"      lists. Fix the regex - do not assume parity is clean."
+        )
+        return failures
+    if any(len(lst) < 20 for lst in sh_lists + ps_lists):
+        failures.append(
+            "  EXTRACTION BROKEN: a skill list parsed to fewer than 20 names.\n"
+            "      Both installers carry 30+; a short list means the regex is\n"
+            "      truncating, not that a list shrank."
+        )
+        return failures
+
+    labelled = [
+        ("bootstrap.sh", "install", sh_lists[0]),
+        ("bootstrap.sh", "verify", sh_lists[1]),
+        ("bootstrap.ps1", "install", ps_lists[0]),
+        ("bootstrap.ps1", "verify", ps_lists[1]),
+    ]
+
+    for fname, role, lst in labelled:
+        # (a) THE BUG THIS EXISTS FOR: a shipped skill named in no list.
+        for name in sorted(shipped - set(lst)):
+            failures.append(
+                f"  UNWIRED SKILL: skills/{name}/ ships but is missing from the\n"
+                f"      {role} list in {fname}. The install loop copies only what its\n"
+                f"      list names, so this skill reaches no user on that platform.\n"
+                f"      Add it to the list."
+            )
+        # (b) a name with no skill dir: a typo, or a skill deleted without
+        #     cleaning the lists. Allowed only with a VERIFY_ONLY reason.
+        for name in sorted(set(lst) - shipped):
+            if name in VERIFY_ONLY and role == "verify":
+                continue
+            why = (
+                "it is VERIFY_ONLY but appears in an INSTALL list, where the loop "
+                "would look for a skills/ dir that does not exist"
+                if name in VERIFY_ONLY
+                else "there is no skills/<name>/SKILL.md"
+            )
+            failures.append(
+                f"  PHANTOM SKILL: {fname} {role} list names '{name}' but {why}."
+            )
+        # (c) hand-edited lists accumulate duplicates; harmless but a tell.
+        dupes = sorted({n for n in lst if lst.count(n) > 1})
+        if dupes:
+            failures.append(
+                f"  DUPLICATE in {fname} {role} list: {', '.join(dupes)}."
+            )
+
+    # (d) stale amnesty, same ratchet as KNOWN_GAPS.
+    every_listed = {n for _, _, lst in labelled for n in lst}
+    for name in sorted(set(VERIFY_ONLY) - every_listed):
+        failures.append(
+            f"  STALE AMNESTY: '{name}' is in VERIFY_ONLY but appears in no list.\n"
+            f"      DELETE the row - a standing exemption nothing uses is how the\n"
+            f"      next real gap gets waved through."
+        )
+    return failures
+
+
+def _self_test() -> None:
+    """Negative controls. A guard that has never failed is not known to work.
+
+    These run on EVERY invocation, not behind a flag: a dead guard and a quiet
+    one print the same thing, and this one is cheap enough that there is no
+    reason to let that ambiguity exist.
+
+    The fixtures carry EVERY VERIFY_ONLY name in their verify lists, because
+    the stale-amnesty ratchet is live here too -- a row missing from the
+    fixture fails these controls exactly as it would fail the real tree. That
+    is intentional: adding a VERIFY_ONLY row you never use breaks the build.
+    """
+    core = [f"s{i}" for i in range(30)] + ["alpha"]
+    verify_extra = sorted(VERIFY_ONLY)
+    shipped = set(core)
+
+    good_sh = (
+        "for sub in " + " ".join(core) + "; do\n"
+        "for sub in " + " ".join(core + verify_extra) + "; do\n"
+    )
+    good_ps = (
+        "foreach ($sub in @(" + ", ".join(f'"{n}"' for n in core) + ")) {\n"
+        "foreach ($sub in @(" + ", ".join(f'"{n}"' for n in core + verify_extra) + ")) {\n"
+    )
+
+    def fails(sh=good_sh, ps=good_ps, shp=shipped):
+        return check_skill_lists(sh, ps, shp)
+
+    assert not fails(), f"control: clean input must PASS, got {fails()}"
+
+    # (1) the bug this guard exists for: a shipped skill named in no list.
+    assert any("UNWIRED SKILL" in f for f in fails(shp=shipped | {"newskill"})), \
+        "control: an unwired shipped skill must FAIL"
+
+    # (2) the SECOND bug from the same incident: wired on one platform only.
+    #     This is the one a destination-token guard cannot see at all.
+    one_platform = good_ps.replace('", "alpha")) {', '")) {', 1)
+    assert any("UNWIRED SKILL" in f for f in fails(ps=one_platform)), \
+        "control: a skill missing from the Windows install list must FAIL"
+
+    # (3) a vacuous pass must be impossible.
+    assert any("EXTRACTION BROKEN" in f for f in fails(sh="", ps="")), \
+        "control: unparseable installers must FAIL, never silently pass"
+    short = "for sub in a b c; do\nfor sub in a b c; do\n"
+    assert any("EXTRACTION BROKEN" in f for f in fails(sh=short)), \
+        "control: a truncated list must FAIL rather than report clean parity"
+
+    # (4) a listed name no skills/ dir backs (typo, or a deleted skill).
+    assert any("PHANTOM SKILL" in f for f in fails(shp=shipped - {"alpha"})), \
+        "control: a listed name with no skills/ dir must FAIL"
+
+    # (5) a VERIFY_ONLY name in an INSTALL list is still wrong -- the loop
+    #     would look for a skills/ dir that does not exist.
+    bad_install = good_sh.replace(
+        "for sub in " + " ".join(core) + "; do",
+        "for sub in " + " ".join(core + verify_extra[:1]) + "; do", 1)
+    assert any("PHANTOM SKILL" in f for f in fails(sh=bad_install)), \
+        "control: a VERIFY_ONLY name in an install list must FAIL"
+
+    # (6) duplicates from hand-editing.
+    dup = good_sh.replace("for sub in " + " ".join(core) + "; do",
+                          "for sub in " + " ".join(core + ["alpha"]) + "; do", 1)
+    assert any("DUPLICATE" in f for f in fails(sh=dup)), \
+        "control: a duplicated name must FAIL"
+
+    # (7) the ratchet: an exemption nothing uses must be deleted, not kept.
+    no_extra_sh = "for sub in " + " ".join(core) + "; do\n" * 1 + \
+                  "for sub in " + " ".join(core) + "; do\n"
+    no_extra_ps = (
+        "foreach ($sub in @(" + ", ".join(f'"{n}"' for n in core) + ")) {\n"
+        "foreach ($sub in @(" + ", ".join(f'"{n}"' for n in core) + ")) {\n"
+    )
+    assert any("STALE AMNESTY" in f for f in fails(sh=no_extra_sh, ps=no_extra_ps)), \
+        "control: an unused VERIFY_ONLY row must FAIL as stale"
+
 
 def main() -> int:
+    _self_test()
     sh_dests = destinations(SH, DEST_RE_SH)
     ps_dests = destinations(PS1, DEST_RE_PS)
 
@@ -159,6 +378,12 @@ def main() -> int:
             f"      a closed gap into a standing exemption for the next one."
         )
 
+    failures += check_skill_lists(
+        SH.read_text(encoding="utf-8", errors="replace"),
+        PS1.read_text(encoding="utf-8", errors="replace"),
+        shipped_skills(),
+    )
+
     if failures:
         print("bootstrap install-parity guard FAILED:\n", file=sys.stderr)
         print("\n".join(failures), file=sys.stderr)
@@ -167,7 +392,9 @@ def main() -> int:
     print(
         f"OK - bootstrap install parity: {len(sh_dests)} destination(s) in "
         f"bootstrap.sh, {len(gaps)} known gap(s) still open "
-        f"({', '.join(sorted(gaps)) or 'none'}), 0 unlisted and 0 stale."
+        f"({', '.join(sorted(gaps)) or 'none'}), 0 unlisted and 0 stale; "
+        f"skill lists: {len(shipped_skills())} shipped skill(s) present in all "
+        f"4 list(s), negative controls passed."
     )
     return 0
 

--- a/scripts/test_bootstrap_install_parity.py
+++ b/scripts/test_bootstrap_install_parity.py
@@ -120,7 +120,7 @@ def destinations(path: Path, pattern: re.Pattern[str]) -> set[str]:
     ]
     return {m for m in pattern.findall("\n".join(lines))} - IGNORE
 
-# ─────────────────────────────────────────────────────────────────────────────
+# -----------------------------------------------------------------------------
 # SECOND CHECK: skill-list coverage.
 #
 # The destination check above deliberately IGNOREs "skills" (see IGNORE) --
@@ -138,7 +138,7 @@ def destinations(path: Path, pattern: re.Pattern[str]) -> set[str]:
 #
 # A skill dir is the SOURCE OF TRUTH. Adding skills/<name>/SKILL.md and
 # forgetting the lists must fail RED here rather than ship an unreachable skill.
-# ─────────────────────────────────────────────────────────────────────────────
+# -----------------------------------------------------------------------------
 
 SKILLS_DIR = REPO / "skills"
 


### PR DESCRIPTION
## Why

The destination-parity check in `scripts/test_bootstrap_install_parity.py` deliberately `IGNORE`s `"skills"` — both installers write under `.claude/skills`, so the token matches on both sides and parity reads perfect. True, and useless: **which** skills get installed is decided by four hardcoded name lists, and a skill missing from a list is invisible to a check that only compares destinations.

That blind spot shipped a real bug (MYC-4139, instance fixed in #593):

- `security-snapshot`, `vault-system`, `skillify-meta-loop` shipped as complete skills under `skills/` while named in **none** of the four lists — installed on no platform.
- `optimize-brain` was added to `bootstrap.sh` only by #592, leaving the Windows installer's own last instruction (`/optimize-brain`) broken.

#593 fixed the instance. This is the class.

## What it does

`skills/<name>/` carrying a `SKILL.md` is the source of truth — it must appear in all four lists or the build fails. Also flags:

- a listed name with **no** skill dir (a typo, or a skill deleted without cleaning the lists)
- duplicates from hand-editing — which caught a real one, the doubled `longitudinal` in `bootstrap.sh`'s install list, removed here

`VERIFY_ONLY` holds the two names that legitimately appear in a verify list without an install list (`humanizer` ships from its own fork; `ai-brain-starter` is the parent install). Ratcheted in **both** directions like `KNOWN_GAPS` — an unused row fails as `STALE AMNESTY`, so it cannot become a parking lot.

## Negative controls

Seven, running on **every invocation** rather than behind a flag — a dead guard and a quiet one print the same thing. They cover: unwired skill · one-platform skill · vacuous pass from a broken regex · truncated list · phantom name · duplicate · stale exemption.

Verified against the real repo, not just fixtures:

| control | result |
|---|---|
| re-remove `security-snapshot` from the sh install list (the original bug) | exit 1, names the skill and the list |
| re-remove `optimize-brain` from the ps1 install list (the cross-platform one) | exit 1 |
| add a brand-new unwired `skills/zz-new/` | exit 1, one finding per list (4) |
| restored tree | exit 0 |

The passing line now states what it measured: `skill lists: 37 shipped skill(s) present in all 4 list(s), negative controls passed.`

## Not dormant

`scripts/ci.sh` gate (f) globs `scripts/test_*.py`, so this runs already — no new job, no new dependency, stdlib only.

Refs MYC-4139
