### PR TITLE
journal guard: stop resolving the vault root to its PARENT on a relative save

### DIFF
--- a/hooks/warn-journal-saved-without-context.py
+++ b/hooks/warn-journal-saved-without-context.py
@@ -72,20 +72,134 @@ def _norm(text):
     return text.replace("\\", "/")
 
 
+# A heredoc opener: `<< EOF`, `<<'EOF'`, `<<"EOF"`, `<<-EOF`. `<<<` herestrings
+# do not match (the third '<' is not a delimiter character).
+_HEREDOC_RE = re.compile(r"""<<-?[ \t]*(["']?)([A-Za-z_][A-Za-z0-9_]*)\1""")
+
+
+def _strip_heredocs(cmd):
+    """The command LINES, with every heredoc BODY removed.
+
+    The gate must open on what a command WRITES, not on whatever text it happens
+    to carry. A journal entry's body, a test fixture, or a doc that quotes a
+    journal path all travel inside a heredoc, and matching those opened the gate
+    on writes that are not journal saves at all — measured 2026-08-28, when a
+    write to `tests/integration/*.sh` was blocked because the test's own PROSE
+    contained `Journals/August 2026/`. A guard that fires on unrelated writes
+    teaches the operator to reach for the bypass, and a bypass reached for by
+    habit is how the real block gets waved through.
+
+    Only the GATE narrows. `creationDate:` is still read from the full text,
+    because that lives in the body by construction."""
+    if "<<" not in cmd:
+        return cmd
+    lines = cmd.split("\n")
+    kept, i = [], 0
+    while i < len(lines):
+        line = lines[i]
+        kept.append(line)
+        i += 1
+        for m in _HEREDOC_RE.finditer(line):
+            delim = m.group(2)
+            while i < len(lines) and lines[i].strip() != delim:
+                i += 1
+            i += 1  # drop the closing delimiter line too
+    return "\n".join(kept)
+
+
 def _vault_root(text):
-    """Absolute dir before the '<optional emoji >Journals/<Month YYYY>/' segment.
+    r"""Absolute dir before the '<optional emoji >Journals/<Month YYYY>/' segment,
+    or None when the text carries no ABSOLUTE journal path.
+
     Anchored on the absolute path (starts at a real '/', or a `C:/` drive root),
     so a leading shell prefix like `cat > '/vault/.../x.md'` is NOT captured into
-    the root (that was the 2026-07-07 Bash-path fail-open bug). Quotes bound the
-    segment on the Bash path.
+    the root (that was the 2026-07-07 Bash-path fail-open bug).
 
     The drive-letter alternative is guarded by `(?<![A-Za-z])` so a URL like
-    `http://host/Journals/May 2026/` cannot have its `p:` read as a drive."""
+    `http://host/Journals/May 2026/` cannot have its `p:` read as a drive.
+
+    The optional emoji-prefix segment is bounded on quotes and shell operators,
+    not only on '/' and newline. Journals are written as
+
+        cd "<vault>" && cat > "<emoji> Journals/August 2026/e.md" << 'EOF'
+
+    where the journal path is RELATIVE. With the old `(?:[^/\n]*\s)?` the segment
+    swallowed `vault" && cat > "<emoji> ` and matched `Journals/` anyway, so group 1
+    stopped at the vault's PARENT and the marker was looked up one directory too
+    high (measured 2026-08-28 on a real save). Returning None here is the honest
+    answer for a relative path; `_resolve_root` recovers the real root from the
+    `cd` target or the session cwd."""
     m = re.search(
-        r"((?:(?<![A-Za-z])[A-Za-z]:)?/[^\n\"']*?)/(?:[^/\n]*\s)?"
+        r"((?:(?<![A-Za-z])[A-Za-z]:)?/[^\n\"']*?)/(?:[^/\n\"'&|;<>]*\s)?"
         r"Journals/[A-Z][a-zA-Z]+\s+\d{4}/",
         text)
     return m.group(1) if m else None
