### PR TITLE
worktree_safety: remove_worktree must not report a half-removal as success

### DIFF
--- a/hooks/_lib/worktree_safety.py
+++ b/hooks/_lib/worktree_safety.py
@@ -509,12 +509,33 @@ def snapshot_unrecoverable(main_repo: Path, worktree: Path, slug: str) -> tuple[
 
 
 def remove_worktree(main_repo: Path, worktree: Path, force: bool = True) -> bool:
-    """`git worktree remove` (keeps the branch ref). True on success."""
+    """`git worktree remove` (keeps the branch ref). True on success.
+
+    `timeout=None` is LOAD-BEARING. `git worktree remove` unlinks the working
+    tree in raw readdir order, so killing it partway leaves a contiguous PREFIX
+    of the checkout deleted while `.git`, HEAD and the admin record survive --
+    the worktree still lists as registered and gets re-damaged on the next run.
+    Tracked files come back with `git checkout -- .`; an untracked `.env.local`
+    does not come back at all. This helper defaulted to GIT_TIMEOUT (120s) AND
+    force=True, which is the same hazard with a longer fuse and no confirmation
+    prompt. Measured on a reaper carrying this bug 2026-08-02: 26+ damaged
+    worktrees.
+
+    Reporting the side effect rather than `returncode == 0` is the other half:
+    git exiting 0 is its report, not the outcome. A caller must never be able to
+    record a half-removal as a removal. `os.path.lexists` (not `Path.exists`)
+    because the latter follows symlinks and would call a leftover dangling link
+    at the worktree path a clean removal.
+
+    Negative control: hooks/test_worktree_remove_verifies_side_effect.py
+    """
     args = ["worktree", "remove"] + (["--force"] if force else []) + [str(worktree)]
     try:
-        return git(main_repo, args).returncode == 0
+        if git(main_repo, args, timeout=None).returncode != 0:
+            return False
     except (subprocess.TimeoutExpired, OSError):
         return False
+    return not os.path.lexists(worktree)
 
 
 def list_orphan_dirs(main_repo: Path) -> list[Path]:

--- a/hooks/test_worktree_remove_verifies_side_effect.py
+++ b/hooks/test_worktree_remove_verifies_side_effect.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Negative control for remove_worktree(): a half-removal must not report success.
+
+THE BUG CLASS. `git worktree remove` unlinks the working tree in raw readdir
+order. Killed partway — by a timeout — it leaves a contiguous PREFIX of the
+checkout deleted while `.git`, HEAD and the admin record survive. The worktree
+still lists as registered, so the next run re-damages it. Tracked files come
+back with `git checkout -- .`; untracked ones (`.env.local`) do not come back
+at all.
+
+Two independent defects made that reachable:
+  1. the call inherited GIT_TIMEOUT (120s), so a large checkout could be killed
+     mid-unlink;
+  2. success was read off `returncode == 0` alone, so a half-removal that git
+     reported 0 for was recorded as a clean removal.
+
+These tests pin the SIDE EFFECT (is the directory actually gone), not git's
+self-report. Run: python3 hooks/test_worktree_remove_verifies_side_effect.py
+"""
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _lib import worktree_safety as ws  # noqa: E402
+
+
+class _FakeCompleted:
+    def __init__(self, returncode):
+        self.returncode = returncode
+        self.stdout = b""
+        self.stderr = b""
+
+
+def _with_fake_git(returncode, record):
+    def fake_git(repo, args, timeout=ws.GIT_TIMEOUT):
+        record["timeout"] = timeout
+        record["args"] = args
+        return _FakeCompleted(returncode)
+    return fake_git
+
+
+def test_half_removal_is_not_success():
+    """git says 0 but the dir survives -> must report False."""
+    real = ws.git
+    rec = {}
+    try:
+        ws.git = _with_fake_git(0, rec)
+        with tempfile.TemporaryDirectory() as td:
+            wt = Path(td) / "survivor"
+            wt.mkdir()                      # dir still there == half-removal
+            got = ws.remove_worktree(Path(td), wt)
+        assert got is False, (
+            "remove_worktree reported SUCCESS while the worktree directory "
+            "still exists — a half-removal recorded as a removal"
+        )
+    finally:
+        ws.git = real
+
+
+def test_real_removal_is_success():
+    """Positive control: dir actually gone -> True. Guards against a fix that just returns False."""
+    real = ws.git
+    rec = {}
+    try:
+        ws.git = _with_fake_git(0, rec)
+        with tempfile.TemporaryDirectory() as td:
+            wt = Path(td) / "gone"          # never created == really removed
+            got = ws.remove_worktree(Path(td), wt)
+        assert got is True, "a genuine removal must still report True"
+    finally:
+        ws.git = real
+
+
+def test_removal_is_not_timeout_bounded():
+    """The unlink must not be killable mid-flight."""
+    real = ws.git
+    rec = {}
+    try:
+        ws.git = _with_fake_git(0, rec)
+        with tempfile.TemporaryDirectory() as td:
+            wt = Path(td) / "gone"
+            ws.remove_worktree(Path(td), wt)
+        assert rec.get("timeout") is None, (
+            f"remove_worktree passed timeout={rec.get('timeout')!r}; a bounded "
+            "timeout can kill `git worktree remove` mid-unlink and destroy "
+            "untracked files permanently"
+        )
+    finally:
+        ws.git = real
+
+
+def test_dangling_symlink_is_not_success():
+    """A leftover dangling symlink at the worktree path is not a clean removal."""
+    real = ws.git
+    rec = {}
+    try:
+        ws.git = _with_fake_git(0, rec)
+        with tempfile.TemporaryDirectory() as td:
+            wt = Path(td) / "linky"
+            wt.symlink_to(Path(td) / "nonexistent-target")
+            got = ws.remove_worktree(Path(td), wt)
+        assert got is False, (
+            "a dangling symlink still at the worktree path was reported as a "
+            "clean removal (Path.exists() follows symlinks; use lexists)"
+        )
+    finally:
+        ws.git = real
+
+
+def test_nonzero_returncode_is_failure():
+    real = ws.git
+    rec = {}
+    try:
+        ws.git = _with_fake_git(1, rec)
+        with tempfile.TemporaryDirectory() as td:
+            wt = Path(td) / "gone"
+            assert ws.remove_worktree(Path(td), wt) is False
+    finally:
+        ws.git = real
+
+
+def main():
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if not name.startswith("test_") or not callable(fn):
+            continue
+        try:
+            fn()
+            print(f"PASS {name}")
+        except AssertionError as exc:
+            failures += 1
+            print(f"FAIL {name}: {exc}")
+    print(f"\n{failures} failure(s)")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    # Windows cp1252-console safety (ai-brain-starter#313): this file's
+    # docstring and assertion text carry non-ASCII, and a print() of that on a
+    # cp1252 console raises UnicodeEncodeError -- the control would die before
+    # it could report, which is the one failure a negative control must not have.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
+    sys.exit(main())

--- a/scripts/check-utf8-file-io.py
+++ b/scripts/check-utf8-file-io.py
@@ -161,6 +161,16 @@ def violations_in(path):
         if not isinstance(node, ast.Call):
             continue
         name = getattr(node.func, "id", None) or getattr(node.func, "attr", None)
+        # `os.open()` returns a file DESCRIPTOR (an int). It takes no encoding=
+        # at all and performs no text decoding, so it is not text I/O -- but it
+        # matches on the bare attribute name `open`, which made every caller a
+        # false positive. The only way to silence one was to content-pin the
+        # whole file in the baseline, which then went STALE on the next edit and
+        # re-surfaced the same false positive as a fresh FAIL.
+        if (name == "open"
+                and isinstance(node.func, ast.Attribute)
+                and getattr(node.func.value, "id", None) == "os"):
+            continue
         if name not in ("open", "write_text", "read_text"):
             continue
         if any(kw.arg == "encoding" for kw in node.keywords):
@@ -252,6 +262,11 @@ def d(p, raw):
         f.write(raw)
 def e(p, obj):
     Path(p).write_text(json.dumps(obj))  # provably ASCII (ensure_ascii defaults True)
+def f(p, raw):
+    import os
+    fd = os.open(p, os.O_WRONLY | os.O_CREAT, 0o600)   # fd, not text I/O
+    with os.fdopen(fd, "wb") as stream:
+        stream.write(raw)
 '''
     tmp = Path(tempfile.mkdtemp())
     failures = []

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1177,6 +1177,7 @@ PY_DIRECT=(
   tests/test_graphify_stage_select_cache_key.py
   hooks/test_live_session_reap.py
   hooks/test_relocation_orphan_reclaim.py
+  hooks/test_worktree_remove_verifies_side_effect.py
   hooks/test_secret_patterns_fp_filter.py
   hooks/test_secret_patterns_nvidia.py
   hooks/test_check_fabricated_verification.py

--- a/scripts/utf8-file-io-baseline.txt
+++ b/scripts/utf8-file-io-baseline.txt
@@ -56,9 +56,7 @@ bf2aa37b1fc14be871ed01920e719d1f71d87052e536d4c435ed2fff227ca8ec SEV-A-write scr
 a29f6c2b98ccf874e4c818e2487ce74f32248ecbbce73a11c91a738561f3aa84 SEV-A-write skills/graphify/scripts/graphify_chunk.py
 8397e371e756c7cff96453d8f8f2c895e1e8ac0762edc8538c573c059e07d19d SEV-A-write skills/graphify/scripts/graphify_prep.py
 
-# ---- SEV-B-read-only  (26 file(s)) ----
-3f7a1805473134ddb49cd1957cc4f94c8e84a1ccb4e8f875e6765b3dac33f289 SEV-B-read-only hooks/_lib/safe_read.py
-52c331ed8a99a90e12e347215144e6799dbe1d278024432dfc46639a4de68405 SEV-B-read-only hooks/_lib/worktree_safety.py
+# ---- SEV-B-read-only  (23 file(s)) ----
 b647243fdf0a358d46a6a79b0bf7f817ee121f68d5d685fabe4b0ee2a93af94d SEV-B-read-only hooks/check-fabricated-hook-attribution.py
 3599a56754108272a15a2c879a23a52c0e844edf2991932118ecf16b24706af9 SEV-B-read-only hooks/dev-hub-refresh-on-session-start.py
 383b879b07fd9dce4a66c6a9beb449e2c7ec378b7f94d393b2bf486cf26531fb SEV-B-read-only hooks/observe-tool-calls.py
@@ -74,7 +72,6 @@ a1129452c2c68c67d4e4d81074625b198cb02a5a32e30eaa588f3a3fd5606b7f SEV-B-read-only
 5b2a426f96ba2f79637975888633c7de53cdc3028baaccd33ed24c83db3f32eb SEV-B-read-only scripts/graphify_canonicalize.py
 4a5f57798e6752eccdbdad8e3d367c5313efcdc93e06ebebb5060a240b39de8f SEV-B-read-only scripts/graphify_dedupe_by_adjacency.py
 c005821701b63b26d2fb4bd2c6f9d49f979fc26ed838879ff074f6bb6f666d2b SEV-B-read-only scripts/graphify_preextract_block.py
-d07949ff88fd853a45c2dbb17f06bc0d1629021196f6baa416413ffc47014c98 SEV-B-read-only scripts/hook_runner.py
 6082be21cce7a61305998c0b07dd6c1148aebe660dcf364d8998d317b7cdcc57 SEV-B-read-only scripts/insight-fact-check.py
 c7c7ac03bdc38b1db366faf67be0f4e9aceacf8c68b0b420c38c831463da5e1e SEV-B-read-only scripts/mcps/graph-query-server.py
 f226d40cae4f1876faa3756c9d85446e6e4a7277551223df30fa219972d52d74 SEV-B-read-only scripts/test_hook_runner_single_interpreter.py


### PR DESCRIPTION
## Why

`git worktree remove` unlinks the working tree in raw readdir order. Killed partway it leaves a contiguous **prefix** of the checkout deleted while `.git`, HEAD and the admin record survive — the worktree still lists as registered and gets re-damaged next run. Tracked files come back with `git checkout -- .`; an untracked `.env.local` does not come back at all.

Two independent defects in `remove_worktree` made that reachable:

1. the call inherited `GIT_TIMEOUT` (120s), so a large checkout could be killed mid-unlink;
2. success was read off `returncode == 0` alone, so a half-removal git reported 0 for was recorded as a clean removal.

Reached by `remove-ended-worktree.py` on **every SessionEnd**, plus `enforce-worktree-cap.py` and `scripts/worktree-reclaim.py`.

## What changed

**`hooks/_lib/worktree_safety.py`** — `timeout=None` on the unlink, and the return value is now the **side effect** (`os.path.lexists`, not `Path.exists`, so a leftover dangling symlink at the worktree path is not called a clean removal). All four call sites already branch on the bool (`continue` / WARN), so a now-correct `False` is handled; the cap counter also stops counting half-removals toward the cap.

**`hooks/test_worktree_remove_verifies_side_effect.py`** — negative control, verified **RED against unmodified source** on all three defects (half-removal reported success; `timeout=120`; dangling symlink reported success), with two positive controls green so a fix that merely returns `False` cannot pass. Wired into `PY_DIRECT` so it is not a dormant suite.

**`scripts/check-utf8-file-io.py`** — found while gating the above. `os.open()` returns a file descriptor, takes no `encoding=` and does no text decoding, but matched on the bare attribute name `open`, so every `os.open` caller was a false positive. The only way to silence one was to content-pin the whole file — and that pin then went **stale** on the next edit and re-surfaced the same false positive as a fresh FAIL. Fixed at the detection site; `os.open` + `os.fdopen(fd, "wb")` added to the self-test's GOOD fixture as a regression control.

With the false positive gone, three baseline rows are genuinely clean and are dropped (`hooks/_lib/safe_read.py`, `hooks/_lib/worktree_safety.py`, `scripts/hook_runner.py`). Baseline **83 to 80** rows; section header corrected 26 to 23. The ratchet only moves down.

## Verification

`ci-test` GREEN on `cc7e15d` — `GATE_EXIT=0`, 0 FAIL, 0 error annotations, 3233 lines, sha-keyed marker written. The new suite is confirmed to actually run in that gate.

Five earlier gate runs went RED on environment, not on this diff (worktree deleted mid-gate, two `Broken pipe` flakes, one transient network failure). Each was controlled: the named test passes on clean `origin/main` and in isolation, and `git diff --name-only origin/main..HEAD` never touched it. Evidence added to MYC-3391 and MYC-3889.

No conflict with #609 or #610 (`merge-tree` clean against both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
