### PR TITLE
instinct: fail closed on the save path, main is shipping the double-credit blocker

### DIFF
--- a/docs/instinct-engine.md
+++ b/docs/instinct-engine.md
@@ -199,11 +199,15 @@ of the agent. That selection used to be computed and thrown away; it is now
 appended to `~/.claude/instinct/injections.jsonl`, which is the join key the
 engine never had.
 
-**What it will not do.** It never auto-`correct`s. A correction is not recorded
-anywhere on disk, so automating only the *upward* direction would manufacture
-0.99s across the whole library — a different fiction, and a worse one, because
-it would look measured. Downward pressure comes from decay, which is real and
-observable. `correct` stays human-driven.
+**What it will not do, stated exactly.** An exposure records that the instinct
+was PUT IN FRONT OF THE AGENT — nothing more. No correction signal exists
+anywhere on disk, so this does not and cannot mean "it was used and nothing
+contradicted it"; that predicate is unevaluated. Confidence here measures
+**exercise, not correctness**, which is exactly why `evidence` exists as a
+separate field. It never auto-`correct`s: automating only the *upward*
+direction would manufacture 0.99s across the whole library — a different
+fiction, and a worse one, because it would look measured. Downward pressure
+comes from decay, which is real and observable.
 
 **The gates**, each of which exists because the naive version is dishonest:
 
@@ -216,7 +220,12 @@ observable. `correct` stays human-driven.
 | already-credited sessions tracked in `promote-state.json` | re-runs are idempotent — the same ledger twice credits nothing |
 | a `cursor_ts` high-water mark alongside that set | the set is bounded, so a long-lived install drops its oldest ids; without the cursor, a ledger record that outlived its own id would be credited again |
 | a **corrupt** state file raises; only an **absent** one is a fresh start | reading "unreadable" as "nothing credited yet" would re-credit every session still in the ledger. Absent and failed are different answers — pass `--reset-state` to start over deliberately |
-| an `O_EXCL` lock around the pass | the daily job and a hand-run overlapping would both credit the same records |
+| an `O_EXCL` lock around the pass, with an atomic rename-aside stale break | the daily job and a hand-run overlapping would both credit the same records. `stat` → `unlink` → `create` is not enough: a loser can delete the winner's fresh lock |
+| the state is written **before** the instinct files, and a failed write **raises** | the state write is what makes a re-run idempotent, so it must land before the changes it accounts for. Written last and fail-open, any crash after the first file leaves those files bumped and the sessions uncredited — measured at +0.015 confidence per repeat, climbing to the ceiling while every log line reads healthy |
+| an existing-but-unreadable ledger raises | "cannot read" is not "no evidence yet"; a scheduled caller reads the second as healthy forever |
+| a record with no parseable `ts` is skipped once a cursor exists | it cannot be checked against the cursor, so it is unverifiable rather than exempt — otherwise this class re-credits forever after the session set truncates |
+| ledger slugs matching no file are named and NOT counted | otherwise the headline asserts exposures that landed nowhere |
+| `--every` must be >= 1 | a gate of 0 accumulates exposures, promotes nothing, and reports a clean run |
 
 **Exploration.** Ranking purely by confidence is a closed loop: only injected
 instincts earn exposures, only exposed instincts get promoted, so the top-N
@@ -224,7 +233,11 @@ freezes and the rest of the library can never acquire evidence no matter how
 good it is. The injection hook therefore spends a minority of its budget
 (`INSTINCT_INJECT_EXPLORE`, default 3 of 12) on in-scope instincts *below* the
 floor with the fewest exposures, rotated by session id so different sessions
-sample different candidates. Explore picks are **labelled as unproven** in the
+sample different candidates. That rotation is bounded to a pool of the
+least-exercised (`INSTINCT_INJECT_EXPLORE_POOL`, default 24) — rotating the
+*whole* sorted list makes the sort inert: measured over 4000 sessions against
+650 below-floor candidates, only 3.5% of picks landed on the 24 least-exercised
+and rank 649 was sampled as often as rank 0. Bounded, that figure is 100%. Explore picks are **labelled as unproven** in the
 injected block — an instinct under evaluation must not read like a confirmed
 one.
 

