### PR TITLE
A running process in the tree is liveness; a lock file is only a report

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -155,6 +155,30 @@ jobs:
       - name: baseline section-header negative controls (the guard must still bite)
         run: python3 scripts/_baseline_sections.py --self-test
 
+      # Every scripts/test_*.py, DISCOVERED BY GLOB. Measured 2026-08-26: the
+      # repo carried 30 such suites and exactly ONE (test_ps1_encoding_gate.py)
+      # was named in any workflow, so 29 had never run in CI - including
+      # test_dev_worktree_prune.py and test_dev_worktree_prune_failsafe.py, the
+      # safety controls for the tool that DELETES whole worktrees. A suite that
+      # never runs and a suite that passes report the same green. Naming them
+      # here would re-create the bug: the next suite added would be dormant too.
+      - name: scripts/test_*.py suites (globbed - a dormant suite is not a passing one)
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          suites=(scripts/test_*.py)
+          if [ ${#suites[@]} -eq 0 ]; then
+            echo "no scripts/test_*.py found - the glob broke, not the repo"; exit 1
+          fi
+          echo "discovered ${#suites[@]} suite(s)"
+          rc=0
+          for t in "${suites[@]}"; do
+            echo "::group::$t"
+            if python3 "$t"; then echo "  ok   $t"; else echo "  FAIL $t"; rc=1; fi
+            echo "::endgroup::"
+          done
+          exit $rc
+
       # Every tiered baseline, DISCOVERED BY GLOB rather than named here. Naming
       # them would be the original bug one level up: a hand-maintained list of
       # what to check goes stale exactly as silently as a hand-maintained count,

--- a/hooks/_lib/dev_repo_scan.py
+++ b/hooks/_lib/dev_repo_scan.py
@@ -865,6 +865,90 @@ def _lock_entries(data: dict) -> list:
     return []
 
 
+PROC_CWD_CACHE_TTL_SEC = 30.0
+_PROC_CWD_CACHE = {"at": 0.0, "value": None}
+_PROC_PROBE_WARNED = [False]
+
+
+def _claude_pids() -> Optional[list]:
+    """PIDs of running Claude processes, or None if the process table is unreadable."""
+    try:
+        r = subprocess.run(["ps", "ax", "-o", "pid=,command="],
+                           capture_output=True, text=True, timeout=15)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if r.returncode != 0:
+        return None
+    pids = []
+    for line in r.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        pid, _, cmd = line.partition(" ")
+        if pid.isdigit() and "claude" in cmd.lower():
+            pids.append(pid)
+    return pids
+
+
+def live_process_cwds(now_ts: Optional[float] = None) -> Optional[set]:
+    """Directories a running Claude process currently has as its CWD.
+
+    THREE-STATE, and the third state is the point: a `set()` means "measured,
+    nobody is here"; `None` means "could not measure". Collapsing None into an
+    empty set is how a probe that failed reports a busy worktree as idle.
+
+    Cached for PROC_CWD_CACHE_TTL_SEC because the destructive callers ask once
+    per worktree and there can be dozens; one `lsof` over all PIDs at once costs
+    a fraction of one call each.
+    """
+    now_ts = now_ts or time.time()
+    if (_PROC_CWD_CACHE["value"] is not None
+            and (now_ts - _PROC_CWD_CACHE["at"]) < PROC_CWD_CACHE_TTL_SEC):
+        return _PROC_CWD_CACHE["value"]
+
+    pids = _claude_pids()
+    if pids is None:
+        return None
+    if not pids:
+        _PROC_CWD_CACHE.update(at=now_ts, value=set())
+        return set()
+
+    try:
+        r = subprocess.run(["lsof", "-a", "-p", ",".join(pids), "-d", "cwd", "-Fn"],
+                           capture_output=True, text=True, timeout=30)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    # lsof exits 1 when SOME pids vanished mid-run but still prints the rest.
+    if r.returncode not in (0, 1):
+        return None
+    cwds = {ln[1:] for ln in r.stdout.splitlines() if ln.startswith("n") and len(ln) > 1}
+    if r.returncode == 1 and not cwds:
+        return None  # exited non-zero AND told us nothing: could not measure.
+    _PROC_CWD_CACHE.update(at=now_ts, value=cwds)
+    return cwds
+
+
+def _process_is_live_in(path: Path, now_ts: float) -> Optional[bool]:
+    """True/False if measurable, None if the probe could not run."""
+    cwds = live_process_cwds(now_ts)
+    if cwds is None:
+        return None
+    try:
+        target = os.path.realpath(path)
+    except OSError:
+        return True  # cannot resolve the thing we are about to delete -> LOCKED
+    for c in cwds:
+        try:
+            rc = os.path.realpath(c)
+        except OSError:
+            continue
+        # The separator is load-bearing: without it `~/dev/repo` would match
+        # the sibling worktree `~/dev/repo-slug` and lock the whole fleet.
+        if rc == target or rc.startswith(target + os.sep):
+            return True
+    return False
+
+
 def has_live_session_lock(path: Path, now_ts: Optional[float] = None) -> bool:
     """Is a Claude session live in this working tree? THE one answer.
 
@@ -883,15 +967,35 @@ def has_live_session_lock(path: Path, now_ts: Optional[float] = None) -> bool:
     worktree and having its `target/` deleted. `dev-worktree-prune.py` deletes
     the whole worktree.
 
-    Three probes, in order of authority. Legacy mtime probes are kept because
-    they cost one stat and any future tool that drops a plain `.session-lock`
-    still gets protected.
+    FOUR probes, in order of authority. Probe 0 is a running process whose CWD
+    is this tree: direct evidence, needing no cooperating writer, and it cannot
+    go stale. It exists because the lock-file probes depend on session-lock.py
+    actually writing, and measured 2026-08-26 one busy repo's lock held ZERO
+    session entries and had not been written in 3210 minutes while THREE live
+    sessions held that repo's worktrees as their CWD. Every lock probe below
+    returned False for all of them; `dev-worktree-prune.py` duly classified two
+    actively-edited worktrees REAP. A guard that depends on a writer is dead
+    wherever that writer is dead, and it fails in the unsafe direction.
+
+    Legacy mtime probes are kept because they cost one stat and any future tool
+    that drops a plain `.session-lock` still gets protected.
 
     An OSError anywhere reads as LOCKED, never unlocked: "I could not tell" and
     "nobody is here" are different answers, and only one is safe to act on when
     the action is deletion.
     """
     now_ts = now_ts or time.time()
+
+    # 0. A live process sitting in this tree. Highest authority: observed, not
+    #    reported. `None` means the probe could not run -- fall through to the
+    #    lock probes rather than silently reporting "idle", and say so once.
+    proc = _process_is_live_in(path, now_ts)
+    if proc:
+        return True
+    if proc is None and not _PROC_PROBE_WARNED[0]:
+        _PROC_PROBE_WARNED[0] = True
+        print("dev_repo_scan: live-process probe unavailable (ps/lsof); "
+              "falling back to session-lock files only.", file=sys.stderr)
 
     # 1. Legacy per-worktree marker files (cheap, and back-compatible).
     for cand in (path / ".session-lock", path / ".claude" / ".session-lock"):

--- a/hooks/_lib/dev_repo_scan.py
+++ b/hooks/_lib/dev_repo_scan.py
@@ -827,7 +827,7 @@ def _has_live_session_lock(repo: Path, now_ts: Optional[float] = None) -> bool:
     now_ts = now_ts or time.time()
     lock = repo / ".claude" / ".session-lock.json"
     try:
-        data = json.loads(lock.read_text())
+        data = json.loads(lock.read_text(encoding="utf-8", errors="replace"))
     except (OSError, ValueError):
         return False
     if not isinstance(data, dict):
@@ -1481,7 +1481,7 @@ def fetch_repos_capped(
     """
     now_ts = now_ts or time.time()
     try:
-        last = float(json.loads(state_path.read_text()).get("last_fetch_ts", 0))
+        last = float(json.loads(state_path.read_text(encoding="utf-8", errors="replace")).get("last_fetch_ts", 0))
     except Exception:
         last = 0.0
     if now_ts - last < cap_hours * 3600:

--- a/hooks/_lib/dev_repo_scan.py
+++ b/hooks/_lib/dev_repo_scan.py
@@ -874,8 +874,9 @@ def _claude_pids() -> Optional[list]:
     """PIDs of running Claude processes, or None if the process table is unreadable."""
     try:
         r = subprocess.run(["ps", "ax", "-o", "pid=,command="],
-                           capture_output=True, text=True, timeout=15)
-    except (OSError, subprocess.SubprocessError):
+                           capture_output=True, text=True, timeout=15,
+                           encoding="utf-8", errors="replace")
+    except (OSError, subprocess.SubprocessError, UnicodeDecodeError):
         return None
     if r.returncode != 0:
         return None
@@ -915,8 +916,9 @@ def live_process_cwds(now_ts: Optional[float] = None) -> Optional[set]:
 
     try:
         r = subprocess.run(["lsof", "-a", "-p", ",".join(pids), "-d", "cwd", "-Fn"],
-                           capture_output=True, text=True, timeout=30)
-    except (OSError, subprocess.SubprocessError):
+                           capture_output=True, text=True, timeout=30,
+                           encoding="utf-8", errors="replace")
+    except (OSError, subprocess.SubprocessError, UnicodeDecodeError):
         return None
     # lsof exits 1 when SOME pids vanished mid-run but still prints the rest.
     if r.returncode not in (0, 1):

--- a/scripts/test_live_process_probe.py
+++ b/scripts/test_live_process_probe.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Controls for the live-process liveness probe (MYC-3533).
+
+`has_live_session_lock` is the ONLY thing standing between an actively-compiling
+worktree and `dev-build-reclaim.py` deleting its `target/`, or
+`dev-worktree-prune.py` deleting the whole worktree. Until 2026-08-26 every one
+of its probes read a lock FILE, so the guard was alive only where session-lock.py
+was actually writing. Measured that day: one busy repo's lock held ZERO
+session entries and had not been written in 3210 minutes, while THREE live
+sessions held that repo's worktrees as their CWD. The prune classified two
+actively-edited worktrees REAP.
+
+  [0] live process in the tree     -> LOCKED, with no lock file anywhere
+  [1] live process in a SUBDIR     -> LOCKED (a session may cd deeper)
+  [2] sibling prefix worktree      -> NOT locked (`repo` must not match
+                                      `repo-slug`; without the separator one
+                                      live session locks the whole fleet)
+  [3] measured, nobody home        -> falls through to the lock probes
+  [4] probe UNAVAILABLE (None)     -> falls through AND warns; never reads as idle
+  [5] unresolvable path            -> LOCKED (cannot inspect what we would delete)
+  [6] three-state contract         -> set() and None are not interchangeable
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
+from _lib import dev_repo_scan as drs  # noqa: E402
+
+FAILED = []
+
+
+def check(name, cond):
+    print(("  ok   " if cond else "  FAIL ") + name)
+    if not cond:
+        FAILED.append(name)
+
+
+def _reset_cache():
+    drs._PROC_CWD_CACHE.update(at=0.0, value=None)
+    drs._PROC_PROBE_WARNED[0] = False
+
+
+def with_cwds(value):
+    """Force live_process_cwds to a fixed answer (set or None)."""
+    _reset_cache()
+    drs.live_process_cwds = lambda now_ts=None: value
+
+
+def main():
+    real = drs.live_process_cwds
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            wt = root / "repo-slug"
+            (wt / "src").mkdir(parents=True)
+            sibling = root / "repo"          # prefix of "repo-slug" by design
+            sibling.mkdir()
+
+            # [0] a live process whose cwd IS the worktree, no lock file at all
+            with_cwds({str(wt)})
+            check("[0] live process in the tree -> LOCKED",
+                  drs.has_live_session_lock(wt, 1.0) is True)
+
+            # [1] cwd deeper inside the worktree still counts
+            with_cwds({str(wt / "src")})
+            check("[1] live process in a subdir -> LOCKED",
+                  drs.has_live_session_lock(wt, 1.0) is True)
+
+            # [2] THE prefix bug: a session in `repo` must not lock `repo-slug`
+            with_cwds({str(sibling)})
+            check("[2] sibling prefix does NOT lock",
+                  drs.has_live_session_lock(wt, 1.0) is False)
+            with_cwds({str(wt)})
+            check("[2b] and the converse holds too",
+                  drs.has_live_session_lock(sibling, 1.0) is False)
+
+            # [3] measured and empty -> fall through (no locks here -> False)
+            with_cwds(set())
+            check("[3] measured-empty falls through to lock probes",
+                  drs.has_live_session_lock(wt, 1.0) is False)
+
+            # [4] unavailable -> fall through, but WARN. A silent fallback is how
+            #     "could not measure" becomes "idle, safe to delete".
+            with_cwds(None)
+            import io
+            import contextlib
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                res = drs.has_live_session_lock(wt, 1.0)
+            check("[4] unavailable probe does not read as LOCKED-false-positive",
+                  res is False)
+            check("[4b] unavailable probe WARNS once (fail loud, not silent)",
+                  "probe unavailable" in err.getvalue())
+
+            # [5] a path we cannot resolve is LOCKED, never idle
+            with_cwds({str(wt)})
+            drs.live_process_cwds = lambda now_ts=None: {str(wt)}
+
+            class Boom(type(Path())):
+                pass
+
+            saved = os.path.realpath
+
+            def boom(p):
+                raise OSError("unresolvable")
+
+            os.path.realpath = boom
+            try:
+                check("[5] unresolvable path -> LOCKED",
+                      drs._process_is_live_in(wt, 1.0) is True)
+            finally:
+                os.path.realpath = saved
+
+            # [6] the three-state contract is the whole point
+            drs.live_process_cwds = real
+            _reset_cache()
+            live = drs.live_process_cwds(None)
+            check("[6] real probe returns a set or None, never a bare falsy int",
+                  live is None or isinstance(live, set))
+    finally:
+        drs.live_process_cwds = real
+        _reset_cache()
+
+    print()
+    if FAILED:
+        print(f"FAILED ({len(FAILED)}):")
+        for f in FAILED:
+            print(f"  x {f}")
+        return 1
+    print("OK - live-process probe: observes a session with no lock file; counts "
+          "subdirectories; refuses to match a sibling on a path prefix; treats "
+          "'could not measure' as neither locked nor idle, and says so out loud.")
+    return 0
+
+
+if __name__ == "__main__":
+    for _s in (sys.stdout, sys.stderr):
+        try:
+            _s.reconfigure(encoding="utf-8")
+        except (AttributeError, ValueError):
+            pass
+    sys.exit(main())

--- a/scripts/utf8-file-io-baseline.txt
+++ b/scripts/utf8-file-io-baseline.txt
@@ -59,8 +59,7 @@ bf2aa37b1fc14be871ed01920e719d1f71d87052e536d4c435ed2fff227ca8ec SEV-A-write scr
 a29f6c2b98ccf874e4c818e2487ce74f32248ecbbce73a11c91a738561f3aa84 SEV-A-write skills/graphify/scripts/graphify_chunk.py
 8397e371e756c7cff96453d8f8f2c895e1e8ac0762edc8538c573c059e07d19d SEV-A-write skills/graphify/scripts/graphify_prep.py
 
-# ---- SEV-B-read-only  (29 file(s)) ----
-b266f20ff920feeb950d48705939568f13e71e844707b90876c179c76d013da9 SEV-B-read-only hooks/_lib/dev_repo_scan.py
+# ---- SEV-B-read-only  (28 file(s)) ----
 3f7a1805473134ddb49cd1957cc4f94c8e84a1ccb4e8f875e6765b3dac33f289 SEV-B-read-only hooks/_lib/safe_read.py
 52c331ed8a99a90e12e347215144e6799dbe1d278024432dfc46639a4de68405 SEV-B-read-only hooks/_lib/worktree_safety.py
 b647243fdf0a358d46a6a79b0bf7f817ee121f68d5d685fabe4b0ee2a93af94d SEV-B-read-only hooks/check-fabricated-hook-attribution.py


### PR DESCRIPTION
## The bug

`has_live_session_lock` is, by its own docstring, "the ONLY thing standing between an actively-compiling worktree and having its `target/` deleted" — and `dev-worktree-prune.py` deletes the whole worktree. Every one of its probes read a lock **file**, so the guard is alive only where `session-lock.py` is actually writing.

Measured 2026-08-26 on a real dev root:

- one busy repo's `.claude/.session-lock.json` held **0 session entries** and had not been written in **3210 minutes**
- **3 live sessions** held that repo's worktrees as their CWD at that moment
- `has_live_session_lock` returned **False for every one of them**
- `dev-worktree-prune.py --idle-days 0` duly classified **two actively-edited worktrees REAP**, one with 3 uncommitted source files

A guard that depends on a cooperating writer is dead wherever that writer is dead, and it fails in the unsafe direction. The lock file is a *report*; a running process is *evidence*.

## The fix

Probe 0: a running Claude process whose CWD is the tree. Observed, not reported. No writer to depend on, nothing to go stale.

Three-state on purpose — `set()` is "measured, nobody home", `None` is "could not measure". Collapsing them is exactly how a failed probe reports a busy worktree as idle. `None` falls through to the lock probes **and warns once on stderr**, rather than silently reading as safe-to-delete.

The path match requires a trailing separator. Without it `~/dev/repo` matches the sibling worktree `~/dev/repo-slug`, and one live session locks the entire fleet.

Verified against ground truth after the change: the probe's answer matches the live-process list **exactly** — every live worktree protected, none missed.

## Also: 29 dormant test suites

The repo carried **30** `scripts/test_*.py` suites. Exactly **one** was named in any workflow, so 29 had never run in CI — including `test_dev_worktree_prune.py` and `test_dev_worktree_prune_failsafe.py`, the safety controls for the tool that deletes worktrees. A suite that never runs and a suite that passes report the same green.

Now discovered by glob, matching the pattern this repo already uses for tiered baselines. Naming them would re-create the bug one level up: the next suite added would be dormant too. **All 31 pass locally.**

## Controls, mutation-proven

A green suite proves nothing until a mutant dies:

| Mutant | Dies on |
| --- | --- |
| drop the `+ os.sep` separator guard | `[2b]` |
| probe 0 never fires (`proc = False`) | `[0]`, `[1]`, `[4b]` |

Cases: live process in the tree with no lock file anywhere · live process in a subdirectory · sibling-prefix worktree must NOT match · measured-empty falls through · unavailable probe falls through and warns · unresolvable path reads as LOCKED · the three-state contract itself.

## Scope

Relates to MYC-3533 but does **not** close it — that ticket's `Done =` also covers `git branch -D` → `-d` in `worktree-prune.sh`, snapshotting unpushed commits with their SHAs, the remote-branch deletion cause, and a per-deletion audit line. The branch is deliberately not named after the ticket so the tracker does not auto-close it on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
