### PR TITLE
hooks: session-lock resolved repo identity from ambient git env

### DIFF
--- a/hooks/session-lock.py
+++ b/hooks/session-lock.py
@@ -102,17 +102,6 @@ IDLE_EXPIRE_SEC = 1800      # prune entries idle > 30 min (stale-lock safety val
 CACHE_TTL_SEC = 604_800     # prune per-session cache pointers older than 7 days
 GIT_TIMEOUT_SEC = 6
 SCHEMA_VERSION = 2
-# Env for _index_is_empty's internal `git -C dirpath diff --cached` probe: the
-# GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE family override `-C` and would redirect
-# this diagnostic call at whatever repo the CALLER's environment points to,
-# defeating the explicit `-C dirpath` and misreading a different repo's index
-# as this one's -- the same GIT_DIR-confusion class this file exists to catch
-# in sibling commands, just self-inflicted here instead. Referenced but never
-# defined since #478 (2026-08-12); every call site passed `_GIT_CLEAN_ENV` and
-# it silently NameError'd -- caught by ruff --select F821, which nothing in
-# this repo's own CI runs over hooks/*.py (only the phase-doc Python blocks).
-_GIT_ENV_STRIP = ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE")
-_GIT_CLEAN_ENV = {k: v for k, v in os.environ.items() if k not in _GIT_ENV_STRIP}
 FLOCK_RETRIES = 20          # 20 * 10ms = 200ms max wait, then fail-open (unlocked)
 FLOCK_SLEEP_SEC = 0.01
 # Test-only determinism knob. When set, acquire the sidecar lock with a BLOCKING
@@ -148,19 +137,48 @@ ALWAYS_MUTATING = {
 # git global options that consume the FOLLOWING token as their value.
 GIT_GLOBAL_VALUE_OPTS = {"-C", "-c", "--git-dir", "--work-tree", "--namespace", "--exec-path"}
 
-# Ambient env vars that override an explicit `-C <path>` argument (GIT_DIR wins
-# over -C; GIT_WORK_TREE / GIT_INDEX_FILE / the object-dir pair follow the same
-# way). _index_is_empty's `git -C dirpath diff --cached --quiet` must always
-# read dirpath's OWN index -- never a repo an inherited env var points at --
-# stripped once at import so no subprocess call in this file can be silently
-# retargeted by the calling shell's environment.
+# git honors the location/index/object env family OVER an explicit `-C <path>`,
+# so a single leaked var silently retargets a probe at a DIFFERENT repo. That is
+# not hypothetical here: `_main_root` (via `_git_common_dir`) resolves the ONE
+# identity this whole hook keys off -- the SessionStart sibling warning and the
+# PreToolUse git-mutation DENY both decide, and write, against it. A git-hook
+# context exports GIT_DIR; a concurrent worktree session can leak one in.
+# Bug class RESOLVES-WRONG-REPO-FROM-AMBIENT-GIT-ENV.
+#
+# Measured (git 2.50.1, hooks/test_session_lock_git_env.py) against `git -C real`
+# with GIT_* pointed at a decoy repo -- which var actually bites which probe:
+#   GIT_DIR         -> ALL THREE (--git-common-dir, --abbrev-ref HEAD, diff --cached)
+#   GIT_COMMON_DIR  -> --git-common-dir
+#   GIT_INDEX_FILE  -> diff --cached
+#   GIT_WORK_TREE   -> none of these three (it relocates only the working tree)
+# GIT_WORK_TREE and the rest (object dirs, namespace, ceiling/discovery, all
+# documented in git(1)) are stripped anyway: same location family, and the cost
+# of stripping a var that does not currently bite is zero. GIT_PREFIX and CDPATH
+# are belt-and-braces only -- neither is documented in git(1) as a `-C` override,
+# and CDPATH was measured NOT to affect `git -C` (nothing here uses shell=True).
+#
+# Stripped once at import, and passed EXPLICITLY at all three call sites. A strip
+# set is inert unless `env=` is threaded through, which is exactly how
+# `_git_common_dir` stayed unprotected while this comment claimed otherwise.
 _GIT_CLEAN_ENV = {
     k: v for k, v in os.environ.items()
     if k not in (
-        "GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE",
-        "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_COMMON_DIR",
+        "GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_NAMESPACE", "GIT_CEILING_DIRECTORIES",
+        "GIT_DISCOVERY_ACROSS_FILESYSTEM", "GIT_PREFIX", "CDPATH",
     )
 }
+# History, because it explains why a SECOND definition of this name existed here
+# and why the duplicate was the dangerous part. #478 (2026-08-12) referenced
+# `_GIT_CLEAN_ENV` without defining it, so it silently NameError'd. #492 defined
+# it (2026-08-25 22:12). #530 defined it AGAIN 31 minutes later (22:43) with a
+# narrower 3-var set, fixing a NameError #492 had already fixed. Python keeps the
+# LAST binding, so #492's wider set won and the duplicate was inert -- but only by
+# ordering luck: land them the other way round and the strip set silently narrows
+# to three vars with no test, no lint and no reviewer able to see it. Neither
+# guard could catch it: this repo's CI runs ruff F821 over phase-doc blocks only,
+# never hooks/*.py, and py_compile cannot see an undefined name at all.
 
 # ---- `git commit` option tables (for the scoped-commit exemption) -----------
 # The parse has ONE catastrophic failure mode: mistaking an option's VALUE for a
@@ -240,6 +258,7 @@ def _git_common_dir(cwd):
                 ["git", "-C", cwd] + args,
                 capture_output=True, text=True,
                 encoding="utf-8", errors="replace", timeout=GIT_TIMEOUT_SEC,
+                env=_GIT_CLEAN_ENV,
             )
         except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
             return ""
