### PR TITLE
fix(ci): doc-promises watched 98 of 287 docs, by an allowlist that loses by design

### DIFF
--- a/scripts/check-doc-promises.py
+++ b/scripts/check-doc-promises.py
@@ -102,7 +102,20 @@ from _lib.safe_read import safe_read_text  # noqa: E402
 # Scan surface
 # ---------------------------------------------------------------------------
 
-DOC_GLOBS = ["README.md", "docs/**/*.md", "phases/**/*.md", "skills/*/SKILL.md"]
+# INCLUDE EVERY MARKDOWN FILE, exclude by documented category below.
+#
+# This was an allowlist of four globs and it covered 98 of 287 markdown files.
+# Widening it to eleven globs reached 248 -- but an allowlist of directory
+# NAMES is a denylist against an open set wearing the other hat: the next
+# top-level directory someone adds is silently unwatched, which is exactly
+# the failure being fixed, one level up. Both team-onboarding directories
+# (for-teams/, para-equipos/ -- a paying client's first surface, EN and ES)
+# sat outside the original four for months for precisely that reason.
+#
+# So the default is now EVERYTHING, and every exemption below is a bounded
+# category with a stated reason. A new directory is watched the day it
+# appears, and anyone who wants it exempt has to say why, in writing, here.
+DOC_GLOBS = ["**/*.md"]
 
 # CHANGELOG.md is a chronological development log ("full development history
 # including internal refactors and bug fixes" -- its own framing in
@@ -118,7 +131,33 @@ EXCLUDED_DOC_FILES = {"docs/CHANGELOG.md"}
 # removed) to justify the current decision. docs/adr/0003 describes
 # scripts/email-gate-hook.py, which the ADR itself says was deleted -- an
 # accurate historical record, not a live promise about repo contents.
-EXCLUDED_DOC_PREFIXES = ("docs/adr/",)
+EXCLUDED_DOC_PREFIXES = (
+    # An ADR's Context section narrates a past design, often one deliberately
+    # removed, to justify the current decision -- accurate history, not a live
+    # promise. Same category as CHANGELOG.md above.
+    "docs/adr/",
+    # Test fixtures deliberately contain fabricated commands and paths; that
+    # is their job. This module's own --fixture-test plants one.
+    "tests/",
+    # Third-party content we do not author and cannot fix.
+    "vendor/",
+    # Issue/PR templates and workflow docs, written for contributors to THIS
+    # repo rather than instructions a client follows.
+    ".github/",
+)
+
+# A file under templates/ is COPIED INTO THE USER'S OWN VAULT, so a path
+# written inside one names a file in THEIR tree, not an artifact this repo
+# promises to ship. templates/generated/todo-system-template.md illustrates
+# what a context anchor looks like with "(e.g., `scripts/extract.py`,
+# `drafts/Q3-plan.md`)" -- neither exists here, and neither should. That is
+# the same reasoning _VAULT_PATH_PREFIXES already applies to "Meta/..."
+# paths, just reached by directory instead of by prefix.
+#
+# Scoped to the SCRIPT check only, deliberately. A template that tells a user
+# to type a slash command IS making a promise this repo has to keep, so the
+# command check still reads every template (negative control proves it).
+SCRIPT_CHECK_EXCLUDED_PREFIXES = ("templates/",)
 
 # ---------------------------------------------------------------------------
 # Non-command tokens: bounded, documented categories only (see module
@@ -161,6 +200,15 @@ NON_COMMAND_TOKENS = {
     # is disclosed construction at install time, not a claim that this repo
     # ships a team-weekly skill of its own -- it doesn't, by design.
     "team-weekly",
+    # An HTTP health endpoint, not a slash command. This module's own
+    # docstring already names /healthz as the reason the HTTP-verb table-row
+    # exemption exists; that exemption covers it inside an endpoint TABLE,
+    # while services/memory-api/README.md also names it in prose ("All
+    # endpoints except `/healthz` require Authorization"). Same object, same
+    # category, one sentence outside a table. Note the bounded-category rule
+    # above still holds: this is a route, not a skill name, so nothing is
+    # being silenced -- there is no /healthz skill anyone could ship.
+    "healthz",
 }
 
 # Confirmed references to something this repo does NOT resolve, found by
@@ -490,7 +538,12 @@ def scan(root: Path) -> list[Finding]:
     skills_scripts = build_skills_scripts_index(root)
     findings: list[Finding] = []
     findings += check_commands(root, files, vocabulary)
-    findings += check_scripts(root, files, skills_scripts)
+    findings += check_scripts(
+        root,
+        [f for f in files
+         if not f.relative_to(root).as_posix().startswith(SCRIPT_CHECK_EXCLUDED_PREFIXES)],
+        skills_scripts,
+    )
     findings += check_flags(root)
     return findings
 
@@ -514,6 +567,20 @@ def self_test() -> int:
         else:
             print(f"  FAIL {name:60s} expected {'RED' if expect else 'clean'}, got {'RED' if got else 'clean'}")
             failures += 1