+
+
+# `cd <path>`, honouring quotes and skipping option flags (`cd -P /x`). Bounded on
+# shell operators so it cannot run past the end of the cd word.
+_CD_RE = re.compile(
+    r"""(?:^|[;&|]|\s)cd\s+(?:-[A-Za-z]+\s+)*("[^"\n]+"|'[^'\n]+'|[^\s;&|<>]+)""")
+
+# The journal folder as it is spelled in this command -- `Journals` or, in the
+# default vault layout, `<emoji> Journals`. The class cannot cross '/', so an
+# absolute path yields the last segment only.
+_JOURNAL_DIR_RE = re.compile(r"([^/\n\"']*Journals)/[A-Z][a-zA-Z]+\s+\d{4}/")
+
+
+def _is_vault(root, journal_dirname=None):
+    """True only if `root` actually holds a journals folder.
+
+    This is the check that would have caught the 2026-08-28 bug on its own: the
+    stitched root `/Users/me` holds no Journals dir, so it can never be mistaken
+    for a vault no matter what the regex hands over. A candidate that fails here
+    is discarded rather than trusted, so a wrong guess degrades to fail-open
+    instead of to a confident answer about the wrong directory.
+
+    Metadata-only (isdir/listdir), never a file read, so it stays safe on a
+    cloud-mirrored vault per the cloud-safe-filesystem-walk rule."""
+    try:
+        if not os.path.isdir(root):
+            return False
+        if journal_dirname and os.path.isdir(os.path.join(root, journal_dirname)):
+            return True
+        if os.path.isdir(os.path.join(root, "Journals")):
+            return True
+        for entry in os.listdir(root):
+            if entry.endswith(" Journals") and os.path.isdir(os.path.join(root, entry)):
+                return True
+    except OSError:
+        return False
+    return False
+
+
+def _resolve_root(text, cwd):
+    """The vault root for this write, or None when it cannot be determined.
+
+    Ordered by how directly each candidate names the write target:
+      1. an ABSOLUTE journal path in the text  (strongest -- names the vault itself)
+      2. the `cd` target in the same command   (the relative-path write form)
+      3. the session cwd from the hook payload (relative path, no cd)
+
+    Every candidate must pass `_is_vault`, so a wrong one is dropped instead of
+    being used. None means fail-open, which is the correct posture for ambiguity:
+    this guard blocks only on a POSITIVE determination that the marker is absent."""
+    jm = _JOURNAL_DIR_RE.search(text)
+    journal_dirname = jm.group(1) if jm else None
+
+    candidates = []
+    root = _vault_root(text)
+    if root:
+        candidates.append(root)
+    for cm in _CD_RE.finditer(text):
+        candidates.append(cm.group(1).strip("\"'"))
+    if cwd:
+        candidates.append(cwd)
+
+    for cand in candidates:
+        if cand and _is_vault(cand, journal_dirname):
+            return cand
+    return None
 
 
 def _marker_exists(vault, date_iso):
@@ -117,17 +231,23 @@ elif tool_name == "Bash":
        re.search(r"(^|\s)JOURNAL_CONTEXT_BYPASS=1(\s|$)", cmd):
         sys.exit(0)
     cmd_norm = _norm(cmd)
