### PR TITLE
guard: the machinery scan did not know the word "worktrees" (MYC-4188)

### DIFF
--- a/docs/CLOUD_SYNC.md
+++ b/docs/CLOUD_SYNC.md
@@ -340,7 +340,7 @@ judgment.
 | SessionStart | `worktree-footprint-signal.py` | warns early on worktree count, orphan dirs, low free disk, and the dangerous vault-in-a-cloud-sync-folder combo |
 | SessionStart | `remediate-runaway-procs.py` | reaps orphaned runaway processes (the `yes`-pileup class), pure waste with zero recoverable output |
 | weekly cron | `scripts/worktree-prune.sh` | backstop: safe reclaim of orphan dirs + merged-branch cleanup + snapshot retention |
-| on-demand / weekly | `hooks/check-sync-folder-machinery.py` | audits **every** cloud-synced root (iCloud Drive, iCloud Desktop & Documents, OneDrive, Dropbox, Box, Google Drive) for machinery — `.git`, `node_modules`, build dirs, any 5k+-file dir — *anywhere on the machine*, not just the vault. Broader than the per-session `worktree-footprint-signal.py` (which only checks the vault's own location). Advisory, never blocks; `--self-test` proves it fires. |
+| on-demand / weekly | `hooks/check-sync-folder-machinery.py` | audits **every** cloud-synced root (iCloud Drive, iCloud Desktop & Documents, OneDrive, Dropbox, Box, Google Drive) for machinery — `.git`, `.claude/worktrees`, `node_modules`, `.codegraph`, `.smart-env`, build dirs, any 5k+-file dir — *anywhere on the machine*. An **empty** `.claude/worktrees` counts: it is 0 files, so the size leg cannot see it, and it fills with a full checkout the next time a session opens a worktree there, not just the vault. Broader than the per-session `worktree-footprint-signal.py` (which only checks the vault's own location). Advisory, never blocks; `--self-test` proves it fires. |
 
 **The non-destructive contract.** Auto-remediation fixes only reconstructible
 things: a scratch worktree directory (recreatable from its branch), an orphaned

--- a/hooks/check-sync-folder-machinery.py
+++ b/hooks/check-sync-folder-machinery.py
@@ -55,7 +55,15 @@ STATE_PATH = os.path.join(HOME, ".claude", "state", "sync-guard-last.json")
 
 # Directory names that mean "machinery, never sync this"
 MARKER_DIRS = {".git", "node_modules", ".venv", "venv", "target",
-               "__pycache__", ".next", "dist", "build", ".tox", ".gradle"}
+               "__pycache__", ".next", "dist", "build", ".tox", ".gradle",
+               ".codegraph", ".smart-env"}
+# `worktrees` is machinery ONLY under a tool dir. A bare folder named
+# "worktrees" is plausible user content, so it is scoped by PARENT rather than
+# added as another ambiguous bare name alongside dist/build/target. See
+# scan_root. Deliberately absent everywhere: `.obsidian` -- it legitimately
+# syncs, that is how Obsidian mobile works, and a guard that cries wolf on real
+# folders teaches bypass, which then masks the true hits.
+WORKTREE_PARENTS = {".claude", ".git"}
 # A plain folder this big is also too much for a File Provider to live-sync
 FILE_COUNT_THRESHOLD = 5000
 # Per-root safety budget so a streamed Google Drive can't hang the scan
@@ -142,13 +150,20 @@ def scan_root(root, provider):
         if dirpath.count("/") - base_depth >= MAX_DEPTH:
             dirnames[:] = []
             continue
-        hit = MARKER_DIRS.intersection(dirnames)
+        hit = set(MARKER_DIRS.intersection(dirnames))
+        # An EMPTY .claude/worktrees still counts -- it is the SEED, not the
+        # storm. 0 files, so FILE_COUNT_THRESHOLD structurally cannot see it,
+        # and it fills with a ~6.5K-file checkout the next time a session ticks
+        # the worktree box. Missed for 8 days inside a live Google Drive root
+        # while this scan reported findings:[] every morning (MYC-4188).
+        if "worktrees" in dirnames and os.path.basename(dirpath.rstrip("/")) in WORKTREE_PARENTS:
+            hit.add("worktrees")
         for h in sorted(hit):
             findings.append({"path": os.path.join(dirpath, h), "provider": provider,
                              "reason": f"machinery dir '{h}' inside synced folder",
                              "severity": "high"})
         # don't descend into machinery we already flagged
-        dirnames[:] = [d for d in dirnames if d not in MARKER_DIRS]
+        dirnames[:] = [d for d in dirnames if d not in hit and d not in MARKER_DIRS]
         if len(filenames) >= FILE_COUNT_THRESHOLD:
             findings.append({"path": dirpath, "provider": provider,
                              "reason": f"{len(filenames)}+ files in one synced dir",
@@ -212,6 +227,27 @@ def self_test():
         print(f"[self-test] detects oversized synced dir:      {got_big}")
         print(f"[self-test] clean docs tree -> no findings:    {len(f2) == 0}")
         ok = got_marker and got_big and len(f2) == 0
+
+        # --- MYC-4188: the seed case. An EMPTY .claude/worktrees inside a
+        # synced root must fire, and the innocent look-alikes must stay silent.
+        # This leg exists because the previous control suite was built only from
+        # bugs already fixed, so it could not report a word missing from its own
+        # vocabulary -- the guard walked into the directory, looked straight at
+        # the hazard, and did not know the name.
+        seed = os.path.join(tmp, "seed_root")
+        os.makedirs(os.path.join(seed, ".claude", "worktrees"))   # empty -> MUST flag
+        os.makedirs(os.path.join(seed, ".obsidian"))              # legit sync -> silent
+        os.makedirs(os.path.join(seed, "worktrees"))              # bare name -> silent
+        open(os.path.join(seed, ".claude", "settings.local.json"), "w").close()
+        f3 = scan_root(seed, "TEST")
+        seed_paths = {x["path"] for x in f3}
+        got_seed = os.path.join(seed, ".claude", "worktrees") in seed_paths
+        quiet_obsidian = os.path.join(seed, ".obsidian") not in seed_paths
+        quiet_bare = os.path.join(seed, "worktrees") not in seed_paths
+        print(f"[self-test] detects EMPTY .claude/worktrees:   {got_seed}")
+        print(f"[self-test] .obsidian stays silent:            {quiet_obsidian}")
+        print(f"[self-test] bare worktrees/ stays silent:      {quiet_bare}")
+        ok = ok and got_seed and quiet_obsidian and quiet_bare
 
         # Metadata-only negative control: a FIFO has the same forever-blocking
         # behavior as a placeholder if opened for content. This scanner must

--- a/hooks/check-sync-folder-machinery.py
+++ b/hooks/check-sync-folder-machinery.py
@@ -191,7 +191,7 @@ def write_snapshot(findings, high):
     try:
         os.makedirs(os.path.dirname(STATE_PATH), exist_ok=True)
         tmp = STATE_PATH + ".tmp"
-        with open(tmp, "w") as fh:
+        with open(tmp, "w", encoding="utf-8") as fh:
             json.dump({
                 "scanned_at": time.time(),
                 "roots": [{"path": p, "provider": prov} for p, prov in synced_roots()],
@@ -214,14 +214,14 @@ def self_test():
         big = os.path.join(tmp, "hugedir")
         os.makedirs(big)
         for i in range(FILE_COUNT_THRESHOLD + 5):
-            open(os.path.join(big, f"f{i}"), "w").close()
+            open(os.path.join(big, f"f{i}"), "w", encoding="utf-8").close()
         f = scan_root(tmp, "TEST")
         got_marker = any(x["reason"].startswith("machinery dir '.git'") for x in f)
         got_big = any("files in one synced dir" in x["reason"] for x in f)
         # control: a clean docs tree must produce NOTHING
         clean = os.path.join(tmp, "clean_docs")
         os.makedirs(clean)
-        open(os.path.join(clean, "notes.md"), "w").close()
+        open(os.path.join(clean, "notes.md"), "w", encoding="utf-8").close()
         f2 = scan_root(clean, "TEST")
         print(f"[self-test] detects .git inside synced folder: {got_marker}")
         print(f"[self-test] detects oversized synced dir:      {got_big}")
@@ -238,7 +238,7 @@ def self_test():
         os.makedirs(os.path.join(seed, ".claude", "worktrees"))   # empty -> MUST flag
         os.makedirs(os.path.join(seed, ".obsidian"))              # legit sync -> silent
         os.makedirs(os.path.join(seed, "worktrees"))              # bare name -> silent
-        open(os.path.join(seed, ".claude", "settings.local.json"), "w").close()
+        open(os.path.join(seed, ".claude", "settings.local.json"), "w", encoding="utf-8").close()
         f3 = scan_root(seed, "TEST")
         seed_paths = {x["path"] for x in f3}
         got_seed = os.path.join(seed, ".claude", "worktrees") in seed_paths
@@ -285,7 +285,7 @@ def self_test():
         os.makedirs(os.path.join(mirror_git, ".git"))
         mirror_clean = os.path.join(tmp, "mirror_clean")    # Mirror, clean -> no finding
         os.makedirs(mirror_clean)
-        open(os.path.join(mirror_clean, "notes.md"), "w").close()
+        open(os.path.join(mirror_clean, "notes.md"), "w", encoding="utf-8").close()
         stream_git = os.path.join(tmp, "stream_vault")      # sync_type=2 -> IGNORED
         os.makedirs(os.path.join(stream_git, ".git"))
 

--- a/hooks/check-sync-folder-machinery.py
+++ b/hooks/check-sync-folder-machinery.py
@@ -60,10 +60,14 @@ MARKER_DIRS = {".git", "node_modules", ".venv", "venv", "target",
 # `worktrees` is machinery ONLY under a tool dir. A bare folder named
 # "worktrees" is plausible user content, so it is scoped by PARENT rather than
 # added as another ambiguous bare name alongside dist/build/target. See
-# scan_root. Deliberately absent everywhere: `.obsidian` -- it legitimately
+# scan_root. Deliberately absent from THIS file's marker set: `.obsidian` -- it legitimately
 # syncs, that is how Obsidian mobile works, and a guard that cries wolf on real
 # folders teaches bypass, which then masks the true hits.
-WORKTREE_PARENTS = {".claude", ".git"}
+# Only ".claude": ".git" is itself in MARKER_DIRS and is pruned from dirnames before the
+# walk descends, so os.walk never yields a dirpath ending in "/.git" and a ".git" entry
+# here could only fire if a scan ROOT were named .git. Listing it read as coverage that
+# does not exist. A repo's own .git/worktrees is covered by the .git hit itself.
+WORKTREE_PARENTS = {".claude"}
 # A plain folder this big is also too much for a File Provider to live-sync
 FILE_COUNT_THRESHOLD = 5000
 # Per-root safety budget so a streamed Google Drive can't hang the scan
@@ -141,7 +145,18 @@ def scan_root(root, provider):
     findings = []
     start = time.monotonic()
     base_depth = root.rstrip("/").count("/")
-    for dirpath, dirnames, filenames in os.walk(root, topdown=True):
+    def _unreadable(err):
+        # os.walk's default onerror is None -- it SWALLOWS a permission/IO failure and
+        # yields nothing for that subtree, so an unreadable root produced findings:[] and
+        # main() printed "clean". That routes an unproven scan into the one verdict this
+        # guard must never emit. Recorded as coverage-PARTIAL, same channel as a budget
+        # truncation.
+        findings.append({"path": getattr(err, "filename", root) or root,
+                         "provider": provider,
+                         "reason": f"unreadable subtree ({type(err).__name__}) -- coverage PARTIAL, not clean",
+                         "severity": "info"})
+
+    for dirpath, dirnames, filenames in os.walk(root, topdown=True, onerror=_unreadable):
         if time.monotonic() - start > ROOT_TIME_BUDGET_S:
             findings.append({"path": root, "provider": provider,
                              "reason": "scan-time-budget-exceeded (large/streamed tree)",
@@ -150,20 +165,29 @@ def scan_root(root, provider):
         if dirpath.count("/") - base_depth >= MAX_DEPTH:
             dirnames[:] = []
             continue
-        hit = set(MARKER_DIRS.intersection(dirnames))
+        candidates = set(MARKER_DIRS.intersection(dirnames))
         # An EMPTY .claude/worktrees still counts -- it is the SEED, not the
         # storm. 0 files, so FILE_COUNT_THRESHOLD structurally cannot see it,
         # and it fills with a ~6.5K-file checkout the next time a session ticks
         # the worktree box. Missed for 8 days inside a live Google Drive root
         # while this scan reported findings:[] every morning (MYC-4188).
         if "worktrees" in dirnames and os.path.basename(dirpath.rstrip("/")) in WORKTREE_PARENTS:
-            hit.add("worktrees")
+            candidates.add("worktrees")
+        # A SYMLINK here is the documented CURE, never the disease. Shape B in
+        # CLOUD_SYNC.md tells the user to run relocate-machinery-sidecar, which moves
+        # .smart-env / .codegraph / .claude/worktrees to a sidecar and leaves a symlink
+        # behind -- the churn is then outside the synced tree by construction. os.walk
+        # lists a symlinked directory in dirnames, so without this filter a vault fixed
+        # EXACTLY as our own docs instruct reports three permanent HIGH findings that no
+        # action can clear. The pre-existing markers were accidentally immune: .git
+        # remediates to a pointer FILE, which never appears in dirnames.
+        hit = {h for h in candidates if not os.path.islink(os.path.join(dirpath, h))}
         for h in sorted(hit):
             findings.append({"path": os.path.join(dirpath, h), "provider": provider,
                              "reason": f"machinery dir '{h}' inside synced folder",
                              "severity": "high"})
         # don't descend into machinery we already flagged
-        dirnames[:] = [d for d in dirnames if d not in hit and d not in MARKER_DIRS]
+        dirnames[:] = [d for d in dirnames if d not in candidates and d not in MARKER_DIRS]
         if len(filenames) >= FILE_COUNT_THRESHOLD:
             findings.append({"path": dirpath, "provider": provider,
                              "reason": f"{len(filenames)}+ files in one synced dir",
@@ -180,7 +204,8 @@ def run_scan():
 
 def truncated_roots(findings):
     """Roots whose walk hit the time budget -> coverage is PARTIAL, not clean."""
-    return [f["path"] for f in findings if "budget" in f.get("reason", "")]
+    return [f["path"] for f in findings
+            if "budget" in f.get("reason", "") or "coverage PARTIAL" in f.get("reason", "")]
 
 
 def write_snapshot(findings, high):
@@ -239,6 +264,17 @@ def self_test():
         os.makedirs(os.path.join(seed, ".obsidian"))              # legit sync -> silent
         os.makedirs(os.path.join(seed, "worktrees"))              # bare name -> silent
         open(os.path.join(seed, ".claude", "settings.local.json"), "w", encoding="utf-8").close()
+        # Sidecar-symlink control. The islink regression above shipped past this diff's
+        # own new legs because every fixture here was a REAL dir. A suite made only of
+        # the bug you just fixed cannot see the bug you just made.
+        sidecar = os.path.join(tmp, "sidecar_target")
+        os.makedirs(os.path.join(sidecar, "worktrees"))
+        os.makedirs(os.path.join(sidecar, "smart-env"))
+        fixed = os.path.join(tmp, "fixed_vault")
+        os.makedirs(os.path.join(fixed, ".claude"))
+        os.symlink(os.path.join(sidecar, "worktrees"), os.path.join(fixed, ".claude", "worktrees"))
+        os.symlink(os.path.join(sidecar, "smart-env"), os.path.join(fixed, ".smart-env"))
+
         f3 = scan_root(seed, "TEST")
         seed_paths = {x["path"] for x in f3}
         got_seed = os.path.join(seed, ".claude", "worktrees") in seed_paths
@@ -247,7 +283,22 @@ def self_test():
         print(f"[self-test] detects EMPTY .claude/worktrees:   {got_seed}")
         print(f"[self-test] .obsidian stays silent:            {quiet_obsidian}")
         print(f"[self-test] bare worktrees/ stays silent:      {quiet_bare}")
-        ok = ok and got_seed and quiet_obsidian and quiet_bare
+        f4 = scan_root(fixed, "TEST")
+        quiet_sidecar = len(f4) == 0
+        print(f"[self-test] sidecar SYMLINKS stay silent:      {quiet_sidecar}")
+        ok = ok and got_seed and quiet_obsidian and quiet_bare and quiet_sidecar
+
+        # Unreadable-subtree control: coverage must read PARTIAL, never clean.
+        locked = os.path.join(tmp, "locked_root")
+        os.makedirs(os.path.join(locked, "vault", ".git"))
+        os.chmod(locked, 0o000)
+        try:
+            f5 = scan_root(locked, "TEST")
+            loud_unreadable = bool(truncated_roots(f5))
+        finally:
+            os.chmod(locked, 0o755)
+        print(f"[self-test] unreadable root reports PARTIAL:   {loud_unreadable}")
+        ok = ok and loud_unreadable
 
         # Metadata-only negative control: a FIFO has the same forever-blocking
         # behavior as a placeholder if opened for content. This scanner must

--- a/hooks/surface-sync-guard-findings.py
+++ b/hooks/surface-sync-guard-findings.py
@@ -111,7 +111,7 @@ def main():
     if os.environ.get("SYNC_GUARD_SURFACE_BYPASS") == "1":
         return 0
     try:
-        with open(STATE_PATH) as fh:
+        with open(STATE_PATH, encoding="utf-8") as fh:
             snap = json.load(fh)
     except FileNotFoundError:
         # Never ran, or ran only on a version predating snapshots. Silent:

--- a/scripts/utf8-file-io-baseline.txt
+++ b/scripts/utf8-file-io-baseline.txt
@@ -23,12 +23,11 @@
 #
 # <sha256-of-normalized-content> <tag> <repo-relative-path>
 
-# ---- SEV-A-write  (34 file(s)) ----
+# ---- SEV-A-write  (33 file(s)) ----
 b87ac14c241be51fb2427ac9a86ab8de4a5b161549f2ee0d445b6e9ca4f65550 SEV-A-write hooks/_lib/session_echo.test.py
 62adfe6bbcfecc12d8e6bbad292ab40215e9f15c8812ec91f53dfe42156e7886 SEV-A-write hooks/_lib/standing_report.test.py
 987aca2ae82229a42d29a8c89fed690e9de7e6fad4182dea564bc92557a81922 SEV-A-write hooks/auto-capture-public-ships.py
 9cbf3bb52c04fd00a41852d12baf7640f9212db9b5a34aaac2247ee6abb4312f SEV-A-write hooks/check-py-import-precommit.py
-fa31be94c34f90a59be61d732555563dad22c492d1c8d1bd735a09c56289a0cd SEV-A-write hooks/check-sync-folder-machinery.py
 a04ec6c84be6756813f4cde517ff379338b57ec9bf4c9c4172172951e62f91c3 SEV-A-write hooks/imessage-mcp-auto-export.py
 d293427274a02ef33d15ec50b17860aa305405adc9f372fde46a46454267becd SEV-A-write hooks/relocate-watch-surface.py
 95e98712d44f2ee71cdfb8ba3aa7a1fe21967160cd5b2bdaab20bd3d6869c10d SEV-A-write hooks/retry-budget.py

--- a/scripts/utf8-file-io-baseline.txt
+++ b/scripts/utf8-file-io-baseline.txt
@@ -58,14 +58,13 @@ bf2aa37b1fc14be871ed01920e719d1f71d87052e536d4c435ed2fff227ca8ec SEV-A-write scr
 a29f6c2b98ccf874e4c818e2487ce74f32248ecbbce73a11c91a738561f3aa84 SEV-A-write skills/graphify/scripts/graphify_chunk.py
 8397e371e756c7cff96453d8f8f2c895e1e8ac0762edc8538c573c059e07d19d SEV-A-write skills/graphify/scripts/graphify_prep.py
 
-# ---- SEV-B-read-only  (28 file(s)) ----
+# ---- SEV-B-read-only  (27 file(s)) ----
 3f7a1805473134ddb49cd1957cc4f94c8e84a1ccb4e8f875e6765b3dac33f289 SEV-B-read-only hooks/_lib/safe_read.py
 52c331ed8a99a90e12e347215144e6799dbe1d278024432dfc46639a4de68405 SEV-B-read-only hooks/_lib/worktree_safety.py
 b647243fdf0a358d46a6a79b0bf7f817ee121f68d5d685fabe4b0ee2a93af94d SEV-B-read-only hooks/check-fabricated-hook-attribution.py
 2050c962d8ba4b38910d207c75e786f4b4831406ba3d8e799fe9f475623c8bff SEV-B-read-only hooks/detect-secrets-in-bash-output.py
 3599a56754108272a15a2c879a23a52c0e844edf2991932118ecf16b24706af9 SEV-B-read-only hooks/dev-hub-refresh-on-session-start.py
 383b879b07fd9dce4a66c6a9beb449e2c7ec378b7f94d393b2bf486cf26531fb SEV-B-read-only hooks/observe-tool-calls.py
-9ac734ab62df2f6176c7aabad09b72768fe553c93ef15a876ddae32e9a830ca4 SEV-B-read-only hooks/surface-sync-guard-findings.py
 2b14fd8dbb3f827ca22270bee60bdacf598984bd28f2221856702b7791ba71b2 SEV-B-read-only hooks/test_footprint_aggregate_bloat.py
 074e59997be3432d5dbab5858429d1185d65c4061dbbade2325f08d3b2165160 SEV-B-read-only hooks/test_secret_patterns_fp_filter.py
 5ab0af49336eca75f51dd8a442afb3d4e429294bf7f167e4bba9736b8c7ec6a7 SEV-B-read-only hooks/verify-discoverability-on-close.py


### PR DESCRIPTION
Closes MYC-4188 — https://linear.app/myceliumai/issue/MYC-4188

---

## The guard reported clean over a live hit

`check-sync-folder-machinery.py` ran, completed, and wrote `findings: []` while machinery sat in a synced Google Drive root for 8 days — on the surface paying clients install.

Measured 2026-08-26:

| signal | value |
|---|---|
| `sync-guard-last.json` mtime | 09:00:04 |
| roots scanned | includes the `GoogleDrive-…` CloudStorage root |
| `findings` / `high_count` / `truncated_roots` | `[]` / `0` / `[]` |
| the hazard | a `.claude/worktrees` dir, created Aug 18 |
| its depth vs `MAX_DEPTH` | 5 vs 7 — the walk reached it |

Not dormancy (MYC-1133), not truncation, not depth, not Mirror-root discovery (MYC-705 / MYC-1130 found the root correctly). `scan_root` flags on `MARKER_DIRS.intersection(dirnames)`, and `MARKER_DIRS` had no `worktrees`. The walk stood in the directory, looked straight at the hazard, and did not know the name.

**The miss is on the seed, not the storm.** An empty `worktrees` dir is 0 files, so the `FILE_COUNT_THRESHOLD` leg structurally cannot see it either. It stays invisible until a session opens a worktree there and lands a ~6.5K-file checkout inside the synced root.

Bug class **GUARD-BLIND-TO-THE-HAZARD-ITS-OWN-DOCS-DESCRIBE**.

## Changes

1. `MARKER_DIRS` gains `.codegraph` and `.smart-env`.
2. `worktrees` detected **parent-scoped** to `.claude` via `WORKTREE_PARENTS`, rather than added as another bare name beside `dist`/`build`/`target`. A bare folder called `worktrees` is plausible user content, and a guard that cries wolf on real folders teaches bypass, which then masks the true hits.
3. `.obsidian` stays deliberately unlisted — it legitimately syncs; that is how Obsidian mobile works.
4. `self_test` grows from 12 legs to 14.

## What the adversarial review caught, and why it mattered

Two independent reviewers, split by lens (evasion vs regression), both refused the first draft. The blocking finding was mine:

`MARKER_DIRS` matches on directory **name**, and `os.walk` lists a **symlinked** directory in `dirnames`. `relocate-machinery-sidecar.sh` — Shape B in `CLOUD_SYNC.md`, the mode we advertise as *keep your notes in iCloud and edit them on your iPhone* — moves `.smart-env`, `.codegraph` and `.claude/worktrees` to a sidecar and leaves symlinks behind. Same fixture, both refs:

```
origin/main (correctly-fixed vault):  no findings
first draft (correctly-fixed vault):  3 × severity=high, unclearable
```

A client who followed our own remediation would have gotten three permanent HIGH alerts at every SessionStart with no available action. The pre-existing markers were accidentally immune — `.git` remediates to a pointer **file**, which never appears in `dirnames`. The three new ones have no such property, and my new legs could not see it because every fixture I wrote was a real directory. *A suite made only of the bug you just fixed cannot see the bug you just made* — the same sentence from the first commit, one level up. Fixed with an `os.path.islink` filter plus a sidecar-symlink control.

Also from the reviews:

- `os.walk` ran with the default `onerror=None`, which **swallows** a permission/IO error and yields nothing for that subtree. An unreadable root returned `findings: []` and printed `clean` — an unproven scan rendering as the one verdict this guard must never emit. Now reported as coverage-PARTIAL through the existing `truncated_roots` channel, with a control that `chmod 000`s a root holding a `.git`.
- `surface-sync-guard-findings.py` read the snapshot with **no** `encoding=` while the writer had just been pinned to UTF-8. Harmless today, but one `ensure_ascii=False` away from a `UnicodeDecodeError` swallowed by a bare `except`, silencing the surfacer on Windows. Reader pinned, baseline row retired, SEV-B ledger corrected.
- `WORKTREE_PARENTS` carried `.git`, which is unreachable — `.git` is a marker and is pruned before descent, so no `dirpath` ever ends in `/.git`. It read as coverage that does not exist. Dropped.

**Correction carried in the third commit.** The second commit's message claimed the missing `encoding=` on `write_snapshot` meant Windows would corrupt the reported paths. That is not true at that call site: `json.dump` defaults to `ensure_ascii=True`, so the payload is pure ASCII and cp1252 and UTF-8 agree byte for byte — which `check-utf8-file-io.py`'s own header documents as the provably-safe exemption. The baseline row existed for the self-test's file creations. The encoding pins are still correct and worth keeping; the stated reason was not evidence-backed.

## Review-risky areas

- The `islink` filter changes what is REPORTED but not what is PRUNED — pruning still uses the unfiltered candidate set. Worth confirming that split reads correctly.
- `truncated_roots` now matches two reason shapes; anything downstream keying on the old string should be checked.

## Known gaps, not closed here

Reviewers surfaced further evasions worth their own ticket rather than scope creep: case-insensitive matching (`.Claude/Worktrees` is silent on macOS, and once such a dir exists `makedirs` reuses it), bare/detached gitdirs (`objects`+`refs`+`HEAD` with no `.git` name), unfollowed symlinks into out-of-tree content that Dropbox still syncs, and missing vocabulary — notably `.smart-connections`, the direct predecessor of the `.smart-env` added here.

## Verification

- `self_test` **exit 0**, 14 legs
- `test-sync-folder-machinery-guard.sh`, `test_sync_guard_surface.sh`, `test_cloud_safe_file_walkers.sh` — all exit 0
- `ci-test` **GREEN**: `py_compile` (391 files) + 136 integration tests + 31 `scripts/` + 24 `hooks/tests` suites + shellcheck + every lint gate; marker `5e625c5a.ok`
- personal-data scrub exit 0, each pattern proven against a planted specimen first

Drafted with Claude Code, reviewed by two independent adversarial agents that blocked the first draft, gates run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
