### PR TITLE
feat(scripts): pair the implementations that keep drifting apart (MYC-4036)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -283,6 +283,50 @@ jobs:
       - name: every hook is wired on both POSIX and Windows, or reviewed as not
         run: python3 scripts/check-hook-parity.py
 
+      # The cross-REPO sibling of the gate above. That one asks whether one
+      # behaviour reaches both PLATFORMS; this asks whether one contract's several
+      # hand-written IMPLEMENTATIONS know about each other.
+      #
+      # machinery-sidecar/1 drifted three times: Google Drive Mirror roots taught
+      # here and not in the Rust twin (MYC-1088), the vault-target guard that let
+      # Studio git-init a repo over a founder's $HOME (MYC-4035), and the python
+      # interpreter probe the Windows leg had already solved correctly while the
+      # POSIX leg kept the weaker check. Every check on both sides stayed green
+      # each time, because each implementation is internally consistent and no
+      # gate had ever seen another.
+      #
+      # G4 is the load-bearing one: a sentence in THIS repo asserting the current
+      # state of code in ANOTHER repo cannot stay true, because nothing here runs
+      # when that repo merges. ADR-0007 carried exactly such a sentence; it was
+      # accurate for 29 minutes and wrong for the following eight days.
+      # Self-test first (cheap, and proves the gate bites a synthetic mismatch).
+      - name: paired-implementation negative controls (the gate must bite)
+        run: python3 scripts/check-paired-implementations.py --self-test
+
+      - name: paired implementations are declared, present, and claim-free
+        run: python3 scripts/check-paired-implementations.py
+
+      # The advisory half. A PR touching one side of a paired contract gets the
+      # other side named inline on its Files tab. ADVISORY, never blocking: the
+      # repos have different release cadences and a hard cross-repo gate would
+      # only get bypassed. This is the step that would have said "the Rust twin
+      # also implements this" on the PR that shipped the vault-target guard here
+      # and not there (MYC-4028 -> MYC-4035).
+      #
+      # Security note: github.base_ref is bound to an env var per the SAFE pattern
+      # documented at the top of this file, never interpolated into the shell.
+      # Paths go through a FILE, not word-splitting, so a path with a space
+      # cannot silently become two arguments.
+      - name: name the counterparts of any paired file this PR touches (advisory)
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git fetch --quiet origin "$BASE_REF"
+          git diff --name-only "origin/$BASE_REF...HEAD" > "$RUNNER_TEMP/changed.txt"
+          python3 scripts/check-paired-implementations.py \
+            --changed-from "$RUNNER_TEMP/changed.txt"
+
       # The READ half of the UTF-8 console guard below. That one fails a CLI that
       # PRINTS non-ASCII without reconfiguring stdout; this fails one that READS a
       # child's output with text=True and no encoding=, so the decode uses the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -78,6 +78,12 @@ If you never give an email, or you decline the ask, none of these fire. A declin
 
 What is **never** sent, under any path: journal text, note contents, file contents, file names, your contacts, or anything from your vault. Only the opaque token tied to the email you chose to give, an OS label, and (once) a single date. The token is local to your machine; delete `~/.claude/.ai-brain-starter-email-on-file` to stop all of the above.
 
+The rule this section states — every egress is disclosed AND user-stoppable — is
+also implemented in the paid Studio app, which has its own analytics path and its
+own opt-out. Both are declared under `egress-disclosure` in
+`scripts/paired-implementations.json`. Changing the policy here means changing it
+there too; the list names where.
+
 ---
 
 ## 6. Corporate / hardened install profile

--- a/docs/adr/0007-no-force-escape-on-the-home-refusal.md
+++ b/docs/adr/0007-no-force-escape-on-the-home-refusal.md
@@ -65,6 +65,15 @@ The system-root list is compared **resolved**, not as strings: on macOS `/tmp`
 is a symlink to `/private/tmp`, and a literal match waves it through. Case A4 in
 the test suite pins that.
 
-A second implementation of this feature exists in `mycelium-studio`
-(`apps/desktop/src-tauri/src/commands/vault_safety.rs`) and does not yet carry
-this decision — MYC-4035. Until it does, the guarantee here is partial.
+A second implementation of this decision lives in `mycelium-studio`
+(`apps/desktop/src-tauri/src/commands/vault_safety.rs`). Both are declared under
+`vault-target-refusal` in `scripts/paired-implementations.json`; read the
+counterpart itself for what it enforces today.
+
+This note deliberately does not describe that implementation's state. The
+previous version did — it said the Rust twin had not taken this decision yet —
+and it was written at 04:55:58Z and refuted at 05:25:12Z the same morning when
+MYC-4035 landed the port. It then sat wrong for eight days, through another edit
+to the file it described, because nothing in this repo runs when that one merges.
+Naming a counterpart is durable; describing it is not.
+`scripts/check-paired-implementations.py` (G4) now fails any such sentence.

