### PR TITLE
fix(windows): CRLF frontmatter was denied at the write boundary

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,18 @@ description: What's new in AI Brain Starter — plain English, no jargon
 
 ---
 
+## 2026-08-25: on Windows, the frontmatter guard was blocking most edits to your own vault
+
+**Who this affects:** Windows users. Mac and Linux are unaffected.
+
+Before Claude writes to a decision, session, or journal note, a guard checks the little block of settings at the top of the file — the frontmatter — and refuses the write if it is malformed. Good guard. On Windows it was refusing writes to files that were perfectly fine.
+
+The reason is invisible unless you go looking. Windows ends every line with two characters where Mac and Linux use one. The guard's pattern only recognised the one-character version, so a valid file saved on Windows read as "the '---' delimiter is not properly closed" and the write was denied. On the machine where this was found, 274 of 400 notes in the vault were in the Windows format — so the guard blocked most edits to that vault, on a file that had nothing wrong with it. The deeper checker it hands off to already tolerated both formats; the guard in front of it did not, so the file was rejected before the real check ever ran.
+
+Also fixed alongside it: if a person's note in your CRM lists `relationship:` as a list rather than a single phrase — both are valid ways to write it — the person extractor crashed and took the whole mapping run down with it. It now reads either spelling.
+
+Both fixes ship with a test that fails without them, so they cannot quietly regress.
+
 ## 2026-08-19: the privacy checker no longer publishes the private word list it checks for
 
 **Who this affects:** anyone who publishes repos with this starter installed, and anyone who forked one of ours.

--- a/hooks/lint-vault-frontmatter.py
+++ b/hooks/lint-vault-frontmatter.py
@@ -167,7 +167,7 @@ def main() -> int:
         emit_allow()
         return 0
 
