### PR TITLE
fix(scripts): the sidecar python guard checks the name, not the interpreter

### DIFF
--- a/scripts/relocate-machinery-sidecar.sh
+++ b/scripts/relocate-machinery-sidecar.sh
@@ -134,7 +134,25 @@ _maybe_die() {
   return 0
 }
 
-PYBIN="$(command -v python3 || command -v python || true)"
+# `command -v` answers "is this name on PATH", which is a weaker claim than
+# "this executes python". On Windows the gap is routine: the app-execution
+# alias for python3 ships enabled by default in
+# %LOCALAPPDATA%\Microsoft\WindowsApps, sits on PATH, satisfies `command -v`,
+# and then exits non-zero printing an ad for the Microsoft Store -- while a real
+# python is on the same PATH one candidate later. So the guard below passes and
+# the script dies at the first real call with a third-party message instead of
+# the one written here. Probe each candidate, same rule session-close-runner.sh
+# uses.
+PYBIN=""
+for _abs_c in python3 python py; do
+  _abs_p="$(command -v "$_abs_c" 2>/dev/null)" || continue
+  [ -n "$_abs_p" ] || continue
+  if "$_abs_p" -c 'import sys; sys.exit(0)' >/dev/null 2>&1; then
+    PYBIN="$_abs_p"
+    break
+  fi
+done
+unset _abs_c _abs_p
 [ -n "$PYBIN" ] || { err "python3 required for the move record"; exit 4; }
 
 # absolutize (portable realpath: cd + pwd -P)

--- a/scripts/repair-sidecar-note-deletion.sh
+++ b/scripts/repair-sidecar-note-deletion.sh
@@ -98,7 +98,25 @@ say()  { [ "$QUIET" = 1 ] || printf '%s\n' "$*"; }
 warn() { printf 'WARN  %s\n' "$*" >&2; }
 err()  { printf 'ERROR %s\n' "$*" >&2; }
 
-PYBIN="$(command -v python3 || command -v python || true)"
+# `command -v` answers "is this name on PATH", which is a weaker claim than
+# "this executes python". On Windows the gap is routine: the app-execution
+# alias for python3 ships enabled by default in
+# %LOCALAPPDATA%\Microsoft\WindowsApps, sits on PATH, satisfies `command -v`,
+# and then exits non-zero printing an ad for the Microsoft Store -- while a real
+# python is on the same PATH one candidate later. So the guard below passes and
+# the script dies at the first real call with a third-party message instead of
+# the one written here. Probe each candidate, same rule session-close-runner.sh
+# uses.
+PYBIN=""
+for _abs_c in python3 python py; do
+  _abs_p="$(command -v "$_abs_c" 2>/dev/null)" || continue
+  [ -n "$_abs_p" ] || continue
+  if "$_abs_p" -c 'import sys; sys.exit(0)' >/dev/null 2>&1; then
+    PYBIN="$_abs_p"
+    break
+  fi
+done
+unset _abs_c _abs_p
 [ -n "$PYBIN" ] || { err "python3 is required (used only to read paths safely)"; exit 1; }
 
 VAULT="$(cd "$VAULT" && pwd -P)"


### PR DESCRIPTION
## What

Both sidecar scripts resolve their interpreter like this:

```sh
PYBIN="$(command -v python3 || command -v python || true)"
[ -n "$PYBIN" ] || { err "python3 required for the move record"; exit 4; }
```

`command -v` answers *"is this name on PATH"*, which is a weaker claim than *"this executes python"*.

## Why it matters

On Windows the gap is routine, not exotic. The app-execution alias for `python3` ships **enabled by default** in `%LOCALAPPDATA%\Microsoft\WindowsApps`. It is a real file, it sits on PATH, it satisfies `command -v` — and it exits `49` printing an ad for the Microsoft Store. A working python is usually on the same PATH, one candidate later.

So the guard passes. Then, under `set -euo pipefail`, the script dies a few lines down at the realpath normalisation:

```sh
SIDECAR="$("$PYBIN" -c 'import os,sys; print(os.path.realpath(...))' "$SIDECAR")"
```

Reproduced with a stub first on PATH:

```
PYBIN: .../fakestub/python3
-> passes the [ -n ] guard
Python was not found; run without arguments to install from the Microsoft Store
exit=49
```

This is **not** data loss — `set -e` does stop the script. It is worse in a smaller way: the run aborts telling the user to visit a store, instead of telling them python is missing, which is the one thing that guard exists to say. On a script whose whole job is moving a vault's machinery around, an unexplained third-party abort is a bad place to land.

## The fix

#601 already solved exactly this in `session-close-runner.sh` — probe each candidate, take the first that runs. This applies the same rule to the two scripts that predate it, with the same comment, so the three read alike.

I kept it inline rather than factoring a shared helper, to match what #601 did. Happy to extract one instead if you'd prefer a single copy.

## Testing

Windows 11, Git Bash, with a refuse-stub first on PATH:

- probe skips the stub and selects the real interpreter
- with no working python at all, both scripts abort with **their own** message and exit code (`4` / `1`)
- `bash -n` clean on both

Project suites, same box, before → after:

| suite | baseline | with patch |
|---|---|---|
| `test-machinery-sidecar.sh` | 20 failing | 20 failing |
| `test-repair-sidecar-note-deletion.sh` | 13 failing | 13 failing |

Those failures are pre-existing on Windows and unrelated to this change — I ran both suites on unmodified `main` to establish the baseline. I have not verified them on macOS/Linux, where I'd expect the counts to be lower.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
