### PR TITLE
guard: a deferral naming an owner must resolve that owner in-repo (DEFERRAL-TO-AN-UNSHIPPED-OWNER)

### DIFF
--- a/hooks/context-budget-measure.py
+++ b/hooks/context-budget-measure.py
@@ -51,7 +51,7 @@ Modes:
   --self-test                  positive + negative control; exit 0 iff all pass
 
 Bug class: ALWAYS-LOADED-TEXT-UNMEASURED (sibling of ARTIFACT-WITHOUT-MEASUREMENT).
-MEMORY.md remediation is owned by check-memory-md-cap.py — this hook measures
+MEMORY.md remediation is owned by session-start-context.py — this hook measures
 MEMORY.md for the total but does NOT duplicate its cliff warning.
 """
 from __future__ import annotations
@@ -107,7 +107,7 @@ def noop():
 # --- file discovery (generic, name-free) --------------------------------------
 def _memory_md(cwd: str) -> Path | None:
     """Locate MEMORY.md the way Claude Code loads it (sanitized-cwd projects dir),
-    falling back to the in-vault canonical path. Mirrors check-memory-md-cap.py."""
+    falling back to the in-vault canonical path. Mirrors session-start-context.py."""
     cands: list[Path] = []
     env = os.environ.get("CLAUDE_PROJECT_DIR")
     if env:
@@ -168,7 +168,7 @@ def discover(cwd: str) -> list[dict]:
 
     `kind` drives reporting; `ceiling` is the hard per-file warn threshold (None =
     baseline-drift only); `defer_to` names a guard that owns this file's hard
-    warning so we don't double-nag (MEMORY.md -> check-memory-md-cap.py)."""
+    warning so we don't double-nag (MEMORY.md -> session-start-context.py)."""
     items: list[dict] = []
 
     def add(path: Path | None, kind: str, ceiling: int | None, defer_to: str | None = None):
@@ -183,7 +183,7 @@ def discover(cwd: str) -> list[dict]:
 
     add(HOME / ".claude" / "CLAUDE.md", GLOBAL_KIND, GLOBAL_CEILING)
     add(_project_file(cwd, "CLAUDE.md"), "project CLAUDE.md", None)
-    add(_memory_md(cwd), "MEMORY.md", None, defer_to="check-memory-md-cap.py")
+    add(_memory_md(cwd), "MEMORY.md", None, defer_to="session-start-context.py")
     add(_project_file(cwd, "CONTEXT.md"), "project CONTEXT.md", None)
     # de-dup by resolved path (global and project CLAUDE.md can coincide)
     seen: set[str] = set()

