### PR TITLE
hooks: derive the session umbrella map from SKILL.md frontmatter, so it reaches a client install (MYC-4238)

### DIFF
--- a/hooks/_lib/umbrella_map.py
+++ b/hooks/_lib/umbrella_map.py
@@ -1,0 +1,309 @@
+"""Render the routing-umbrella map for the install this session is running on.
+
+WHY THIS DERIVES INSTEAD OF HARDCODING. The map this replaces was a string
+literal naming 13 umbrellas, living in a machine-local repo with no remote, so
+it never reached a client install at all. The obvious fix -- copy the literal
+into the substrate -- is wrong three ways, and each is its own bug class:
+
+  1. SCOPE. Most umbrellas are private/paid skills a free install does not
+     have. A hardcoded map routes the user to a dozen skills that are not on
+     their machine. The map's NAME claims to describe THIS session's routing
+     surface; a literal describes the AUTHOR's surface instead.
+  2. BOUNDARY. Hardcoding the paid catalogue into a public MIT repo publishes
+     that inventory.
+  3. DRIFT. The literal already disagreed with two other hardcoded copies of
+     the same fact -- one said 14, one still routed a skill deprecated seven
+     weeks earlier. A third copy would have made that worse.
+
+So the substrate ships the MECHANISM and each skill carries its own
+DECLARATION. A skill is an umbrella when its SKILL.md frontmatter says
+`umbrella: true`. Nothing here enumerates skill names, which is what keeps it
+correct on an install whose skill set we have never seen.
+
+FRONTMATTER CONTRACT (all optional except `umbrella`):
+    umbrella: true            marks this skill as a routing umbrella
+    umbrella_group: <text>    heading it renders under (default "Skills")
+    umbrella_domain: <text>   the one-line "what it covers" (default: first
+                              sentence of `description`)
+    umbrella_order: <int>     sort key, lower first (default 50). A GROUP is
+                              ordered by its earliest member, so group order is
+                              declared by the skills too -- this file knows no
+                              group name in advance.
+
+WHY A _lib MODULE AND NOT A WIRED HOOK. footprint-budgets.json caps
+SessionStart fan-out at 19 and the event measured exactly 19. That budget's own
+`_budget_rationale` directs the next addition to optimize the fan-out rather
+than raise it again. session-start-context.py is already wired and already pays
+for the interpreter, and the umbrella map IS session-start context, so it folds
+in there for zero added fan-out (measured: footprint-sla-check --gate, 19/19,
+exit 0). Living in _lib/ also keeps it directly testable.
+
+HONEST SCOPE. This runs once per session start and scales with the user's skill
+count, which makes it a concurrency multiplier: N simultaneous sessions means N
+simultaneous scans. So it is bounded on purpose -- two `iterdir` levels (never
+os.walk/rglob), one bounded read per candidate, AND a wall-clock budget across
+the whole scan. It also COUNTS what it could not read and says so in the
+header, because a map that silently shrinks is a map that lies about its scope.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+try:
+    from _lib.safe_read import safe_read_text
+except ImportError:  # direct import when hooks/_lib is already on sys.path
+    from safe_read import safe_read_text  # type: ignore[no-redef]
+
+DEFAULT_GROUP = "Skills"
+DEFAULT_ORDER = 50
+SCAN_BUDGET_S = 2.0   # whole-scan wall clock, not per file
+PER_READ_S = 0.5      # safe_read's own default is 5s; N files x 5s is not a bound
+# A YAML block-scalar indicator means the value is on the FOLLOWING lines, so
+# the key's own line carries only the indicator. Treat it as "no value" rather
+# than rendering a literal ">" as a skill's domain.
+BLOCK_SCALARS = {">", "|", ">-", "|-", ">+", "|+", ">>"}
+
+
+def default_skills_dir() -> Path:
+    return Path.home() / ".claude" / "skills"
+
+
+def _strip_comment(value: str) -> str:
+    """Drop an unquoted trailing `# comment`, the way real YAML does.
+
+    Without this, `umbrella: true  # routing umbrella` parses to
+    `"true  # routing umbrella"`, which is not truthy -- a syntactically valid
+    declaration the map ignores, failing identically to "not an umbrella".
+    """
+    if not value or value[:1] in ("'", '"'):
+        return value
+    for sep in (" #", "\t#"):
+        head, found, _ = value.partition(sep)
+        if found:
+            value = head
+    return value.strip()
+
+
+def parse_frontmatter(text: str) -> dict:
+    """Minimal `key: value` YAML-frontmatter reader.
+
+    Deliberately NOT a YAML parser. scripts/ci.sh installs PyYAML only under
+    GITHUB_ACTIONS, so a hook cannot REQUIRE it; the sibling hooks that import
+    yaml all guard it and degrade to a skip, and for this map a skip renders
+    nothing -- indistinguishable from an install with no umbrellas.
+
+    Requires a CLOSING delimiter. Without that check an unclosed frontmatter
+    scans to EOF, and a SKILL.md that DOCUMENTS this very contract inside a
+    fenced code block would promote itself and inherit the example's group.
+    """
+    text = text.lstrip("﻿").lstrip()  # BOM, or a blank line before ---
+    if not text.startswith("---"):
+        return {}
+    out: dict = {}
+    closed = False
+    for line in text.splitlines()[1:]:
+        stripped = line.strip()
+        if stripped in ("---", "..."):
+            closed = True
+            break
+        # Top-level keys only. An indented line belongs to a nested structure
+        # this does not model, and treating it as top-level would let a nested
+        # `umbrella:` promote an unrelated skill into the map.
+        if line[:1] in (" ", "\t") or ":" not in stripped:
+            continue
+        key, _, value = stripped.partition(":")
+        key = key.strip()
+        if not key:
+            continue
+        value = _strip_comment(value.strip())
+        if value in BLOCK_SCALARS:
+            value = ""
+        out[key] = value.strip("\"'")
+    return out if closed else {}
+
+
+def first_sentence(text: str, limit: int = 96) -> str:
+    """First sentence of a description, clipped. Used when a skill declares
+    `umbrella: true` but gives no `umbrella_domain`."""
+    text = " ".join(text.split())
+    for stop in (". ", " - ", "; "):
+        head, sep, _ = text.partition(stop)
+        if sep:
+            text = head
+            break
+    return text if len(text) <= limit else text[: limit - 1].rstrip() + "…"
+
+
+def _truthy(value: str) -> bool:
+    return value.strip().lower() in ("true", "yes", "1", "on")
+
+
+def _skill_md_candidates(skills_dir: Path) -> list:
+    """Every place a SKILL.md legitimately lives, FLAT ENTRIES FIRST.
+
+    TWO LAYOUTS, both real, and missing the second is the whole bug this module
+    exists to fix. A skills repo linked into ~/.claude/skills puts each skill
+    FLAT (`<root>/<name>/SKILL.md`). A cloned skill BUNDLE keeps its own tree,
+    so its skills sit NESTED (`<root>/<bundle>/skills/<name>/SKILL.md`).
+    Measured: a maintainer box has BOTH, so a flat-only scan passes there and
+    renders NOTHING on a substrate-only install -- exactly the client case.
+
+    TWO PASSES, not one interleaved walk. The dedup below is first-wins, and
+    the flat copy is the one the harness actually loads, so every flat entry
+    must be enumerated before any nested one. Interleaving silently inverts
+    that whenever a bundle directory sorts before a flat skill of the same
+    name -- measured on a real tree: 49 colliding names, 46 resolving to the
+    nested copy, including this module's own vault-system.
+
+    Still bounded: two `iterdir` levels, no os.walk / rglob.
+    """
+    try:
+        entries = sorted(skills_dir.iterdir())
+    except OSError:
+        return []
+    def _dirs(paths) -> list:
+        # DIRECTORIES only. A skills tree legitimately contains loose files --
+        # measured: five `.zip` archives beside the skill dirs of one bundle --
+        # and `<archive>.zip/SKILL.md` reads as an ERROR, which the unreadable
+        # counter would then report as five broken skills on a healthy machine.
+        # A guard that cries on correct state is one people learn to ignore.
+        out = []
+        for x in paths:
+            try:
+                if x.is_dir():
+                    out.append(x)
+            except OSError:
+                continue
+        return out
+
+    flat = [(e.name, e / "SKILL.md") for e in _dirs(entries)]
+    nested: list = []
+    for e in _dirs(entries):
+        sub = e / "skills"
+        try:
+            if sub.is_dir():
+                nested.extend((s.name, s / "SKILL.md") for s in _dirs(sorted(sub.iterdir())))
+        except OSError:
+            continue
+    return flat + nested
+
+
+def _read_skill(path: Path, timeout: float):
+    """Bounded read that also tolerates a SKILL.md which is ITSELF a symlink.
+
+    safe_read opens with O_NOFOLLOW and rejects a non-regular final component,
+    so a symlinked SKILL.md comes back `not-regular` and would be skipped
+    identically to "not declared" -- silent. Symlinked skill DIRECTORIES are
+    fine either way; only the final component is constrained.
+    """
+    result = safe_read_text(path, errors="replace", timeout=timeout)
+    if not result.ok and getattr(result, "status", "") == "not-regular":
+        try:
+            if path.is_symlink():
+                target = path.resolve(strict=True)
+                if target.is_file():
+                    return safe_read_text(target, errors="replace", timeout=timeout)
+        except OSError:
+            pass
+    return result
+
+
+def collect_umbrellas(skills_dir: Path) -> tuple:
+    """Return (umbrellas, unreadable_count).
+
+    The count is not decoration. safe_read's per-file deadline is 5s and there
+    is no budget across a scan, so a stalled cloud-sync folder could block
+    session start for minutes AND -- if every read fails -- return an empty
+    list that is indistinguishable from a genuine "nothing declared". A scan
+    that ran out of budget or hit unreadable files must be able to say so.
+    """
+    found: list = []
+    seen: set = set()
+    unreadable = 0
+    deadline = time.monotonic() + SCAN_BUDGET_S
+    for entry_name, skill_md in _skill_md_candidates(skills_dir):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            unreadable += 1
+            continue
+        result = _read_skill(skill_md, timeout=min(PER_READ_S, remaining))
+        if not result.ok:
+            # "missing" is the overwhelmingly common case (a dir with no
+            # SKILL.md) and is NOT a failure; anything else is.
+            if getattr(result, "status", "") != "missing":
+                unreadable += 1
+            continue
+        fm = parse_frontmatter(result.text or "")
+        if not _truthy(fm.get("umbrella", "")):
+            continue
+        name = fm.get("name") or entry_name
+        if name in seen:
+            continue  # first wins, and flat is enumerated first by construction
+        seen.add(name)
+        try:
+            order = int(fm.get("umbrella_order", DEFAULT_ORDER))
+        except ValueError:
+            order = DEFAULT_ORDER
+        found.append({
+            "name": name,
+            "group": fm.get("umbrella_group") or DEFAULT_GROUP,
+            "domain": fm.get("umbrella_domain") or first_sentence(fm.get("description", "")),
+            "order": order,
+        })
+    return found, unreadable
+
+
+def render(umbrellas: list, unreadable: int = 0) -> str:
+    groups: dict = {}
+    for u in umbrellas:
+        groups.setdefault(str(u["group"]), []).append(u)
+    ordered = sorted(
+        groups.items(),
+        key=lambda kv: (min(int(u["order"]) for u in kv[1]), kv[0]),
+    )
+    count = len(umbrellas)
+    noun = "umbrella" if count == 1 else "umbrellas"
+    header = f"[skill-umbrellas] {count} routing {noun} available this session."
+    if unreadable:
+        # State the scope rather than let the count imply completeness.
+        header += f" ({unreadable} skill file(s) unreadable, so this list may be short.)"
+    lines = [header, ""]
+    for group, members in ordered:
+        lines.append(f"{group}:")
+        for u in sorted(members, key=lambda x: (int(x["order"]), str(x["name"]))):
+            domain = str(u["domain"])
+            lines.append(f"  /{u['name']}" + (f" — {domain}" if domain else ""))
+        lines.append("")
+    lines.append(
+        "Pick the umbrella whose domain matches the work. Multiple matches → chain."
+    )
+    return "\n".join(lines)
+
+
+def render_umbrella_map(skills_dir: Path | None = None) -> str | None:
+    """The map, or None when there is nothing honest to say.
+
+    Three states kept distinct even though all render nothing, because
+    collapsing them is how a failed read starts reading as an empty answer:
+      - bypassed           -> None
+      - no skills dir      -> None  (fresh install; nothing to route yet)
+      - dir with 0 marked  -> None  (a real zero, not a failure)
+    A scan that found nothing but COULD NOT READ anything is the fourth state,
+    and it renders a header saying so rather than masquerading as the third.
+    """
+    if _truthy(os.environ.get("UMBRELLA_MAP_BYPASS", "")):
+        return None
+    try:
+        root = skills_dir or default_skills_dir()
+        if not root.is_dir():
+            return None
+        umbrellas, unreadable = collect_umbrellas(root)
+        if not umbrellas:
+            return render([], unreadable) if unreadable else None
+        return render(umbrellas, unreadable)
+    except Exception:
+        # A SessionStart payload is not worth breaking a session over.
+        return None

--- a/hooks/session-start-context.py
+++ b/hooks/session-start-context.py
@@ -77,6 +77,35 @@ def _memory_index_warning() -> str:
         return ""
 
 
+def _umbrella_map() -> str:
+    """The routing-umbrella map for THIS install, or "" if there is none.
+
+    Folded in here rather than wired as its own SessionStart hook on purpose:
+    footprint-budgets.json caps SessionStart fan-out at 19, the event measured
+    exactly 19, and that budget's own rationale records the decision that the
+    next addition should optimize fan-out rather than raise again. This hook
+    already emits SessionStart context and already pays for the interpreter,
+    so the map adds ZERO SessionStart fan-out (measured: footprint-sla-check
+    --gate reports 19 / 19, exit 0, with this in the tree). Not free in wall
+    clock, though: two bounded iterdir levels plus one capped read per skill.
+    Fails open -- a missing map must never cost the session its start context.
+    """
+    try:
+        import os
+        sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "_lib"))
+        import umbrella_map
+        result = umbrella_map.render_umbrella_map()
+        # isinstance, not truthiness: a non-str return would blow up the
+        # concatenation in main() OUTSIDE this try, and the hook would exit 1
+        # with no JSON at all -- the one outcome this function exists to avoid.
+        return result if isinstance(result, str) else ""
+    except BaseException:
+        # BaseException, not Exception: a stray sys.exit() in an imported module
+        # raises SystemExit, which `except Exception` does not catch. "Must
+        # never cost the session its start context" has to mean every exit path.
+        return ""
+
+
 def main() -> int:
     context = CONTEXT
     try:
@@ -85,6 +114,12 @@ def main() -> int:
         warning = ""
     if warning:
         context = context + "\n\n" + warning
+    try:
+        umbrellas = _umbrella_map()
+    except BaseException:
+        umbrellas = ""
+    if isinstance(umbrellas, str) and umbrellas:
+        context = context + "\n\n" + umbrellas
     payload = {
         "hookSpecificOutput": {
             "hookEventName": "SessionStart",
@@ -96,4 +131,16 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # UTF-8 console guard (ai-brain-starter#313 cp1252 crash class). This file
+    # previously sat on utf8-stdout-baseline.txt as "SEV-4-json-encoded" -- safe
+    # only because every write goes through json.dumps(), which escapes non-ASCII
+    # by default. That reasoning is true today and is one raw print() away from
+    # being false, and the payload now carries the umbrella map (em dashes and
+    # arrows). Guarding is 5 lines; the baseline row is deleted rather than
+    # re-pinned, which the checker explicitly asks for.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     raise SystemExit(main())

--- a/hooks/test_umbrella_map.py
+++ b/hooks/test_umbrella_map.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Controls for _lib/umbrella_map.
+
+NAMED test_*.py AND AT hooks/ ON PURPOSE. scripts/ci.sh collects suites with
+`git ls-files -- 'hooks/test_*.py' 'tests/test_*.py'`. An earlier suite in this
+repo shipped as `<name>.test.py` and was never collected -- ci.sh documents that
+incident in its own comments. A suite under hooks/_lib/ is invisible to that
+glob twice over (wrong directory AND wrong naming), so this file lives here.
+check-hook-activation.py exempts a `test_` basename, so being at hooks/ does not
+make it a hook that must be wired.
+
+WHAT THIS GUARDS. The map's failure mode is not "wrong text" -- it is CLAIMING A
+SCOPE IT DOES NOT HAVE. A map that renders skills the machine lacks, or silently
+drops skills it could not read, reads exactly like a correct map. The
+predecessor was a hardcoded literal, so this was unfalsifiable by construction.
+
+Run: python3 hooks/test_umbrella_map.py
+"""
+import os
+import pathlib
+import sys
+import tempfile
+
+HERE = pathlib.Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+sys.path.insert(0, str(HERE / "_lib"))
+
+import _lib.umbrella_map as um  # noqa: E402
+
+# PRECONDITION. Checks 1 and 2 below assert "renders nothing"; if the bypass is
+# ambiently set they pass for the WRONG REASON and every mutant against those
+# invariants survives silently. Assert the environment before relying on it.
+_SAVED_BYPASS = os.environ.pop("UMBRELLA_MAP_BYPASS", None)
+
+fails = []
+
+
+def check(name, cond, detail=""):
+    if cond:
+        print(f"  ok   {name}")
+    else:
+        print(f"  FAIL {name} {detail}")
+        fails.append(name)
+
+
+def write_skill(root, name, body):
+    d = pathlib.Path(root) / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "SKILL.md").write_text(body, encoding="utf-8")
+
+
+def fm(body):
+    return um.parse_frontmatter(body)
+
+
+print("negative controls (must render nothing):")
+check("absent dir -> None", um.render_umbrella_map(pathlib.Path("/nonexistent-xyz")) is None)
+
+with tempfile.TemporaryDirectory() as tmp:
+    write_skill(tmp, "plain", "---\nname: plain\ndescription: Not an umbrella.\n---\n")
+    check("dir with 0 declarations -> None (a REAL zero)",
+          um.render_umbrella_map(pathlib.Path(tmp)) is None)
+    write_skill(tmp, "real", "---\nname: real\ndescription: Yes.\numbrella: true\n---\n")
+    os.environ["UMBRELLA_MAP_BYPASS"] = "1"
+    check("bypass -> None", um.render_umbrella_map(pathlib.Path(tmp)) is None)
+    os.environ.pop("UMBRELLA_MAP_BYPASS")
+    # Control on the control: a bypass test passes trivially if the input could
+    # never have rendered in the first place.
+    check("...same dir DOES render once bypass is cleared",
+          um.render_umbrella_map(pathlib.Path(tmp)) is not None)
+    for falsy in ("0", "false", "no", "off", ""):
+        os.environ["UMBRELLA_MAP_BYPASS"] = falsy
+        check(f"bypass={falsy!r} does NOT suppress (bare truthiness would)",
+              um.render_umbrella_map(pathlib.Path(tmp)) is not None)
+        os.environ.pop("UMBRELLA_MAP_BYPASS")
+
+print("declaration parsing:")
+check("umbrella: false does not declare", not fm("---\na: b\numbrella: false\n---\n").get("umbrella") == "true")
+check("bare `umbrella:` does not declare", fm("---\numbrella:\n---\n").get("umbrella") == "")
+for v in ("true", "yes", "1", "on", "TRUE", "True"):
+    check(f"_truthy accepts {v!r}", um._truthy(v))
+for v in ("false", "no", "0", "off", "", "maybe"):
+    check(f"_truthy rejects {v!r}", not um._truthy(v))
+# A trailing YAML comment must not un-declare a skill: real YAML strips it, and
+# without stripping `true  # note` is not truthy -- a valid declaration the map
+# would ignore, failing identically to "not an umbrella".
+check("trailing `# comment` stripped from a value",
+      um._truthy(fm("---\numbrella: true  # routing umbrella\n---\n").get("umbrella", "")))
+check("comment stripped from a group heading",
+      fm("---\numbrella_group: Ops  # the group\n---\n").get("umbrella_group") == "Ops")
+check("comment stripped from an order",
+      fm("---\numbrella_order: 5 # first\n---\n").get("umbrella_order") == "5")
+check("a QUOTED value keeps its #",
+      fm("---\nx: 'a # b'\n---\n").get("x") == "a # b")
+# An unclosed frontmatter scans to EOF, so a SKILL.md that DOCUMENTS this
+# contract in a fenced block would promote itself and inherit the example group.
+check("unclosed frontmatter parses as nothing",
+      fm("---\nname: s\n\n```yaml\numbrella: true\numbrella_group: 'Fake'\n```\n") == {})
+check("nested/indented `umbrella: true` never promotes",
+      not um._truthy(fm("---\nname: s\nmeta:\n  umbrella: true\n---\n").get("umbrella", "")))
+check("BOM before --- still parses", fm("﻿---\nname: s\numbrella: true\n---\n").get("name") == "s")
+check("leading blank line before --- still parses", fm("\n---\nname: s\numbrella: true\n---\n").get("name") == "s")
+check("CRLF parses", fm("---\r\nname: s\r\numbrella: true\r\n---\r\n").get("name") == "s")
+check("description containing ': ' keeps its tail",
+      fm("---\ndescription: 'Use when X: do Y'\n---\n").get("description") == "Use when X: do Y")
+# A block-scalar indicator means the value is on the FOLLOWING lines; rendering
+# the literal ">" as a skill's domain is worse than rendering none.
+check("block scalar `>` yields empty, not '>'", fm("---\ndescription: >\n  Folded.\n---\n").get("description") == "")
+
+print("domain + ordering:")
+check("first_sentence stops at '. '", um.first_sentence("A. B.") == "A")
+check("first_sentence stops at ' - '", um.first_sentence("A - B") == "A")
+check("first_sentence stops at '; '", um.first_sentence("A; B") == "A")
+check("first_sentence clips long text", len(um.first_sentence("x" * 300)) <= 96)
+
+with tempfile.TemporaryDirectory() as tmp:
+    root = pathlib.Path(tmp)
+    # Group names chosen so ALPHABETICAL order is the REVERSE of declared order;
+    # otherwise the ordering assertion passes under a sort that ignores
+    # umbrella_order entirely -- a control that cannot vary.
+    write_skill(root, "beta", "---\nname: beta\ndescription: B.\numbrella: true\n"
+                              "umbrella_group: 'Aardvark layer'\numbrella_order: 20\n"
+                              "umbrella_domain: 'b domain'\n---\n")
+    write_skill(root, "alpha", "---\nname: alpha\ndescription: A.\numbrella: true\n"
+                               "umbrella_group: 'Zebra layer'\numbrella_order: 10\n"
+                               "umbrella_domain: 'a domain'\n---\n")
+    write_skill(root, "gamma", "---\nname: gamma\n"
+                               "description: derived domain here. Tail must be dropped.\n"
+                               "umbrella: true\numbrella_group: 'Aardvark layer'\numbrella_order: 21\n---\n")
+    write_skill(root, "defaulted", "---\nname: defaulted\ndescription: D.\numbrella: true\n"
+                                   "umbrella_order: notanint\n---\n")
+    write_skill(root, "decoy-malformed", "no frontmatter\numbrella: true\n")
+    out = um.render_umbrella_map(root)
+    check("counts only declared umbrellas (4)", "4 routing umbrellas" in out, repr(out[:70]))
+    check("malformed frontmatter skipped", "decoy-malformed" not in out)
+    check("domain fallback = first sentence", "/gamma — derived domain here" in out)
+    check("fallback drops the tail", "Tail must be dropped" not in out)
+    check("group ordered by earliest member, NOT alphabetically",
+          out.index("Zebra layer:") < out.index("Aardvark layer:"))
+    check("within-group order respected", out.index("/beta") < out.index("/gamma"))
+    check("missing umbrella_group defaults to 'Skills'", "Skills:" in out)
+    check("non-int umbrella_order falls back (renders, does not crash)", "/defaulted" in out)
+    check("no unreadable warning on a clean tree", "unreadable" not in out)
+
+with tempfile.TemporaryDirectory() as tmp:
+    root = pathlib.Path(tmp)
+    write_skill(root, "only", "---\nname: only\ndescription: O.\numbrella: true\n---\n")
+    check("1 umbrella reads singular", "1 routing umbrella available" in um.render_umbrella_map(root))
+    # name falls back to the DIRECTORY when frontmatter omits it
+    write_skill(root, "dirnamed", "---\ndescription: X.\numbrella: true\n---\n")
+    check("name falls back to the directory name", "/dirnamed" in um.render_umbrella_map(root))
+
+print("layout controls (the maintainer-box blind spot):")
+# A skills repo linked into ~/.claude/skills is FLAT; a cloned BUNDLE keeps its
+# own tree one level deeper. A maintainer box has BOTH, so a flat-only scan
+# passes there and renders NOTHING on a substrate-only install -- the client case.
+with tempfile.TemporaryDirectory() as tmp:
+    root = pathlib.Path(tmp)
+    write_skill(root / "some-bundle" / "skills", "nested-umbrella",
+                "---\nname: nested-umbrella\ndescription: N.\numbrella: true\n---\n")
+    out = um.render_umbrella_map(root)
+    check("NESTED-only layout renders", out is not None, "flat-only scan returns None here")
+    if out:
+        check("nested skill is named", "/nested-umbrella" in out)
+
+# Precedence is asserted on IDENTITY, not count: identical bodies pass under
+# either winner. The bundle dir is named to sort BEFORE the flat entry, which is
+# what an interleaved builder gets wrong.
+with tempfile.TemporaryDirectory() as tmp:
+    root = pathlib.Path(tmp)
+    mk = lambda d: f"---\nname: twice\ndescription: T.\numbrella: true\numbrella_domain: '{d}'\n---\n"
+    write_skill(root, "twice", mk("FLAT-COPY"))
+    write_skill(root / "aaa-bundle" / "skills", "twice", mk("NESTED-COPY"))
+    out = um.render_umbrella_map(root)
+    check("same skill flat+nested renders ONCE", out.count("/twice") == 1, f"{out.count('/twice')}x")
+    check("FLAT copy wins even when the bundle sorts first", "FLAT-COPY" in out,
+          "nested copy shadowed the flat one the harness actually loads")
+
+# Loose non-directory entries are normal in a skills tree (measured: five .zip
+# archives beside real skill dirs). They must not be counted as broken skills.
+with tempfile.TemporaryDirectory() as tmp:
+    root = pathlib.Path(tmp)
+    write_skill(root, "good", "---\nname: good\ndescription: G.\numbrella: true\n---\n")
+    (root / "archive.zip").write_bytes(b"PK\x03\x04not a skill")
+    (root / "bundle").mkdir()
+    (root / "bundle" / "skills").mkdir()
+    (root / "bundle" / "skills" / "inner.zip").write_bytes(b"PK\x03\x04")
+    out = um.render_umbrella_map(root)
+    check("loose .zip files are not reported as unreadable skills", "unreadable" not in out, repr(out[:90]))
+
+print("scope honesty:")
+# An empty result from a scan that could not READ is NOT the same as a real zero.
+with tempfile.TemporaryDirectory() as tmp:
+    root = pathlib.Path(tmp)
+    write_skill(root, "s", "---\nname: s\ndescription: S.\numbrella: true\n---\n")
+    (root / "s" / "SKILL.md").write_bytes(b"\x00\x01\x02binary")  # safe_read -> binary
+    out = um.render_umbrella_map(root)
+    check("an unreadable skill is COUNTED, not silently dropped",
+          out is not None and "unreadable" in out,
+          "a scan that read nothing rendered as a real zero" if out is None else repr(out[:90]))
+
+print("scan budget (a stalled tree must not block session start):")
+# safe_read's deadline is PER FILE (5s default) and there is no budget across a
+# scan. On a stalled cloud-sync folder that is N x 5s of blocked session start
+# -- and if every read fails, an empty list is indistinguishable from a genuine
+# "nothing declared". Both halves are asserted here.
+import time as _time
+import _lib.safe_read as _sr
+
+_real_read = um.safe_read_text
+
+
+def _stalled(path, **kw):
+    _time.sleep(min(kw.get("timeout", 5.0), 0.2))
+    return _sr.SafeTextRead(pathlib.Path(path), "timeout")
+
+
+try:
+    um.safe_read_text = _stalled
+    um._read_skill.__globals__["safe_read_text"] = _stalled
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        for i in range(120):
+            write_skill(root, f"s{i:03d}", "---\numbrella: true\n---\n")
+        t0 = _time.monotonic()
+        out = um.render_umbrella_map(root)
+        elapsed = _time.monotonic() - t0
+        check("a stalled tree is bounded by the scan budget, not N x per-file deadline",
+              elapsed < um.SCAN_BUDGET_S + 1.0,
+              f"took {elapsed:.1f}s; unbounded would be 120 x {_sr.DEFAULT_TIMEOUT_S}s")
+        check("a scan that read NOTHING does not masquerade as a real zero",
+              out is not None and "unreadable" in out,
+              "returned None, which is the 'nothing declared' signal")
+finally:
+    um.safe_read_text = _real_read
+    um._read_skill.__globals__["safe_read_text"] = _real_read
+
+print()
+if _SAVED_BYPASS is not None:
+    os.environ["UMBRELLA_MAP_BYPASS"] = _SAVED_BYPASS
+if fails:
+    print(f"FAILED {len(fails)}: {fails}")
+    sys.exit(1)
+print("all checks passed")

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1170,6 +1170,7 @@ echo "    OK - $unit_count scripts/ unit suite(s) passed"
 # fails the gate LOUD (the false-green class MYC-2922 closed for scripts/, MYC-2959
 # for hooks/+tests/). PY_DIRECT then runs the non-wrapped suites exactly once.
 PY_DIRECT=(
+  hooks/test_umbrella_map.py
   hooks/test_surface_stalled_git_operation.py
   hooks/test_memory_index.py
   tests/test_instinct.py

--- a/scripts/utf8-stdout-baseline.txt
+++ b/scripts/utf8-stdout-baseline.txt
@@ -99,7 +99,7 @@
 ed1d68dba02ab76c99907e8efc27ac0aac8c98a14dad261da73fa5d8e1610369 SEV-3-doc-only hooks/_lib/template_purity.py
 8dea18caf79e387a2fbeddca90403ef8af0d0ff1e6395e3b1f00e1b396491a4b SEV-3-doc-only hooks/inject-instinct-context.py
 
-# ---- SEV-4-json-encoded  (22 file(s)) ----
+# ---- SEV-4-json-encoded  (21 file(s)) ----
 02627cdfcde451edc91149f9092154b2b846cb1a19d30f1f5ca01d66258791b2 SEV-4-json-encoded hooks/block-branch-switch-with-untracked-build.py
 e943857ef9482c097b4357ee8abf2e4ede3ffcab3b9bae3a1a0687b0ae371e2b SEV-4-json-encoded hooks/block-populated-public-skill.py
 73ec7598cd563971fcafc2542818e297df5ed045714d7b66263de949f4619093 SEV-4-json-encoded hooks/block-secret-in-note.py
@@ -114,7 +114,6 @@ adad427e89295283853dd1dfb9963e698eb45fe5c4ca3c302adce4a3d47b5b35 SEV-4-json-enco
 056a2f7966b8c4f75a62e80be906bd899956f9871a92eb98738e262988bc8dc5 SEV-4-json-encoded hooks/reconcile-worktree-shared.py
 d293427274a02ef33d15ec50b17860aa305405adc9f372fde46a46454267becd SEV-4-json-encoded hooks/relocate-watch-surface.py
 8ed780b62186a0142813b71fb610ce0a1d2650ff900766fb08c4236ea1132f41 SEV-4-json-encoded hooks/route-suggest.py
-f8528465aef417373bf26591b9fcc7d0b76814d19b39142b4908ddaa1d003347 SEV-4-json-encoded hooks/session-start-context.py
 58eaf3668330264cdb9095dda2c7a425e3f69009c5ecbb1d764a6f40340f7ca8 SEV-4-json-encoded hooks/surface-connector-liveness.py
 64eae7b79237dab8b0b8b666b5a7d8b0a26b7c38bafd18313556c790ddf622bc SEV-4-json-encoded hooks/surface-dependabot-backlog.py
 6a55aed5c658a5361501e1144b26c501d95fd1f359383af4499e8894be76ff93 SEV-4-json-encoded hooks/surface-orphan-claude-branches.py

--- a/skills/vault-system/SKILL.md
+++ b/skills/vault-system/SKILL.md
@@ -1,5 +1,9 @@
 ---
 name: vault-system
+umbrella: true
+umbrella_group: 'Information layer'
+umbrella_order: 54
+umbrella_domain: 'graph + drift + rules + memory + Obsidian + skill repos'
 description: 'Use when maintaining the vault ITSELF as a system, not its content: knowledge-graph build/rebuild/query (graphify), second-brain mapping, vault diagnose/audit/hygiene, drift detection, extract rules from vault, backfill journals, setup vault types, consolidate memory (index over cap), Obsidian tooling (CLI/Bases/Markdown/JSON Canvas), vault bloat or Obsidian slow. Answering questions FROM the graph, use graph-query tools; daily journal/coaching/pattern detection, use those skills.'
 trigger: /vault-system
 ---


### PR DESCRIPTION
Closes part of MYC-4238 — https://linear.app/myceliumai/issue/MYC-4238
Companion (merged): mycelium-hq/mycelium-skills#22

## The bug

The routing-umbrella map reached a session only through a hook tracked solely in a **machine-local repo with no git remote**. Every client-serving skill was routing-wired; the table that made them discoverable simply never shipped. A note in the maintainer's own routing index had recorded the gap in prose months earlier and nothing acted on it.

## Why the obvious port was wrong

That hook was a hardcoded string listing 13 umbrellas. Copying it here fails three ways:

1. **Scope.** Most of those umbrellas are private/paid skills a free install does not have. A hardcoded map routes the user to a dozen skills that are not on their machine — the map's NAME claims to describe *this* session's routing surface.
2. **Boundary.** That list is a paid catalogue. It does not belong in a public MIT repo.
3. **Drift.** The literal already disagreed with two other hardcoded copies of the same fact — one said 14, one still routed a skill deprecated seven weeks earlier. A third copy makes that worse.

## What this does

Ships the **mechanism**; each skill carries its own **declaration**. A skill is an umbrella when its `SKILL.md` frontmatter says `umbrella: true` (optional `umbrella_group` / `umbrella_order` / `umbrella_domain`). `hooks/_lib/umbrella_map.py` enumerates **no skill names**, which is what keeps it correct on an install whose skill set we have never seen — and is why it can ship publicly at all.

**No new SessionStart hook.** `footprint-budgets.json` caps SessionStart fan-out at 19 and the event measured exactly 19; that budget's own `_budget_rationale` directs the next addition to optimize the fan-out rather than raise it again. `session-start-context.py` is already wired and already pays for the interpreter, so the map folds in there. Measured: `footprint-sla-check.py --gate` → `SessionStart 19 / 19`, exit 0.

## Correctness work, mostly from an independent adversarial review

- **Two layouts.** Skills live FLAT (`<root>/<name>/SKILL.md`) *and* NESTED inside a bundle (`<root>/<bundle>/skills/<name>/SKILL.md`). A maintainer box has both, so a flat-only scan passes there and renders **nothing** on a substrate-only install — the client case. Flat is enumerated first in a separate pass; interleaving inverted the documented precedence whenever a bundle dir sorted first (on a real tree: 46 of 49 name collisions resolved to the wrong copy).
- **A whole-scan wall-clock budget.** `safe_read`'s deadline is per *file* (5s), so a stalled cloud-sync folder was N×5s of blocked session start — and a scan where every read failed was indistinguishable from a real zero. Now bounded at 2s total, and it **counts unreadable files and says so in the header** rather than letting the count imply completeness. Measured: 200 stalled candidates → 2.01s instead of ~1000s.
- **Host cannot be broken by the module.** A non-str return or a stray `sys.exit()` previously made the hook exit non-zero with *no JSON at all*. All four poison modes (raise / non-str / `sys.exit` / int) now exit 0 with valid JSON.
- Parser hardening, each with a control: trailing `# comment` no longer silently un-declares an umbrella; unclosed frontmatter is rejected (a `SKILL.md` documenting this contract in a fenced block would otherwise promote itself); `BYPASS=0` no longer suppresses; BOM tolerated; block-scalar descriptions no longer render a literal `>`; a symlinked `SKILL.md` is followed rather than skipped.
- Stdlib only. PyYAML is installed here only under `GITHUB_ACTIONS`, so a hook cannot require it — and a guarded skip would render nothing, which looks exactly like an install with no umbrellas.

## Tests

`hooks/test_umbrella_map.py` — **57 controls**. Negative controls run first and must render nothing; absence, bypass and a real zero are kept as three distinct states.

Named `test_*.py` and placed at `hooks/` **on purpose**: `ci.sh` collects `hooks/test_*.py` + `tests/test_*.py`, and this suite originally shipped as `hooks/_lib/umbrella_map.test.py`, which misses that glob twice over — wrong directory *and* wrong naming convention. It was dormant. `ci.sh` documents the same incident happening before with `warn-recreate-deleted-file.test.py`. Now collected and listed in `PY_DIRECT`.

Ten mutants killed, including one that initially **survived** because the fixture's group names made alphabetical and declared order agree — a control that could not vary.

One self-inflicted regression worth recording: an 8 KB read cap I added as an "optimization" took the live map from 13 umbrellas to 1. `safe_read`'s `max_bytes` is a **refusal** threshold, not a truncation, so an ordinary 16 KB `SKILL.md` came back `too-large` and was skipped in silence — a skill would have vanished from the map as its file grew. Reverted, with a 40 KB fixture that kills the regression.

## Also here

`scripts/utf8-stdout-baseline.txt` loses one row: `session-start-context.py` was pinned as `SEV-4-json-encoded`, safe only because every write goes through `json.dumps()`. Editing it staled the pin, and the checker explicitly says to delete the row rather than re-pin. It now carries the real UTF-8 console guard, retiring a legacy exemption.

## Risk

`scripts/ci.sh` gains exactly one line (a `PY_DIRECT` entry). Five branches currently touch that file; `merge-tree` reports zero conflicts against both open PRs (#608, #609).
