### PR TITLE
fix(optimize-brain): route Phase 10 through {SKILL_DIR}, not ~/.claude/skills

### DIFF
--- a/skills/optimize-brain/SKILL.md
+++ b/skills/optimize-brain/SKILL.md
@@ -7,6 +7,8 @@ trigger: /optimize-brain
 
 # Optimize Brain — Deep Vault Optimization
 
+> **`{SKILL_DIR}`** = this skill's own folder (locally: the directory this SKILL.md lives in; a served brain substitutes the real absolute path before you read this). Shared starter files live at the repo root two levels up: `{SKILL_DIR}/../..`. If a path does not resolve, name the missing file and stop — never guess another location.
+
 You are running a deep optimization on an existing Obsidian vault. The user has already set up the basics (folder structure, CLAUDE.md, context layer) — either through `/setup-brain` or manually. Now they want the full treatment.
 
 This is a weekend project, not an afternoon one. Set expectations upfront and let them choose which phases to run.
@@ -482,18 +484,16 @@ last_updated: [today]
 "Let me make sure all your skills are working and your CLAUDE.md has the right routing entries."
 
 ### Step 1: Verify skill paths
-Check that every skill file referenced in CLAUDE.md actually exists:
+Check that every skill file referenced in CLAUDE.md actually exists.
+
+Skills install as sibling folders of this one, so list what is actually on disk rather than guessing at a fixed set of names:
 
 ```bash
-# Check each skill directory
-ls ~/.claude/skills/daily-journal/SKILL.md
-ls ~/.claude/skills/humanizer/SKILL.md
-ls ~/.claude/skills/graphify/SKILL.md
-ls ~/.claude/skills/insights/SKILL.md
-ls ~/.claude/skills/ai-brain-starter/SKILL.md
+# Every installed skill's SKILL.md, whatever the install shape
+ls "{SKILL_DIR}"/../*/SKILL.md
 ```
 
-For any missing skill, offer to reinstall it.
+Now read the routing entries in their CLAUDE.md and compare the two lists. Any skill CLAUDE.md routes to that is missing from the listing is a dead routing entry — name it and offer to reinstall it. The reverse case (installed but unrouted) is Step 3, not this one.
 
 ### Step 2: Verify save paths in skills
 Read each skill file and check that any file paths it references (journal save path, insight save path, etc.) resolve to real folders. Common bug: double "Desktop" in paths, missing emoji prefixes on folders.
@@ -514,11 +514,11 @@ Check that the user's CLAUDE.md has routing entries for all installed skills:
 - `/humanizer` → humanizer skill
 - `/setup-brain` → ai-brain-starter skill
 
-For any missing routing, add it:
+For any missing routing, add it. Route by skill NAME, not by install path — the Skill tool resolves the name, and a hardcoded path goes stale the moment the brain is read on another machine or by another tool:
 
 ```markdown
 # [skill name]
-- **[skill-name]** (`~/.claude/skills/[skill-name]/SKILL.md`) — [description]. Trigger: `/[command]`
+- **[skill-name]** — [description]. Trigger: `/[command]`
 When the user types `/[command]`, invoke the Skill tool with `skill: "[skill-name]"` before doing anything else.
 ```
 


### PR DESCRIPTION
## What was broken

The downstream portfolio compile (`compile_portfolio.py --check`) blocks on any `~/.claude/skills/` path in a public skill body. A served client cannot resolve one host tool's install layout, so the pointer dangles — that is the whole reason the `{SKILL_DIR}` token contract exists.

`optimize-brain` was the last public body still carrying those paths — six of them, all inside *Phase 10: Skill & Routing Health Check* — and it was the sole reason that gate was red:

```
PUBLIC-BODY CHANNEL-BINDING GATE FAILED for skill 'optimize-brain':
internal ref class 'host-tool skills path (~/.claude)' — served clients
cannot resolve host-tool install paths; use the {SKILL_DIR} token.
```

## What changed

Three edits, all in the `optimize-brain` skill body.

**1. The `{SKILL_DIR}` definition blockquote**, copied verbatim from `diagnose` and `evolve` so all three read identically.

**2. Phase 10 Step 1** — the skill-existence check. It used to `ls` five hardcoded names:

```bash
ls ~/.claude/skills/daily-journal/SKILL.md
ls ~/.claude/skills/humanizer/SKILL.md
...
```

Two of those five, `humanizer` and `ai-brain-starter`, are not sibling skills in this repo. So the check reported them missing on every single run, and Step 1's "for any missing skill, offer to reinstall it" fired against skills that were never there. Replaced the frozen list with a glob over the sibling folders:

```bash
ls "{SKILL_DIR}"/../*/SKILL.md
```

That is what the step's own heading already asks for — *every skill file referenced in CLAUDE.md* — rather than a list that has to be hand-maintained. It resolves on any install shape, and the comparison is now made against CLAUDE.md's actual routing entries. The reverse case (installed but unrouted) was always Step 3's job, and the text now says so.

**3. Phase 10 Step 3** — the routing-entry template. This one could not take the token. The template text is written *into the user's CLAUDE.md*, where nothing substitutes `{SKILL_DIR}`, so the token would dangle exactly like the path did. Dropped the path instead:

```markdown
- **[skill-name]** — [description]. Trigger: `/[command]`
When the user types `/[command]`, invoke the Skill tool with `skill: "[skill-name]"` before doing anything else.
```

Dispatch was never path-based. The second line resolves the skill by name through the Skill tool; the path was decoration that could only go stale.

## Verification

- Repo's own canonical gate (`scripts/ci.sh` via the lint/ci workflow): **green**, sha-keyed marker written.
- Downstream portfolio compile pointed at this branch: **exit 0, `CHECK OK`**, 37 public skills compiled.
- Negative control — same gate, same runner, only this one file reverted to its pre-fix state: **exit 1**, reproducing the original failure verbatim, same skill and same six sites. The green is sensitive to this change, not vacuous.

The first control I ran was a bad one and is worth naming: it pointed at a checkout whose `skills/` tree was missing `optimize-brain` altogether, so it passed for the wrong reason. The tell was the skill count — 36 public instead of 37.

## Not changed on purpose

The setup phase docs still write path-carrying routing entries into the user's CLAUDE.md. They sit outside the compiled skill bodies, so no gate covers them, and they are setup behaviour rather than this defect. Worth a follow-up for consistency, but folding them in here would mean changing how install writes routing inside what is otherwise a CI unblock.

---

Drafted with Claude Code; gates and negative control run before merge.
