### PR TITLE
instinct: add --shareable to export, fail closed on disclosure

### DIFF
--- a/scripts/instinct.py
+++ b/scripts/instinct.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 from datetime import date, datetime, timezone
 from pathlib import Path
@@ -258,15 +259,112 @@ def cmd_report(args, memory_dir: Path) -> int:
     return 0
 
 
+# ---------------------------------------------------------------------------
+# --shareable: type filter + disclosure scan for `export`
+# ---------------------------------------------------------------------------
+# Only these two types are PROVEN transferable. `reference`/`project` are
+# audit bookmarks (private companies, tickets, artifact URLs) that happen to
+# live in the same feedback_*/discovery_* files the Instinct Engine scans; an
+# instinct with no resolvable type at all is treated the same as an unsafe
+# one. This is an ALLOW-list, not a denylist of {reference, project}, on
+# purpose: a denylist only stops the types it already knows about, and a
+# brand-new type value tomorrow would sail straight through it unexamined.
+SHAREABLE_TYPES = frozenset({"feedback", "discovery"})
+
+# Deliberately conservative. A false positive here costs a re-run; a missed
+# one ships a disclosure. Two matching STYLES on purpose:
+#   substring     catches a compound brand token wherever it appears, even
+#                 inside a longer word (see the ondeplan note below).
+#   word_boundary catches a short bare name/word WITHOUT matching it as a
+#                 substring of something unrelated.
+# CRITICAL: `\bonde\b` does NOT match inside "ondeplan" (no word boundary
+# between "e" and "p"), which is exactly why the compound names
+# (ondeplan/onde-platform/onde_team) are their own substring entries instead
+# of being folded into the bare `\bonde\b` word-boundary pattern. Merging
+# them back into one word-boundary pattern reopens the exact leak this gate
+# exists to close. All patterns are matched case-insensitively -- these are
+# names and tickets, and there is no safe casing to assume away.
+DISCLOSURE_PATTERNS: dict[str, tuple[str, ...]] = {
+    "substring": (
+        "ondeplan", "onde-platform", "onde_team", "mycelium", "myceliumai", "diazroa",
+    ),
+    "word_boundary": (
+        r"\bonde\b", r"\badelaida\b", r"\bdiaz-roa\b", r"\bsergio\b", r"\bnelly\b",
+        r"\bcolombia\b", r"\bbogot[aá]\b", r"\baccenture\b", r"\bpanorama\b",
+    ),
+    "regex": (
+        r"MYC-\d+", r"OND-\d+", r"claude\.ai/code/artifact",
+    ),
+}
+
+
+def _compile_disclosure_patterns() -> list[tuple[str, re.Pattern]]:
+    compiled = []
+    for raw in DISCLOSURE_PATTERNS["substring"]:
+        compiled.append((raw, re.compile(re.escape(raw), re.IGNORECASE)))
+    for raw in DISCLOSURE_PATTERNS["word_boundary"] + DISCLOSURE_PATTERNS["regex"]:
+        compiled.append((raw, re.compile(raw, re.IGNORECASE)))
+    return compiled
+
+
+_DISCLOSURE_COMPILED = _compile_disclosure_patterns()
+
+
+def _disclosure_hits(filename: str, body: str) -> list[str]:
+    """Scan `filename` and `body` against every DISCLOSURE_PATTERNS entry.
+
+    Returns one human-readable line per hit (empty list = clean). Checks
+    ALL patterns against BOTH surfaces rather than stopping at the first hit,
+    so a single failing run can report everything that needs fixing at once.
+    """
+    hits: list[str] = []
+    for surface, text in (("filename", filename), ("body", body)):
+        for raw, rx in _DISCLOSURE_COMPILED:
+            m = rx.search(text)
+            if m:
+                hits.append(f"{surface} matched {raw!r} -> {m.group(0)!r}")
+    return hits
+
+
+def _resolve_type(inst: il.Instinct, yaml_mod) -> str | None:
+    """The instinct's declared `type`, checked in both schemas real memory
+    files use.
+
+    Some instincts carry a flat top-level `type:` (written by `import`'s
+    _write_inherited, and already read elsewhere via fm.get("type") for
+    confidence seeding). Others -- including ones written by Claude's own
+    project-memory tooling -- nest it under a `metadata:` mapping instead
+    (measured live: a real vault discovery_*.md carries `metadata.type:
+    project` despite its discovery_ filename, which is exactly the bookmark
+    this filter exists to keep out of a shareable pack). Returns None when
+    neither form is present; callers must treat that as UNKNOWN, never as
+    safe -- that is what makes the SHAREABLE_TYPES check below fail closed.
+    """
+    flat = inst.fm.get("type")
+    if flat:
+        return str(flat).strip().lower()
+    try:
+        full = yaml_mod.safe_load("\n".join(inst.fm_lines)) or {}
+    except Exception:
+        return None
+    meta = full.get("metadata") if isinstance(full, dict) else None
+    if isinstance(meta, dict) and meta.get("type"):
+        return str(meta["type"]).strip().lower()
+    return None
+
+
 def cmd_export(args, memory_dir: Path) -> int:
     try:
         import yaml
     except ImportError:
         print("ERROR: export needs PyYAML (pip install pyyaml).", file=sys.stderr)
         return 2