--- a/hooks/context-budget-measure.py
+++ b/hooks/context-budget-measure.py
@@ -107,7 +107,10 @@ def noop():
 # --- file discovery (generic, name-free) --------------------------------------
 def _memory_md(cwd: str) -> Path | None:
     """Locate MEMORY.md the way Claude Code loads it (sanitized-cwd projects dir),
-    falling back to the in-vault canonical path. Mirrors session-start-context.py."""
+    falling back to the in-vault canonical path. NOT the same resolver as
+    _lib/memory_index.memory_dirs(), which globs every ~/.claude/projects/*/memory
+    dir; this resolves THIS project only. memory_index covers a superset, so the
+    defer_to below still holds."""
     cands: list[Path] = []
     env = os.environ.get("CLAUDE_PROJECT_DIR")
     if env:

--- a/hooks/context-budget-measure.py
+++ b/hooks/context-budget-measure.py
@@ -51,8 +51,9 @@ Modes:
   --self-test                  positive + negative control; exit 0 iff all pass
 
 Bug class: ALWAYS-LOADED-TEXT-UNMEASURED (sibling of ARTIFACT-WITHOUT-MEASUREMENT).
-MEMORY.md remediation is owned by session-start-context.py — this hook measures
-MEMORY.md for the total but does NOT duplicate its cliff warning.
+MEMORY.md's cliff warning is owned by session-start-context.py (it reports and
+advises; it does not auto-fix) — this hook measures MEMORY.md for the total but
+does NOT duplicate that warning. Coverage is not total: see MYC-4239.
 """
 from __future__ import annotations
 
@@ -106,11 +107,18 @@ def noop():
 
 # --- file discovery (generic, name-free) --------------------------------------
 def _memory_md(cwd: str) -> Path | None:
-    """Locate MEMORY.md the way Claude Code loads it (sanitized-cwd projects dir),
-    falling back to the in-vault canonical path. NOT the same resolver as
-    _lib/memory_index.memory_dirs(), which globs every ~/.claude/projects/*/memory
-    dir; this resolves THIS project only. memory_index covers a superset, so the
-    defer_to below still holds."""
+    """Locate MEMORY.md: CLAUDE_PROJECT_DIR's in-vault path, then the
+    sanitized-cwd projects dir, then a walk-up for the in-vault canonical path.
+
+    This is NOT the resolver _lib/memory_index.memory_dirs() uses, and NEITHER
+    COVERS THE OTHER. memory_index globs only ~/.claude/projects/*/memory (a
+    superset of candidate 2, blind to the in-vault candidates 1 and 3), and an
+    AGENT_MEMORY_DIR override narrows it to a single dir this function never
+    reads. So the defer_to below holds only when MEMORY.md is reached via the
+    projects dir; an in-vault MEMORY.md is measured here and warned about by
+    nobody. Measured, not assumed -- see MYC-4239. Do not restate this as a
+    superset: that sentence was here, it was false, and an adversarial review
+    reproduced two configurations that refute it."""
     cands: list[Path] = []
     env = os.environ.get("CLAUDE_PROJECT_DIR")
     if env:

--- a/scripts/check-defer-targets.py
+++ b/scripts/check-defer-targets.py
@@ -45,8 +45,9 @@ reader does not mistake a green for proof of absence):
   - Detection is LINE-BY-LINE. A deferral whose verb and filename wrap onto
     different lines is NOT seen.
   - Only string LITERALS are seen. `defer_to=SOME_CONST` is not.
-  - Resolution is by BASENAME anywhere in the repo, not by path. A deferral to
-    "x.py" resolves against an unrelated tests/fixtures/x.py.
+  - A BARE target resolves by basename anywhere in the repo, so a deferral to
+    "x.py" resolves against an unrelated tests/fixtures/x.py. A PATH-qualified
+    target is matched against tracked paths exactly, so it does not.
   - Documentation that quotes a real-looking deferral string will trip this
     check. Write examples as `<owner>.py` -- the angle brackets fall outside
     the basename class, so they cannot parse as a real target.
@@ -83,10 +84,19 @@ READ_MAX_BYTES = 4_000_000
 
 SCAN_DIRS = ("hooks", "scripts")
 
-BASENAME = r"[A-Za-z0-9_.-]+\.(?:py|sh)"
-STRUCTURAL_RE = re.compile(r"""defer_to\s*=\s*(['"])(""" + BASENAME + r""")\1""")
+# Extensions actually shipped under hooks/ + scripts/ in this repo: py (335),
+# sh (80), ps1 (11). A deferral to a .ps1 owner used to be invisible in BOTH
+# directions -- never flagged dangling, never confirmed resolved.
+_EXT = r"(?:py|sh|ps1)"
+# A target may be written bare ("session-start-context.py") or path-qualified
+# ("hooks/session-start-context.py"). The path-qualified form is the natural way
+# to write it -- and used to match NOTHING, so a deferral to a path that did not
+# exist produced zero hits and the run reported "all resolve".
+_SEG = r"[A-Za-z0-9_.-]+"
+TARGET = r"(?:" + _SEG + r"/)*" + _SEG + r"\." + _EXT
+STRUCTURAL_RE = re.compile(r"""defer_to\s*=\s*(['"])(""" + TARGET + r""")\1""")
 PROSE_RE = re.compile(
-    r"\b(?:owned by|handled by|delegates to|deferred to)\s+(" + BASENAME + r")\b"
+    r"\b(?:owned by|handled by|delegates to|deferred to)\s+(" + TARGET + r")\b"
 )
 
 
@@ -121,7 +131,22 @@ def walk_files() -> List[str]:
 
 
 def resolvable_basenames(paths: List[str]) -> Set[str]:
-    return {Path(p).name for p in paths}
+    """Both spellings a deferral may use: every tracked path verbatim, and every
+    tracked basename. A path-qualified target ("hooks/x.py") must match a real
+    PATH -- matching it on basename alone would let a wrong directory pass."""
+    out: Set[str] = set()
+    for p in paths:
+        out.add(p)
+        out.add(Path(p).name)
+    return out
+
+
+def target_resolves(target: str, known: Set[str]) -> bool:
+    """Path-qualified -> must match a tracked path exactly (a wrong directory is
+    a real defect). Bare basename -> must match some tracked basename."""
+    if "/" in target:
+        return target in known
+    return target in known
 
 
 def scan_targets(paths: List[str]) -> List[str]:
@@ -160,7 +185,7 @@ def dangling(hits_by_path: Dict[str, List[Tuple[int, str]]],
     out = []
     for path in sorted(hits_by_path):
         for lineno, target in sorted(hits_by_path[path]):
-            if target not in known_basenames:
+            if not target_resolves(target, known_basenames):
                 out.append(f"{path}:{lineno} -> {target}")
     return out
 
@@ -204,10 +229,18 @@ def main() -> int:
     if skipped:
         # INCOMPLETE is not CLEAN. Exit 2 so a partial scan can never be read
         # as a pass (a scanner states how much of its input it actually read).
+        # Print any dangling targets found in the files we DID read, so an
+        # unreadable file never costs the operator a second round-trip to
+        # discover a real finding that was already in hand.
         print(f"::error::incomplete scan - {len(skipped)} file(s) could not be "
               f"read, so this run cannot claim every deferral resolves:")
         for s in skipped:
             print(f"  {s}")
+        if problems:
+            print(f"::error::also, {len(problems)} dangling defer target(s) in "
+                  f"the files that WERE read:")
+            for pr in problems:
+                print(f"  {pr}")
         return 2
 
     if problems:
@@ -296,6 +329,36 @@ def self_test() -> int:
     if found != expected:
         fails.append(f"DETECTOR: expected {sorted(expected)}, got {sorted(found)}")
 
+    # 4b. PATH-QUALIFIED + .ps1 RESOLUTION. Regression pins for an adversarial
+    #     review finding: a directory-qualified target used to match NOTHING, so
+    #     `owned by hooks/does-not-exist.py` produced zero hits and the run
+    #     printed "all resolve" -- reproducing the exact reads-as-covered failure
+    #     this guard exists to catch. A wrong directory must also NOT resolve.
+    qualified_src = (
+        'add(x, defer_to="hooks/session-start-context.py")\n'
+        "owned by hooks/does-not-exist-at-all.py\n"
+        'defer_to="relocate-vault.ps1"\n'
+        "handled by WRONGDIR/session-start-context.py\n"
+    )
+    qhits = find_deferrals(qualified_src)
+    qtargets = [tg for _, tg in qhits]
+    q_expected = ["hooks/session-start-context.py", "hooks/does-not-exist-at-all.py",
+                  "relocate-vault.ps1", "WRONGDIR/session-start-context.py"]
+    if qtargets != q_expected:
+        fails.append(f"PATH-QUALIFIED: expected {q_expected}, got {qtargets}")
+    else:
+        q_known = {"hooks/session-start-context.py", "session-start-context.py",
+                   "scripts/relocate-vault.ps1", "relocate-vault.ps1"}
+        q_dangling = dangling({"hooks/q.py": qhits}, q_known)
+        q_missing = sorted(d.split(" -> ")[1] for d in q_dangling)
+        q_want = sorted(["hooks/does-not-exist-at-all.py",
+                         "WRONGDIR/session-start-context.py"])
+        if q_missing != q_want:
+            fails.append(
+                f"PATH-QUALIFIED: expected exactly {q_want} to be dangling, got "
+                f"{q_missing} - a path-qualified target must resolve as a PATH, "
+                f"so a right basename in a wrong directory does not pass")
+
     # 5. SELF-EXCLUSION: this checker's own path must never be part of a real
     #    scan (its docstring/self-test are a guaranteed false positive).
     real_paths = tracked_files()
@@ -314,13 +377,26 @@ def self_test() -> int:
     import tempfile
     tmpd = tempfile.mkdtemp(prefix="defer-targets-selftest-")
     try:
-        fifo = os.path.join(tmpd, "a-fifo")
-        os.mkfifo(fifo)
-        fifo_result = safe_read_text(fifo, timeout=1.0, max_bytes=READ_MAX_BYTES,
-                                     encoding="utf-8", errors="replace")
-        if fifo_result.ok:
-            fails.append("INCOMPLETE-CONTROL: a FIFO read as ok - the skipped-read "
-                         "branch would never fire and a partial scan would print clean")
+        # os.mkfifo does not exist on Windows. Guarded the way this repo already
+        # guards it in check-sync-folder-machinery.py, test_safe_read.py,
+        # test_worktree_cloud_safe_recovery.py and test-relocate-sweep.py.
+        if hasattr(os, "mkfifo"):
+            fifo = os.path.join(tmpd, "a-fifo")
+            os.mkfifo(fifo)
+            fifo_result = safe_read_text(fifo, timeout=1.0, max_bytes=READ_MAX_BYTES,
+                                         encoding="utf-8", errors="replace")
+            if fifo_result.ok:
+                fails.append("INCOMPLETE-CONTROL: a FIFO read as ok - the skipped-read "
+                             "branch would never fire and a partial scan would print clean")
+        else:
+            # No FIFO available: use a directory, which is also not a regular file.
+            notfile = os.path.join(tmpd, "a-dir")
+            os.mkdir(notfile)
+            dir_result = safe_read_text(notfile, timeout=1.0, max_bytes=READ_MAX_BYTES,
+                                        encoding="utf-8", errors="replace")
+            if dir_result.ok:
+                fails.append("INCOMPLETE-CONTROL: a directory read as ok - the "
+                             "skipped-read branch would never fire")
         plain = os.path.join(tmpd, "plain.py")
         with open(plain, "w", encoding="utf-8") as fh:
             fh.write('defer_to="whatever.py"\n')

--- a/scripts/check-defer-targets.py
+++ b/scripts/check-defer-targets.py
@@ -40,8 +40,10 @@ THE RULE
     self-test necessarily contain example deferral strings, and scanning
     itself would be a guaranteed false positive on every run.
 
-Exit 0 when every named target resolves. Exit 1, listing each
-`path:line -> missing target`, when any dangling deferral is found.
+Three states, distinguished by exit code (a failed read is not an empty
+answer): 0 = every named target resolves; 1 = a dangling deferral was found,
+listing each `path:line -> missing target`; 2 = the scan was INCOMPLETE
+because a file could not be read, so no clean verdict is claimable.
 
 Usage:
   check-defer-targets.py               # scan tracked hooks/ + scripts/ files
@@ -57,6 +59,16 @@ from typing import Dict, List, Optional, Set, Tuple
 
 REPO = Path(__file__).resolve().parent.parent
 SELF_PATH = Path(__file__).resolve()
+
+# This walker rglobs a tree and reads what it finds, so it MUST go through the
+# shared cloud-safe reader rather than Path.read_text: a vault under Google
+# Drive / iCloud / OneDrive can hand back an offline placeholder, a FIFO, or a
+# mount that stalls forever. Enforced by tests/integration/test_cloud_safe_file_walkers.sh.
+sys.path.insert(0, str(REPO / "hooks"))
+from _lib.safe_read import safe_read_text  # noqa: E402
+
+READ_TIMEOUT_S = 5.0
+READ_MAX_BYTES = 4_000_000
 
 SCAN_DIRS = ("hooks", "scripts")
 
@@ -142,9 +154,9 @@ def dangling(hits_by_path: Dict[str, List[Tuple[int, str]]],
     return out
 
 
-def scan_repo() -> Tuple[List[str], Dict[str, List[Tuple[int, str]]], Set[str]]:
+def scan_repo() -> Tuple[List[str], Dict[str, List[Tuple[int, str]]], Set[str], List[str]]:
     """I/O shell: real discovery + real file reads, feeding the pure functions
-    above. Returns (scanned paths, hits by path, resolvable basename set)."""
+    above. Returns (scanned paths, hits by path, resolvable basenames, skipped)."""
     all_paths = tracked_files()
     if all_paths is None:
         all_paths = walk_files()
@@ -152,24 +164,40 @@ def scan_repo() -> Tuple[List[str], Dict[str, List[Tuple[int, str]]], Set[str]]:
 
     scanned = scan_targets(all_paths)
     hits_by_path: Dict[str, List[Tuple[int, str]]] = {}
+    skipped: List[str] = []
     for rel in scanned:
-        fp = REPO / rel
-        try:
-            text = fp.read_text(encoding="utf-8", errors="replace")
-        except OSError:
+        result = safe_read_text(
+            REPO / rel, timeout=READ_TIMEOUT_S, max_bytes=READ_MAX_BYTES,
+            encoding="utf-8", errors="replace",
+        )
+        if not result.ok:
+            # A file we could not read is a file we did not scan. Silence here
+            # would print "all resolve" over an unread file that may hold a
+            # dangling deferral -- a false clean. Surface it and fail.
+            detail = (" (" + result.detail + ")") if result.detail else ""
+            skipped.append("%s [%s]%s" % (rel, result.status, detail))
             continue
-        hits = find_deferrals(text)
+        hits = find_deferrals(result.text or "")
         if hits:
             hits_by_path[rel] = hits
-    return scanned, hits_by_path, known
+    return scanned, hits_by_path, known, skipped
 
 
 def main() -> int:
     if "--self-test" in sys.argv:
         return self_test()
 
-    scanned, hits_by_path, known = scan_repo()
+    scanned, hits_by_path, known, skipped = scan_repo()
     problems = dangling(hits_by_path, known)
+
+    if skipped:
+        # INCOMPLETE is not CLEAN. Exit 2 so a partial scan can never be read
+        # as a pass (a scanner states how much of its input it actually read).
+        print(f"::error::incomplete scan - {len(skipped)} file(s) could not be "
+              f"read, so this run cannot claim every deferral resolves:")
+        for s in skipped:
+            print(f"  {s}")
+        return 2
 
     if problems:
         print(f"::error::dangling defer target(s) ({len(problems)}) - named as "
@@ -267,12 +295,50 @@ def self_test() -> int:
     if self_rel in real_scanned:
         fails.append("SELF-EXCLUSION: the checker's own path was included in a real scan")
 
+    # 6. INCOMPLETE-SCAN control: the skipped-read path must actually trigger
+    #    on something unreadable, and must NOT trigger on an ordinary file.
+    #    Without this, the exit-2 branch is a sentence nobody has ever run.
+    #    Uses a FIFO (never a regular file) in a temp dir -- the repo is untouched.
+    import os
+    import tempfile
+    tmpd = tempfile.mkdtemp(prefix="defer-targets-selftest-")
+    try:
+        fifo = os.path.join(tmpd, "a-fifo")
+        os.mkfifo(fifo)
+        fifo_result = safe_read_text(fifo, timeout=1.0, max_bytes=READ_MAX_BYTES,
+                                     encoding="utf-8", errors="replace")
+        if fifo_result.ok:
+            fails.append("INCOMPLETE-CONTROL: a FIFO read as ok - the skipped-read "
+                         "branch would never fire and a partial scan would print clean")
+        plain = os.path.join(tmpd, "plain.py")
+        with open(plain, "w", encoding="utf-8") as fh:
+            fh.write('defer_to="whatever.py"\n')
+        plain_result = safe_read_text(plain, timeout=1.0, max_bytes=READ_MAX_BYTES,
+                                      encoding="utf-8", errors="replace")
+        if not plain_result.ok or "whatever.py" not in (plain_result.text or ""):
+            fails.append("INCOMPLETE-CONTROL: an ordinary file did not read back "
+                         "cleanly - every scan would report INCOMPLETE")
+    except (OSError, NotImplementedError) as exc:
+        fails.append(f"INCOMPLETE-CONTROL: could not run ({exc.__class__.__name__})")
+    finally:
+        for root, _dirs, files in os.walk(tmpd, topdown=False):
+            for f in files:
+                try:
+                    os.unlink(os.path.join(root, f))
+                except OSError:
+                    pass
+        try:
+            os.rmdir(tmpd)
+        except OSError:
+            pass
+
     if fails:
         for f in fails:
             print(f"FAIL: {f}")
         return 1
     print("OK - check-defer-targets self-test passed "
-          "(positive + negative + negative-control-check + detector + self-exclusion)")
+          "(positive + negative + negative-control-check + detector + "
+          "self-exclusion + incomplete-scan)")
     return 0
 
 

--- a/scripts/check-defer-targets.py
+++ b/scripts/check-defer-targets.py
@@ -40,6 +40,17 @@ THE RULE
     self-test necessarily contain example deferral strings, and scanning
     itself would be a guaranteed false positive on every run.
 
+KNOWN LIMITS (this gate is a FLOOR, not a ceiling -- state them so the next
+reader does not mistake a green for proof of absence):
+  - Detection is LINE-BY-LINE. A deferral whose verb and filename wrap onto
+    different lines is NOT seen.
+  - Only string LITERALS are seen. `defer_to=SOME_CONST` is not.
+  - Resolution is by BASENAME anywhere in the repo, not by path. A deferral to
+    "x.py" resolves against an unrelated tests/fixtures/x.py.
+  - Documentation that quotes a real-looking deferral string will trip this
+    check. Write examples as `<owner>.py` -- the angle brackets fall outside
+    the basename class, so they cannot parse as a real target.
+
 Three states, distinguished by exit code (a failed read is not an empty
 answer): 0 = every named target resolves; 1 = a dangling deferral was found,
 listing each `path:line -> missing target`; 2 = the scan was INCOMPLETE

--- a/scripts/check-defer-targets.py
+++ b/scripts/check-defer-targets.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""check-defer-targets.py - a named deferral target must actually exist.
+
+SCOPE (the check's NAME is a claim about its SCOPE - state it, do not let the
+code silently narrow it): scans tracked files under hooks/ and scripts/ ONLY.
+A deferral naming a basename anywhere else (docs/, tests/, phases/) is out of
+scope for this checker.
+
+THE BUG CLASS THIS EXISTS FOR
+    A hook or script routinely defers a responsibility to a named sibling --
+    "MEMORY.md remediation is owned by X", `defer_to="X"` -- so it can measure
+    or half-handle something without duplicating a warning some OTHER file
+    already owns. That is a legitimate pattern (context-budget-measure.py does
+    it on purpose, to avoid double-nagging on MEMORY.md). But the deferral is
+    only true while X actually SHIPS in this repo. Caught live:
+    context-budget-measure.py deferred MEMORY.md's cliff warning to
+    check-memory-md-cap.py -- a file that has 0 hits in `git log --all` and 0
+    files on disk in this repo, and exists only in a private, remote-less,
+    machine-local repo. Every install of this public repo read "handled
+    elsewhere" and got nothing, silently, forever.
+
+    Bug class: DEFERRAL-TO-AN-UNSHIPPED-OWNER. A dangling deferral is WORSE
+    than a dormant guard: a dormant guard is absent and looks absent; a
+    dangling deferral is absent and looks COVERED.
+
+THE RULE
+    Two ways a file can name a deferral target:
+      (a) STRUCTURAL - a `defer_to="<basename>"` / `defer_to='<basename>'`
+          keyword-argument string literal.
+      (b) PROSE - "owned by <basename>", "handled by <basename>",
+          "delegates to <basename>", "deferred to <basename>", where
+          <basename> matches [A-Za-z0-9_.-]+\\.(py|sh).
+
+    A target RESOLVES if a tracked file ANYWHERE in the repo (not just
+    hooks/scripts/) has that basename -- built from `git ls-files`, so a
+    renamed or relocated owner still resolves. No git available -> fall back
+    to walking the tree from the repo root.
+
+    This checker's OWN path is excluded from the scan: its docstring and
+    self-test necessarily contain example deferral strings, and scanning
+    itself would be a guaranteed false positive on every run.
+
+Exit 0 when every named target resolves. Exit 1, listing each
+`path:line -> missing target`, when any dangling deferral is found.
+
+Usage:
+  check-defer-targets.py               # scan tracked hooks/ + scripts/ files
+  check-defer-targets.py --self-test   # positive + negative control
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+
+REPO = Path(__file__).resolve().parent.parent
+SELF_PATH = Path(__file__).resolve()
+
+SCAN_DIRS = ("hooks", "scripts")
+
+BASENAME = r"[A-Za-z0-9_.-]+\.(?:py|sh)"
+STRUCTURAL_RE = re.compile(r"""defer_to\s*=\s*(['"])(""" + BASENAME + r""")\1""")
+PROSE_RE = re.compile(
+    r"\b(?:owned by|handled by|delegates to|deferred to)\s+(" + BASENAME + r")\b"
+)
+
+
+def tracked_files() -> Optional[List[str]]:
+    """All tracked repo paths (relative, forward-slash) via `git ls-files`, or
+    None when git itself is unavailable (not: repo empty, which is a real
+    empty list and must NOT fall back)."""
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "-z"],
+            cwd=REPO, capture_output=True, text=True,
+            encoding="utf-8", errors="replace",
+        )
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+    return [p for p in result.stdout.split("\0") if p]
+
+
+def walk_files() -> List[str]:
+    """Fallback file listing when git is unavailable: walk the tree, skip .git."""
+    out: List[str] = []
+    for p in REPO.rglob("*"):
+        if not p.is_file():
+            continue
+        rel = p.relative_to(REPO)
+        if ".git" in rel.parts:
+            continue
+        out.append(rel.as_posix())
+    return out
+
+
+def resolvable_basenames(paths: List[str]) -> Set[str]:
+    return {Path(p).name for p in paths}
+
+
+def scan_targets(paths: List[str]) -> List[str]:
+    """Tracked paths under hooks/ or scripts/ (any depth), self excluded."""
+    out = []
+    for p in paths:
+        parts = Path(p).parts
+        if not parts or parts[0] not in SCAN_DIRS:
+            continue
+        if (REPO / p).resolve() == SELF_PATH:
+            continue
+        out.append(p)
+    return out
+
+
+def find_deferrals(text: str) -> List[Tuple[int, str]]:
+    """Pure detection: (1-indexed line, target basename) for every deferral
+    reference in `text` -- structural and prose combined, in line order. No
+    I/O here; the self-test drives this directly against synthetic strings so
+    no real repo file is ever touched."""
+    hits: List[Tuple[int, str]] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        for m in STRUCTURAL_RE.finditer(line):
+            hits.append((lineno, m.group(2)))
+        for m in PROSE_RE.finditer(line):
+            hits.append((lineno, m.group(1)))
+    return hits
+
+
+def dangling(hits_by_path: Dict[str, List[Tuple[int, str]]],
+             known_basenames: Set[str]) -> List[str]:
+    """Pure: given {path: [(line, target), ...]} and the resolvable basename
+    set, return one 'path:line -> missing target' string per dangling hit, in
+    stable (path, line) order. The one predicate the whole checker rests on:
+    membership in `known_basenames`."""
+    out = []
+    for path in sorted(hits_by_path):
+        for lineno, target in sorted(hits_by_path[path]):
+            if target not in known_basenames:
+                out.append(f"{path}:{lineno} -> {target}")
+    return out
+
+
+def scan_repo() -> Tuple[List[str], Dict[str, List[Tuple[int, str]]], Set[str]]:
+    """I/O shell: real discovery + real file reads, feeding the pure functions
+    above. Returns (scanned paths, hits by path, resolvable basename set)."""
+    all_paths = tracked_files()
+    if all_paths is None:
+        all_paths = walk_files()
+    known = resolvable_basenames(all_paths)
+
+    scanned = scan_targets(all_paths)
+    hits_by_path: Dict[str, List[Tuple[int, str]]] = {}
+    for rel in scanned:
+        fp = REPO / rel
+        try:
+            text = fp.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        hits = find_deferrals(text)
+        if hits:
+            hits_by_path[rel] = hits
+    return scanned, hits_by_path, known
+
+
+def main() -> int:
+    if "--self-test" in sys.argv:
+        return self_test()
+
+    scanned, hits_by_path, known = scan_repo()
+    problems = dangling(hits_by_path, known)
+
+    if problems:
+        print(f"::error::dangling defer target(s) ({len(problems)}) - named as "
+              f"the owner of a responsibility but no tracked file in the repo "
+              f"has that basename:")
+        for p in problems:
+            print(f"  {p}")
+        return 1
+
+    total_hits = sum(len(v) for v in hits_by_path.values())
+    print(f"OK - {len(scanned)} tracked hooks/+scripts/ file(s) scanned, "
+          f"{total_hits} defer target(s) found, all resolve.")
+    return 0
+
+
+def self_test() -> int:
+    """POSITIVE (a dangling target must be reported) + NEGATIVE (a target that
+    resolves must be silent) + a check that the negative control itself would
+    catch a checker that reports every hit regardless of the known set, plus a
+    detector round-trip and the self-exclusion invariant. Everything below
+    drives the pure find_deferrals()/dangling() functions against synthetic
+    strings and injected sets -- no real repo file is read or written."""
+    fails: List[str] = []
+
+    # 1. POSITIVE: a deferral naming a basename nothing in the known set ships
+    #    must come back as a dangling hit, one per occurrence.
+    positive_src = (
+        'x = 1  # defer_to="ghost-guard.py"\n'
+        "prose: MEMORY.md remediation is owned by ghost-guard.py\n"
+    )
+    hits = {"hooks/fake.py": find_deferrals(positive_src)}
+    known_without_ghost = {"fake.py", "other.py"}  # ghost-guard.py deliberately absent
+    problems = dangling(hits, known_without_ghost)
+    if len(problems) != 2:
+        fails.append(f"POSITIVE: expected 2 dangling hits, got {len(problems)}: {problems}")
+    elif not all("ghost-guard.py" in p for p in problems):
+        fails.append(f"POSITIVE: dangling hits did not name the missing target: {problems}")
+
+    # 2. NEGATIVE: deferrals naming basenames that DO exist in the known set
+    #    must be silent -- one case per prose verb plus the structural form.
+    negative_src = (
+        'add(x, defer_to="session-start-context.py")\n'
+        "handled by auto-snapshot.sh\n"
+        "delegates to worktree-footprint-signal.py\n"
+        "deferred to check-py39-annotations.py\n"
+    )
+    hits2 = {"hooks/real.py": find_deferrals(negative_src)}
+    known_all_present = {
+        "session-start-context.py", "auto-snapshot.sh",
+        "worktree-footprint-signal.py", "check-py39-annotations.py",
+        "unrelated-decoy.py",
+    }
+    problems2 = dangling(hits2, known_all_present)
+    if problems2:
+        fails.append(f"NEGATIVE: known targets wrongly reported dangling: {problems2}")
+
+    # 3. NEGATIVE CONTROL CHECK: prove the negative control above would
+    #    actually catch a checker that reports every hit regardless of the
+    #    known set (the "reports everything" failure mode named in the brief).
+    #    Re-run the SAME hits against an EMPTY known set: every one of the 4
+    #    must now come back dangling. If dangling() ignored `known_basenames`
+    #    and always returned nothing, this would still show 0 and the
+    #    negative control above would be proven not to discriminate.
+    problems2_empty = dangling(hits2, set())
+    if len(problems2_empty) != 4:
+        fails.append(
+            f"NEGATIVE-CONTROL-CHECK: against an empty known set, expected all "
+            f"4 hits to be dangling, got {len(problems2_empty)} - the negative "
+            f"control above cannot be trusted to discriminate"
+        )
+
+    # 4. DETECTOR: both quote styles + all four prose verbs fire; a bare
+    #    filename mention with none of the trigger phrases must NOT fire.
+    detector_src = (
+        "a = defer_to='single.py'\n"
+        "b = defer_to=\"double.sh\"\n"
+        "owned by a1.py\n"
+        "handled by a2.py\n"
+        "delegates to a3.sh\n"
+        "deferred to a4.py\n"
+        "see also unrelated.py for context\n"  # must NOT fire -- no trigger phrase
+    )
+    found = {target for _, target in find_deferrals(detector_src)}
+    expected = {"single.py", "double.sh", "a1.py", "a2.py", "a3.sh", "a4.py"}
+    if found != expected:
+        fails.append(f"DETECTOR: expected {sorted(expected)}, got {sorted(found)}")
+
+    # 5. SELF-EXCLUSION: this checker's own path must never be part of a real
+    #    scan (its docstring/self-test are a guaranteed false positive).
+    real_paths = tracked_files()
+    if real_paths is None:
+        real_paths = walk_files()
+    real_scanned = scan_targets(real_paths)
+    self_rel = SELF_PATH.relative_to(REPO).as_posix()
+    if self_rel in real_scanned:
+        fails.append("SELF-EXCLUSION: the checker's own path was included in a real scan")
+
+    if fails:
+        for f in fails:
+            print(f"FAIL: {f}")
+        return 1
+    print("OK - check-defer-targets self-test passed "
+          "(positive + negative + negative-control-check + detector + self-exclusion)")
+    return 0
+
+
+if __name__ == "__main__":
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
+    sys.exit(main())

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -85,6 +85,14 @@
 #                           so the class was caught one full CI round-trip AFTER
 #                           the push. Both callers now run the same script and
 #                           scripts/test_ps1_encoding_gate.py pins that.
+#   (e8) file I/O encoding - scripts/check-utf8-file-io.py fails a file read or
+#                           write in text mode with no encoding=, which uses the
+#                           LOCALE encoding: identical source then produces UTF-8
+#                           artifacts on macOS and cp1252 artifacts on Windows.
+#                           The read half is the quiet one -- it usually does not
+#                           raise, it decodes into mojibake. (Summary bullet was
+#                           missing while the step itself has always run, so a
+#                           top-to-bottom reader saw e7 jump straight to e9.)
 #   (e9) defer targets    - scripts/check-defer-targets.py fails a hook/script
 #                           under hooks/ or scripts/ that names a sibling as the
 #                           owner of a responsibility (`defer_to="<owner>.py"`, or

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -87,9 +87,9 @@
 #                           scripts/test_ps1_encoding_gate.py pins that.
 #   (e9) defer targets    - scripts/check-defer-targets.py fails a hook/script
 #                           under hooks/ or scripts/ that names a sibling as the
-#                           owner of a responsibility (`defer_to="x.py"`, or
-#                           prose "owned by x.py" / "handled by x.py" / "delegates
-#                           to x.py" / "deferred to x.py") when no tracked file in
+#                           owner of a responsibility (`defer_to="<owner>.py"`, or
+#                           prose "owned by <owner>.py" / "handled by <owner>.py" / "delegates
+#                           to <owner>.py" / "deferred to <owner>.py") when no tracked file in
 #                           the repo has that basename. A dangling deferral is
 #                           worse than a dormant guard: a dormant guard is absent
 #                           and looks absent, a dangling deferral is absent and
@@ -1157,8 +1157,8 @@ echo "==> (e8) file I/O encoding: $PY scripts/check-utf8-file-io.py"
 # ---- (e9) Dangling defer targets --------------------------------------------
 # scripts/check-defer-targets.py fails a hook/script under hooks/ or scripts/
 # that names a sibling guard as the owner of a responsibility -- structurally
-# (`defer_to="x.py"`) or in prose ("owned by x.py" / "handled by x.py" /
-# "delegates to x.py" / "deferred to x.py") -- when no tracked file in the repo
+# (`defer_to="<owner>.py"`) or in prose ("owned by <owner>.py" / "handled by <owner>.py" /
+# "delegates to <owner>.py" / "deferred to <owner>.py") -- when no tracked file in the repo
 # has that basename. Bug class: DEFERRAL-TO-AN-UNSHIPPED-OWNER, and it is worse
 # than plain dormancy: a dormant guard is absent and looks absent, a dangling
 # deferral is absent and looks COVERED. Caught live: context-budget-measure.py

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -85,6 +85,20 @@
 #                           so the class was caught one full CI round-trip AFTER
 #                           the push. Both callers now run the same script and
 #                           scripts/test_ps1_encoding_gate.py pins that.
+#   (e9) defer targets    - scripts/check-defer-targets.py fails a hook/script
+#                           under hooks/ or scripts/ that names a sibling as the
+#                           owner of a responsibility (`defer_to="x.py"`, or
+#                           prose "owned by x.py" / "handled by x.py" / "delegates
+#                           to x.py" / "deferred to x.py") when no tracked file in
+#                           the repo has that basename. A dangling deferral is
+#                           worse than a dormant guard: a dormant guard is absent
+#                           and looks absent, a dangling deferral is absent and
+#                           reads as covered. Caught live: context-budget-measure.py
+#                           deferred MEMORY.md's cliff warning to a file that only
+#                           ever existed in a private, remote-less, machine-local
+#                           repo - every install of THIS repo read "handled
+#                           elsewhere" and got nothing. Self-test first, then the
+#                           fleet. Pure stdlib.
 #   (f) Python unit tests - the scripts/test_*.py stdlib suites (the claude-router
 #                           structured-envelope gate, the graph-liveness
 #                           STAMP-GREEN-WHILE-GONE guard). Gate (a) py_compiles them,
@@ -1139,6 +1153,25 @@ bash scripts/check-ps1-encoding.sh
 echo "==> (e8) file I/O encoding: $PY scripts/check-utf8-file-io.py"
 "$PY" scripts/check-utf8-file-io.py --self-test >/dev/null
 "$PY" scripts/check-utf8-file-io.py
+
+# ---- (e9) Dangling defer targets --------------------------------------------
+# scripts/check-defer-targets.py fails a hook/script under hooks/ or scripts/
+# that names a sibling guard as the owner of a responsibility -- structurally
+# (`defer_to="x.py"`) or in prose ("owned by x.py" / "handled by x.py" /
+# "delegates to x.py" / "deferred to x.py") -- when no tracked file in the repo
+# has that basename. Bug class: DEFERRAL-TO-AN-UNSHIPPED-OWNER, and it is worse
+# than plain dormancy: a dormant guard is absent and looks absent, a dangling
+# deferral is absent and looks COVERED. Caught live: context-budget-measure.py
+# deferred MEMORY.md's cliff warning to a guard that shipped only on one
+# contributor's private, remote-less machine-local repo -- never in this one --
+# so every install read "handled elsewhere" and got nothing, silently. Fixed by
+# re-pointing the deferral at the real owner (session-start-context.py), which
+# already existed under a different name. Self-test first (positive + negative,
+# both driven off injected sets so no real file is touched), then the fleet.
+# Pure stdlib.
+echo "==> (e9) defer targets: $PY scripts/check-defer-targets.py"
+"$PY" scripts/check-defer-targets.py --self-test >/dev/null
+"$PY" scripts/check-defer-targets.py
 
 # ---- (f) Python unit tests (scripts/ + hooks/ + tests/) --------------------
 # Every Python unit suite in the repo, run under the SAME interpreter as the rest


### PR DESCRIPTION
## What was wrong

`hooks/context-budget-measure.py` deferred MEMORY.md's cliff warning to a guard named `check-memory-md-cap.py` — structurally (`defer_to=`, rendered to the user as `(cliff guard: ...)`) and in its docstring, where it justifies *not* duplicating that warning because another file owns it.

That file has never existed here:

| | this repo | control (the deferring hook itself) |
|---|---|---|
| files in tree @ `origin/main` | **0** | 1 |
| commits across all history | **0** | 4 |

It ships only in a private, remote-less, machine-local repo. Both hooks are registered by `scripts/install-hooks-user-level.py`, so **every install** rendered a cliff guard that owns their MEMORY.md and does not exist for them.

A dangling deferral is worse than a dormant guard: a dormant guard is absent and *looks* absent; a dangling one is absent and *reads as covered* — and it had also suppressed the deferring hook's own warning.

## The fix: re-point, not port

This repo already owns that warning under a different name — `hooks/session-start-context.py` via `hooks/_lib/memory_index.py`. Porting the machine-local guard would have created exactly the double-nag the deferring hook's own comment says it avoids.

**Coverage is not total, and the docstring now says so.** An earlier revision of this branch claimed `memory_index` covers a superset. Adversarial review refuted it by driving both real functions: in a fresh vault whose per-project memory symlink is not yet established, and under an `AGENT_MEMORY_DIR` override, a MEMORY.md past its warn threshold gets **no warning from either hook**. Same symptom as the bug being fixed, reached another way. The docstring now states the divergence in both directions; the coverage gap itself is MYC-4239.

## The general guard

`scripts/check-defer-targets.py`, wired into `scripts/ci.sh` as **(e9)**. Fails any `hooks/` or `scripts/` file naming a sibling as the owner of a responsibility — structurally or in prose — when no tracked file matches.

Bug class: **DEFERRAL-TO-AN-UNSHIPPED-OWNER**. Measured population before scoping: **3 deferral sites, 1 dangling**. The 2 that resolve today are the point — nothing stopped them rotting the same way.

Targets may be bare (`x.py`) or path-qualified (`hooks/x.py`); a path-qualified target must match a tracked **path**, so a right basename in a wrong directory does not pass. Covers `.py`, `.sh`, `.ps1` (the repo ships 11 `.ps1`).

Three states by exit code, because a failed read is not an empty answer: `0` clean, `1` dangling, `2` INCOMPLETE.

## Controls

- **positive** — a synthetic dangling target is reported
- **negative** — targets that resolve are silent
- **negative-control-check** — the same hits against an empty known set must *all* fire, proving the negative control discriminates
- **detector** — both quote styles, all four prose verbs, plus a bare filename that must *not* fire
- **path-qualified** — pins the review finding: `owned by hooks/does-not-exist.py` is detected and does not resolve; a wrong directory does not pass
- **self-exclusion** — the checker's own path is never scanned
- **incomplete-scan** — a FIFO (or a directory, where `mkfifo` is unavailable) must come back not-ok; an ordinary file must read back
- **end-to-end** — reintroducing `defer_to="check-memory-md-cap.py"` reds the gate naming `context-budget-measure.py:189`; restoring returns it to green

Mutation-tested rather than assumed: forcing `target_resolves() -> True` kills three controls; restoring the pre-fix regex kills the path-qualified control specifically, proving it would have caught the original miss.

## Caught by the gate and by review

1. `test_cloud_safe_file_walkers` flagged three call sites UNSAFE — rglob then `read_text` without the shared `safe_read` primitive, which exists because a cloud-synced vault can return an offline placeholder, a FIFO, or a stalled mount. Now uses `_lib.safe_read.safe_read_text` with an explicit timeout and byte bound.
2. The read swallowed `OSError` and continued, so an unreadable file was dropped while the run printed "all resolve" — a false clean of the same family as the bug being fixed.
3. `os.mkfifo` was called unconditionally (raises on Windows); guarded with `hasattr`, matching four existing precedents here.
4. `ci.sh`'s header summary jumped e7 to e9; the missing `(e8)` bullet is restored.

## Known limits (documented in the file)

Line-by-line detection misses prose wrapped across lines; only string literals are seen, not variables or f-strings; a bare target resolves by basename anywhere in the repo. A green here is a floor, not proof of absence.

## Verification

`ci-test` GREEN on `aac9021` — py_compile (392 files) + 136 integration tests + 31 scripts + 25 hooks suites + shellcheck + every sub-gate. ReDoS-probed: sub-4ms on 8K-82K char pathological inputs.

MYC-4236, MYC-4239

🤖 Generated with [Claude Code](https://claude.com/claude-code)