--- a/scripts/check-cloud-sync.py
+++ b/scripts/check-cloud-sync.py
@@ -7,9 +7,21 @@ high-churn `.git/` + per-session worktree checkouts generate millions of file
 events the sync client tries to upload, pegging CPU and freezing the machine.
 The vault belongs on a real local disk; the index belongs server-side.
 
-This is the SINGLE source of truth for that check — install (phase-01-welcome),
-diagnose.sh/.ps1, and the SessionStart footprint signal all route through the
-same `detect_cloud_sync()` so there is no drift between surfaces.
+This is the single source of truth for that check IN THIS REPO — install
+(phase-01-welcome), diagnose.sh/.ps1, and the SessionStart footprint signal all
+route through the same `detect_cloud_sync()`, so those surfaces cannot drift from
+each other.
+
+It is NOT the only implementation. `mycelium-studio` carries a native Rust
+`detect_cloud_sync`. That pair has drifted before — MYC-1088 records the incident
+and the port that closed it. Every implementation is declared in
+scripts/paired-implementations.json under `cloud-sync-detection`; change this
+file, check that list.
+
+(An earlier draft of this paragraph described what the Rust twin did at the time.
+scripts/check-paired-implementations.py refused it, correctly: a ticket id is a
+durable reference to a dated event, a sentence about another repo's behaviour is
+not.)
 
 Usage:
   check-cloud-sync.py <vault-path>          # human-readable verdict + remedy