+    shareable = getattr(args, "shareable", False)
     today = _today()
     proj = args.project or il.current_project_id()
     out = []
+    excluded_type = 0
+    disclosure_report: list[str] = []
     for path in il.iter_instinct_paths(memory_dir):
         inst = il.parse_instinct(path)
         fm = inst.fm
@@ -276,6 +374,15 @@ def cmd_export(args, memory_dir: Path) -> int:
         eff = round(_effective(inst, today), 3)
         if eff < args.min_confidence:
             continue
+        if shareable:
+            itype = _resolve_type(inst, yaml)
+            if itype not in SHAREABLE_TYPES:
+                excluded_type += 1
+                continue
+            hits = _disclosure_hits(path.name, inst.body)
+            if hits:
+                disclosure_report.extend(f"{path.name}: {h}" for h in hits)
+                continue
         out.append({
             "id": inst.slug,
             "trigger": fm.get("name", inst.slug),
@@ -285,13 +392,26 @@ def cmd_export(args, memory_dir: Path) -> int:
             "action": (fm.get("description", "") or "").strip(),
             "evidence": inst.body.strip()[:1200],
         })
+
+    if disclosure_report:
+        # FAIL CLOSED, always -- never write a partial pack with only the
+        # offender silently dropped (that is the SILENT-NO-OP bug class: a
+        # pack that "worked" while quietly shipping less coverage than it
+        # claimed, with nobody told which file was cut).
+        print("ERROR: --shareable disclosure scan failed. Refusing to write any "
+              "output. Fix or exclude the file(s) below and re-run:", file=sys.stderr)
+        for line in disclosure_report:
+            print(f"  {line}", file=sys.stderr)
+        return 1
+
     out.sort(key=lambda r: r["confidence"], reverse=True)
     doc = {"instinct_pack_version": 1, "exported_for_project": proj,
            "exported_count": len(out), "instincts": out}
     text = yaml.safe_dump(doc, sort_keys=False, allow_unicode=True, width=100)
+    suffix = f" (--shareable excluded {excluded_type} reference/project/untyped)" if shareable else ""
     if args.out:
         Path(args.out).expanduser().write_text(text, encoding="utf-8")
-        print(f"export: {len(out)} instinct(s) -> {args.out}")
+        print(f"export: {len(out)} instinct(s) -> {args.out}{suffix}")
     else:
         sys.stdout.write(text)
     return 0
@@ -501,6 +621,10 @@ def build_parser() -> argparse.ArgumentParser:
     sp = sub.add_parser("export", parents=[common])
     sp.add_argument("--project"); sp.add_argument("--min-confidence", type=float, default=0.0)
     sp.add_argument("--all", action="store_true"); sp.add_argument("--out")