+
+    # DEFERRED_UNRESOLVED_TOKENS is a suppression list, and an appendable
+    # suppression list is a gate anyone can buy past: a future session facing
+    # a RED guard can add one string and the finding vanishes with no test,
+    # no reviewer, and no record. Its comment says empty is the correct
+    # steady state; this makes that a FACT the suite enforces rather than a
+    # sentence someone can read past. Re-filling it now costs a deliberate
+    # edit to this assertion too, which is exactly the visible, arguable
+    # moment the original two entries never got.
+    check(
+        "DEFERRED_UNRESOLVED_TOKENS is empty (suppression lists ratchet down, never up)",
+        bool(DEFERRED_UNRESOLVED_TOKENS),
+        False,
+    )
 
     vocabulary = {"graphify", "optimize-brain", "coaching"}
     skills_scripts: dict[str, list[Path]] = {"real_script.py": [Path("skills/x/scripts/real_script.py")]}


### PR DESCRIPTION
Follow-up to #592 and #594. Resolving the two deferred tokens raised the question those PRs could not answer: not *is this promise true*, but **what is the guard not reading at all**.

## Measured

The four original globs covered **98 of 287** markdown files. Outside them:

| unwatched | why it matters |
| -- | -- |
| `for-teams/`, `para-equipos/` | team onboarding, EN and **ES** — a paying client's first surface |
| `skills/*/` reference docs | LESSONS.md, RUNBOOK.md, `references/` — read as much as SKILL.md |
| `agentic-os/`, `templates/`, `commands/`, `floors/` | |
| root `*.md` | SKILL.md, CLAUDE.md, CONTRIBUTING.md, EXAMPLES.md, SECURITY.md |

## The first fix here was the wrong shape, and that is the point

I first widened the allowlist to eleven globs and reached 248 files. That is the same defect one level up: **an allowlist of directory NAMES is a denylist against an open set wearing the other hat.** The next directory someone adds is silently unwatched — which is exactly how `for-teams/` and `para-equipos/` stayed unwatched for months.

So the default is now **every markdown file**, and each exemption is a bounded category with a stated reason in the source:

- `docs/adr/` + `CHANGELOG.md` — accurate history, not live promises (pre-existing)
- `tests/` — fixtures contain fabricated commands deliberately; this module's own `--fixture-test` plants one
- `vendor/` — third-party, not ours to fix
- `.github/` — contributor templates, not client instructions

**265 files scanned.** A new directory is watched the day it appears, and exempting one now costs a written reason.

## Proven, not assumed

- A fabricated command planted in `skills/graphify/LESSONS.md`, `skills/graphify/RUNBOOK.md`, `for-teams/README.md`, `para-equipos/README.md`, `CONTRIBUTING.md` and `SECURITY.md` is caught in **all six**.
- A markdown file placed in a top-level directory **created seconds earlier** is caught.
- Every exclusion verified to contribute exactly zero files.

## Two false positives, fixed at the category level

Neither was silenced by muting a token.

**`templates/`** teaches what a context anchor looks like: "(e.g., `scripts/extract.py`, `drafts/Q3-plan.md`)". Neither exists here and neither should — a template is copied into the *user's* vault, so a path inside one names a file in their tree. Carved out of the **script** check only, the same reasoning `_VAULT_PATH_PREFIXES` applies to `Meta/...` paths. A template that tells a user to type a slash command **is** a promise this repo must keep, so the command check still reads every template, negative-controlled.

**`/healthz`** in `services/memory-api/README.md`. This module's docstring already cites `/healthz` as the reason the HTTP-verb table-row exemption exists; this is the same object one sentence outside a table. It is a route, not a skill name, so the bounded-category rule holds — there is no `/healthz` skill anyone could ship instead.

## Closes the hole #594 left behind

`DEFERRED_UNRESOLVED_TOKENS` is a suppression list, and an appendable suppression list is a gate anyone can buy past: a session facing a RED guard could add one string and the finding vanishes with no test, no reviewer, no record. Its comment *said* empty was the correct steady state. The self-test now enforces it.

Control: with `"plan"` put back, the self-test fails and exits 1.

## Deliberately NOT built

Catching **unbackticked** slash commands in prose. Measured across all 265 files: 14 distinct tokens, **14 of 14 false positives** — `</summary>` and `</details>` closing tags, `./run-insights.sh`, `~/instinct-pack.yaml`, `<org>/master-vault@<sha>`, URL path segments. Zero real defects, on a guard whose entire value is that it does not cry wolf.

## Verification

| Gate | Result |
|---|---|
| `--self-test` (15 cases incl. the new one) | pass |
| `--fixture-test` | pass |
| Real run | clean, exit 0 |
| `ci-test` (canonical) | GREEN, marker `15f482c0.ok` |
| Personal-data scrub | clean; 19 gated + 16 markdown patterns each proven against a planted specimen |

Doubt-pass: this change adds no regex and no exception handler. It widens which files are read (all bounded by the existing `safe_read_text` timeout/size caps) and adds one `str.startswith` filter that only ever *removes* files from the script check. The residual weakness the doubt-pass found — the allowlist shape — is what prompted the inversion above.