--- a/scripts/check-paired-implementations.py
+++ b/scripts/check-paired-implementations.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+"""check-paired-implementations.py - a behaviour implemented twice must SAY so,
+and a cross-repo pointer must never assert the other side's state.
+
+THE BUG CLASS. One contract, several hand-written implementations, nothing
+pairing them. Someone fixes one; the rest stay wrong; every check on both sides
+stays green, because each implementation is internally consistent and no gate has
+ever seen another. machinery-sidecar/1 drifted three times this way: cloud-sync
+Mirror roots (MYC-1088), the vault-target guard (MYC-4035), and the Python
+interpreter probe - which the Windows leg had already solved correctly while the
+POSIX leg kept the weaker check.
+
+WHY HEADER COMMENTS ALONE FAILED. They were tried and they half-worked. Every
+one of them points from the NEWER implementation to the older: the .ps1 names the
+.sh, vault_safety.rs names the .sh, and the .sh names nothing at all. So the file
+whose edit STARTS every drift is the one file with no pointer. This gate fixes
+the direction (G3) rather than trusting people to keep writing the comment.
+
+WHY A POINTER AND NOT AN ENUMERATION. A header listing its siblings is itself a
+copy of the list, and rots exactly like one. Each paired file carries ONE durable
+pointer to scripts/paired-implementations.json; that file holds the enumeration.
+Adding a fourth implementation edits one place, not four.
+
+G4 IS THE ONE THAT PAYS FOR ITSELF. A sentence in this repo asserting the CURRENT
+STATE of code in another repo cannot stay true - nothing here runs when that repo
+merges. ADR-0007 said the Rust twin "does not yet carry this decision"; it was
+written at 04:55:58Z and refuted at 05:25:12Z the same morning, then sat false for
+eight days while the file it described was edited again. Naming a counterpart is
+durable. Describing its state is not. G4 permits the first and fails the second.
+
+WHAT THIS DELIBERATELY DOES NOT DO. It does not check out another repo, diff the
+implementations, or claim they agree - public CI cannot read a private paid repo,
+and a gate that pretends to verify what it cannot see is worse than none. Remote
+entries are declarations. The verification this DOES perform is entirely local.
+
+Usage:
+    python3 scripts/check-paired-implementations.py             # the gate
+    python3 scripts/check-paired-implementations.py --json      # machine-readable
+    python3 scripts/check-paired-implementations.py --self-test # negative controls
+    python3 scripts/check-paired-implementations.py --changed <paths...>
+    python3 scripts/check-paired-implementations.py --changed-from FILE
+                                                    # advisory: name counterparts
+
+Exit codes:
+    0  every declared pair is well-formed, present, pointing at the list, and
+       free of cross-repo state claims (or: advisory mode, which never fails)
+    1  a malformed entry, a missing local file, a paired file with no pointer,
+       or a cross-repo state claim
+    2  UNEVALUATED - the list could not be read or parsed. Never 0: nothing
+       compared is not parity.
+
+Provenance: MYC-4036. Sibling gate: scripts/check-hook-parity.py (which asks
+whether one behaviour reaches both PLATFORMS; this asks whether one contract's
+several IMPLEMENTATIONS know about each other).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+LIST_PATH = REPO / "scripts" / "paired-implementations.json"
+
+# The durable pointer every paired file must carry.
+POINTER = "paired-implementations.json"
+
+# Repos whose state this repo must not assert.
+FOREIGN_REPOS = ("mycelium-studio", "memory-runtime-pro", "mycelium-site")
+FOREIGN_TOKENS = FOREIGN_REPOS + ("vault_safety.rs", "src-tauri")
+
+# Prose that asserts the CURRENT state of code living somewhere else. Naming a
+# counterpart is fine and encouraged; describing what it does or does not do
+# right now is the half that rots. Derived from the real ADR-0007 sentence.
+STATE_CLAIM = re.compile(
+    r"\b("
+    r"do(?:es)?\s+not\s+yet|doesn't\s+yet|"
+    r"not\s+yet\s+(?:carry|carried|ported|have|has|implement)|"
+    r"ha(?:s|ve)\s+not\s+been\s+ported|hasn't\s+been\s+ported|"
+    r"is\s+still\s+blind|remains?\s+blind|is\s+blind\s+to|stayed?\s+blind|"
+    r"currently\s+(?:lacks|does\s+not|has\s+no|is\s+not)|"
+    r"until\s+it\s+does|"
+    r"does\s+not\s+carry|do\s+not\s+carry"
+    r")\b",
+    re.IGNORECASE,
+)
+
+# A cross-repo mention and its state claim often sit on different lines (ADR-0007
+# split across two). Join a small window so the pair is visible.
+WINDOW = 2
+
+
+class Unevaluated(Exception):
+    """The gate could not run. Never reported as a pass."""
+
+
+def load_contracts(list_path: Path) -> list[dict]:
+    try:
+        raw = json.loads(list_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise Unevaluated(f"{list_path} is missing") from exc
+    except json.JSONDecodeError as exc:
+        raise Unevaluated(f"{list_path} is not valid JSON: {exc}") from exc
+    contracts = raw.get("contracts")
+    if not isinstance(contracts, list) or not contracts:
+        raise Unevaluated(f"{list_path} declares no contracts")
+    return contracts
+
+
+def _adr_files(repo: Path) -> list[Path]:
+    adr = repo / "docs" / "adr"
+    return sorted(adr.glob("*.md")) if adr.is_dir() else []
+
+
+def check(repo: Path, list_path: Path) -> list[str]:
+    """Pure verdict: returns a list of failure strings (empty == pass).
+
+    Separated from argument plumbing so --self-test can drive it against
+    synthetic trees without touching the real repo.
+    """
+    contracts = load_contracts(list_path)
+    failures: list[str] = []
+    seen_ids: set[str] = set()
+    local_declared: list[Path] = []
+
+    for idx, c in enumerate(contracts):
+        cid = c.get("id")
+        where = f"contracts[{idx}]"
+
+        # G1 SHAPE
+        if not cid or not isinstance(cid, str):
+            failures.append(f"G1 SHAPE: {where} has no 'id'")
+            continue
+        if cid in seen_ids:
+            failures.append(f"G1 SHAPE: duplicate contract id '{cid}'")
+        seen_ids.add(cid)
+        if not (c.get("what") or "").strip():
+            failures.append(f"G1 SHAPE: '{cid}' has no 'what' (state the behaviour, not the files)")
+
+        impls = c.get("implementations")
+        if not isinstance(impls, list) or len(impls) < 2:
+            # G5 NO-ORPHAN: one implementation is not a pair. Either a sibling was
+            # deleted (the pairing is stale) or this never belonged here.
+            failures.append(
+                f"G5 NO-ORPHAN: '{cid}' declares {len(impls) if isinstance(impls, list) else 0} "
+                f"implementation(s); a contract with fewer than 2 is not a pair"
+            )
+            continue
+
+        for j, impl in enumerate(impls):
+            tag = f"'{cid}'.implementations[{j}]"
+            path = impl.get("path")
+            if not path:
+                failures.append(f"G1 SHAPE: {tag} has no 'path'")
+                continue
+            if not (impl.get("role") or "").strip():
+                failures.append(f"G1 SHAPE: {tag} ({path}) has no 'role'")
+            if not isinstance(impl.get("local"), bool):
+                failures.append(f"G1 SHAPE: {tag} ({path}) has no boolean 'local'")
+                continue
+
+            if not impl["local"]:
+                # Remote: a declaration only. Must name the repo it lives in, so
+                # the reader can find it; must NOT be verified here.
+                if not impl.get("repo"):
+                    failures.append(f"G1 SHAPE: {tag} is local=false but names no 'repo'")
+                continue
+
+            # G2 EXISTS
+            target = repo / path
+            if not target.exists():
+                failures.append(
+                    f"G2 EXISTS: '{cid}' declares {path}, which does not exist "
+                    f"(renamed or deleted? the pairing is now wrong)"
+                )
+                continue
+            local_declared.append(target)
+
+            # G3 DECLARED - the direction fix. Every paired file points at the list.
+            try:
+                body = target.read_text(encoding="utf-8", errors="replace")
+            except OSError as exc:
+                failures.append(f"G2 EXISTS: could not read {path}: {exc}")
+                continue
+            if POINTER not in body:
+                failures.append(
+                    f"G3 DECLARED: {path} is a declared implementation of '{cid}' but "
+                    f"contains no pointer to {POINTER}. A reader editing this file "
+                    f"cannot discover it has counterparts."
+                )
+
+    # G4 NO-STATE-CLAIM - across declared local files AND every ADR.
+    for f in sorted(set(local_declared) | set(_adr_files(repo))):
+        try:
+            lines = f.read_text(encoding="utf-8", errors="replace").splitlines()
+        except OSError:
+            continue
+        rel = f.relative_to(repo)
+        for i, line in enumerate(lines):
+            if not any(tok in line for tok in FOREIGN_TOKENS):
+                continue
+            window = " ".join(lines[i : i + 1 + WINDOW])
+            m = STATE_CLAIM.search(window)
+            if m:
+                failures.append(
+                    f"G4 NO-STATE-CLAIM: {rel}:{i + 1} asserts the current state of "
+                    f"another repo (\"{m.group(0)}\"). Name the counterpart; do not "
+                    f"describe it. Nothing here runs when that repo merges, so the "
+                    f"sentence rots silently. Point at {POINTER} instead."
+                )
+    return failures
+
+
+def advise(repo: Path, list_path: Path, changed: list[str]) -> list[str]:
+    """Advisory: for each changed file that is a declared implementation, name its
+    counterparts. Never fails - the repos have different release cadences and a
+    hard cross-repo gate would only get bypassed."""
+    contracts = load_contracts(list_path)
+    notes: list[str] = []
+    changed_set = {c.strip().lstrip("./") for c in changed if c.strip()}
+    for c in contracts:
+        impls = c.get("implementations") or []
+        for impl in impls:
+            if impl.get("path") not in changed_set or not impl.get("local"):
+                continue
+            others = [i for i in impls if i is not impl]
+            lines = [
+                f"{impl['path']} implements '{c['id']}', which has "
+                f"{len(others)} other implementation(s):"
+            ]
+            for o in others:
+                loc = o["path"] if o.get("local") else f"{o.get('repo')}/{o['path']}"
+                sym = f"::{o['symbol']}" if o.get("symbol") else ""
+                lines.append(f"  - {loc}{sym}  ({o.get('role', '')})")
+            hist = c.get("drift_history") or []
+            if hist:
+                lines.append(f"  This contract has drifted before: {', '.join(hist)}.")
+            lines.append("  Does your change need to land there too?")
+            notes.append("\n".join(lines))
+    return notes
+
+
+# ---------------------------------------------------------------- self-test
+
+def _fixture(tmp: Path, list_obj: dict, files: dict[str, str]) -> Path:
+    (tmp / "scripts").mkdir(parents=True, exist_ok=True)
+    lp = tmp / "scripts" / "paired-implementations.json"
+    lp.write_text(json.dumps(list_obj), encoding="utf-8")
+    for rel, body in files.items():
+        p = tmp / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body, encoding="utf-8")
+    return lp
+
+
+def _base_list() -> dict:
+    return {
+        "contracts": [
+            {
+                "id": "demo/1",
+                "what": "a demo behaviour",
+                "implementations": [
+                    {"path": "scripts/a.sh", "role": "posix", "local": True},
+                    {"repo": "mycelium-studio", "path": "src/b.rs", "role": "native", "local": False},
+                ],
+            }
+        ]
+    }
+
+
+def self_test() -> int:
+    import tempfile
+
+    cases: list[tuple[str, dict, dict[str, str], str]] = []
+
+    ok_files = {"scripts/a.sh": f"# see scripts/{POINTER}\n"}
+    cases.append(("control (must PASS)", _base_list(), ok_files, ""))
+
+    missing = _base_list()
+    cases.append(("G2 missing local file", missing, {}, "G2 EXISTS"))
+
+    cases.append(("G3 no pointer", _base_list(), {"scripts/a.sh": "# nothing\n"}, "G3 DECLARED"))
+
+    orphan = _base_list()
+    orphan["contracts"][0]["implementations"] = [
+        {"path": "scripts/a.sh", "role": "posix", "local": True}
+    ]
+    cases.append(("G5 single implementation", orphan, ok_files, "G5 NO-ORPHAN"))
+
+    noid = {"contracts": [{"what": "x", "implementations": []}]}
+    cases.append(("G1 no id", noid, {}, "G1 SHAPE"))
+
+    nowhat = _base_list()
+    nowhat["contracts"][0]["what"] = ""
+    cases.append(("G1 no what", nowhat, ok_files, "G1 SHAPE"))
+
+    # G4, in the exact shape that actually shipped: the repo token and the state
+    # claim on DIFFERENT lines.
+    split = {
+        "scripts/a.sh": (
+            f"# see scripts/{POINTER}\n"
+            "# A second implementation exists in `mycelium-studio`\n"
+            "# (`vault_safety.rs`) and does not yet carry this decision.\n"
+        )
+    }
+    cases.append(("G4 split-line state claim", _base_list(), split, "G4 NO-STATE-CLAIM"))
+
+    # G4 must NOT fire on a bare, durable counterpart NAME.
+    named = {
+        "scripts/a.sh": (
+            f"# see scripts/{POINTER}\n"
+            "# Paired with mycelium-studio apps/desktop/src-tauri/.../vault_safety.rs.\n"
+        )
+    }
+    cases.append(("G4 bare name is allowed (must PASS)", _base_list(), named, ""))
+
+    failed = 0
+    for name, lst, files, expect in cases:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            lp = _fixture(tmp, lst, files)
+            try:
+                found = check(tmp, lp)
+            except Unevaluated as exc:
+                found = [f"UNEVALUATED: {exc}"]
+            hit = any(expect in f for f in found) if expect else not found
+            if hit:
+                print(f"  ok    {name}")
+            else:
+                failed += 1
+                print(f"  FAIL  {name}")
+                print(f"        expected: {expect or '(no failures)'}")
+                print(f"        got:      {found or '(no failures)'}")
+
+    # UNEVALUATED control: a corrupt list must never read as a pass.
+    with tempfile.TemporaryDirectory() as td:
+        lp = Path(td) / "bad.json"
+        lp.write_text("{ not json", encoding="utf-8")
+        try:
+            check(Path(td), lp)
+            failed += 1
+            print("  FAIL  corrupt list must raise Unevaluated")
+        except Unevaluated:
+            print("  ok    corrupt list -> UNEVALUATED (never 0)")
+
+    print()
+    if failed:
+        print(f"{failed} negative control(s) did not bite. The gate is not proven.")
+        return 1
+    print("all negative controls bit.")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--self-test", action="store_true", help="run negative controls")
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    ap.add_argument("--changed", nargs="*", default=None,
+                    help="advisory mode: name counterparts of these changed paths")
+    ap.add_argument("--changed-from", default=None, metavar="FILE",
+                    help="advisory mode, reading newline-separated paths from FILE "
+                         "(avoids shell word-splitting on paths with spaces)")
+    ap.add_argument("--list", default=str(LIST_PATH))
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    list_path = Path(args.list)
+
+    if args.changed_from:
+        try:
+            args.changed = Path(args.changed_from).read_text(
+                encoding="utf-8").splitlines()
+        except OSError as exc:
+            print(f"UNEVALUATED: cannot read {args.changed_from}: {exc}",
+                  file=sys.stderr)
+            return 2
+
+    if args.changed is not None:
+        try:
+            notes = advise(REPO, list_path, args.changed)
+        except Unevaluated as exc:
+            print(f"UNEVALUATED: {exc}", file=sys.stderr)
+            return 2
+        if args.json:
+            print(json.dumps({"advisories": notes}, indent=2))
+        else:
+            for n in notes:
+                # GitHub renders this inline on the PR; harmless locally.
+                print(f"::notice::{n}")
+                print(n, file=sys.stderr)
+        return 0
+
+    try:
+        failures = check(REPO, list_path)
+    except Unevaluated as exc:
+        if args.json:
+            print(json.dumps({"status": "unevaluated", "reason": str(exc)}, indent=2))
+        else:
+            print(f"UNEVALUATED: {exc}", file=sys.stderr)
+            print("Nothing compared is not parity.", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps({"status": "fail" if failures else "pass",
+                          "failures": failures}, indent=2))
+        return 1 if failures else 0
+
+    if failures:
+        print("Paired-implementation check FAILED:\n", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}\n", file=sys.stderr)
+        return 1
+    print("paired implementations: every declared pair is present, pointed at the "
+          "list, and free of cross-repo state claims.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-vault-target.py
+++ b/scripts/check-vault-target.py
@@ -10,10 +10,18 @@ tree — with `~/.ssh`, `~/.aws`, `~/.netrc` and `~/.config/gh` sitting untracke
 inside it and one `git add -A` away from being written into git objects
 permanently. Observed on a real machine, not theoretical (MYC-4028).
 
-This is the SINGLE source of truth for that check — relocate-vault.sh/.ps1,
-relocate-machinery-sidecar.sh/.ps1 and the SessionStart footprint signal all
-route through it, so there is no drift between surfaces. Same porcelain shape
-as check-cloud-sync.py, which the same callers already use.
+This is the single source of truth for that check IN THIS REPO —
+relocate-vault.sh/.ps1, relocate-machinery-sidecar.sh/.ps1 and the SessionStart
+footprint signal all route through it, so those surfaces cannot drift from each
+other. Same porcelain shape as check-cloud-sync.py, which the same callers
+already use.
+
+It is NOT the only implementation of the contract. `mycelium-studio` reimplements
+these rules natively in Rust, because a desktop app cannot assume python is on
+PATH. Read scripts/paired-implementations.json (contract `vault-target-refusal`)
+before changing the rules here: an earlier version of this paragraph claimed
+there was "no drift between surfaces" full stop, and that sentence is how the
+Studio twin shipped without this guard at all (MYC-4035).
 
 Usage:
   check-vault-target.py <path>                # human-readable verdict + remedy

--- a/scripts/paired-implementations.json
+++ b/scripts/paired-implementations.json
@@ -1,0 +1,81 @@
+{
+  "_README": [
+    "Declared paired implementations. Enforced by scripts/check-paired-implementations.py.",
+    "",
+    "THE BUG CLASS. One behavioural contract, implemented by hand more than once,",
+    "with nothing pairing the copies. Someone fixes one; the others stay wrong; every",
+    "check on both sides stays green, because each implementation is internally",
+    "consistent and no gate has ever seen the other one. Measured three times on",
+    "machinery-sidecar/1 alone (MYC-1088, MYC-4035, and the interpreter probe).",
+    "",
+    "WHY A LIST AND NOT CODEGEN. Codegen needs a canonical machine-readable source to",
+    "generate FROM (MYC-136 has an OpenAPI document, MYC-306 a Rust enum). Here the",
+    "shared artefact is a manifest schema and the thing that drifts is not in it:",
+    "'refuse $HOME with no force escape' is a BEHAVIOUR, and nothing emits it. Neither",
+    "side is canonical. So the lever is not generation, it is visibility.",
+    "",
+    "WHY ONE LIST AND NOT N HEADER COMMENTS. Header comments were tried first and",
+    "half-worked: they exist, but only ever pointing from the NEWER implementation to",
+    "the older one. relocate-machinery-sidecar.ps1 names the .sh; the .sh names",
+    "nothing. vault_safety.rs names the .sh; the .sh names nothing. So the person",
+    "editing the ORIGINAL - the one who starts every drift - is the one file with no",
+    "pointer. Worse, a comment enumerating its siblings is itself a copy of this list,",
+    "and rots the same way. Each paired file therefore carries ONE durable pointer to",
+    "THIS file, and this file holds the enumeration.",
+    "",
+    "WHAT 'local' MEANS. true = the path lives in this repo and the gate can verify it.",
+    "false = it lives in another repo (usually a private paid one) which public CI",
+    "cannot and should not check out. Remote entries are DECLARATIONS, not assertions:",
+    "the gate never claims anything about their current state, because a cross-repo",
+    "state claim written here goes stale the moment the other repo merges. ADR-0007",
+    "carried exactly such a sentence and it was false 29 minutes after it was written.",
+    "",
+    "ADDING A CONTRACT. Say what the behaviour IS, not which files are involved. If",
+    "you cannot state the contract in one sentence without naming a file, it is",
+    "probably not one contract."
+  ],
+
+  "contracts": [
+    {
+      "id": "machinery-sidecar/1",
+      "what": "Relocate a vault's churning git machinery (.git, worktrees, caches) out of a cloud-synced tree into a local sidecar, leaving only static pointers behind, and roll that back on request.",
+      "drift_history": ["MYC-1088", "MYC-4035", "MYC-4036"],
+      "implementations": [
+        { "path": "scripts/relocate-machinery-sidecar.sh", "role": "POSIX CLI", "local": true },
+        { "path": "scripts/relocate-machinery-sidecar.ps1", "role": "Windows CLI", "local": true },
+        { "repo": "mycelium-studio", "path": "apps/desktop/src-tauri/src/commands/vault_safety.rs", "role": "desktop native (no bash/python dependency)", "local": false }
+      ]
+    },
+    {
+      "id": "vault-target-refusal",
+      "what": "Refuse to treat $HOME, a filesystem root, a strict ancestor of $HOME, or a system directory as a vault, with no force escape on the home refusal; compare resolved paths, not strings.",
+      "drift_history": ["MYC-4028", "MYC-4035"],
+      "governing_decision": "docs/adr/0007-no-force-escape-on-the-home-refusal.md",
+      "implementations": [
+        { "path": "scripts/check-vault-target.py", "role": "substrate source of truth; the .sh/.ps1 CLIs shell out to it", "local": true },
+        { "repo": "mycelium-studio", "path": "apps/desktop/src-tauri/src/commands/vault_safety.rs", "symbol": "vault_target_guard", "role": "independent Rust reimplementation", "local": false }
+      ]
+    },
+    {
+      "id": "cloud-sync-detection",
+      "what": "Decide whether a given path resolves inside a consumer cloud-sync root (iCloud, OneDrive, Dropbox, Google Drive incl. Mirror roots, Box).",
+      "drift_history": ["MYC-1088"],
+      "implementations": [
+        { "path": "scripts/check-cloud-sync.py", "role": "substrate source of truth", "local": true },
+        { "repo": "mycelium-studio", "path": "apps/desktop/src-tauri/src/commands/vault_safety.rs", "symbol": "detect_cloud_sync", "role": "independent Rust reimplementation", "local": false }
+      ]
+    },
+    {
+      "id": "egress-disclosure",
+      "what": "Every network egress from a Mycelium surface is disclosed to the user AND stoppable by the user; a consent toggle must suppress the send, not merely hide the UI.",
+      "drift_history": [],
+      "governing_decision": "docs/adr/0003-no-runtime-email-gate.md",
+      "implementations": [
+        { "path": "SECURITY.md", "section": "5", "role": "substrate policy statement", "local": true },
+        { "repo": "mycelium-studio", "path": "apps/desktop/src/lib/posthog.ts", "role": "desktop capture path", "local": false },
+        { "repo": "mycelium-studio", "path": "apps/desktop/src/lib/posthog.opt-out.test.ts", "role": "negative control proving the toggle suppresses egress", "local": false },
+        { "repo": "mycelium-studio", "path": "apps/desktop/src/components/settings/privacy-panel.tsx", "role": "the disclosure surface itself", "local": false }
+      ]
+    }
+  ]
+}

--- a/scripts/relocate-machinery-sidecar.ps1
+++ b/scripts/relocate-machinery-sidecar.ps1
@@ -4,6 +4,10 @@
   cloud-sync folder by moving every churning machinery dir OUT of the synced
   tree into a local sidecar, leaving only tiny static pointers/links behind.
 
+  Paired implementation - every implementation of this contract is listed in
+  scripts/paired-implementations.json under `machinery-sidecar/1`. Check it
+  before changing behaviour here.
+
   Windows parity of relocate-machinery-sidecar.sh (MYC-2383). Same contract,
   same manifest schema (machinery-sidecar/1), same --separate-git-dir + worktree
   repair sequencing. Two platform differences: (1) the link is a JUNCTION on

--- a/scripts/relocate-machinery-sidecar.sh
+++ b/scripts/relocate-machinery-sidecar.sh
@@ -3,6 +3,13 @@
 # cloud-sync folder by moving every churning machinery dir OUT of the synced
 # tree into a local sidecar, leaving only tiny static pointers/symlinks behind.
 #
+# PAIRED IMPLEMENTATION. This behaviour is implemented more than once by hand.
+# Every implementation is listed in scripts/paired-implementations.json under
+# `machinery-sidecar/1`. Check that list before changing behaviour here: this
+# contract has drifted three times (MYC-1088, MYC-4035, and the python
+# interpreter probe), and every time it was this file — the original — that got
+# edited by someone with no idea a twin existed.
+#
 # WHY
 # ---
 # A git-backed Obsidian vault inside iCloud Drive / Desktop & Documents melts the


### PR DESCRIPTION
Closes MYC-4036.

One behavioural contract, several hand-written implementations, nothing pairing
them. Someone fixes one; the rest stay wrong; every check on both sides stays
green, because each implementation is internally consistent and no gate has ever
seen another. `machinery-sidecar/1` has drifted three times:

| # | What drifted | Ticket |
|---|---|---|
| 1 | Google Drive Mirror roots taught here, Rust twin left blind | MYC-1088 |
| 2 | The vault-target guard — Studio git-init'd a repo over a founder's `$HOME`, SSH and cloud credentials in the working tree | MYC-4035 |
| 3 | The python interpreter probe: the Windows leg had already solved it correctly while the POSIX leg kept the weaker check | #603, open now |

## Why header comments were not enough

They were the ticket's cheapest proposal, and they had **already been done** organically in five files. Measuring them showed two problems.

**Direction.** Every one points from the NEWER implementation to the older. The `.ps1` names the `.sh`; `vault_safety.rs` names the `.sh`; the `.sh` named nothing at all. The file whose edit starts every drift was the only one with no pointer.

**Rot.** The single substrate-side pointer, in ADR-0007, said the Rust twin "does not yet carry this decision." Written `663bad3` at **04:55:58Z**, refuted by studio `604bd733` at **05:25:12Z** the same morning. True for 29 minutes, false for the following eight days, through another edit to the file it described.

## What lands

- `scripts/paired-implementations.json` — four declared contracts
- `scripts/check-paired-implementations.py` — the gate, with negative controls
- `lint.yml` — self-test, gate, and the PR advisory, as **steps** not jobs (per this file's own billing rule)

**G1** shape · **G2** local files exist · **G3** every paired file carries ONE durable pointer to the list · **G5** a contract with one implementation is not a pair.

**G4** is the one that pays for itself: a sentence in this repo asserting the CURRENT STATE of code in another repo cannot stay true, because nothing here runs when that repo merges. Naming a counterpart is durable; describing it is not. G4 permits the first and fails the second — and it caught this PR's own author writing one, minutes after the rule existed. That prose is now a ticket reference instead.

A header enumerating siblings would itself be a copy of the list, rotting the same way, so each file gets one pointer and the list holds the enumeration. Adding a fourth implementation edits one place.

## Also fixed, same class

Two docstrings claimed to be the SINGLE source of truth "so there is no drift between surfaces." Both are true inside this repo and false across repos, and those sentences are how a maintainer concludes the class cannot happen. `check-cloud-sync.py`'s was the expensive one — drift #1 was literally `detect_cloud_sync`. Both now scope the claim and name the twin.

## The advisory, proven

This PR touches `scripts/relocate-machinery-sidecar.sh`, so it is its own fixture for the `Done =` predicate:

```
::notice::scripts/relocate-machinery-sidecar.sh implements 'machinery-sidecar/1',
which has 2 other implementation(s):
  - scripts/relocate-machinery-sidecar.ps1  (Windows CLI)
  - mycelium-studio/apps/desktop/src-tauri/src/commands/vault_safety.rs  (desktop native)
  This contract has drifted before: MYC-1088, MYC-4035, MYC-4036.
  Does your change need to land there too?
```

## Deliberately not done

No checking out another repo, no diffing implementations, no claiming they agree. Public CI cannot read a private paid repo, and a gate that pretends to verify what it cannot see is worse than none. Remote entries are declarations. The advisory is advisory because the repos ship on different cadences and a hard cross-repo gate would only get bypassed.

## Verification

- `check-paired-implementations.py --self-test` — 9 controls, all bite, including UNEVALUATED on a corrupt list and a control proving a bare counterpart NAME is allowed
- `ci-test` GREEN — `GATE_EXIT=0`, marker `cb079cb8.ok`
- personal-data scrub clean, every pattern proven against a planted specimen first
- `test_ps1_encoding_gate.py` green; the `.ps1` BOM verified intact

Found while auditing this: three further drifts in the same family, now filed as MYC-4240 (manifest key `kind` vs `type` — a Studio rollback of a CLI relocation silently no-ops and deletes the manifest), MYC-4241 (four `vault_safety.rs` divergences), MYC-4242 (a privacy citation that does not resolve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