+    sp.add_argument("--shareable", action="store_true",
+                    help="exclude reference/project-type (and untyped) instincts, and fail "
+                         "closed -- writing nothing -- if any surviving instinct's filename "
+                         "or body matches a private brand/name/ticket disclosure pattern")
 
     sp = sub.add_parser("import", parents=[common]); sp.add_argument("file"); sp.add_argument("--dry-run", action="store_true")
 

--- a/scripts/instinct.py
+++ b/scripts/instinct.py
@@ -345,7 +345,13 @@ def _resolve_type(inst: il.Instinct, yaml_mod) -> str | None:
         return str(flat).strip().lower()
     try:
         full = yaml_mod.safe_load("\n".join(inst.fm_lines)) or {}
-    except Exception:
+    except yaml_mod.YAMLError:
+        # Malformed frontmatter -> type is unproven, not "safe". A bare
+        # `except Exception` here would ALSO swallow a genuine bug unrelated
+        # to YAML (e.g. inst.fm_lines holding something un-joinable), and
+        # silently treat a real defect as "exclude this instinct" instead of
+        # surfacing it -- narrowed to the one error class this call can
+        # actually raise for bad DATA, so anything else still fails loud.
         return None
     meta = full.get("metadata") if isinstance(full, dict) else None
     if isinstance(meta, dict) and meta.get("type"):

--- a/tests/test_instinct.py
+++ b/tests/test_instinct.py
@@ -9,6 +9,7 @@ temp dir — never touches real memory.
 from __future__ import annotations
 
 import os
+import re
 import sys
 import tempfile
 from datetime import date, timedelta
@@ -182,6 +183,126 @@ def test_export_import_roundtrip():
         check(after > before, f"higher-confidence import updates local ({before}->{after})")
 
 