-    m = re.match(r"^---\n(.*?)\n---\s*", projected, re.DOTALL)
+    m = re.match(r"^---\r?\n(.*?)\r?\n---\s*", projected, re.DOTALL)
     if not m:
         emit_deny(
             f"Vault frontmatter linter: '---' delimiter not properly closed in {Path(file_path).name}. "

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1172,6 +1172,8 @@ PY_DIRECT=(
   # repo, so honouring an unresolvable `cd` (now reachable, since newlines split)
   # would turn a blocked op into an allowed one.
   hooks/test_block_raw_vault_git_cd.py
+  # Windows-only: CRLF frontmatter at the write boundary + list-valued relationship.
+  tests/test_windows_crlf_and_list_relationship.py
 )
 dormant_py=()
 while IFS= read -r -d '' f; do

--- a/scripts/extractors/person.py
+++ b/scripts/extractors/person.py
@@ -91,7 +91,10 @@ def _priority(fm):
 
 def _is_public_figure(fm):
     """True if relationship type or notes flag this as author/thinker/public figure."""
-    rel = (fm.get("relationship") or "").lower().strip()
+    raw = fm.get("relationship") or ""
+    if isinstance(raw, (list, tuple, set)):
+        raw = " ".join(str(x) for x in raw)
+    rel = str(raw).lower().strip()
     if rel in PUBLIC_FIGURE_RELATIONSHIP_HINTS:
         return True
     # Also check if any hint word appears within a longer descriptor

--- a/tests/test_windows_crlf_and_list_relationship.py
+++ b/tests/test_windows_crlf_and_list_relationship.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""
+test_windows_crlf_and_list_relationship.py — stdlib-only regression tests for two
+Windows-only failures that are invisible on macOS and Linux.
+
+Run: python3 tests/test_windows_crlf_and_list_relationship.py
+No pytest dependency. Exits non-zero on any failure. Touches no real vault.
+
+Why this file exists
+--------------------
+1. CRLF frontmatter was denied at the write boundary.
+
+   hooks/lint-vault-frontmatter.py matched frontmatter with ^---\\n(.*?)\\n---,
+   an LF-only pattern. A vault file saved on Windows uses \\r\\n, so the pattern
+   does not match and the hook takes the emit_deny branch: "'---' delimiter not
+   properly closed". The frontmatter is perfectly valid — only the line endings
+   differ. On the box this was measured on, 274 of 400 vault .md files were CRLF,
+   so the hook blocked most Write/Edit operations on that vault.
+
+   scripts/vault-schema-validator.py already carries the \\r?\\n tolerance
+   (extract_frontmatter). The hook that calls it did not, so the write was
+   refused before the validator was ever consulted.
+
+2. A list-valued `relationship:` crashed the person extractor.
+
+   scripts/extractors/person.py called .lower() straight on fm["relationship"].
+   YAML frontmatter written as `relationship: [author, mentor]` parses to a list,
+   which has no .lower(), so _is_public_figure raised AttributeError and took the
+   whole extraction run with it. Both spellings are legal YAML and the schema
+   does not forbid the list form.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+FAILS: list[str] = []
+
+VALID_DECISION_FM = (
+    "type: decision\n"
+    "decision_date: 2026-04-30\n"
+    "stakes: high\n"
+    "speed: deliberate\n"
+    "floor: 16\n"
+)
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    if cond:
+        print(f"  ok   {name}")
+    else:
+        FAILS.append(f"{name}{': ' + detail if detail else ''}")
+        print(f"  FAIL {name}{': ' + detail if detail else ''}")
+
+
+def run_hook(file_path: Path, content: str) -> dict:
+    """Drive the PreToolUse hook exactly as Claude Code does: JSON on stdin."""
+    payload = json.dumps({
+        "tool_name": "Write",
+        "tool_input": {"file_path": str(file_path), "content": content},
+    })
+    proc = subprocess.run(
+        [sys.executable, str(ROOT / "hooks" / "lint-vault-frontmatter.py")],
+        input=payload, capture_output=True, text=True,
+    )
+    try:
+        return json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError:
+        return {"_raw": proc.stdout, "_err": proc.stderr}
+
+
+def decision_of(out: dict) -> str:
+    return (out.get("hookSpecificOutput") or {}).get("permissionDecision", "")
+
+
+def test_frontmatter_hook_accepts_both_line_endings() -> None:
+    """LF and CRLF frontmatter are the same document; both must be allowed."""
+    print("test_frontmatter_hook_accepts_both_line_endings")
+    with tempfile.TemporaryDirectory() as td:
+        decisions = Path(td) / "Decisions"
+        decisions.mkdir(parents=True)
+        target = decisions / "2026-04-30T10-00-a-decision.md"
+
+        lf = f"---\n{VALID_DECISION_FM}---\n\n# A decision\n\nBody.\n"
+        crlf = lf.replace("\n", "\r\n")
+
+        lf_decision = decision_of(run_hook(target, lf))
+        check("LF frontmatter is allowed", lf_decision == "allow", f"got {lf_decision!r}")
+
+        crlf_decision = decision_of(run_hook(target, crlf))
+        check(
+            "CRLF frontmatter is allowed",
+            crlf_decision == "allow",
+            f"got {crlf_decision!r} — the LF-only regex denies valid Windows files",
+        )
+
+
+def test_public_figure_accepts_list_relationship() -> None:
+    """`relationship:` is legal YAML as a scalar or a list; neither may raise."""
+    print("test_public_figure_accepts_list_relationship")
+    # person.py imports its sibling _base at module scope; put the package
+    # directory on sys.path the same way the extractor runner does.
+    sys.path.insert(0, str(ROOT / "scripts" / "extractors"))
+    spec = importlib.util.spec_from_file_location(
+        "person_extractor", ROOT / "scripts" / "extractors" / "person.py"
+    )
+    person = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(person)
+
+    hint = next(iter(person.PUBLIC_FIGURE_RELATIONSHIP_HINTS))
+
+    try:
+        scalar = person._is_public_figure({"relationship": hint})
+        check("scalar relationship still detected", scalar is True)
+    except Exception as e:  # noqa: BLE001 - the point is that nothing raises
+        check("scalar relationship still detected", False, f"raised {e!r}")
+
+    try:
+        as_list = person._is_public_figure({"relationship": [hint, "mentor"]})
+        check("list relationship does not raise", True)
+        check("list relationship is detected", as_list is True, f"got {as_list!r}")
+    except Exception as e:  # noqa: BLE001
+        check("list relationship does not raise", False, f"raised {e!r}")
+
+    try:
+        person._is_public_figure({"relationship": None})
+        person._is_public_figure({})
+        check("missing / null relationship stays safe", True)
+    except Exception as e:  # noqa: BLE001
+        check("missing / null relationship stays safe", False, f"raised {e!r}")
+
+
+def main() -> int:
+    test_frontmatter_hook_accepts_both_line_endings()
+    test_public_figure_accepts_list_relationship()
+    if FAILS:
+        print(f"\n{len(FAILS)} failure(s):")
+        for f in FAILS:
+            print(f"  - {f}")
+        return 1
+    print("\nall checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
On Windows, `hooks/lint-vault-frontmatter.py` denied writes to valid vault files because its frontmatter pattern was LF-only; this makes it tolerate `\r\n`, and fixes a list-valued `relationship:` crashing the person extractor alongside it.

## The bug

The hook matches frontmatter with `^---\n(.*?)\n---`. A vault file saved on Windows ends its lines with `\r\n`, so the pattern does not match, and the hook takes the `emit_deny` branch:

> Vault frontmatter linter: '---' delimiter not properly closed

The frontmatter is valid. Only the line endings differ. On the machine where this surfaced, **274 of 400** vault `.md` files were CRLF, so the guard blocked most Write/Edit operations on that vault — on files with nothing wrong with them.

What makes it easy to miss: `scripts/vault-schema-validator.py` **already** carries the tolerance (`^---\r?\n(.*?)\r?\n---` in `extract_frontmatter`, and the `newline=""` note above the tempfile call says exactly why byte-preservation matters here). The hook standing in front of it did not, so the write was refused before the validator it delegates to was ever consulted. The two ends of the same handoff disagreed about line endings.

## The second fix

`_is_public_figure` in `scripts/extractors/person.py` called `.lower()` directly on `fm["relationship"]`. Written as `relationship: [author, mentor]` that parses to a list, which has no `.lower()`, so the call raised `AttributeError` and took the whole extraction run down. Both spellings are legal YAML and no schema forbids the list form. It now joins a list/tuple/set and coerces through `str()`, so scalar behaviour is unchanged.

## Test

`tests/test_windows_crlf_and_list_relationship.py` drives the hook over stdin exactly as Claude Code does, with a valid decision note in both line endings, and exercises `_is_public_figure` with a scalar, a list, `None`, and a missing key. stdlib-only, no pytest, touches no real vault, picked up by the existing `tests/test_*.py` gate.

On `main` it fails:

```
  ok   LF frontmatter is allowed
  FAIL CRLF frontmatter is allowed: got 'deny'
  FAIL list relationship does not raise: raised AttributeError("'list' object has no attribute 'lower'")
```

With this change, all six checks pass.

## What I verified, and what I could not

Verified: the new test RED before / GREEN after, plus `py_compile` over the three touched files.

Not verified: the full `bash scripts/ci.sh` gate. It does not run on the Windows box this was found on — its Python syntax step builds `.pyc` output paths by mixing POSIX and Windows separators and then fails on **every** tracked file, changed or not (`[Errno 2] No such file or directory: 'C:\Users/MARCEL~1/...\...\foo.cpython-312.pyc.123'`). `shellcheck` is also not available there. Both are CI's job here; flagging it rather than claiming a green local gate. Happy to open that as a separate issue if a Windows-runnable CI path is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