@@ -381,6 +400,10 @@ def _current_branch(cwd):
             # brain ships cross-platform with emoji-named vault folders. Caught
             # by scripts/check-utf8-subprocess.py, not by review.
             encoding="utf-8", errors="replace",
+            # Same ambient-git-env strip as _git_common_dir: measured, a leaked
+            # GIT_DIR returns ANOTHER repo's branch, and this value is compared
+            # across sessions to decide the same-branch warning.
+            env=_GIT_CLEAN_ENV,
         )
     except Exception:
         return ""

--- a/hooks/test_session_lock_git_env.py
+++ b/hooks/test_session_lock_git_env.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Negative control: session-lock's git probes must ignore ambient git env vars.
+
+Run: python3 hooks/test_session_lock_git_env.py   (exit 0 = pass)
+
+git honors the GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE / GIT_COMMON_DIR family
+OVER an explicit ``git -C <path>``. session-lock resolves the identity that its
+ENTIRE mechanism keys off -- ``_main_root``, via ``_git_common_dir`` -- with
+exactly such a ``-C`` call, and ``_current_branch`` compares a branch name across
+sessions the same way. So a single leaked var (a git hook context exports GIT_DIR;
+a concurrent worktree session can leak one in) silently retargets the probe at a
+DIFFERENT repo: the SessionStart sibling warning and the PreToolUse git-mutation
+DENY then decide, and write, against the wrong worktree. Bug class
+RESOLVES-WRONG-REPO-FROM-AMBIENT-GIT-ENV.
+
+Each case sets a bogus var pointing at a DECOY repo and asserts the probe still
+resolves the REAL repo named by ``-C``. Vars are set BEFORE the module is
+imported, which is the real-world ordering (the leak predates the hook process)
+and the only ordering that also proves the module-level env snapshot is clean.
+
+Pure stdlib. Creates throwaway repos under a temp dir; touches no user state.
+"""
+import importlib.util
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+HOOK = os.path.join(os.path.dirname(os.path.abspath(__file__)), "session-lock.py")
+
+fails = []
+
+
+def check(name, got, want):
+    ok = (got == want)
+    print(("PASS" if ok else "FAIL"), name, "" if ok else ":: got %r want %r" % (got, want))
+    if not ok:
+        fails.append(name)
+
+
+def _git(*args, **kw):
+    cwd = kw.pop("cwd")
+    subprocess.run(
+        ["git"] + list(args), cwd=cwd, check=True,
+        capture_output=True, encoding="utf-8", errors="replace",
+    )
+
+
+def make_repo(path, branch):
+    """A real repo on a known branch, with an identity so commit works anywhere."""
+    os.makedirs(path)
+    _git("init", "-q", "-b", branch, ".", cwd=path)
+    _git("config", "user.email", "t@example.com", cwd=path)
+    _git("config", "user.name", "t", cwd=path)
+    _git("commit", "-q", "--allow-empty", "-m", "seed", cwd=path)
+    return os.path.realpath(path)
+
+
+class ambient_git_env(object):
+    """Set ambient git vars, import a FRESH session-lock, keep the vars set.
+
+    The var must still be set when the probe RUNS -- that is when subprocess
+    inherits the environment -- not merely when the module is imported. An
+    earlier draft restored the env in a ``finally`` around the import, which
+    silently removed the leak before any probe ran and made all 16 cases pass
+    against the unfixed file: a control that cannot vary. Restoring only on
+    __exit__ keeps the leak live across the assertions.
+
+    Importing per case (module_from_spec yields an isolated object) also proves
+    the module-level env snapshot is clean under the realistic ordering, where
+    the leak predates the hook process.
+    """
+
+    def __init__(self, **env):
+        self.env = env
+        self.saved = {}
+
+    def __enter__(self):
+        for k, v in self.env.items():
+            self.saved[k] = os.environ.get(k)
+            os.environ[k] = v
+        spec = importlib.util.spec_from_file_location("session_lock_git_env_case", HOOK)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    def __exit__(self, *exc):
+        for k, old in self.saved.items():
+            if old is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = old
+        return False
+
+
+def main():
+    tmp = tempfile.mkdtemp(prefix="session-lock-gitenv-")
+    try:
+        real = make_repo(os.path.join(tmp, "real"), "real-branch")
+        decoy = make_repo(os.path.join(tmp, "decoy"), "decoy-branch")
+        decoy_git = os.path.join(decoy, ".git")
+
+        # Positive control: with a CLEAN env the probes must already be correct.
+        # If this leg fails the harness itself is broken and every result below
+        # is meaningless -- a wrong answer here is not evidence about the fix.
+        with ambient_git_env() as clean:
+            check("control: _git_common_dir resolves -C target (clean env)",
+                  clean._git_common_dir(real), os.path.join(real, ".git"))
+            check("control: _main_root resolves -C target (clean env)",
+                  clean._main_root(real), real)
+            check("control: _current_branch resolves -C target (clean env)",
+                  clean._current_branch(real), "real-branch")
+            # And the decoy must be genuinely distinguishable, or a "correct"
+            # answer above could just be both repos looking identical.
+            check("control: decoy is distinguishable",
+                  clean._current_branch(decoy), "decoy-branch")
+
+        # Harness control: the leak must actually BITE raw git, or the cases
+        # below could pass because the var was never effective. This asserts the
+        # vulnerability exists in the tool, independently of our code.
+        leaked = dict(os.environ, GIT_DIR=decoy_git)
+        raw = subprocess.run(
+            ["git", "-C", real, "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True, encoding="utf-8", errors="replace", env=leaked,
+        )
+        check("control: a leaked GIT_DIR does retarget raw git",
+              (raw.stdout or "").strip(), "decoy-branch")
+
+        # The real cases: each leaked var must NOT retarget the probe.
+        for var, val in (
+            ("GIT_DIR", decoy_git),
+            ("GIT_COMMON_DIR", decoy_git),
+            ("GIT_WORK_TREE", decoy),
+            ("GIT_INDEX_FILE", os.path.join(decoy_git, "index")),
+        ):
+            with ambient_git_env(**{var: val}) as mod:
+                check("%s leak does not retarget _git_common_dir" % var,
+                      mod._git_common_dir(real), os.path.join(real, ".git"))
+                check("%s leak does not retarget _main_root" % var,
+                      mod._main_root(real), real)
+                check("%s leak does not retarget _current_branch" % var,
+                      mod._current_branch(real), "real-branch")
+
+        # _index_is_empty is the call site that ALREADY passed env=. Cover it so
+        # a future "cleanup" cannot quietly drop the one strip that was correct.
+        # GIT_INDEX_FILE is the var that bites this probe (GIT_DIR does not
+        # meaningfully, since the index lives under the git dir either way).
+        _git("commit", "-q", "--allow-empty", "-m", "base", cwd=decoy)
+        with open(os.path.join(decoy, "staged.txt"), "w", encoding="utf-8") as fh:
+            fh.write("x")
+        _git("add", "staged.txt", cwd=decoy)
+        decoy_index = os.path.join(decoy_git, "index")
+
+        # Harness control: prove the leak bites raw git here too, else the
+        # assertion below is decorative. Asserted as "not clean" rather than a
+        # literal rc: measured rc is 128 ("fatal: unable to read <sha>"), not the
+        # 1 you would expect, because the decoy index names objects that live in
+        # the DECOY's object store. Either way the probe stops reporting clean,
+        # which is the property that matters -- pinning 1 here would have made
+        # this control fail for the wrong reason.
+        leaked_idx = dict(os.environ, GIT_INDEX_FILE=decoy_index)
+        raw_idx = subprocess.run(
+            ["git", "-C", real, "diff", "--cached", "--quiet"],
+            capture_output=True, encoding="utf-8", errors="replace", env=leaked_idx,
+        )
+        check("control: a leaked GIT_INDEX_FILE stops raw git reporting a clean index",
+              raw_idx.returncode != 0, True)
+
+        with ambient_git_env(GIT_INDEX_FILE=decoy_index) as mod:
+            check("GIT_INDEX_FILE leak does not retarget _index_is_empty",
+                  mod._index_is_empty(real), True)
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+    print()
+    if fails:
+        print("FAILED %d case(s): %s" % (len(fails), ", ".join(fails)))
+        return 1
+    print("all git-env isolation cases passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1186,6 +1186,15 @@ PY_DIRECT=(
   hooks/test_unpushed_drift_surface.py
   hooks/test_claim_surface_honesty.py
   hooks/test_narrow_refspec_falsealarm.py
+  # session-lock resolves the repo identity its whole mechanism keys off with
+  # `git -C <cwd>`, and git honors GIT_DIR/GIT_COMMON_DIR OVER `-C`. `_git_common_dir`
+  # shipped with no env= at all (a second, dead _GIT_CLEAN_ENV definition shadowed
+  # the real one, so the file's own comment claimed a protection only one of three
+  # call sites had). Measured: a leaked GIT_DIR made _main_root AND _current_branch
+  # resolve a different repo entirely -- the SessionStart warning and the PreToolUse
+  # DENY then decide against the wrong worktree. Every leg carries a harness control
+  # asserting the leak still bites raw git, so a leg cannot pass by being inert.
+  hooks/test_session_lock_git_env.py
   # The frontmatter gate's own delimiter pattern stayed LF-only after #409/#431
   # fixed the validator behind it, so CRLF content was still denied one layer
   # out. The hook is fail-open, so an allow-only suite would pass against a


### PR DESCRIPTION
## What

`_git_common_dir` shelled out to `git -C <cwd>` with **no `env=` at all**, so it inherited the caller's environment unfiltered.

git honors `GIT_DIR` **over** `-C`. `_git_common_dir` resolves `_main_root` — the single piece of identity this hook's entire mechanism keys off. So one leaked var pointed the SessionStart sibling warning and the PreToolUse git-mutation DENY at a **different repo**, where they would decide and write.

A git-hook context exports `GIT_DIR`; a concurrent worktree session can leak one in.

## Measured, not assumed

Against `git -C real` with `GIT_*` pointed at a decoy repo (git 2.50.1):

| var | retargets |
|---|---|
| `GIT_DIR` | `--git-common-dir`, `--abbrev-ref HEAD`, `diff --cached` (all three) |
| `GIT_COMMON_DIR` | `--git-common-dir` |
| `GIT_INDEX_FILE` | `diff --cached` |
| `GIT_WORK_TREE` | none of these three |

The last row corrects the prior comment, which asserted the whole family overrides `-C`.

## Why it was invisible

The file defined `_GIT_CLEAN_ENV` **twice**. #492 added the complete 6-var set (2026-08-25 22:12); #530 added a narrower 3-var set **31 minutes later** (22:43), fixing a NameError #492 had already fixed. Python keeps the last binding, so #492's wider set won — **by ordering luck**. Reversed, the strip set silently narrows to three vars.

Nothing could catch it: this repo runs ruff F821 over phase-doc blocks only, never `hooks/*.py`, and `py_compile` cannot see an undefined name.

Separately, the strip set was inert wherever it was never threaded through. It named six vars while **one of three** call sites passed `env=` — under a comment claiming *"no subprocess call in this file can be silently retargeted."*

## Changes

- delete the dead, shadowed duplicate definition
- `env=_GIT_CLEAN_ENV` in `_git_common_dir` (the reported gap)
- `env=_GIT_CLEAN_ENV` in `_current_branch` — the **third** `-C` probe, also unprotected; its branch name is compared across sessions to decide the same-branch warning, and a leaked `GIT_DIR` returns another repo's
- widen the strip set to the full documented location family
- comments now state only what was measured; `GIT_PREFIX` / `CDPATH` marked belt-and-braces (`CDPATH` measured **not** to affect `git -C`)

## The test is a real negative control

`hooks/test_session_lock_git_env.py` **fails 5 ways** against the unfixed file and passes after.

Every leg carries a harness control asserting the leak still bites raw git, so no leg can pass by being inert. That matters: an earlier draft of this test restored the env in a `finally` around the import, removing the leak before any probe ran — it passed all 16 cases against the **unfixed** file. A control that cannot vary is not a control.

Registered in `ci.sh` `PY_DIRECT` — `hooks/test_*.py` is an allow-list, not a glob, so an unregistered suite ships dormant.

## Verification

- `bash scripts/ci.sh` green on this exact tree: 392 files compiled, 136 integration tests, 31 `scripts/` suites, 26 hooks/tests suites, dormancy invariant clean, all static guards passed.
- One iteration was **red first**: `(e8)` caught my own test opening a file with no `encoding=`. Fixed, re-run green.
- No conflict with #608 (also touches `ci.sh`): `merge-tree` clean — it edits the header block, this edits `PY_DIRECT`.

## Not in scope

30+ other hooks call git via subprocess with no env strip. Not touched here; that is its own sweep, and widening this diff to cover it would make it unreviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