-    if JOURNAL_PATH_RE.search(cmd_norm) and any(
-        m in cmd for m in ("cat >", "cat >>", "tee ", "tee -", " > ", " >> ", "mv ", "cp ", "rsync ")
+    # Gate on the command LINES only (heredoc bodies stripped), so a write whose
+    # PAYLOAD merely mentions a journal path is not mistaken for a journal save.
+    gate_text = _strip_heredocs(cmd_norm)
+    if JOURNAL_PATH_RE.search(gate_text) and any(
+        m in gate_text for m in ("cat >", "cat >>", "tee ", "tee -", " > ", " >> ", "mv ", "cp ", "rsync ")
     ):
         # Normalized, because _vault_root() below must see forward slashes too.
+        # The FULL text (body included) is the blob: the gate narrows, the
+        # creationDate scan must not.
         blob = cmd_norm
 
 if not blob:
     sys.exit(0)  # not a journal save
 
-vault = _vault_root(blob)
-if not vault or not os.path.isdir(vault):
+vault = _resolve_root(_strip_heredocs(blob) if tool_name == "Bash" else blob,
+                      payload.get("cwd") or None)
+if not vault:
     sys.exit(0)  # can't locate vault -> fail open
 
 dm = CREATION_DATE_RE.search(blob)

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -474,6 +474,22 @@ INTEGRATION_TESTS=(
   # — silently, on a whole platform. Two layers must hold (the path gate AND the
   # vault-root resolve); fixing only the first looks right and still fails open.
   test_journal_guard_windows_paths
+  # Journal-context guard vs the RELATIVE write form (2026-08-28). Entries are
+  # written as `cd "<vault>" && cat > "<emoji> Journals/<Month>/e.md"`, and the
+  # optional emoji-prefix segment in _vault_root was bounded only on '/' and
+  # newline, so it swallowed `vault" && cat > "<emoji> ` and resolved the root to
+  # the vault's PARENT. Loud direction: a correct save blocked. Quiet direction,
+  # which is worse: a marker in the parent satisfies the check and a journal with
+  # NO context ships silently. 7 assertions fail on the pre-fix hook.
+  test_journal_guard_relative_path_root
+  # Same guard, driven over real stdin against a real temp vault, so both
+  # directions are proven on the artifact people actually run: marker absent must
+  # still DENY (a fix that only removes blocks is indistinguishable from a fix
+  # that removes the guard), and the heredoc-BODY gate must not open on a write
+  # that merely quotes a journal path. Every heredoc control embeds an ABSOLUTE
+  # path, because with a relative one the old code fails open before the gate is
+  # reached and the assertion would pass without varying with the defect.
+  test_journal_guard_end_to_end
   # Close detector, whole-message anchoring + length gate (2026-08-16): the
   # shared pack tiers ran under re.MULTILINE, so every `$`-anchored sign-off
   # matched the end of ANY line and a 60-line handoff whose third line read

--- a/tests/integration/test_journal_guard_end_to_end.sh
+++ b/tests/integration/test_journal_guard_end_to_end.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+#
+# End-to-end control for warn-journal-saved-without-context.py.
+#
+# The unit test next door asserts on _vault_root / _resolve_root. That proves the
+# resolver, not the guard. This drives the SHIPPED hook over real stdin against a
+# real temp vault, so the two directions are proven on the artifact people run:
+#
+#   NEGATIVE CONTROL (the load-bearing one): marker ABSENT -> must DENY.
+#     A guard earns trust only by failing on the thing it catches. A fix that
+#     makes the block go away is indistinguishable from a fix that makes the
+#     guard useless, unless this case is asserted to still fire.
+#
+#   POSITIVE CASE: marker PRESENT -> must ALLOW.
+#     This is the 2026-08-28 regression: the relative-path write form
+#     `cd "<vault>" && cat > "<emoji> Journals/<Month>/e.md"` resolved the root
+#     to the vault's PARENT, found no marker there, and blocked a correct save.
+#
+# Blocking form is a JSON permissionDecision on exit 0 (see the hook's own note),
+# so "denied" is read from the payload, never from the exit code.
+set -euo pipefail
+
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+PY="${PYTHON:-python3}"
+
+"$PY" - "$REPO_ROOT" <<'PYEOF'
+import json, os, subprocess, sys, tempfile
+
+repo = sys.argv[1]
+hook = os.path.join(repo, "hooks", "warn-journal-saved-without-context.py")
+EMOJI = "\U0001F4D3"
+DATE = "2026-08-28"
+failures = 0
+
+def check(label, got, want):
+    global failures
+    if got == want:
+        print("PASS  %s" % label)
+    else:
+        print("FAIL  %s (got %r, want %r)" % (label, got, want))
+        failures += 1
+
+def run(tool_name, tool_input, cwd):
+    """Returns True if the hook DENIED the write."""
+    payload = {"hook_event_name": "PreToolUse", "tool_name": tool_name,
+               "tool_input": tool_input, "cwd": cwd}
+    env = dict(os.environ)
+    env.pop("JOURNAL_CONTEXT_BYPASS", None)   # the harness itself must not bypass
+    p = subprocess.run([sys.executable, hook], input=json.dumps(payload),
+                       capture_output=True, text=True, env=env)
+    if p.returncode != 0:
+        return "CRASH: rc=%d %s" % (p.returncode, p.stderr.strip()[:200])
+    if not p.stdout.strip():
+        return False
+    try:
+        out = json.loads(p.stdout)
+    except ValueError:
+        return "CRASH: non-JSON stdout %r" % p.stdout[:200]
+    return out.get("hookSpecificOutput", {}).get("permissionDecision") == "deny"
+
+with tempfile.TemporaryDirectory() as tmp:
+    tmp = os.path.realpath(tmp)
+    vault = os.path.join(tmp, "vault")
+    jdir = os.path.join(vault, EMOJI + " Journals", "August 2026")
+    os.makedirs(jdir)
+    entry_rel = "%s Journals/August 2026/An Entry.md" % EMOJI
+    entry_abs = os.path.join(jdir, "An Entry.md")
+    body = "---\ntype: journal\ncreationDate: %sT22:45\n---\n\n## Journal\nx\n" % DATE
+    bash_rel = 'cd "%s" && cat > "%s" << \'EOF\'\n%sEOF' % (vault, entry_rel, body)
+    bash_abs = 'cat > "%s" << \'EOF\'\n%sEOF' % (entry_abs, body)
+    marker_dir = os.path.join(vault, "⚙️ Meta", ".journal-context")
+    marker = os.path.join(marker_dir, "%s.json" % DATE)
+
+    # === NEGATIVE CONTROL: no marker anywhere -> every write form must DENY ===
+    check("NEGATIVE CONTROL: relative-path bash write is DENIED without a marker",
+          run("Bash", {"command": bash_rel}, vault), True)
+    check("NEGATIVE CONTROL: absolute-path bash write is DENIED without a marker",
+          run("Bash", {"command": bash_abs}, vault), True)
+    check("NEGATIVE CONTROL: Write tool is DENIED without a marker",
+          run("Write", {"file_path": entry_abs, "content": body}, vault), True)
+
+    # === The bug: a marker in the vault's PARENT must NOT satisfy the check. ===
+    # This is the silent-false-clean direction of the same defect. Before the fix
+    # the root resolved to the parent, so this planted marker would have ALLOWED
+    # a journal that had no context pulled at all.
+    parent_marker_dir = os.path.join(tmp, "⚙️ Meta", ".journal-context")
+    os.makedirs(parent_marker_dir)
+    open(os.path.join(parent_marker_dir, "%s.json" % DATE), "w").write("{}")
+    check("NEGATIVE CONTROL: a marker in the vault PARENT does not satisfy the check",
+          run("Bash", {"command": bash_rel}, vault), True)
+
+    # Remove the planted parent marker before the positive section. Leaving it
+    # in place makes the positive cases pass on UNFIXED source for the wrong
+    # reason (the parent marker satisfies the wrongly-resolved root), so the
+    # assertion could not vary with the defect and would prove nothing.
+    os.remove(os.path.join(parent_marker_dir, "%s.json" % DATE))
+
+    # === POSITIVE: the real marker, in the real vault -> ALLOW ===
+    os.makedirs(marker_dir)
+    open(marker, "w").write('{"date": "%s"}' % DATE)
+    check("relative-path bash write is ALLOWED with the marker (the 2026-08-28 regression)",
+          run("Bash", {"command": bash_rel}, vault), False)
+    check("absolute-path bash write is ALLOWED with the marker",
+          run("Bash", {"command": bash_abs}, vault), False)
+    check("Write tool is ALLOWED with the marker",
+          run("Write", {"file_path": entry_abs, "content": body}, vault), False)
+
+    # === CONTROLS: the gate must not open on things that are not journal saves ===
+    check("CONTROL: a non-journal note write is not gated",
+          run("Write", {"file_path": os.path.join(vault, "Notes", "x.md"), "content": "x"}, vault),
+          False)
+    check("CONTROL: reading a journal is not gated",
+          run("Bash", {"command": 'cat "%s"' % entry_abs}, vault), False)
+    os.remove(marker)
+    check("CONTROL: inline bypass still allows the write with no marker",
+          run("Bash", {"command": "JOURNAL_CONTEXT_BYPASS=1 " + bash_rel}, vault), False)
+    check("CONTROL: unknown cwd and no absolute path -> fail OPEN, never a wrong block",
+          run("Bash", {"command": 'cat > "Journals/August 2026/e.md"'}, tmp), False)
+
+    # === The heredoc-body gate (2026-08-28, second defect, same session) ======
+    # A write whose PAYLOAD mentions a journal path is not a journal save. The
+    # gate used to scan the whole command, so writing a test or a doc that quotes
+    # a journal path was blocked (that is how this defect was found: a write to
+    # tests/integration/*.sh was denied because the test's own PROSE contained a
+    # journal path). A guard that fires on unrelated writes teaches the operator
+    # to reach for the bypass by habit, which is how a real block later gets
+    # waved through.
+    #
+    # The body must carry an ABSOLUTE journal path. With a relative one the OLD
+    # code fails open at root resolution and the assertion passes for a reason
+    # that has nothing to do with the gate -- a control that cannot vary with the
+    # defect proves nothing. With the absolute path the old code resolves the
+    # vault, finds no marker, and denies, so each case genuinely flips.
+    doc_body = "see %s/%s Journals/August 2026/An Entry.md for the format\n" % (vault, EMOJI)
+    target = os.path.join(tmp, "t.sh")
+    HEREDOC_FORMS = [
+        ("quoted delimiter",   "cat > %s << 'EOF'\n%sEOF" % (target, doc_body)),
+        ("unquoted delimiter", "cat > %s << EOF\n%sEOF" % (target, doc_body)),
+        ("dash-suppressed",    "cat > %s <<-EOF\n%sEOF" % (target, doc_body)),
+        ("double-quoted",      'cat > %s << "EOF"\n%sEOF' % (target, doc_body)),
+        ("custom delimiter",   "cat > %s << 'TESTEOF'\n%sTESTEOF" % (target, doc_body)),
+    ]
+    for label, cmd in HEREDOC_FORMS:
+        check("CONTROL: non-journal write quoting a journal path in a %s heredoc is not gated"
+              % label, run("Bash", {"command": cmd}, vault), False)
+
+    check("POSITIVE CONTROL: a real heredoc journal save is still gated (denied, no marker)",
+          run("Bash", {"command": bash_rel}, vault), True)
+
+print()
+if failures:
+    print("FAILED (%d)" % failures)
+    sys.exit(1)
+print("ALL PASS (17 assertions; 5 negative controls)")
+PYEOF

--- a/tests/integration/test_journal_guard_relative_path_root.sh
+++ b/tests/integration/test_journal_guard_relative_path_root.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# Integration test: warn-journal-saved-without-context.py must not stitch a vault
+# root across a shell operator, and must resolve the relative-path write form.
+#
+# The bug (measured 2026-08-28, on a real journal save that was wrongly blocked):
+# entries are written as
+#
+#     cd "<vault>" && cat > "<emoji> Journals/August 2026/e.md" << 'EOF'
+#
+# The journal path here is RELATIVE. _vault_root()'s optional emoji-prefix segment
+# was `(?:[^/\n]*\s)?` -- bounded only on '/' and newline, so it happily swallowed
+#
+#     vault" && cat > "<emoji>
+#
+# and matched `Journals/`. Group 1 then stopped at `/Users/me`, i.e. the vault's
+# PARENT. The hook looked for the preflight marker one directory too high.
+#
+# Both failure directions are real, and the quiet one is worse:
+#   - parent has no Meta dir  -> marker never found -> a correct save is BLOCKED
+#                                (loud, which is how this got caught at all)
+#   - parent HAS a Meta dir   -> a stale marker satisfies the check -> a journal
+#                                with NO context ships SILENTLY, which is the exact
+#                                failure the guard exists to prevent
+#
+# The comment on _vault_root claimed "quotes bound the segment on the Bash path".
+# Quotes bound GROUP 1. They did not bound the optional prefix segment. That gap
+# is the whole bug.
+#
+# Asserted against the hook's OWN predicates, so this tests shipped code rather
+# than a reimplementation. Every claim carries a control.
+set -euo pipefail
+
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+PY="${PYTHON:-python3}"
+
+"$PY" - "$REPO_ROOT" <<'PYEOF'
+import importlib.util, os, pathlib, sys, tempfile
+
+repo = pathlib.Path(sys.argv[1])
+path = repo / "hooks" / "warn-journal-saved-without-context.py"
+spec = importlib.util.spec_from_file_location("journal_guard", path)
+m = importlib.util.module_from_spec(spec)
+sys.modules["journal_guard"] = m
+try:
+    spec.loader.exec_module(m)
+except SystemExit:
+    pass
+
+vault_root, norm = m._vault_root, m._norm
+EMOJI = "\U0001F4D3"
+failures = 0
+
+def check(label, got, want):
+    global failures
+    if got == want:
+        print(f"PASS  {label}")
+    else:
+        print(f"FAIL  {label} (got {got!r}, want {want!r})")
+        failures += 1
+
+# ---------------------------------------------------------------------------
+# 1. _vault_root must not stitch a root across a shell operator.
+#    A relative journal path carries NO absolute root, so the honest answer is
+#    None. Returning the parent dir is worse than returning nothing, because the
+#    caller cannot tell a wrong answer from a right one.
+# ---------------------------------------------------------------------------
+STITCH_CASES = [
+    ("cd + emoji folder",
+     'cd "/Users/me/vault" && cat > "%s Journals/August 2026/e.md" << \'EOF\'' % EMOJI),
+    ("cd + plain folder",
+     'cd "/Users/me/vault" && cat > "Journals/August 2026/e.md" << \'EOF\''),
+    ("cd single-quoted + tee",
+     "cd '/Users/me/vault' && tee 'Journals/August 2026/e.md'"),
+    ("semicolon operator",
+     'cd "/Users/me/vault"; cat > "%s Journals/August 2026/e.md"' % EMOJI),
+]
+for label, raw in STITCH_CASES:
+    check("no stitched root: %s" % label, vault_root(norm(raw)), None)
+
+# ---------------------------------------------------------------------------
+# 2. _resolve_root must recover the real vault from the `cd` target / cwd, and
+#    must reject a candidate that is not actually a vault.
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as tmp:
+    tmp = os.path.realpath(tmp)
+    vault = os.path.join(tmp, "vault")
+    os.makedirs(os.path.join(vault, EMOJI + " Journals", "August 2026"))
+    plain = os.path.join(tmp, "plainvault")
+    os.makedirs(os.path.join(plain, "Journals", "August 2026"))
+    notvault = os.path.join(tmp, "notavault")
+    os.makedirs(notvault)
+
+    cmd = 'cd "%s" && cat > "%s Journals/August 2026/e.md" << \'EOF\'' % (vault, EMOJI)
+    check("resolve from cd target (emoji vault)", m._resolve_root(norm(cmd), None), vault)
+
+    cmd_plain = 'cd "%s" && cat > "Journals/August 2026/e.md"' % plain
+    check("resolve from cd target (plain Journals)", m._resolve_root(norm(cmd_plain), None), plain)
+
+    # No cd in the command: the session cwd is the vault.
+    check("resolve from payload cwd",
+          m._resolve_root(norm('cat > "%s Journals/August 2026/e.md"' % EMOJI), vault), vault)
+
+    # An absolute journal path still wins, and still resolves the same as before.
+    abs_cmd = 'cat > "%s/%s Journals/August 2026/e.md"' % (vault, EMOJI)
+    check("absolute path still wins over cwd", m._resolve_root(norm(abs_cmd), notvault), vault)
+
+    # CONTROL: a directory with no Journals folder is NOT accepted as a vault.
+    # Without this, any wrong candidate silently becomes the root -- which is
+    # how the original bug produced a confident answer about the wrong place.
+    check("CONTROL: non-vault cd target is rejected",
+          m._resolve_root(norm('cd "%s" && cat > "Journals/August 2026/e.md"' % notvault), None),
+          None)
+    check("CONTROL: non-vault cwd is rejected",
+          m._resolve_root(norm('cat > "Journals/August 2026/e.md"'), notvault), None)
+
+    # CONTROL: the parent of a real vault must never validate. This is the exact
+    # value the bug returned; it has to be rejected on its own merits, not merely
+    # be unreachable by the current regex.
+    check("CONTROL: vault parent is rejected as a root",
+          m._resolve_root(norm('cd "%s" && cat > "Journals/August 2026/e.md"' % tmp), None),
+          None)
+
+# ---------------------------------------------------------------------------
+# 3. CONTROLS: previously-correct behaviour must not regress.
+# ---------------------------------------------------------------------------
+check("CONTROL: POSIX absolute path root unchanged",
+      vault_root(norm("/Users/me/vault/Journals/May 2026/e.md")), "/Users/me/vault")
+check("CONTROL: Windows absolute path root unchanged",
+      vault_root(norm(r"C:\Users\me\vault\Journals\May 2026\e.md")), "C:/Users/me/vault")
+check("CONTROL: emoji vault folder root unchanged",
+      vault_root(norm("/Users/me/v/%s Journals/May 2026/e.md" % EMOJI)), "/Users/me/v")
+check("CONTROL: heredoc with absolute path root unchanged",
+      vault_root(norm("cat > '/Users/me/vault/Journals/May 2026/e.md' <<EOF")), "/Users/me/vault")
+check("CONTROL: a URL is still not parsed as a drive root",
+      vault_root(norm("see http://host/x/Journals/May 2026/e.md")), "//host/x")
+
+print()
+if failures:
+    print("FAILED (%d)" % failures)
+    sys.exit(1)
+print("ALL PASS (16 assertions, controls included)")
+PYEOF


### PR DESCRIPTION
A journal entry is written as `cd "<vault>" && cat > "<emoji> Journals/<Month> <Year>/e.md" << 'EOF'`, so the journal path is **relative**. `_vault_root`'s optional emoji-prefix segment was bounded only on `/` and newline, never on a quote or a shell operator. It swallowed `vault" && cat > "<emoji>` and still matched the `Journals/` segment, leaving group 1 at the vault's **parent**.

The docstring claimed quotes bound the segment on the Bash path. Quotes bound *group 1*, not the optional prefix. That gap is the whole defect.

Both directions are real, and the quiet one is worse:

- parent has no Meta dir → marker never found → **a correct save is blocked**. Loud, which is the only reason this surfaced.
- parent **has** a Meta dir → a stale marker satisfies the check → **a journal with no context ships silently**. That is precisely the failure this guard was built to prevent, so it could report healthy while permitting the exact thing it exists to stop.

### The fix

Narrowing the regex alone would only convert a wrong answer into a fail-open, so it is three parts:

1. Bound the prefix segment on quotes and shell operators. A relative path now yields `None`, which is the honest answer.
2. `_resolve_root` recovers the real root, ordered by how directly each candidate names the target: absolute path in the text → `cd` target in the same command → session `cwd`.
3. `_is_vault` requires the candidate to actually hold a journals folder. This is the check that would have caught the bug on its own, and it means a wrong candidate degrades to fail-open rather than to a confident answer about the wrong directory. Metadata-only, so it stays safe on a cloud-mirrored vault.

### Second defect, found while testing the first

The Bash gate ran the path pattern over the **entire** command, so a write whose heredoc *body* merely quoted a journal path was treated as a journal save. Writing the test for this very fix was blocked that way. `_strip_heredocs` narrows the gate to the command lines; the `creationDate` scan still reads the full text, because that lives in the body by construction.

### Tests

`test_journal_guard_relative_path_root` (16 assertions) and `test_journal_guard_end_to_end` (17 assertions, 5 negative controls), both registered in `scripts/ci.sh` so they actually run.

**7 assertions fail on the pre-fix hook.** The end-to-end suite drives the shipped hook over real stdin against a real temp vault. Its negative controls are the load-bearing half: marker absent must still **deny** on every write form, and a marker planted in the vault's *parent* must **not** satisfy the check. Without those, a change that simply disabled the guard would pass a suite made only of "this no longer blocks" assertions.

**Review-risky area, flagged deliberately:** two controls were rewritten mid-review because they could not vary with the defect. The positive case originally ran while a planted parent-marker was still present, and the heredoc cases originally used relative paths, where the old code fails open at root resolution before the gate is ever reached. Both passed on unfixed source for reasons unrelated to the change, which is indistinguishable from rigour until you check. Worth a reviewer's attention that each assertion still flips.

### Verification

Full canonical gate green on this commit: `py_compile` (394 files) + 138 integration tests + 31 `scripts/` + 26 `hooks/` unit suites + shellcheck + phase-doc + utf8 console + hook block-protocol + vault-root reads + home-hook deploy + subprocess decode + py3.9 parity + ps1 encoding. Zero failures. Pre-existing `test_journal_guard_windows_paths` and `test_heal_journal_guard` still green. Personal-data scrub clean, every pattern proven against a planted specimen before scanning.

### Not in this PR

The sibling `block-journal-save-without-panel-shown` has the same heredoc defect and is fixed in `local-machinery`. It is model-general but lives only there, so it protects one machine — tracked as MYC-4247 to port it into this substrate. Kept separate deliberately: that change *adds* a new blocking gate to every install, a different blast radius from fixing a bug.

Drafted with Claude Code; gate run and controls verified before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