+def _write_shareable_fixture(md: Path, name: str, frontmatter: str, body: str) -> Path:
+    p = md / name
+    p.write_text(f"---\n{frontmatter}\n---\n{body}\n", encoding="utf-8")
+    return p
+
+
+def test_shareable_export():
+    """`export --shareable`: type-filters reference/project/untyped instincts
+    and fails closed (writes NOTHING) if any surviving instinct's filename or
+    body matches a private disclosure pattern.
+
+    The reference-type fixture uses the NESTED `metadata: {type: ...}`
+    frontmatter shape -- the shape real memory files actually carry (measured
+    live against a real vault file: discovery_308_redirect_kills_failopen_
+    reporters.md has `metadata.type: project` despite its discovery_
+    filename -- an audit bookmark, not a transferable instinct). The other
+    fixtures use the flat top-level `type:` shape (already read elsewhere via
+    fm.get("type")), so both schemas this repo's memory files use get
+    exercised.
+    """
+    print("test_shareable_export")
+    try:
+        import yaml
+    except ImportError:
+        print("  [SKIP] test_shareable_export: PyYAML not installed (optional dep)")
+        return
+
+    # Sanity anchor for the regression Control 3 exists to catch: a bare
+    # word-boundary pattern for "onde" must NOT match inside "ondeplan" (no
+    # boundary between "e" and "p"). If this ever stopped being true the
+    # substring/word-boundary split in DISCLOSURE_PATTERNS would be pointless.
+    check(re.search(r"\bonde\b", "ondeplan", re.IGNORECASE) is None,
+          r"sanity: \bonde\b does NOT match inside 'ondeplan' (why substring is separate)")
+
+    # --- CONTROL 1 + POSITIVE CONTROL: one pack, nothing disclosed ----------
+    with tempfile.TemporaryDirectory() as t:
+        md = Path(t) / "Agent Memory"
+        md.mkdir(parents=True)
+        _write_shareable_fixture(
+            md, "discovery_audit_bookmark_reference_type.md",
+            "name: audit bookmark example\n"
+            "description: private audit note, not a transferable instinct\n"
+            "metadata:\n"
+            "  node_type: memory\n"
+            "  confidence: 0.9\n"
+            "  observations: 1\n"
+            "  last_seen: 2026-01-01\n"
+            "  project_id: global\n"
+            "  type: reference",
+            "Bookmark only. Nothing transferable here.")
+        _write_shareable_fixture(
+            md, "feedback_clean_shareable_example.md",
+            "name: a perfectly ordinary rule\n"
+            "description: ship the fix, verify the tests, done\n"
+            "type: feedback\nstrength: explicit",
+            "A perfectly ordinary instinct body with no private tokens.")
+        cli.cmd_backfill(Args(no_backup=True), md)
+        out = Path(t) / "pack.yaml"
+        rc = cli.cmd_export(Args(project=None, min_confidence=0.0, all=True,
+                                 out=str(out), shareable=True), md)
+        check(rc == 0, f"clean fixture + one reference-typed fixture exports OK (rc={rc})")
+        check(out.is_file(), "--shareable wrote the output file when nothing disclosed")
+        doc = yaml.safe_load(out.read_text()) if out.is_file() else {}
+        ids = {r["id"] for r in doc.get("instincts", [])}
+        check("discovery_audit_bookmark_reference_type" not in ids,
+              "CONTROL 1: metadata.type: reference EXCLUDED by --shareable")
+        check("feedback_clean_shareable_example" in ids,
+              "POSITIVE CONTROL: clean type: feedback fixture with no tokens EXPORTED")
+
+    # --- CONTROL 2: a brand token in the body fails the WHOLE export --------
+    with tempfile.TemporaryDirectory() as t:
+        md = Path(t) / "Agent Memory"
+        md.mkdir(parents=True)
+        leak = _write_shareable_fixture(
+            md, "feedback_accidental_brand_leak.md",
+            "name: some rule\ndescription: a normal feedback rule\n"
+            "type: feedback\nstrength: explicit",
+            "Ship the mycelium runtime pattern here.")
+        cli.cmd_backfill(Args(no_backup=True), md)
+        out = Path(t) / "pack.yaml"
+        import io
+        from contextlib import redirect_stderr
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            rc = cli.cmd_export(Args(project=None, min_confidence=0.0, all=True,
+                                     out=str(out), shareable=True), md)
+        err = buf.getvalue()
+        check(rc != 0, f"CONTROL 2: brand token 'mycelium' in body -> non-zero exit (rc={rc})")
+        check(not out.exists(), "CONTROL 2: no output file written on disclosure hit")
+        check(leak.name in err, "CONTROL 2: stderr names the offending file")
+        check("mycelium" in err.lower(), "CONTROL 2: stderr names the matched token")
+
+    # --- CONTROL 3: the ondeplan regression ----------------------------------
+    # A fixture whose BODY says "ondeplan" must be caught by the substring
+    # bucket even though the word-boundary \bonde\b pattern would miss it.
+    with tempfile.TemporaryDirectory() as t:
+        md = Path(t) / "Agent Memory"
+        md.mkdir(parents=True)
+        leak = _write_shareable_fixture(
+            md, "feedback_regression_case_body_token.md",
+            "name: some rule\ndescription: a normal feedback rule\n"
+            "type: feedback\nstrength: explicit",
+            "Verified this against the ondeplan e2e baselines.")
+        cli.cmd_backfill(Args(no_backup=True), md)
+        out = Path(t) / "pack.yaml"
+        import io
+        from contextlib import redirect_stderr
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            rc = cli.cmd_export(Args(project=None, min_confidence=0.0, all=True,
+                                     out=str(out), shareable=True), md)
+        err = buf.getvalue()
+        check(rc != 0, f"CONTROL 3: 'ondeplan' in body -> non-zero exit (rc={rc})")
+        check(not out.exists(), "CONTROL 3: no output file written on disclosure hit")
+        check(leak.name in err, "CONTROL 3: stderr names the offending file")
+        check("ondeplan" in err.lower(),
+              "CONTROL 3: substring pattern catches 'ondeplan' in the body "
+              "(the case a word-boundary-only pattern would silently miss)")
+
+
 def test_evolve():
     print("test_evolve")
     with tempfile.TemporaryDirectory() as t:
@@ -280,6 +401,7 @@ def main():
     test_surgical_frontmatter()
     test_backfill_and_correct()
     test_export_import_roundtrip()
