### PR TITLE
secret_patterns: add npm_ and Backblaze B2 shapes to the registry

### DIFF
--- a/hooks/_lib/secret_patterns.py
+++ b/hooks/_lib/secret_patterns.py
@@ -164,6 +164,35 @@ _PROVIDER = [
         redaction="[REDACTED-neon-password]",
         description="Neon-issued database password (npg_ prefix, >=12 chars).",
     ),
+    SecretPattern(
+        # Backblaze B2 applicationKey. The B2 *keyID* is non-secret (it is a
+        # username); the *applicationKey* is the secret. Shape: `K` + 3-digit
+        # cluster + 27 alphanumerics = 31 chars. Boundaried BOTH sides so it
+        # matches at clean delimiters but skips a mid-base64 run -- same
+        # discipline as the google-api-key carve-out above, because a 31-char
+        # alphanumeric run is common inside encoded blobs.
+        name="backblaze-b2-app-key",
+        regex=re.compile(r"\bK[0-9]{3}[A-Za-z0-9]{27}\b", re.ASCII),
+        redaction="[REDACTED-b2-app-key]",
+        description=(
+            "Backblaze B2 application key (K + 3-digit cluster + 27 chars = 31). "
+            "The keyID is non-secret; this is the applicationKey."
+        ),
+    ),
+    SecretPattern(
+        # npm automation/access token. This shape is named in the operator
+        # pre-push scrub checklist a human reads, and was in NO executable
+        # detector on either the deployed or the substrate copy -- the same
+        # GUARD-BLIND-TO-THE-CREDENTIAL-ITS-OWN-DOCS-TELL-YOU-TO-USE class the
+        # nvidia-api-key entry above was added for. It is not hypothetical for
+        # this repo: ci.sh, the release workflow and bootstrap.sh all reach the
+        # npm registry, and an npm_ automation token is the standard credential
+        # for a publish path. Boundaried both sides, same reason as B2.
+        name="npm-access-token",
+        regex=re.compile(r"\bnpm_[A-Za-z0-9]{36,}\b", re.ASCII),
+        redaction="[REDACTED-npm-access-token]",
+        description="npm automation/access token, format npm_{36+ alphanumerics}.",
+    ),
 ]
 
 
@@ -483,6 +512,17 @@ if __name__ == "__main__":
         "real-google-api-key": 'GOOGLE_MAPS_KEY="AIza' + "Y" * 35 + '"',
         # Real Google API key at line start — MUST still match
         "real-google-api-key-bare": "AIza" + "Z" * 35,
+        # Backblaze B2 applicationKey — MUST match. K + 3-digit cluster + 27.
+        "real-b2-app-key": "B2_KEY=K005" + "A" * 27,
+        # Same shape mid-base64 (no boundary either side) — MUST be skipped.
+        "b2-in-base64": "x" + "K005" + "A" * 27 + "z",
+        # npm automation token — MUST match. npm_ + 36.
+        "real-npm-token": "NPM_TOKEN=npm_" + "B" * 36,
+        # Same shape mid-base64 (no boundary either side) — MUST be skipped.
+        "npm-in-base64": "x" + "npm_" + "B" * 36 + "z",
+        # Longer-than-36 token — MUST still match. Pins the `,` in {36,}:
+        # a bare {36} would silently miss any future longer npm shape.
+        "real-npm-token-long": "NPM_TOKEN=npm_" + "C" * 44,
     }
     expected_hits = {
         "github-asset-digest": [],   # sha256: prefix → skipped
@@ -497,6 +537,11 @@ if __name__ == "__main__":
         "aiza-in-base64": [],         # surrounded by alphanumerics → skipped
         "real-google-api-key": ["google-api-key"],
         "real-google-api-key-bare": ["google-api-key"],
+        "real-b2-app-key": ["backblaze-b2-app-key"],
+        "b2-in-base64": [],           # no boundary before K → skipped
+        "real-npm-token": ["npm-access-token"],
+        "npm-in-base64": [],          # no boundary before npm_ → skipped
+        "real-npm-token-long": ["npm-access-token"],
     }
     failures = 0
     for label, sample in FP_SAMPLES.items():


### PR DESCRIPTION
## Why

Two credential shapes that no scanner could see.

**`npm_` — new to BOTH copies.** The operator pre-push scrub checklist names eight key shapes; `npm_` was in **zero** executable detectors, deployed or substrate. Same `GUARD-BLIND-TO-THE-CREDENTIAL-ITS-OWN-DOCS-TELL-YOU-TO-USE` class the `nvidia-api-key` entry was added for. Not hypothetical here: `ci.sh`, the release workflow and `bootstrap.sh` all reach the npm registry, and an `npm_` automation token is the standard credential for a publish path.

**`backblaze-b2-app-key` — a port.** Present on the deployed copy since 2026-06-07, never carried upstream, so clients had no detector for it. The B2 *keyID* is non-secret (a username); the *applicationKey* is the secret.

## Doubt pass

`{36,}`, not `{36}`. I first wrote the bare `{36}` from the checklist, then measured it: on a 44-char token `{36}` returns **False** and `{36,}` returns **True**. For a credential detector a silent miss is strictly worse than a mild over-match, and `npm_` is a specific enough prefix to carry an open bound. There is now a long-token fixture pinning that comma.

Both patterns are boundaried on **both** sides (`\b...\b`), the same discipline as the `google-api-key` carve-out above them: a 31-char alphanumeric run is common inside encoded blobs, so an unboundaried pattern fires mid-base64. Each shape has an explicit mid-base64 fixture asserting it is skipped.

No new `except` clauses, no workflow/CI-surface changes, no `paths-ignore`.

## Negative control

Five fixtures, verified **RED before the patterns existed**:

```
[FAIL] real-b2-app-key: got=[] want=['backblaze-b2-app-key']
[FAIL] real-npm-token:  got=[] want=['npm-access-token']
```

After: all five green, full self-test exit 0. Fixtures use repeated-character values rather than realistic-looking ones, so our own test data cannot trip a scanner — the discipline this file already applies to its `hex-256` and `google-api-key` samples. (The deployed copy's realistic fixtures tripped the secret detector three times while I was auditing it.)

## Verification

`ci-test` GREEN on `eaa5e35` — `GATE_EXIT=0`, 0 FAIL, 0 error annotations, 3361 lines, sha-keyed marker written.

Found during a three-way audit of `~/.claude/hooks/_lib` against `origin/main`. Registry copies still diverge by name and content; MYC-844 owns unification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