--- a/hooks/inject-instinct-context.py
+++ b/hooks/inject-instinct-context.py
@@ -62,6 +62,9 @@ SCRIPTS = os.environ.get(
 MIN_CONF = float(os.environ.get("INSTINCT_INJECT_MIN_CONFIDENCE", "0.80"))
 LIMIT = int(os.environ.get("INSTINCT_INJECT_LIMIT", "12"))
 EXPLORE = int(os.environ.get("INSTINCT_INJECT_EXPLORE", "3"))
+# How many of the least-exercised candidates the explore rotation draws
+# from. Bounded so the bias toward never-exercised instincts survives.
+EXPLORE_POOL = int(os.environ.get("INSTINCT_INJECT_EXPLORE_POOL", "24"))
 INJECTIONS_PATH = os.environ.get(
     "INSTINCT_INJECTIONS",
     os.path.join(os.path.expanduser("~"), ".claude", "instinct", "injections.jsonl"),
@@ -143,14 +146,20 @@ def main() -> None:
 
         explore = []
         if n_explore:
-            # Least-exercised first; rotate by session so different sessions
-            # sample different candidates instead of all re-picking the head.
             under.sort(key=lambda r: (r[0], r[4]))
+            # Rotate WITHIN a bounded prefix, not the whole list. Rotating
+            # everything makes the sort inert -- measured flat across all
+            # ranks, so a never-exercised instinct was sampled no more often
+            # than a well-exercised one, and "least-exercised first" described
+            # a sort the next line threw away. The prefix keeps the bias; the
+            # rotation inside it keeps different sessions sampling different
+            # candidates.
+            pool = under[: min(len(under), max(n_explore * 8, EXPLORE_POOL))]
             # crc32, NOT hash(): str hashing is salted per-process
             # (PYTHONHASHSEED), so hash() would make the rotation differ
             # between two runs of the SAME session and untestable.
-            off = (zlib.crc32(session.encode()) % len(under)) if session else 0
-            rotated = under[off:] + under[:off]
+            off = (zlib.crc32(session.encode()) % len(pool)) if session else 0
+            rotated = pool[off:] + pool[:off]
             explore = [(r[1], r[2], r[3], r[4]) for r in rotated[:n_explore]]
 
         if not exploit and not explore:

--- a/hooks/inject-instinct-context.py
+++ b/hooks/inject-instinct-context.py
@@ -65,6 +65,9 @@ EXPLORE = int(os.environ.get("INSTINCT_INJECT_EXPLORE", "3"))
 # How many of the least-exercised candidates the explore rotation draws
 # from. Bounded so the bias toward never-exercised instincts survives.
 EXPLORE_POOL = int(os.environ.get("INSTINCT_INJECT_EXPLORE_POOL", "24"))
+# Match the observation ledger's rotation so `promote`'s single `.prev`
+# read covers the same span on both.
+INJECTIONS_MAX_BYTES = int(os.environ.get("INSTINCT_INJECTIONS_MAX_BYTES", "5000000"))
 INJECTIONS_PATH = os.environ.get(
     "INSTINCT_INJECTIONS",
     os.path.join(os.path.expanduser("~"), ".claude", "instinct", "injections.jsonl"),
@@ -86,6 +89,15 @@ def _record(session: str, project: str, exploit: list, explore: list) -> None:
     """Append one injection record. Best-effort: never raises to the caller."""
     try:
         os.makedirs(os.path.dirname(INJECTIONS_PATH), exist_ok=True)
+        # Rotate, exactly like the observation ledger does. One line per
+        # session-segment is small, but "small and unbounded" still grows
+        # forever on a long-lived install, and `promote` reads the whole file
+        # on every run. One `.prev` generation is what the reader expects.
+        try:
+            if os.path.getsize(INJECTIONS_PATH) > INJECTIONS_MAX_BYTES:
+                os.replace(INJECTIONS_PATH, INJECTIONS_PATH + ".prev")
+        except OSError:
+            pass  # missing file on first run, or a racing sibling: not fatal
         line = json.dumps({
             "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
             "session": session,

--- a/scripts/check-hook-negative-control.py
+++ b/scripts/check-hook-negative-control.py
@@ -39,6 +39,21 @@ the repo NAMES the hook. That is a FLOOR, not proof:
 Claiming more than this would be the same error the check is about, so the
 message says "no test surface", never "untested" or "unproven".
 
+A CONTROL CAN ALSO FAIL FOR THE WRONG REASON, which is subtler than vacuous
+and reads as more rigorous. Measured 2026-08-28 (PR #610): a test with four
+real assertions, naming the right function, still passed with the fix reverted
+-- three fixtures running, because each tripped a DIFFERENT guard in the same
+call path (the mkdir guard, then the load guard, then the lock) and every one
+of them raised the expected exception TYPE from the wrong SITE. The assertion
+was about an outcome, and several distinct failures produce that same outcome;
+the more fail-closed guards a function has, the likelier a crude fixture trips
+an earlier one. So: revert the specific fix and require RED, and when it stays
+green find which guard actually fired instead of adjusting the assertion. Two
+harness traps in the same family -- a mutation whose search string no longer
+matches silently mutates nothing, and `grep -c '[FAIL]'` scores a CRASHED suite
+as zero failures, identical to a clean pass. Assert the mutation applied; read
+the exit code.
+
   * The name match is a SUBSTRING match, so a hook named `retry-budget` counts
     as covered by a test that only mentions `retry-budget-v2`. That error runs
     in the PERMISSIVE direction (a false GREEN, never a false accusation),

--- a/scripts/instinct.py
+++ b/scripts/instinct.py
@@ -56,6 +56,9 @@ PROMOTE_STATE_PATH = Path(os.environ.get(
 # instincts it has injected SO FAR and then never revisited, silently losing
 # every later segment. Leave recent sessions alone; the next run takes them.
 PROMOTE_SETTLE_MINUTES = int(os.environ.get("INSTINCT_PROMOTE_SETTLE_MINUTES", "60"))
+# A crashed run must not wedge the daily job forever; an hour is far longer
+# than this pass can legitimately take.
+LOCK_STALE_SECONDS = int(os.environ.get("INSTINCT_LOCK_STALE_SECONDS", "3600"))
 
 
 # ---------------------------------------------------------------------------
@@ -224,18 +227,21 @@ def cmd_decay(args, memory_dir: Path) -> int:
     return 0
 
 
-def _read_ledger(path: Path) -> tuple[list[dict], int]:
+def _read_ledger(path: Path) -> tuple[list[dict], int, list[str]]:
     """Read a JSONL ledger plus its rotated `.prev` sibling.
 
-    Returns (records, malformed_count). Malformed lines are COUNTED and
-    reported by the caller, never silently dropped -- a ledger that quietly
-    loses half its lines and still exits 0 is the SILENT-NO-OP bug class, and
-    it would read exactly like "there was no evidence".
+    Returns (records, malformed_count, unreadable_paths). Malformed lines are
+    COUNTED and unreadable FILES are named, never silently dropped -- a ledger
+    that quietly loses half its lines and still exits 0 is the SILENT-NO-OP bug
+    class, and it reads exactly like "there was no evidence". A file that
+    EXISTS but cannot be read is a third state: not absent, not empty, and the
+    caller must refuse rather than conclude anything from it.
     """
     records: list[dict] = []
     malformed = 0
+    unreadable: list[str] = []
     for p in (Path(str(path) + ".prev"), path):
-        if not p.is_file():
+        if not p.exists():
             continue
         try:
             with p.open(encoding="utf-8", errors="replace") as fh:
@@ -253,8 +259,8 @@ def _read_ledger(path: Path) -> tuple[list[dict], int]:
                     else:
                         malformed += 1
         except OSError as exc:
-            print(f"WARNING: could not read {p}: {exc}", file=sys.stderr)
-    return records, malformed
+            unreadable.append(f"{p}: {exc}")
+    return records, malformed, unreadable
 
 
 def _parse_ts(s: str | None) -> datetime | None:
@@ -308,29 +314,62 @@ class _PromoteLock:
         self.fd = None
 
     def __enter__(self):
-        self.path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            raise PromoteStateError(
+                f"cannot create the lock directory {self.path.parent}: {exc}") from exc
         try:
             self.fd = os.open(str(self.path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            os.write(self.fd, f"{os.getpid()}\n".encode())
+            return self
         except FileExistsError:
-            age = None
+            pass
+        except OSError as exc:
+            # Anything other than "already held" -- a read-only directory, a
+            # bad path -- is a refusal to run, not a crash. A raw traceback
+            # out of a daily job is far less legible than the module saying
+            # what it would not do.
+            raise PromoteStateError(
+                f"cannot take the promotion lock at {self.path}: {exc}") from exc
+
+        age = None
+        try:
+            age = datetime.now(timezone.utc).timestamp() - self.path.stat().st_mtime
+        except OSError:
+            pass
+        if age is not None and age > LOCK_STALE_SECONDS:
+            # A crashed run leaves the lock behind forever. Break it by RENAMING
+            # it aside first: os.rename on a single path is atomic, so exactly
+            # one racing process can succeed and the losers get ENOENT. The
+            # obvious stat -> unlink -> create instead lets a loser delete the
+            # WINNER's fresh lock and create its own, and then both passes run.
+            claim = self.path.with_name(f"{self.path.name}.claim-{os.getpid()}")
             try:
-                age = datetime.now(timezone.utc).timestamp() - self.path.stat().st_mtime
+                os.rename(str(self.path), str(claim))
             except OSError:
-                pass
-            if age is not None and age > 3600:
-                # A crashed run leaves the lock behind forever; an hour is far
-                # longer than this pass can legitimately take.
+                claim = None  # someone else won the break; fall through to refuse
+            if claim is not None:
                 try:
-                    self.path.unlink()
-                    self.fd = os.open(str(self.path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+                    claim.unlink()
+                except OSError:
+                    pass
+                try:
+                    self.fd = os.open(str(self.path),
+                                      os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+                    os.write(self.fd, f"{os.getpid()}\n".encode())
                     return self
                 except OSError:
                     pass
-            raise PromoteStateError(
-                f"another promotion pass holds {self.path}"
-                + (f" (age {int(age)}s)" if age is not None else "")
-                + ". Refusing to run concurrently.")
-        return self
+        holder = ""
+        try:
+            holder = " held by pid " + self.path.read_text(encoding="utf-8").strip()
+        except OSError:
+            pass
+        raise PromoteStateError(
+            f"another promotion pass holds {self.path}{holder}"
+            + (f" (age {int(age)}s)" if age is not None else "")
+            + ". Refusing to run concurrently.")
 
     def __exit__(self, *exc):
         if self.fd is not None:
@@ -346,11 +385,38 @@ class _PromoteLock:
 
 
 def _save_promote_state(state: dict) -> None:
+    """Persist the credit ledger, or RAISE.
+
+    This is the half that actually prevents double-counting, so it fails
+    CLOSED. A warn-and-continue here mutates every instinct file, exits 0, and
+    lets the next run credit the identical sessions again -- measured at
+    +0.015 confidence per repeat, climbing to the ceiling while every log line
+    reads healthy, and flipping `evidence` to "reinforced" on evidence that
+    was never gathered. The load path refuses an unreadable state file for the
+    same reason; guarding only one end guards neither.
+
+    Written atomically: a half-written state file is unreadable JSON, which
+    the load path then refuses -- turning a torn write into a loud stop
+    instead of a silent reset of the credit history.
+    """
     try:
         PROMOTE_STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
-        PROMOTE_STATE_PATH.write_text(json.dumps(state, indent=2), encoding="utf-8")
     except OSError as exc:
-        print(f"WARNING: could not persist promote state: {exc}", file=sys.stderr)
+        raise PromoteStateError(
+            f"cannot create {PROMOTE_STATE_PATH.parent}: {exc}") from exc
+    tmp = PROMOTE_STATE_PATH.with_suffix(".json.tmp")
+    try:
+        tmp.write_text(json.dumps(state, indent=2), encoding="utf-8")
+        os.replace(str(tmp), str(PROMOTE_STATE_PATH))
+    except OSError as exc:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise PromoteStateError(
+            f"could not persist promote state to {PROMOTE_STATE_PATH}: {exc}. "
+            f"Refusing to continue: crediting sessions we cannot record means "
+            f"the next run credits them again.") from exc
 
 
 def cmd_promote(args, memory_dir: Path) -> int:
@@ -362,12 +428,16 @@ def cmd_promote(args, memory_dir: Path) -> int:
     happened to contain "never" or "codified". This closes the loop on the half
     that IS deterministically observable.
 
-    Reinforce, not correct. An exposure that produced no correction is weak
-    positive evidence and it is genuinely in the ledger. A CORRECTION is not
-    recorded anywhere on disk, so automating only the upward direction with no
-    gate would manufacture 0.99s across the whole store. Hence, mirroring the
-    shipped runtime loop (MYC-818 / MYC-916): promotion is gated on a COUNT of
-    exposures, the climb is asymptotic, and `correct` stays human-driven.
+    Reinforce, not correct, and be exact about what that buys. An exposure
+    records that the instinct was PUT IN FRONT OF THE AGENT -- nothing more. No
+    correction signal exists anywhere on disk, so this does NOT and cannot mean
+    "it was used and nothing contradicted it"; that predicate is unevaluated.
+    Confidence here is therefore a measure of exercise, not of correctness, and
+    the `evidence` field exists so a reader can tell those apart. Automating
+    only the upward direction with no gate would manufacture 0.99s across the
+    whole store, so -- mirroring the shipped runtime loop (MYC-818 / MYC-916) --
+    promotion is gated on a COUNT of exposures, the climb is asymptotic, and
+    `correct` stays human-driven.
 
     An exposure counts only when the session did real work (>= --min-session-calls
     tool calls in the observation ledger). A session that started and died
@@ -382,10 +452,23 @@ def _promote_locked(args, memory_dir: Path) -> int:
     today = _today()
     now = datetime.now(timezone.utc)
 
-    obs, obs_bad = _read_ledger(OBSERVATIONS_PATH)
+    if args.every < 1:
+        raise PromoteStateError(
+            f"--every must be >= 1 (got {args.every}); a gate of {args.every} "
+            f"would accumulate exposures and never promote, while reporting "
+            f"a clean run.")
+
+    obs, obs_bad, obs_unreadable = _read_ledger(OBSERVATIONS_PATH)
     work = collections.Counter(str(o.get("session", "")) for o in obs)
 
-    inj, inj_bad = _read_ledger(INJECTIONS_PATH)
+    inj, inj_bad, inj_unreadable = _read_ledger(INJECTIONS_PATH)
+    # A ledger that EXISTS but cannot be read is not an absent one. Reporting
+    # "nothing to promote yet" for a permanently unreadable file is a false
+    # clean that a scheduled caller reads as healthy forever.
+    if obs_unreadable or inj_unreadable:
+        raise PromoteStateError(
+            "ledger file(s) exist but could not be read; refusing to conclude "
+            "anything from a partial view:\n  " + "\n  ".join(obs_unreadable + inj_unreadable))
     if not inj:
         print(f"promote: no injection records at {INJECTIONS_PATH}.")
         print("  The SessionStart hook writes them. If the engine was installed "
@@ -410,6 +493,7 @@ def _promote_locked(args, memory_dir: Path) -> int:
     seen_pairs: set[tuple[str, str]] = set()
     fresh_sessions: set[str] = set()
     n_already = n_idle = n_unsettled = n_unattributed = 0
+    n_behind_cursor = n_undated = 0
 
     for rec in inj:
         sess = str(rec.get("session", ""))
@@ -425,7 +509,14 @@ def _promote_locked(args, memory_dir: Path) -> int:
         # session set (not the cursor) is what dedupes them. The cursor is only
         # the backstop for when that bounded set eventually truncates.
         if ts and cursor and ts < cursor:
-            n_already += 1
+            n_behind_cursor += 1
+            continue
+        # An unparseable/absent ts cannot be checked against the cursor, so
+        # once the cursor is in play it is UNVERIFIABLE, not exempt. Crediting
+        # it would let exactly this class re-credit forever after the bounded
+        # session set truncates -- the hole the cursor exists to close.
+        if ts is None and cursor is not None:
+            n_undated += 1
             continue
         if ts and (now - ts).total_seconds() < PROMOTE_SETTLE_MINUTES * 60:
             n_unsettled += 1
@@ -444,7 +535,23 @@ def _promote_locked(args, memory_dir: Path) -> int:
             seen_pairs.add(pair)
             deltas[str(slug)] += 1
 
+    # CLAIM THE SESSIONS FIRST, THEN MUTATE. The state write is what makes a
+    # re-run idempotent, so it must land before the changes it accounts for.
+    # Written last, any failure after the first instinct file -- a crash, a
+    # kill, a full disk -- leaves those files bumped and the sessions
+    # uncredited, and the next run credits them all over again. This ordering
+    # trades that for the safe failure: a crash mid-apply loses some credit,
+    # and losing credit is recoverable in a way that inventing it is not.
+    if not args.dry_run and fresh_sessions:
+        credited.extend(sorted(fresh_sessions))
+        state["credited_sessions"] = credited[-il.PROMOTE_SESSION_MEMORY:]
+        if max_credited_ts is not None:
+            state["cursor_ts"] = max_credited_ts.strftime("%Y-%m-%dT%H:%M:%SZ")
+        state["last_run"] = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+        _save_promote_state(state)   # raises -> nothing below runs
+
     touched = promoted = unbackfilled = 0
+    matched_slugs: set[str] = set()
     for path in il.iter_instinct_paths(memory_dir):
         inst = il.parse_instinct(path)
         fm = inst.fm
@@ -453,6 +560,8 @@ def _promote_locked(args, memory_dir: Path) -> int:
             unbackfilled += 1
             continue
         delta = deltas.get(inst.slug, 0)
+        if delta:
+            matched_slugs.add(inst.slug)
         prev_exp = il.parse_int(fm.get("exposures"), 0)
         new_exp = prev_exp + delta
         steps = il.promotion_steps(prev_exp, new_exp, args.every)
@@ -495,22 +604,24 @@ def _promote_locked(args, memory_dir: Path) -> int:
         if steps:
             promoted += 1
 
-    if not args.dry_run and fresh_sessions:
-        credited.extend(sorted(fresh_sessions))
-        state["credited_sessions"] = credited[-il.PROMOTE_SESSION_MEMORY:]
-        if max_credited_ts is not None:
-            state["cursor_ts"] = max_credited_ts.strftime("%Y-%m-%dT%H:%M:%SZ")
-        state["last_run"] = now.strftime("%Y-%m-%dT%H:%M:%SZ")
-        _save_promote_state(state)
-
     verb = "would credit" if args.dry_run else "credited"
+    landed = sum(v for k, v in deltas.items() if k in matched_slugs)
     print(f"promote: {verb} {len(fresh_sessions)} session(s) -> "
-          f"{sum(deltas.values())} exposure(s) across {len(deltas)} instinct(s); "
+          f"{landed} exposure(s) across {len(matched_slugs)} instinct(s); "
           f"{touched} file(s) updated, {promoted} reinforced "
           f"(gate: 1 step per {args.every} exposures).")
-    print(f"  skipped: {n_already} already-credited, {n_unsettled} still-recent "
+    print(f"  skipped: {n_already} already-credited, {n_behind_cursor} behind the "
+          f"cursor, {n_undated} undated, {n_unsettled} still-recent "
           f"(< {PROMOTE_SETTLE_MINUTES}m), {n_idle} idle "
           f"(< {args.min_session_calls} tool calls), {n_unattributed} unattributed.")
+    ghosts = sorted(set(deltas) - matched_slugs)
+    if ghosts:
+        # Counting these into the headline would assert exposures that landed
+        # nowhere. Name them: a slug in the ledger with no file behind it is
+        # a renamed or deleted memory, not evidence.
+        print(f"  {len(ghosts)} ledger slug(s) matched no instinct file and were "
+              f"NOT credited: {', '.join(ghosts[:5])}"
+              + (" ..." if len(ghosts) > 5 else ""), file=sys.stderr)
     if obs_bad or inj_bad:
         print(f"  WARNING: {inj_bad} malformed injection line(s), "
               f"{obs_bad} malformed observation line(s) skipped.", file=sys.stderr)

--- a/tests/test_instinct.py
+++ b/tests/test_instinct.py
@@ -668,6 +668,131 @@ def test_promote_refuses_concurrent_run():
         check(not lock.exists(), "the lock is released on exit")
 
 
+
+def test_promote_refuses_when_it_cannot_record_credit():
+    print("test_promote_refuses_when_it_cannot_record_credit")
+    with tempfile.TemporaryDirectory() as t:
+        tmp = Path(t)
+        md = make_memory(tmp)
+        cli.cmd_backfill(Args(no_backup=True), md)
+        slug = "feedback_voice_humanizer"
+        before = il.parse_float(il.parse_instinct(md / f"{slug}.md").fm["confidence"])
+        inj = [{"ts": _old_ts(), "session": f"s{i}", "injected": [slug], "explored": []}
+               for i in range(3)]
+        obs = []
+        for i in range(3):
+            obs += _busy(f"s{i}")
+        _write_ledgers(tmp, inj, obs)
+
+        # The state file is the ONLY thing that makes a re-run idempotent. If it
+        # cannot be written, crediting anyway means the next run credits the
+        # same sessions again -- confidence climbing on evidence never gathered,
+        # with every log line reading healthy.
+        #
+        # Fail at the WRITE specifically, not at mkdir: an earlier version of
+        # this fixture made the state path's PARENT a file, so it tripped the
+        # directory guard and stayed green even with the write guard removed --
+        # a test that appeared to cover this blocker and did not.
+        # The state file must be ABSENT (so the load path returns {} normally,
+        # a legitimate first run) with only the WRITE impossible. Two earlier
+        # fixtures failed to isolate this: a parent that was a file tripped the
+        # mkdir guard, and a target that was a directory tripped the LOAD
+        # guard -- both stayed green with the write guard removed, so both
+        # looked like coverage of this blocker and were not.
+        statedir = tmp / "state"
+        statedir.mkdir()
+        cli.PROMOTE_STATE_PATH = statedir / "promote-state.json"
+        # Block the atomic temp write and NOTHING else: the state file stays
+        # absent (so the load path is a normal first run) and the directory
+        # stays writable (so the lock is takeable). Two earlier fixtures failed
+        # to isolate this -- a parent that was a file tripped the mkdir guard,
+        # a target that was a directory tripped the LOAD guard -- and both
+        # stayed green with the write guard removed, looking like coverage of
+        # this blocker while covering a different one.
+        (statedir / "promote-state.json.tmp").mkdir()
+        raised = False
+        try:
+            cli.cmd_promote(_promote_args(), md)
+        except cli.PromoteStateError:
+            raised = True
+        check(raised, "an unwritable state file RAISES instead of crediting blind")
+        fm = il.parse_instinct(md / f"{slug}.md").fm
+        check(il.parse_int(fm.get("exposures"), 0) == 0,
+              "no instinct was mutated when the credit could not be recorded")
+        check(abs(il.parse_float(fm["confidence"]) - before) < 1e-9,
+              "confidence untouched by the refused run")
+        check(fm.get("evidence") == "seed",
+              "`evidence` did not certify a promotion that never happened")
+
+
+def test_promote_refuses_unreadable_ledger():
+    print("test_promote_refuses_unreadable_ledger")
+    with tempfile.TemporaryDirectory() as t:
+        tmp = Path(t)
+        md = make_memory(tmp)
+        cli.cmd_backfill(Args(no_backup=True), md)
+        inj, _obs = _write_ledgers(
+            tmp, [{"ts": _old_ts(), "session": "s1",
+                   "injected": ["feedback_voice_humanizer"], "explored": []}],
+            _busy("s1"))
+        os.chmod(inj, 0o000)
+        try:
+            raised = False
+            try:
+                cli.cmd_promote(_promote_args(), md)
+            except cli.PromoteStateError:
+                raised = True
+            # An EXISTING but unreadable ledger is not an ABSENT one; reporting
+            # "nothing to promote yet" is a false clean a cron reads as healthy
+            # forever.
+            check(raised, "an unreadable ledger raises rather than reading as empty")
+        finally:
+            os.chmod(inj, 0o644)
+
+
+def test_promote_does_not_credit_undated_records_past_the_cursor():
+    print("test_promote_does_not_credit_undated_records_past_the_cursor")
+    with tempfile.TemporaryDirectory() as t:
+        tmp = Path(t)
+        md = make_memory(tmp)
+        cli.cmd_backfill(Args(no_backup=True), md)
+        slug = "feedback_voice_humanizer"
+        # A record whose ts cannot be parsed cannot be checked against the
+        # cursor. Once the bounded session set has truncated, crediting it
+        # would re-credit it on every later pass, forever -- the exact hole
+        # the cursor exists to close.
+        _write_ledgers(tmp, [
+            {"session": "nodate", "injected": [slug], "explored": []},
+            {"ts": "2026-08-28 10:00:00", "session": "badfmt",
+             "injected": [slug], "explored": []},
+        ], _busy("nodate") + _busy("badfmt"))
+        cli.PROMOTE_STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        cli.PROMOTE_STATE_PATH.write_text(
+            json.dumps({"credited_sessions": [], "cursor_ts": _old_ts(minutes_ago=60)}),
+            encoding="utf-8")
+        cli.cmd_promote(_promote_args(), md)
+        fm = il.parse_instinct(md / f"{slug}.md").fm
+        check(il.parse_int(fm.get("exposures"), 0) == 0,
+              "undated / unparseable-ts records are not credited once a cursor exists")
+
+
+def test_promote_rejects_a_gate_of_zero():
+    print("test_promote_rejects_a_gate_of_zero")
+    with tempfile.TemporaryDirectory() as t:
+        tmp = Path(t)
+        md = make_memory(tmp)
+        cli.cmd_backfill(Args(no_backup=True), md)
+        _write_ledgers(tmp, [{"ts": _old_ts(), "session": "s1",
+                              "injected": ["feedback_voice_humanizer"], "explored": []}],
+                       _busy("s1"))
+        raised = False
+        try:
+            cli.cmd_promote(_promote_args(every=0), md)
+        except cli.PromoteStateError:
+            raised = True
+        check(raised, "--every 0 is refused, not silently accepted as a no-promote run")
+
+
 def main():
     print("=== Instinct Engine regression tests ===")
     test_confidence_math()
@@ -687,6 +812,10 @@ def main():
     test_promote_reports_unbackfilled()
     test_promote_state_three_ways()
     test_promote_refuses_concurrent_run()
+    test_promote_refuses_when_it_cannot_record_credit()
+    test_promote_refuses_unreadable_ledger()
+    test_promote_does_not_credit_undated_records_past_the_cursor()
+    test_promote_rejects_a_gate_of_zero()
     print(f"\n{'ALL PASS' if not FAILS else str(len(FAILS)) + ' FAILURE(S): ' + '; '.join(FAILS)}")
     return 1 if FAILS else 0
 

--- a/tests/test_instinct.py
+++ b/tests/test_instinct.py
@@ -578,6 +578,20 @@ def test_injection_hook_writes_stems():
         ctx = block.get("hookSpecificOutput", {}).get("additionalContext", "")
         check("Under evaluation" in ctx, "explore picks are LABELLED as unproven in the block")
 
+        # The ledger must rotate like its sibling. "Small and unbounded" still
+        # grows forever, and `promote` reads the whole file every run.
+        before = inj.read_text(encoding="utf-8")
+        r2 = subprocess.run(
+            [sys.executable, str(ROOT / "hooks" / "inject-instinct-context.py")],
+            input=_json.dumps({"session_id": "secondrun", "hook_event_name": "SessionStart"}),
+            capture_output=True, text=True,
+            env=dict(env, INSTINCT_INJECTIONS_MAX_BYTES="1"))
+        prev = Path(str(inj) + ".prev")
+        check(r2.returncode == 0 and prev.is_file(),
+              "the injection ledger rotates to .prev past its size cap")
+        check(prev.read_text(encoding="utf-8") == before,
+              "rotation preserves the prior generation verbatim (promote reads .prev)")
+
 
 def test_promote_reports_unbackfilled():
     print("test_promote_reports_unbackfilled")


### PR DESCRIPTION
## Main is currently shipping a blocker this PR removes

PR #610 squash-merged **before** its adversarial review landed. So `origin/main` has the promotion pass with the **fail-open state save** — verified directly, not inferred:

```
git show origin/main:scripts/instinct.py | grep "Refusing to continue: crediting sessions we cannot record"
→ no match
```

### What that means

The state file is the only thing making a re-run idempotent. With the save fail-open, a failed write mutates every instinct file, exits 0, and lets the next run credit the identical sessions again. Measured on the pre-fix code, same three ledger sessions, four consecutive runs:

| run | exposures | confidence | observations | rc |
|---|---|---|---|---|
| 1 | 3 | 0.900 → 0.915 | 2 | 0 |
| 2 | 6 | 0.928 | 3 | 0 |
| 3 | 9 | 0.939 | 4 | 0 |
| 4 | 12 | 0.948 | 5 | 0 |

Every run printed a truthful-looking `credited 3 session(s)` line about sessions it had already banked, and `evidence` flipped to `reinforced` — the provenance field added to keep the number honest certifying fabricated evidence. Ordering compounded it: state was written **last**, after every instinct file, so a crash or kill mid-run did the same thing.

**Correction, measured after this PR was opened.** The first version of this section claimed `injections.jsonl` does not exist yet. That was wrong — #610's hook is already deployed and the ledger holds **126 records across 63 sessions**. The safety conclusion stands, but for a different reason: **`promote` has never run.** There is no `promote-state.json` on disk at all, and the daily job is not installed, so nothing has ever read that ledger and no double-crediting has occurred. The daemon stays uninstalled until this PR lands.

Incidental good news from checking: all 126 records carry an 8-char session id, all 126 populate `explored[]`, and **191 of 191 distinct slugs resolve to a real instinct file — zero ghosts.** That is most of MYC-4245 step 1 already satisfied on real data.

### The fix

Sessions are claimed **before** the mutations they account for, and a failed write **raises**. The failure mode flips from inventing credit to losing it, which is the recoverable direction.

### Also in here, all from the same review

- An existing-but-unreadable ledger reported "nothing to promote yet" and exited 0 — the same absent-vs-failed collapse, two functions from the guard that refuses it.
- A record with an unparseable or absent `ts` bypassed the cursor, so that class would re-credit forever once the bounded session set truncates.
- The stale-lock break was `stat` → `unlink` → `create`, where a loser can delete the winner's fresh lock. Now an atomic rename-aside claim, and the lock records its pid.
- Ledger slugs matching no file were counted into the headline as exposures that landed nowhere.
- `--every 0` was accepted: credited exposures, promoted nothing, exit 0.
- The docstring claimed "an exposure that produced no correction is weak positive evidence." Nothing evaluates that predicate. Confidence here measures **exercise, not correctness**.
- `injections.jsonl` had no rotation while its sibling rotates at 5MB, so the reader's `.prev` handling was dead code for it.

### Verification

`ci-test` GREEN (`GATE_EXIT=0`), suite ALL PASS, scrub clean.

Every new assertion is mutation-checked. Worth stating plainly: **the blocker's own test was blind three times.** Fixture 1 made the state path's parent a file → tripped the `mkdir` guard. Fixture 2 made the target a directory → tripped the **load** guard. Fixture 3 made the dir read-only → the lock failed first. All three raised the right exception *type* from the wrong *site*, and all three passed with the fix reverted. Only blocking the atomic temp write and nothing else actually bit. That lesson is now in `check-hook-negative-control.py`'s docstring, where the next guard author reads it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