+    test_shareable_export()
     test_evolve()
     test_project_scoping()
     test_reseed()


### PR DESCRIPTION
## Summary

`scripts/instinct.py export` had no type filter and no disclosure scan. The
Agent Memory store holds 665 instincts: 132 are `type: reference` and 18 are
`type: project` -- audit bookmarks naming private companies, tickets, and
artifact URLs, not transferable instincts. A bookmark with a high seed
confidence could export cleanly into a pack meant for a client. That's a
disclosure defect.

This adds `--shareable` to `export`:

- **Type filter (allow-list, fails closed):** keeps only `type: feedback` /
  `type: discovery`. Excludes `reference`/`project`, and excludes an instinct
  with no resolvable type at all -- unknown is never treated as safe. Checks
  both frontmatter schemas real memory files use: the flat top-level `type:`
  (already read elsewhere via `fm.get("type")`) and the nested `metadata:
  {type: ...}` form Claude's own project-memory tooling writes (measured
  against a real vault file: a `discovery_*.md`-named file whose
  `metadata.type` is `project` despite the filename).
- **Disclosure scan (fails closed):** every surviving instinct's filename and
  body are checked against a conservative, named pattern set
  (`DISCLOSURE_PATTERNS`) covering brand/name/ticket tokens, split into
  case-insensitive substring / word-boundary / regex buckets. Any hit prints
  the offending file and matched token and exits non-zero -- **nothing is
  written**, including the otherwise-clean instincts in the same pack. A
  partial pack with just the offender silently dropped is exactly the
  SILENT-NO-OP failure mode this is built to avoid.
- Critical detail preserved from the design: `\bonde\b` (word-boundary) does
  NOT match inside `ondeplan`, which is why the compound brand names
  (`ondeplan`, `onde-platform`, `onde_team`) are separate substring entries
  rather than folded into the bare word-boundary pattern.

A follow-up commit (second commit on this branch) narrows a bare `except
Exception` in the new nested-metadata type resolver to `except
yaml_mod.YAMLError` -- found during the mandatory pre-push doubt-pass on new
security-control code. The broad clause would also have swallowed a genuine
bug unrelated to malformed YAML and silently treated it as "exclude this
instinct" instead of surfacing it. Verified `yaml.YAMLError` is the correct
base class for `ScannerError`/`ParserError` before making the change; no
behavior change on the happy path (full suite still green).

## Test plan

`tests/test_instinct.py` gains `test_shareable_export`, matching the existing
suite's style (a `check()` helper, PASS/FAIL per assertion, no pytest dep):

- [x] **Negative control 1:** a fixture with nested `metadata.type: reference`
      is excluded from the pack.
- [x] **Negative control 2:** a `type: feedback` fixture whose body contains a
      brand token (`mycelium`) causes a non-zero exit and no output file.
- [x] **Negative control 3 (the regression this exists for):** a fixture whose
      body says `ondeplan` is caught by the substring bucket, specifically
      because the word-boundary `\bonde\b` pattern alone would miss it
      (asserted directly as a sanity check too).
- [x] **Positive control:** a clean `type: feedback` fixture with no tokens
      still exports successfully (exit 0, appears in the output YAML).

Each negative control was proven to actually go RED first: run against the
pre-fix `instinct.py` (via a scratch copy under `/tmp`, since this repo's
`git stash` is repo-wide across 4 worktrees and a guard correctly blocks it
here) all three failed as expected; then GREEN against the fix. Both gate
runs (`ci-test`, one per commit on this branch) are fully green, including
this suite:

```
All gates passed: py_compile (391 file(s)) + 136 integration tests + 31
scripts/ + 24 hooks/tests unit suite(s) + shellcheck [passed] + phase-doc
python [passed] + utf8 console guard [passed] + hook block-protocol [passed]
+ vault-root reads [passed] + home-hook deploy [passed] + subprocess decode
[passed] + py3.9 annotation parity [passed] + ps1 encoding [passed].
```

Personal-data scrub (`pii-scrub-local.sh`) run against the diff: clean, exit 0.
