### PR TITLE
hooks: land the stranded vault-command-nudges port, and stop a missing _lib from disarming the guard

### DIFF
--- a/hooks/_lib/shell_parse.py
+++ b/hooks/_lib/shell_parse.py
@@ -1,0 +1,303 @@
+"""shell_parse — quote-aware primitives for hooks that must reason about a
+Bash command STRING before the shell runs it.
+
+A PreToolUse(Bash) guard is handed one string and has to answer questions a
+naive `re.split` cannot: which commands are actually in here, where would each
+one run, and which of them carries the advertised bypass. Every hook that
+hand-rolled that walk grew its own set of fail-opens, because all four of the
+hard parts are invisible until they bite:
+
+  - QUOTES. `echo "hi; cd /tmp" && git push` has ONE `cd`-looking token and it
+    is inside a string. A splitter that ignores quotes forges a segment
+    boundary there and reads a `cd` the shell never runs.
+  - SEPARATORS. `cd X && cmd` runs cmd in X; `cd X || cmd` runs it in the OLD
+    cwd, because the right side of `||` runs only when the left FAILED. A
+    splitter that discards the operator cannot tell those apart, and every
+    consumer read `cd /tmp || git push` as a push from /tmp.
+  - HEREDOC BODIES. A heredoc body is data, never commands, but it is full of
+    real operator characters. Truncating at the first `<<` instead (the older
+    approach) threw away every command AFTER the heredoc, which is where the
+    interesting one usually is.
+  - `$VAR`. `W=/path; cd "$W" && git push` is the shape people actually write.
+    Without expansion the target is the literal string `$W`, which resolves to
+    no repo at all -- and a guard that reads "no repo" as "not my repo" fails
+    open on precisely the command it exists to catch.
+
+Shared primitive, per-caller policy: this module answers "what does the shell
+see", never "should it be allowed". Callers keep their own scoping and
+fail-open/fail-closed decisions, which differ by guard.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+
+__all__ = [
+    "ASSIGN_RE",
+    "ENV_ASSIGN_RE",
+    "WRAPPER_PREFIXES",
+    "expand_vars",
+    "leading_env_assigns",
+    "segment_bypass_flags",
+    "split_segments_with_seps",
+    "strip_heredoc_bodies",
+    "strip_noncode",
+    "tokens",
+]
+
+# Words that may sit in FRONT of a command without changing which program runs.
+# `env` may additionally carry `VAR=VAL` arguments.
+WRAPPER_PREFIXES = {"env", "command", "exec", "builtin", "nohup", "sudo", "time"}
+
+ENV_ASSIGN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+ASSIGN_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)=(.*)$")
+
+_VAR_REF = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)")
+
+# Strip body + closing delimiter; everything before `<<` (the actual command)
+# is outside the match and survives.
+_HEREDOC = re.compile(
+    r"<<-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1[^\n]*\n"  # <<EOF + rest of line
+    r".*?"                                                # body (non-greedy)
+    r"\n[ \t]*\2[ \t]*(?=\n|$)",                          # closing delimiter line
+    re.DOTALL,
+)
+# A herestring (`<<<`) is NOT a heredoc: no body, no closing delimiter. The
+# distinction matters below, where a LEFTOVER `<<` means "unterminated heredoc,
+# be conservative" -- treating `<<<` as unterminated would needlessly discard
+# every command after a herestring.
+_HEREDOC_OPEN = re.compile(r"(?<!<)<<(?!<)")
+
+
+def expand_vars(value, variables):
+    """Expand `$VAR` / `${VAR}` from assignments seen EARLIER in the same command.
+
+    Only literal, already-seen assignments are expanded. An unknown name or a
+    command substitution (`$(...)`, backticks) is left INTACT on purpose, so the
+    caller can still SEE a `$` and know the target is unresolved rather than
+    silently receiving a wrong path. That distinction is the whole value: a
+    guard can then treat "unresolved" as ambiguous instead of as "not mine".
+    """
+    if not value or "$" not in value:
+        return value
+    out = value
+    for _ in range(5):  # bounded: resolves VAR=$OTHER chains, never loops forever
+        nxt = _VAR_REF.sub(
+            lambda m: variables.get(m.group(1) or m.group(2), m.group(0)), out)
+        if nxt == out:
+            break
+        out = nxt
+    return out
+
+
+def tokens(seg):
+    """shlex tokens for one segment, falling back to a whitespace split when the
+    segment is not lexable on its own (an unbalanced quote from slicing)."""
+    try:
+        return shlex.split(seg)
+    except ValueError:
+        return seg.split()
+
+
+def strip_heredoc_bodies(command):
+    """Remove heredoc BODIES (data, never commands) while KEEPING the commands
+    that follow the closing delimiter.
+
+    Replaces the older "truncate at the first `<<`" approach. Truncating threw
+    away everything after the heredoc, so the dominant shape
+
+        cat > notes.md <<'BODY'
+        ...body...
+        BODY
+        cd some/repo
+        git push
+
+    hid BOTH the `cd` and the push from every parser that truncated. Writing
+    body text to a FILE first is the recommended shape, so this is the common
+    case, not an exotic one.
+
+    Unterminated heredoc (an opener with no closing delimiter line) -> fall back
+    to truncating at that opener, so an unmatched body can never be misread as
+    commands. Strictly safer than either extreme.
+    """
+    if not command:
+        return command
+    stripped = _HEREDOC.sub("", command)
+    m = _HEREDOC_OPEN.search(stripped)
+    if m:                       # unterminated heredoc -> conservative truncation
+        stripped = stripped[:m.start()]
+    return stripped
+
+
+def strip_noncode(command):
+    """Reduce a command to the text a shell would actually parse as code: drop
+    `#`-to-end-of-line comments outside quotes.
+
+    A comment tail is TEXT THE SHELL NEVER RUNS, but the operators inside it are
+    still real characters, so a splitter walks straight through them: in
+    `git push # note ; cd /elsewhere` the `;` creates a segment boundary and
+    ` cd /elsewhere` reads as a genuine `cd`. Stripping cuts BOTH ways -- it
+    stops a phantom `cd` from moving a guard off its target (a fail-open), and
+    stops one from dragging an unrelated target ON to it (a false block).
+
+    Line continuations are NOT handled here: split_segments_with_seps deletes
+    `\\`+newline for every consumer, so doing it again would be a second place
+    to keep correct.
+
+    Quote-aware, because the symmetric bug is over-stripping: `-m "issue #42"`
+    and `-m "fix: a # b"` must survive untouched.
+    """
+    out, quote, i, n = [], None, 0, len(command)
+    while i < n:
+        c = command[i]
+        if quote:
+            out.append(c)
+            if c == "\\" and quote == '"' and i + 1 < n:
+                out.append(command[i + 1]); i += 2; continue
+            if c == quote:
+                quote = None
+            i += 1
+            continue
+        if c in ("'", '"'):
+            quote = c; out.append(c); i += 1; continue
+        if c == "\\" and i + 1 < n:
+            out.append(c); out.append(command[i + 1]); i += 2; continue
+        if c == "#" and (not out or out[-1].isspace()):
+            while i < n and command[i] != "\n":     # to end of LINE, not of string
+                i += 1
+            continue
+        out.append(c); i += 1
+    return "".join(out)
+
+
+def split_segments_with_seps(command):
+    """Split a command on shell operators that are OUTSIDE quotes, reporting the
+    operator BETWEEN each adjacent pair.
+
+    Returns `[(sep_before, text), ...]`; `sep_before` is `""` for the first
+    segment and otherwise the exact operator that separated it from the
+    previous one: `&&`, `||`, `|`, `;`, `&`, a newline, `(` or `)`.
+
+    WHY the separator is load-bearing: a `cd` does NOT unconditionally take
+    effect for whatever follows it, and a splitter that throws the operator away
+    cannot tell the cases apart:
+
+        cd X && cmd    -> cmd runs in X           (cd succeeded)
+        cd X || cmd    -> cmd runs in the OLD cwd (right side runs only on FAILURE)
+        cd X |  cmd    -> cmd runs in the OLD cwd (subshell)
+        cd X &  cmd    -> cmd runs in the OLD cwd (the cd was backgrounded)
+        ( cd X ) cmd   -> cmd runs in the OLD cwd (subshell scope)
+        cd X ;  cmd    -> AMBIGUOUS: X if the cd succeeded, the OLD cwd if not
+
+    LINE CONTINUATIONS are DELETED here, outside single quotes, because a shell
+    deletes `\\`+newline before any other parsing: `git \\<newline>push` IS
+    `git push`. Keeping the backslash left a non-whitespace byte between a verb
+    and its argument, so a consumer's `verb\\s+arg` pattern silently stopped
+    matching a command that had merely been wrapped at 80 columns. Consequence
+    to know: the segments no longer reconstruct the input BYTE-for-byte -- they
+    reconstruct what a shell would run.
+    """
+    segs, cur, sep = [], [], ""
+    i, n, quote = 0, len(command), None
+    while i < n:
+        c = command[i]
+        if quote:                      # inside a quote: copy verbatim to the close
+            if c == "\\" and quote == '"' and i + 1 < n and command[i + 1] == "\n":
+                i += 2; continue           # line continuation: deleted, even in " "
+            cur.append(c)
+            if c == "\\" and quote == '"' and i + 1 < n and command[i + 1] in '"\\$`':
+                cur.append(command[i + 1]); i += 2; continue   # \" \\ \$ \` in " "
+            if c == quote:
+                quote = None
+            i += 1
+            continue
+        if c in ("'", '"'):
+            quote = c; cur.append(c); i += 1; continue
+        if c == "\\" and i + 1 < n:     # escaped operator outside quotes -> literal
+            if command[i + 1] == "\n":
+                i += 2; continue           # LINE CONTINUATION -> delete both
+            cur.append(c); cur.append(command[i + 1]); i += 2; continue
+        two = command[i:i + 2]
+        if two in ("&&", "||"):
+            segs.append((sep, "".join(cur))); cur = []; sep = two; i += 2; continue
+        if c in ("|", ";", "\n", "&", "(", ")"):
+            segs.append((sep, "".join(cur))); cur = []; sep = c; i += 1; continue
+        cur.append(c); i += 1
+    segs.append((sep, "".join(cur)))
+    return segs
+
+
+def leading_env_assigns(command):
+    """Dict of `VAR=value` assignments that PREFIX a real command in `command`.
+
+    `FOO=1 BAR=2 git push`           -> {'FOO': '1', 'BAR': '2'}
+    `export FOO=1; git push`         -> {'FOO': '1'}   (exported: reaches later)
+    `git push ; FOO=1`               -> {}             (bare: prefixes nothing)
+    `git status && BSB=1 git switch` -> {'BSB': '1'}   (union across segments)
+    `echo 'FOO=1 git push'`          -> {}             (quoted, not a real assign)
+
+    An inline `VAR=1 <cmd>` prefix lives ONLY in the command STRING and never
+    reaches the hook process's `os.environ`. A gate that advertises an inline
+    bypass must therefore read the token from HERE, not from os.environ alone,
+    or the bypass printed in its own block message can never fire -- which
+    trains people to channel-switch around the gate instead.
+
+    Skips transparent wrappers the way a shell does. Empty dict when none or
+    unparseable. Heredoc (`<<` anywhere): only line 1 up to the first `<<` is
+    parsed, so a heredoc BODY line that merely looks like `X=1 cmd` can never
+    be counted.
+    """
+    if not command or "=" not in command:
+        return {}
+    if "<<" in command:
+        command = command.split("\n", 1)[0].split("<<", 1)[0]
+    assigns = {}
+    for _sep, seg in split_segments_with_seps(command):
+        seg = seg.strip()
+        if not seg:
+            continue
+        toks = tokens(seg)
+        if not toks:
+            continue
+        exported = toks[0] == "export"
+        i = 1 if exported else 0
+        here = {}
+        while i < len(toks) and (ENV_ASSIGN_RE.match(toks[i])
+                                 or toks[i] in WRAPPER_PREFIXES):
+            if ENV_ASSIGN_RE.match(toks[i]):
+                k, _, v = toks[i].partition("=")
+                here[k] = v
+            i += 1
+        # These must PREFIX A REAL COMMAND. A bare trailing `VAR=1` sets only a
+        # SHELL variable -- unexported, so it never reaches any child process's
+        # environment and cannot be a bypass for one. Counting it meant
+        # `<gated cmd> ; GATE_BYPASS=1` silently disarmed a gate for a command
+        # that had ALREADY RUN. `export VAR=1` DOES reach later commands.
+        if here and (exported or i < len(toks)):
+            assigns.update(here)
+    return assigns
+
+
+def segment_bypass_flags(segments, var, value="1"):
+    """Per-segment bypass truth for an ALREADY-SPLIT command: `[bool, ...]`,
+    aligned to `segments`.
+
+    `leading_env_assigns` unions across the whole line, which cannot answer the
+    question a gate actually has -- "is the bypass on the command I am about to
+    block?" -- so a real assignment ANYWHERE disarmed every rule, including one
+    on an unrelated command (`git push && BYPASS=1 echo hi`).
+
+    The caller passes its OWN segments because each gate sanitizes differently
+    (heredoc bodies, comment tails). A bare `VAR=1` segment does not carry to
+    later commands; an `export` does, and is honoured from that point on.
+    """
+    flags, exported = [], False
+    for seg in segments:
+        here = exported or leading_env_assigns(seg).get(var) == value
+        toks = tokens(seg.strip())
+        if toks and toks[0] == "export" and f"{var}={value}" in toks:
+            exported = True
+            here = True
+        flags.append(here)
+    return flags

--- a/hooks/test_vault_command_nudges_lead.py
+++ b/hooks/test_vault_command_nudges_lead.py
@@ -220,6 +220,30 @@ try:
           "git push", VAULT, hook=dhook)
     check(False, "39. degraded parse still allows a non-vault push",
           "git push", PLAIN, hook=dhook)
+
+    print("--- degraded mode: NO _lib at all (a partial install) ---")
+    # Cases 38-39 copy _lib/vault_root.py IN, so they only ever remove
+    # shell_parse.py -- the half that already failed closed. The other import
+    # fell back to `return None`, which means "no vault anywhere", and that
+    # silently switched off EVERY vault-scoped rule in the file. Measured
+    # before the fix: this fixture allowed a vault push, a vault-root rm, and
+    # an unscoped git status. A fixture named for "_lib missing" that supplies
+    # half of _lib is a claim about a scope it never covered.
+    bare = os.path.join(TMP, "bare")
+    os.makedirs(bare)
+    shutil.copy2(os.path.join(hooks_dir, "vault-command-nudges.py"),
+                 os.path.join(bare, "vault-command-nudges.py"))
+    bhook = os.path.join(bare, "vault-command-nudges.py")
+    check(True,  "40. no _lib at all still blocks a vault push",
+          "git push", VAULT, hook=bhook)
+    check(True,  "41. no _lib at all still blocks an rm of the vault root",
+          f'rm -rf "{VAULT}"', os.path.dirname(VAULT), hook=bhook)
+    check(True,  "42. no _lib at all still blocks an unscoped git status",
+          "git status", VAULT, hook=bhook)
+    check(False, "43. no _lib at all still allows a non-vault push",
+          "git push", PLAIN, hook=bhook)
+    check(False, "44. no _lib at all still allows an rm outside any vault",
+          "rm -rf build", PLAIN, hook=bhook)
 finally:
     shutil.rmtree(TMP, ignore_errors=True)
 

--- a/hooks/test_vault_command_nudges_lead.py
+++ b/hooks/test_vault_command_nudges_lead.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Controls for vault-command-nudges.py's command-recognition layer (_LEAD).
+
+Every BLOCK case here was measured EXITING 0 -- silently unguarded -- against
+the revision this suite landed with. The rm rule had been generalised to
+multi-vault targeting, but the push / status / grep / find rules still matched a
+bare `git` / `rm` token at a regex-alternation boundary, and the cwd walk was a
+quote-blind `re.split`. So a transparent wrapper, a one-shot `VAR=` assignment,
+an explicit path to the binary, a subshell, or a `cd` hidden inside a quoted
+string was enough to walk straight past all four.
+
+The ALLOW legs are not decoration. A guard that over-blocks teaches people to
+reach for the bypass, and the fail-closed cwd candidate SET introduced alongside
+_LEAD is exactly the kind of change that over-blocks. Every BLOCK leg is paired
+with an ALLOW leg that must stay allowed, so a hook that simply returned 2 for
+everything would fail this suite rather than pass it.
+
+Fixtures are built here, not borrowed from the developer's machine: a vault is
+"a directory with a Meta-suffixed folder above it" (hooks/_lib/vault_root.py),
+so a tmpdir with `Meta/` and a `git init` is a real one. VAULT_ROOT is pointed
+somewhere ELSE on purpose -- these rules must resolve the vault PER TARGET, and
+pointing the env var at the fixture would let a regression that only ever reads
+$VAULT_ROOT pass.
+
+Stdlib only. Exit 0 = all pass.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+HOOK = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                    "vault-command-nudges.py")
+
+PASS = 0
+FAIL = 0
+
+
+def run(command, cwd, hook=HOOK, env=None):
+    """Exit code of the hook for one crafted PreToolUse payload.
+
+    The hook only PARSES the command string -- nothing here is ever executed by
+    a shell, which is why a `rm -rf <vault>` case is safe to assert on.
+    """
+    payload = json.dumps({"tool_name": "Bash", "cwd": cwd,
+                          "tool_input": {"command": command}})
+    base = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": os.environ.get("HOME", "/tmp"),
+        # Deliberately NOT the fixture vault: per-target detection must win.
+        "VAULT_ROOT": os.path.join(tempfile.gettempdir(), "vcn-not-a-vault"),
+        "SYSTEMROOT": os.environ.get("SYSTEMROOT", ""),   # git needs it on Windows
+    }
+    if env:
+        base.update(env)
+    # encoding pinned, not left to the locale: a vault path can carry non-ASCII
+    # folder names, and on a non-UTF-8 console the default decode would raise
+    # for a reason unrelated to the hook. Enforced repo-wide by
+    # scripts/check-utf8-subprocess.py.
+    proc = subprocess.run([sys.executable, hook], input=payload,
+                          capture_output=True, text=True, encoding="utf-8",
+                          errors="replace", env=base, timeout=60)
+    return proc.returncode
+
+
+def check(want_block, label, command, cwd, hook=HOOK, env=None):
+    global PASS, FAIL
+    rc = run(command, cwd, hook=hook, env=env)
+    got_block = (rc == 2)
+    if got_block == want_block:
+        PASS += 1
+        print(f"PASS  {label} :: {'BLOCK' if got_block else 'allow'}")
+    else:
+        FAIL += 1
+        print(f"FAIL  {label} :: got rc={rc} "
+              f"({'BLOCK' if got_block else 'allow'}), "
+              f"wanted {'BLOCK' if want_block else 'allow'}")
+
+
+def git(*args, cwd):
+    subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True,
+                   encoding="utf-8", errors="replace", check=False)
+
+
+TMP = tempfile.mkdtemp(prefix="vcn-lead-")
+try:
+    # A vault: a Meta-suffixed folder makes vault_root_for() claim it.
+    VAULT = os.path.join(TMP, "brain")
+    os.makedirs(os.path.join(VAULT, "Meta", "rules"))
+    os.makedirs(os.path.join(VAULT, "Journals"))
+    git("init", "-q", cwd=VAULT)
+
+    # A SECOND vault, to prove the rules are not pinned to one root.
+    VAULT2 = os.path.join(TMP, "other-brain")
+    os.makedirs(os.path.join(VAULT2, "Meta"))
+    git("init", "-q", cwd=VAULT2)
+
+    # A normal repo with NO Meta folder anywhere above it: the negative control
+    # that keeps every "does it block?" answer falsifiable.
+    PLAIN = os.path.join(TMP, "plain", "repo")
+    os.makedirs(PLAIN)
+    git("init", "-q", cwd=PLAIN)
+
+    print("--- git push: the command-recognition layer (all measured rc=0 before) ---")
+    check(True,  "01. bare `git push`            [POSITIVE CONTROL]", "git push", VAULT)
+    check(True,  "02. `env git push`", "env git push", VAULT)
+    check(True,  "03. `sudo git push`", "sudo git push", VAULT)
+    check(True,  "04. `command git push`", "command git push", VAULT)
+    check(True,  "05. absolute path to the binary", "/usr/bin/git push", VAULT)
+    check(True,  "06. one-shot assignment prefix", "FOO=bar git push", VAULT)
+    check(True,  "07. lowercase assignment prefix", "foo=bar git push", VAULT)
+    check(True,  "08. subshell `(git push)`", "(git push)", VAULT)
+    check(True,  "09. stacked wrapper + assignment", "sudo env A=1 git push", VAULT)
+
+    print("--- cwd resolution: a wrong guess used to point off the vault ---")
+    check(True,  "10. `$VAR` cd, never expanded before",
+          f'W={VAULT}; cd "$W" && git push', TMP)
+    check(True,  "11. `cd` inside a QUOTED string is not a cd",
+          'echo "hi; cd /tmp" && git push', VAULT)
+    check(True,  "12. `||` is not an unconditional cd",
+          "cd /nonexistent-xyz || git push", VAULT)
+    check(True,  "13. subshell cd does not escape its parens",
+          "(cd /tmp; true) && git push", VAULT)
+
+    print("--- unscoped git status ---")
+    check(True,  "14. `env git status`", "env git status", VAULT)
+    check(True,  "15. `command git status`", "command git status", VAULT)
+
+    print("--- rm -rf: _RM_LEAD covered wrappers but NOT these two ---")
+    check(True,  "16. assignment prefix on rm",
+          f'FOO=bar rm -rf "{VAULT}"', TMP)
+    check(True,  "17. absolute path to rm",
+          f'/bin/rm -rf "{VAULT}"', TMP)
+    check(True,  "18. vault ROOT, plain          [kept from previous rev]",
+          f'rm -rf "{VAULT}"', TMP)
+    check(True,  "19. top-level folder, absolute [kept]",
+          f'rm -rf "{VAULT}/Meta"', TMP)
+    check(True,  "20. a SECOND vault on the machine [kept]",
+          f'rm -rf "{VAULT2}"', TMP)
+    check(True,  "21. sudo rm -rf vault root     [kept]",
+          f'sudo rm -rf "{VAULT}"', TMP)
+    check(True,  "22. relative target from a vault cwd",
+          "rm -rf Meta", VAULT)
+    check(True,  "23. flags AFTER the operand    [kept]",
+          f'rm "{VAULT}/Meta" -rf', TMP)
+
+    print("--- grep / find namespace rules ---")
+    check(True,  "24. `env grep`", "env grep -r foo .", VAULT)
+    check(True,  "25. `sudo find -name`", 'sudo find . -name "*.md"', VAULT)
+
+    print("--- ALLOW legs: a hook that blocked everything would fail here ---")
+    check(False, "26. push from a NON-vault repo [NEGATIVE CONTROL]",
+          "git push", PLAIN)
+    check(False, "27. `env git push` outside any vault", "env git push", PLAIN)
+    check(False, "28. scoped `git status -- <path>`",
+          'git status -- "Meta/"', VAULT)
+    check(False, "29. rm DEEPER than a top-level folder",
+          f'rm -rf "{VAULT}/Meta/rules/foo.md"', TMP)
+    check(False, "30. `cd <non-vault> && git push` from a vault cwd",
+          f'cd "{PLAIN}" && git push', VAULT)
+    check(False, "31. grep entirely outside any vault", "grep -r foo .", PLAIN)
+    check(False, "32. a push MENTIONED in a comment tail",
+          'git status -- "Meta/" # git push', VAULT)
+    check(False, "33. a push quoted as an ARGUMENT, not run",
+          'echo "later; git push"', PLAIN)
+    check(False, "34. documented inline bypass works",
+          "VAULT_VALIDATOR_BYPASS=1 git push", VAULT)
+    check(False, "35. exported bypass disarms the guard",
+          "git push", VAULT, env={"VAULT_VALIDATOR_BYPASS": "1"})
+
+    print("--- heredoc: a BODY is data, never a command ---")
+    check(False, "36. `git push` inside a heredoc body",
+          'cat > notes.md <<\'BODY\'\ngit push\nBODY\n', PLAIN)
+    check(True,  "37. a REAL push after a heredoc closes",
+          'cat > notes.md <<\'BODY\'\nhello\nBODY\ngit push\n', VAULT)
+
+    print("--- degraded mode: _lib missing must FAIL CLOSED, not fail open ---")
+    # The whole point of the fail-closed policy: if the shared parser cannot be
+    # imported, the guard must still stop a vault push rather than wave it
+    # through. Proven by running a COPY with shell_parse.py removed.
+    degraded = os.path.join(TMP, "degraded")
+    shutil.copytree(os.path.dirname(HOOK), degraded,
+                    ignore=shutil.ignore_patterns("__pycache__", "*.pyc"))
+    os.remove(os.path.join(degraded, "_lib", "shell_parse.py"))
+    dhook = os.path.join(degraded, "vault-command-nudges.py")
+    check(True,  "38. degraded parse still blocks a vault push",
+          "git push", VAULT, hook=dhook)
+    check(False, "39. degraded parse still allows a non-vault push",
+          "git push", PLAIN, hook=dhook)
+finally:
+    shutil.rmtree(TMP, ignore_errors=True)
+
+print()
+print(f"=== summary: {PASS} passed, {FAIL} failed ===")
+sys.exit(1 if FAIL else 0)

--- a/hooks/test_vault_command_nudges_lead.py
+++ b/hooks/test_vault_command_nudges_lead.py
@@ -49,9 +49,15 @@ def run(command, cwd, hook=HOOK, env=None):
     """
     payload = json.dumps({"tool_name": "Bash", "cwd": cwd,
                           "tool_input": {"command": command}})
+    # USERPROFILE is set alongside HOME, never instead of it: Path.home() reads
+    # USERPROFILE on Windows, so a HOME-only redirect silently runs the child
+    # against the REAL ~/.claude there while looking sandboxed on POSIX.
+    # scripts/ enforces this pairing fleet-wide.
+    home = os.environ.get("HOME") or os.environ.get("USERPROFILE") or tempfile.gettempdir()
     base = {
         "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
-        "HOME": os.environ.get("HOME", "/tmp"),
+        "HOME": home,
+        "USERPROFILE": home,
         # Deliberately NOT the fixture vault: per-target detection must win.
         "VAULT_ROOT": os.path.join(tempfile.gettempdir(), "vcn-not-a-vault"),
         "SYSTEMROOT": os.environ.get("SYSTEMROOT", ""),   # git needs it on Windows

--- a/hooks/test_vault_command_nudges_lead.py
+++ b/hooks/test_vault_command_nudges_lead.py
@@ -116,6 +116,15 @@ try:
     check(True,  "07. lowercase assignment prefix", "foo=bar git push", VAULT)
     check(True,  "08. subshell `(git push)`", "(git push)", VAULT)
     check(True,  "09. stacked wrapper + assignment", "sudo env A=1 git push", VAULT)
+    # 09a/09b were LOST when _LEAD first replaced the previous rm-only prefix:
+    # a wrapper could no longer carry its own flag+value, and a brace group --
+    # which runs in the CURRENT shell, unlike a subshell -- stopped being seen
+    # at all. tests/integration/test_rm_rf_vault_target.sh caught both on the
+    # rm rule; they are pinned here for the git rules too.
+    check(True,  "09a. wrapper carrying its own flag+value",
+          "sudo -u root git push", VAULT)
+    check(True,  "09b. brace group is not a free pass",
+          "{ git push; }", VAULT)
 
     print("--- cwd resolution: a wrong guess used to point off the vault ---")
     check(True,  "10. `$VAR` cd, never expanded before",
@@ -136,6 +145,10 @@ try:
           f'FOO=bar rm -rf "{VAULT}"', TMP)
     check(True,  "17. absolute path to rm",
           f'/bin/rm -rf "{VAULT}"', TMP)
+    check(True,  "17a. wrapper flag+value on rm (sudo -u root rm)",
+          f'sudo -u root rm -rf "{VAULT}"', TMP)
+    check(True,  "17b. brace group around rm",
+          f'{{ rm -rf "{VAULT}"; }}', TMP)
     check(True,  "18. vault ROOT, plain          [kept from previous rev]",
           f'rm -rf "{VAULT}"', TMP)
     check(True,  "19. top-level folder, absolute [kept]",

--- a/hooks/test_vault_command_nudges_lead.py
+++ b/hooks/test_vault_command_nudges_lead.py
@@ -184,9 +184,18 @@ try:
     # imported, the guard must still stop a vault push rather than wave it
     # through. Proven by running a COPY with shell_parse.py removed.
     degraded = os.path.join(TMP, "degraded")
-    shutil.copytree(os.path.dirname(HOOK), degraded,
-                    ignore=shutil.ignore_patterns("__pycache__", "*.pyc"))
-    os.remove(os.path.join(degraded, "_lib", "shell_parse.py"))
+    os.makedirs(os.path.join(degraded, "_lib"))
+    hooks_dir = os.path.dirname(HOOK)
+    # Copied file-by-file, NOT with shutil.copytree. copytree owns its own
+    # recursion and opens file content internally, which
+    # scripts/check-cloud-safe-file-walkers.py flags fleet-wide unless the call
+    # surface reaches the shared safe_read primitive. Naming the three files the
+    # hook actually needs is also the more precise fixture: it proves
+    # shell_parse.py is the ONLY thing absent, rather than copying the whole
+    # directory and deleting one entry back out of it.
+    for rel in ("vault-command-nudges.py", "_lib/__init__.py", "_lib/vault_root.py"):
+        parts = rel.split("/")
+        shutil.copy2(os.path.join(hooks_dir, *parts), os.path.join(degraded, *parts))
     dhook = os.path.join(degraded, "vault-command-nudges.py")
     check(True,  "38. degraded parse still blocks a vault push",
           "git push", VAULT, hook=dhook)

--- a/hooks/vault-command-nudges.py
+++ b/hooks/vault-command-nudges.py
@@ -354,7 +354,23 @@ def _cwd_candidates(segs, base: str):
 # that did not.
 _ASSIGN_TOK = r'[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|\'[^\']*\'|\S*)'
 _WRAPPER_TOK = r'(?:env|command|exec|builtin|nohup|sudo|time)'
-_LEAD = r'\s*(?:(?:' + _ASSIGN_TOK + r'|' + _WRAPPER_TOK + r')\s+)*(?:\S*/)?'
+# A brace group opens a command without being a subshell: `{ rm -rf <vault>; }`
+# runs in the CURRENT shell. The splitter separates on `(` and `)` but not on
+# `{`, so a brace group arrives as a segment that literally starts with `{ `,
+# and the verb sits behind it. `(` is accepted here too for the spellings the
+# splitter cannot reach. Both require trailing whitespace, which is exactly when
+# a shell treats `{` as the reserved word rather than as brace expansion or the
+# `{` of `${VAR}`.
+_GROUP_OPEN = r'(?:[({]\s+)*'
+# A wrapper may carry its OWN options, including a flag whose value is a
+# SEPARATE argument (`sudo -u root rm`). Bounded at three tokens and reachable
+# only AFTER a literal wrapper word, so this cannot degrade into "any command
+# containing the verb" — `git commit -m "rm -rf x"` never enters this branch,
+# which matters because the operands of a false match would then be resolved
+# against a vault cwd.
+_LEAD = (r'\s*' + _GROUP_OPEN +
+         r'(?:' + _ASSIGN_TOK + r'\s+|' + _WRAPPER_TOK + r'\s+(?:\S+\s+){0,3})*'
+         r'(?:\S*/)?')
 
 # ---------------------------------------------------------------------------
 # rm -rf targeting (target-scoped)

--- a/hooks/vault-command-nudges.py
+++ b/hooks/vault-command-nudges.py
@@ -66,8 +66,30 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 try:
     from _lib.vault_root import vault_root_for  # noqa: E402
-except Exception:  # fail-open: never block a command on an import error
+except Exception:
+    # DEGRADE, never disarm. This fallback used to `return None`, and None here
+    # means "no vault anywhere" -- which silently switched off EVERY vault-scoped
+    # rule in this file, including `rm -rf <vault>`. Measured: with _lib absent
+    # the guard allowed `git push` in the vault, `git status`, and an rm against
+    # the vault root. The FAIL-CLOSED comment below applies to _LIB_OK only, and
+    # this import fails first, so it decided the outcome.
+    #
+    # A partial install is the realistic cause (two installers write ~/.claude/
+    # hooks/_lib, and a client machine gets whichever landed), which is exactly
+    # when a guard must still hold. Name-free by construction: a vault is any
+    # ancestor holding a Meta-suffixed folder -- the same rule
+    # validate-handoff-frontmatter.py already applies in this repo.
     def vault_root_for(target: Path):  # type: ignore
+        try:
+            here = Path(target).resolve()
+        except (OSError, RuntimeError):
+            return None
+        for cand in (here, *here.parents):
+            try:
+                if any(c.is_dir() and c.name.endswith("Meta") for c in cand.iterdir()):
+                    return cand
+            except (OSError, PermissionError):
+                continue
         return None
 
 # The quote-aware splitter, the `$VAR` expander, the heredoc-body stripper and

--- a/hooks/vault-command-nudges.py
+++ b/hooks/vault-command-nudges.py
@@ -5,21 +5,21 @@ PreToolUse Bash hook: vault-wide command nudges + blocks.
 Adapted from anthropics/claude-code examples/hooks/bash_command_validator_example.py.
 
 Enforces CLAUDE.md rules that were codified but not hook-blocked:
-- Blocks `git push` against the personal vault repo (no remote configured)
-- Blocks unscoped `git status` against the vault repo (60K-file walk)
+- Blocks `git push` against a local-only vault repo (no remote configured)
+- Blocks unscoped `git status` against a vault repo (full-tree walk)
 - Blocks `rm -rf` against a vault root or any of its top-level folders
 - Nudges `grep` -> Grep tool / rg, `find -name` -> Glob tool
 
 Three scoping models, tagged per rule:
 
 - repo-scoped (git push / git status): fire ONLY when the git op targets
-  the personal vault repo itself, or a worktree of it. Repo identity is
-  resolved via `git rev-parse --git-common-dir`, NOT a path-string
-  prefix. A prefix mis-fires on `🍄 the user's consulting brand/`, a symlink that lives
-  inside the vault namespace but points at ~/dev/mycelium-vault -- a
-  separate repo that HAS a GitHub remote and is a normal size. Targeting
-  follows `git -C <dir>` and an explicit `git --git-dir <dir>`; the
-  value-taking options (`-C`, `-c`, `--git-dir`, `--work-tree`,
+  a vault repo itself, or a worktree of it. Repo identity is resolved via
+  `git rev-parse --git-common-dir`, NOT a path-string prefix. A prefix
+  mis-fires on a symlinked folder that LIVES inside the vault namespace
+  but POINTS AT a separate repo -- one that has a remote and is a normal
+  size, so pushing from it is fine and blocking it is a false positive.
+  Targeting follows `git -C <dir>` and an explicit `git --git-dir <dir>`;
+  the value-taking options (`-C`, `-c`, `--git-dir`, `--work-tree`,
   `--namespace`) are matched WITH their separate-argument value, so a
   subcommand cannot hide behind the value or a quoted value's space.
 
@@ -29,22 +29,39 @@ Three scoping models, tagged per rule:
   not git, so these keep the path-prefix gate.
 
 - target-scoped (rm -rf): parse the rm's OPERANDS, resolve each one
-  against the effective cwd, and fire only when a resolved target IS a
+  against every candidate cwd, and fire only when a resolved target IS a
   vault root or a direct child of one. See _rm_verdicts.
 
-Escape hatch: prefix the command with VAULT_VALIDATOR_BYPASS=1.
+WHAT THE GUARD CAN SEE comes first (every scoping model above is downstream
+of it). Rules are matched PER SEGMENT against a quote-aware split, and each
+segment is read through `_LEAD`, which absorbs transparent wrappers, one-shot
+`VAR=` assignments and an explicit path to the binary. Matching a bare `git` /
+`rm` token at a regex-alternation boundary instead let all of these run
+completely unguarded, which no amount of correct cwd reasoning downstream can
+recover:
+
+    env git push        sudo git push        /usr/bin/git push
+    FOO=bar git push    command git status   (git push)
+    FOO=bar rm -rf <vault root>              /bin/rm -rf <vault root>
+
+Escape hatch: prefix the command with VAULT_VALIDATOR_BYPASS=1, or export it
+for the session. The inline form is scoped to the command it prefixes, not to
+the whole line.
 """
-# MYC-3529: REQUIRED, not cosmetic. This module annotates with PEP-604
-# `X | None`, which is evaluated at def-time and is a TypeError on Python
-# 3.9 -- the floor version scripts/ci.sh's gate actually runs. py_compile
-# does NOT catch it (the annotation compiles fine and only blows up when
-# the def executes), so the import crash is invisible to the lint gates and
-# shows up only as a hook that silently does nothing.
+# REQUIRED, not cosmetic. This module annotates with PEP-604 `X | None`, which
+# is evaluated at def-time and is a TypeError on Python 3.9 -- the floor version
+# the lint gate actually runs. py_compile does NOT catch it (the annotation
+# compiles fine and only blows up when the def executes), so the import crash is
+# invisible to the lint gates and shows up only as a hook that silently does
+# nothing.
 from __future__ import annotations
 
+import json
 import os
+import re
+import subprocess
+import sys
 from pathlib import Path
-import json, sys, re, os, subprocess
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 try:
@@ -53,17 +70,57 @@ except Exception:  # fail-open: never block a command on an import error
     def vault_root_for(target: Path):  # type: ignore
         return None
 
-# MYC-3529 — every vault root used below is resolved PER TARGET. The module
-# used to bind
+# The quote-aware splitter, the `$VAR` expander, the heredoc-body stripper and
+# the comment stripper are CANONICAL in _lib.shell_parse. This guard used to
+# hand-roll its own `cd` walk and inherited every fail-open that copy had.
+# Shared primitive, per-caller policy: the primitives come from _lib, the
+# fail-closed candidate-set POLICY below is this guard's own.
+try:
+    from _lib.shell_parse import (  # noqa: E402
+        ASSIGN_RE,
+        WRAPPER_PREFIXES,
+        expand_vars,
+        segment_bypass_flags,
+        split_segments_with_seps,
+        strip_heredoc_bodies,
+        strip_noncode,
+        tokens as shell_tokens,
+    )
+    _LIB_OK = True
+except Exception:
+    # FAIL CLOSED. Other consumers of these helpers fail OPEN on a missing _lib
+    # because their job is to let commands through; this guard's job is to STOP
+    # a push to a local-only repo and an rm against a vault, so a degraded parse
+    # must keep the session cwd as the only candidate -- which still blocks the
+    # common case and, at worst, over-blocks a cross-repo one (visible and
+    # bypassable) instead of silently letting a vault push through (invisible).
+    _LIB_OK = False
+
+# Scrub the git-LOCATION / index / object / namespace / discovery env family (+
+# CDPATH) from the env handed to this hook's git subprocesses. git honors
+# GIT_DIR / GIT_WORK_TREE / etc. OVER `git -C <path>` and `cd`, so a leaked one
+# (a git-hook context exports GIT_DIR; a concurrent worktree session can leak
+# one in) would make this hook resolve a DIFFERENT repo than the one it was
+# asked about -- deciding against the wrong worktree.
+_GIT_CLEAN_ENV = {
+    k: v for k, v in os.environ.items()
+    if k not in {
+        "GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_NAMESPACE", "GIT_CEILING_DIRECTORIES",
+        "GIT_DISCOVERY_ACROSS_FILESYSTEM", "GIT_PREFIX", "CDPATH",
+    }
+}
+
+# Every vault root used below is resolved PER TARGET. The module used to bind
 #     VAULT = os.environ.get("VAULT_ROOT", str(Path.home() / "vault"))
 #     VAULT_GIT_DIR = os.path.realpath(os.path.join(VAULT, ".git"))
-# once, at import. That is the #375/#404 shape, and BOTH scoping models here
-# inherited it. UNSET, every rule compared against `~/vault`, which exists on
-# almost no install: `git push`/`git status` in the vault were never blocked,
-# and `rm -rf` against a top-level vault folder was never blocked either — a
-# destructive-command guard that was inert and silent about it. SET, all five
-# rules protected exactly ONE vault while every other vault on the machine was
-# unguarded.
+# once, at import, and BOTH scoping models inherited it. UNSET, every rule
+# compared against `~/vault`, which exists on almost no install: `git push` /
+# `git status` in the vault were never blocked, and `rm -rf` against a
+# top-level vault folder was never blocked either -- a destructive-command
+# guard that was inert and silent about it. SET, all five rules protected
+# exactly ONE vault while every other vault on the machine was unguarded.
 
 # Cap on how many absolute path tokens a single command may be probed for.
 # Namespace scoping has to consider paths NAMED in the command (`cd /tmp &&
@@ -75,13 +132,14 @@ _ABS_PATH_TOKEN_RE = re.compile(
     r'"([^"]{2,})"' r"|'([^']{2,})'" r'|((?:~|/|[A-Za-z]:[\\/])[^\s;|&]+)'
 )
 
+_GLOB_CHARS = set("*?[")
+
 
 def _vault_git_dir_for(target: str) -> str | None:
     """realpath of the `.git` of the vault governing `target`, or None.
 
     None = no vault governs this path; the caller must fail open (allow), which
-    is what keeps every ~/dev/* repo and non-vault repo passing straight
-    through.
+    is what keeps every non-vault repo passing straight through.
     """
     try:
         root = vault_root_for(Path(target) if target else Path.cwd())
@@ -90,39 +148,6 @@ def _vault_git_dir_for(target: str) -> str | None:
     if root is None:
         return None
     return os.path.realpath(os.path.join(str(root), ".git"))
-
-
-def _in_vault_namespace(command: str, cwd: str) -> bool:
-    """True iff this command touches SOME vault's path namespace.
-
-    Namespace-scoped rules (rm -rf / grep / find) are about the filesystem
-    tree, not git identity, so the question is "is a vault path involved" —
-    for ANY vault, not just the one $VAULT_ROOT happens to name. Two signals,
-    matching the pre-MYC-3529 intent:
-      - the effective cwd sits inside a vault, or
-      - the command NAMES a path that sits inside a vault (so
-        `cd /tmp && rm -rf "<abs vault path>"` is still caught).
-    """
-    if cwd:
-        root = vault_root_for(Path(cwd))
-        if root is not None and _is_under(cwd, root):
-            return True
-
-    seen: set[str] = set()
-    for m in _ABS_PATH_TOKEN_RE.finditer(command):
-        raw = next((g for g in m.groups() if g is not None), None)
-        if raw is None:
-            continue
-        token = os.path.expanduser(raw.strip())
-        if not os.path.isabs(token) or token in seen:
-            continue
-        seen.add(token)
-        if len(seen) > _MAX_PATH_TOKENS:
-            break
-        root = vault_root_for(Path(token))
-        if root is not None and _is_under(token, root):
-            return True
-    return False
 
 
 def _is_under(path: str, root: Path) -> bool:
@@ -134,15 +159,13 @@ def _is_under(path: str, root: Path) -> bool:
     reached through a symlinked ANCESTOR -- `/var` -> `/private/var`, which is
     macOS's default TMPDIR -- therefore failed on spelling alone, and every
     namespace-scoped rule (grep, find) silently un-scoped itself: no match, no
-    message, exit 0. The rm rule was unaffected because it goes through
-    _same_dir, which already carries this pair; this function was the half of
-    the fix that never landed.
+    message, exit 0.
 
     The lexical pair is tried FIRST and still carries the deliberate
-    unresolved-operand behaviour _resolve_operand documents (`<vault>/🍄 brand`
-    is a symlink out of the vault, and deleting through it still destroys the
-    vault's own top-level entry). realpath only ever ADDS a match, so nothing
-    that matched before can stop matching.
+    unresolved-operand behaviour _resolve_operand documents (a top-level vault
+    entry can be a symlink OUT of the vault, and deleting through it still
+    destroys the vault's own entry). realpath only ever ADDS a match, so
+    nothing that matched before can stop matching.
 
     No existence requirement either way -- `rm -rf <vault>/x` must be caught
     before x exists, and realpath leaves a missing tail untouched.
@@ -162,76 +185,217 @@ def _is_under(path: str, root: Path) -> bool:
     return False
 
 
-def _effective_cwd(command: str, initial: str) -> str:
-    """Resolve cwd after any leading `cd <path>` commands in the command string."""
-    cwd = os.path.expanduser(initial) if initial else ""
-    for chunk in re.split(r"\s*(?:&&|\|\||;)\s*", command):
-        chunk = chunk.strip()
-        m = re.match(r"cd\s+(?:\"([^\"]+)\"|'([^']+)'|(\S+))", chunk)
-        if m:
-            new_path = os.path.expanduser(next(g for g in m.groups() if g is not None))
-            cwd = new_path if os.path.isabs(new_path) else os.path.normpath(os.path.join(cwd, new_path))
-    return cwd
+def _seg_in_vault_namespace(seg: str, bases) -> bool:
+    """True iff THIS segment touches SOME vault's path namespace.
 
+    Namespace-scoped rules (grep / find) are about the filesystem tree, not git
+    identity, so the question is "is a vault path involved" -- for ANY vault,
+    not just one a `$VAULT_ROOT` happens to name. Two signals:
+      - a candidate cwd sits inside a vault, or
+      - THIS segment NAMES a path that sits inside a vault (so
+        `cd /tmp && grep -r x "<abs vault path>"` is still caught).
+
+    Scoped to the SEGMENT, not the whole command: a vault path sitting in an
+    unrelated argument elsewhere in the line used to nudge on a grep that never
+    touched the vault.
+    """
+    for b in bases:
+        if not b:
+            continue
+        root = vault_root_for(Path(b))
+        if root is not None and _is_under(b, root):
+            return True
+
+    seen: set[str] = set()
+    for m in _ABS_PATH_TOKEN_RE.finditer(seg):
+        raw = next((g for g in m.groups() if g is not None), None)
+        if raw is None:
+            continue
+        token = os.path.expanduser(raw.strip())
+        if not os.path.isabs(token) or token in seen:
+            continue
+        seen.add(token)
+        if len(seen) > _MAX_PATH_TOKENS:
+            break
+        root = vault_root_for(Path(token))
+        if root is not None and _is_under(token, root):
+            return True
+    return False
+
+
+def _cd_operand(rest):
+    """The single directory operand of a `cd`, or None when it is unresolvable.
+
+    None means "this cd may have gone somewhere I cannot name", which callers
+    must treat as AMBIGUOUS (keep the previous cwd in play), never as "no cd
+    happened". `cd -` (OLDPWD) and a multi-operand `cd` land here on purpose.
+    """
+    if "-" in rest[1:]:
+        # `cd -` goes to OLDPWD, which this process cannot know. It must be
+        # UNRESOLVABLE; the option filter below would otherwise discard the "-"
+        # as a flag and silently resolve the cd to HOME -- and if OLDPWD was the
+        # vault, that is a fail-open dressed as a confident answer.
+        return None
+    operands = [t for t in rest[1:] if not t.startswith("-")]
+    if not operands:
+        return os.path.expanduser("~")          # bare `cd` -> HOME
+    if len(operands) > 1:
+        return None
+    return operands[0]
+
+
+def _cwd_candidates(segs, base: str):
+    """Every cwd a command could actually run in, plus the literal `VAR=`
+    assignments seen along the way.
+
+    FAIL-CLOSED BY CONSTRUCTION. This returns a SET, not a single cwd, and the
+    caller blocks when ANY member is a vault. A single "effective cwd" forces a
+    guess at each ambiguity, and every wrong guess in the old walk pointed the
+    same way -- off the vault, i.e. open. Concretely, the old walk allowed all
+    of these vault pushes:
+
+        W=<vault>; cd "$W" && git push       -- `$W` never expanded
+        echo "hi; cd /tmp" && git push       -- `cd` cut out of a QUOTED string
+        cd /tmp || git push                  -- `||` treated as an unconditional cd
+
+    Ambiguity now UNIONS instead of overwriting, so the vault stays in the set
+    and the block stands. The cost is a possible over-block on a genuinely
+    ambiguous command, which is loud and bypassable; the old cost was a silent
+    allow on the one command the guard exists to stop.
+    """
+    base = os.path.expanduser(base) if base else ""
+    cur = {base} if base else set()
+    variables: dict[str, str] = {}
+    if not _LIB_OK:
+        return cur, variables
+
+    depth = 0
+    for idx, (sep, seg) in enumerate(segs):
+        # `(` and `)` arrive as separators, so paren depth is just a running
+        # count -- and it covers BOTH `( cd X ; ... )` and `$( cd X && ... )`,
+        # because a command substitution opens the same paren. A cd below the
+        # top level changes only the SUBSHELL's cwd and is invisible to the
+        # parent, so it must not move the candidate set. Tracking only the
+        # separator IMMEDIATELY after the cd was not enough: in
+        # `(cd /tmp; true) && git push` the cd is followed by `;`, so it looked
+        # top-level and escaped its own subshell.
+        if sep == "(":
+            depth += 1
+        elif sep == ")":
+            depth = max(0, depth - 1)
+        if depth > 0:
+            continue
+        toks = shell_tokens(seg.strip())
+        if not toks:
+            continue
+        k = 1 if toks[0] == "export" else 0
+        while k < len(toks) and ASSIGN_RE.match(toks[k]):
+            name, _, val = toks[k].partition("=")
+            variables[name] = expand_vars(val, variables)
+            k += 1
+        while k < len(toks) and toks[k] in WRAPPER_PREFIXES:
+            k += 1
+        rest = toks[k:]
+        if not rest or rest[0] != "cd":
+            continue
+
+        raw = _cd_operand(rest)
+        target = expand_vars(raw, variables) if raw else None
+        # An unexpanded `$`, a command substitution or a glob is a target we
+        # cannot name -- treat as unresolved rather than resolving it wrongly.
+        if target and ("$" in target or set(target) & _GLOB_CHARS):
+            target = None
+
+        if target is None:
+            moved: set[str] = set()            # unknown destination
+        else:
+            t = os.path.expanduser(target)
+            moved = ({t} if os.path.isabs(t)
+                     else {os.path.normpath(os.path.join(b, t)) for b in (cur or {""})})
+
+        # The operator JOINING this cd to what follows decides whether the cd is
+        # in effect for it. See split_segments_with_seps for the full table.
+        nxt = segs[idx + 1][0] if idx + 1 < len(segs) else ""
+        if not moved:
+            continue                           # destination unknown -> keep old cwd
+        if nxt == "&&":
+            # The right-hand side runs IF AND ONLY IF the cd succeeded, so where
+            # it runs is not in doubt. No existence check: an earlier segment may
+            # legitimately create the directory (`git worktree add W && cd W`).
+            cur = moved
+        elif nxt in (";", "\n", ""):
+            # `cd X ; cmd` runs cmd in X when the cd succeeds and in the OLD cwd
+            # when it fails. That is DECIDABLE, not a coin flip: a cd fails when
+            # the target is not a directory. Deciding it matters -- unioning
+            # unconditionally would keep the vault in the set for the everyday
+            # `cd /repo` + newline + `git push` shape and false-block every one
+            # of them, which is precisely what teaches the bypass.
+            if all(os.path.isdir(m) for m in moved):
+                cur = moved
+            else:
+                cur = cur | {m for m in moved if os.path.isdir(m)}
+        # "||", "|", "&", "(", ")" -> the next command runs in the OLD cwd:
+        # leave `cur` alone.
+    return cur, variables
+
+
+# ---------------------------------------------------------------------------
+# What may sit BETWEEN the start of a command and its verb without changing
+# which program actually runs: transparent wrappers, one-shot `VAR=value`
+# assignments, and an absolute/relative path to the binary.
+#
+# Without this the guard matched the bare token `git` / `rm`, so `/usr/bin/git
+# push`, `env git push`, `command git status` and `FOO=bar rm -rf <vault root>`
+# matched NO rule and ran unguarded. That is a hole in what the guard can SEE,
+# upstream of every scoping model below it.
+#
+# `_lib.shell_parse` already models wrappers this way (WRAPPER_PREFIXES) and
+# callers compare `os.path.basename(argv0)`; these regexes were the last place
+# that did not.
+_ASSIGN_TOK = r'[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|\'[^\']*\'|\S*)'
+_WRAPPER_TOK = r'(?:env|command|exec|builtin|nohup|sudo|time)'
+_LEAD = r'\s*(?:(?:' + _ASSIGN_TOK + r'|' + _WRAPPER_TOK + r')\s+)*(?:\S*/)?'
 
 # ---------------------------------------------------------------------------
 # rm -rf targeting (target-scoped)
 #
 # The rule this replaces pattern-matched FOLDER NAMES immediately after the
 # flags:
-#     ...rm\s+(?:-[A-Za-z]*[rRf][A-Za-z]*\s+)+"?(?:$HOME/vault|⚙️ Meta|...)
+#     ...rm\s+(?:-[A-Za-z]*[rRf][A-Za-z]*\s+)+"?(?:$HOME/vault|<emoji folder>|...)
 # Two independent defects, and the rule advertised in the docstring above was
 # never actually enforced:
 #
 #   1. `$HOME/vault` is a SHELL string sitting in a PYTHON regex. `$` is an
 #      end-of-line anchor, so that branch parses as "end of line, then the
 #      literal text HOME/vault" and cannot match any input, ever. The vault
-#      ROOT — the most destructive target of all — was never blocked.
-#   2. The four emoji branches are literal names anchored right after the
-#      flags, so they only fire on a bare relative `rm -rf "⚙️ Meta"`. An
-#      absolute `rm -rf "/Users/x/Brain/⚙️ Meta"` — the same deletion, spelled
-#      the way an agent actually spells it — sailed straight through.
+#      ROOT -- the most destructive target of all -- was never blocked.
+#   2. The emoji branches are literal names anchored right after the flags, so
+#      they only fire on a bare relative `rm -rf "<folder>"`. An absolute
+#      `rm -rf "/Users/x/Brain/<folder>"` -- the same deletion, spelled the way
+#      an agent actually spells it -- sailed straight through.
 #
 # Both are fixed by asking the filesystem instead of the string: parse the
-# rm's operands, resolve each against the effective cwd, and compare the
+# rm's operands, resolve each against the candidate cwds, and compare the
 # RESULT to the vault that governs it. Names stop mattering, so a vault whose
-# folders are not the four hardcoded ones is covered too, and depth stops
-# mattering, so every spelling of the same target behaves identically.
+# folders are not a hardcoded set is covered too, and depth stops mattering,
+# so every spelling of the same target behaves identically.
 _RM_FLAG = r'(?:--[A-Za-z][A-Za-z-]*|--|-[A-Za-z]+)'
 
-# Wrapper words that put a token in FRONT of `rm` without changing what the
-# command destroys. The predecessor rule required `rm` to be the first word
-# after a command separator, so `sudo rm -rf <vault>` — the single most likely
-# spelling of this mistake — did not match. `env` may also carry VAR=VAL args.
-_RM_WRAPPER = r'(?:sudo|env|time|nohup|command|exec|builtin)'
-# Up to three tokens may sit between a wrapper and `rm`, which covers a flag
-# whose value is a SEPARATE argument (`sudo -u root rm -rf ...`) and `env
-# FOO=bar`. Bounded, and reachable only AFTER a literal wrapper word, so this
-# cannot degrade into "any command containing the word rm" — `git commit -m "rm
-# -rf x"` never enters this branch, which matters because the operands of a
-# false match would be resolved against a vault cwd.
-_RM_LEAD = r'(?:' + _RM_WRAPPER + r'\s+(?:\S+\s+){0,3})*'
+# Operands run to the END of the segment: the quote-aware splitter has already
+# removed every unquoted separator, so a `;` still present here is INSIDE a
+# quoted operand and must not truncate it (`rm -rf "a;b"`).
 _RM_RE = re.compile(
-    # A command boundary — including `(` and `{`, so a subshell or brace group
-    # is not a free pass.
-    r'(?:^|&&|\|\|?|;(?!;)|\(|\{)'
-    r'\s*' + _RM_LEAD +                   # optional sudo/env/time/... wrappers
+    _LEAD +
     r'rm\s+'
     r'((?:' + _RM_FLAG + r'\s+)*)'        # 1: leading flag blob
-    r'([^;&|\n]*)',                       # 2: operands, to the end of the chunk
-    # REQUIRED, and it must match the flag main() passes when it prefilters with
-    # this same pattern. Without it `^` means "start of the string" here while
-    # meaning "start of any line" there, so a newline-separated
-    # `cd /tmp\nrm -rf <vault>` prefilters as a hit and then finds no targets to
-    # judge — the rule reports nothing and the command runs.
-    re.MULTILINE,
+    r'(.*)'                               # 2: operands, to the end of the segment
 )
 
 # One shell word: double-quoted, single-quoted, or bare. The bare arm accepts
-# a backslash-escaped space (`⚙️\ Meta`) as part of the word, because that is
-# the idiomatic unquoted spelling of these folder names. Every OTHER backslash
-# stays literal, so a Windows `C:\Users\x\Brain` is not mangled into an escape
-# sequence.
+# a backslash-escaped space (`My\ Folder`) as part of the word, because that is
+# the idiomatic unquoted spelling of a folder name with a space. Every OTHER
+# backslash stays literal, so a Windows `C:\Users\x\Brain` is not mangled into
+# an escape sequence.
 _RM_TOKEN_RE = re.compile(
     r'"([^"]*)"'
     r"|'([^']*)'"
@@ -242,10 +406,10 @@ _RM_TOKEN_RE = re.compile(
 def _is_destructive_rm(flag_blob: str, operand_text: str) -> bool:
     """True iff these rm flags can destroy a directory tree.
 
-    Keeps the predecessor's `[rRf]` reach (recursive OR force) rather than
-    narrowing to `-r`: a guard on the vault root should not be the place we
-    get clever about which flag combination happens to succeed. Flags are
-    read from BOTH sides of the operands, so `rm dir -rf` counts.
+    Keeps the `[rRf]` reach (recursive OR force) rather than narrowing to `-r`:
+    a guard on the vault root should not be the place we get clever about which
+    flag combination happens to succeed. Flags are read from BOTH sides of the
+    operands, so `rm dir -rf` counts.
     """
     for blob in (flag_blob, operand_text):
         for tok in re.findall(_RM_FLAG, blob):
@@ -257,7 +421,7 @@ def _is_destructive_rm(flag_blob: str, operand_text: str) -> bool:
     return False
 
 
-def _rm_operands(operand_text: str, flag_blob: str):
+def _rm_operands(operand_text: str):
     """Shell words in an rm's operand text that are TARGETS, not flags."""
     targets = []
     for m in _RM_TOKEN_RE.finditer(operand_text):
@@ -277,13 +441,13 @@ def _rm_operands(operand_text: str, flag_blob: str):
 def _resolve_operand(word: str, cwd: str) -> str:
     """An rm operand as an absolute path, WITHOUT resolving symlinks.
 
-    Lexical on purpose, matching _is_under: `<vault>/🍄 brand` is a symlink to
-    a separate repo, and `rm -rf` through it still destroys the vault's own
-    top-level entry. Resolving it first would retarget the check at the
+    Lexical on purpose, matching _is_under: a top-level vault entry can be a
+    symlink to a separate repo, and `rm -rf` through it still destroys the
+    vault's own entry. Resolving it first would retarget the check at the
     symlink's destination and lose exactly that case.
     """
     path = os.path.expanduser(word.strip())
-    # Trailing separators are cosmetic (`rm -rf "⚙️ Meta/"`); dirname would
+    # Trailing separators are cosmetic (`rm -rf "Meta/"`); dirname would
     # otherwise hand back the folder itself instead of its parent.
     stripped = path.rstrip("/\\")
     if stripped and not re.fullmatch(r'[A-Za-z]:', stripped):
@@ -314,16 +478,16 @@ def _same_dir(a: str, b) -> bool:
 def _rm_target_verdict(target: str):
     """'root' | 'top-level' | None for one resolved rm target.
 
-    The vault is resolved PER TARGET (MYC-3529), so this covers every vault on
-    the machine, not the one $VAULT_ROOT happens to name.
+    The vault is resolved PER TARGET, so this covers every vault on the
+    machine, not one a `$VAULT_ROOT` happens to name.
 
     The parent is probed SEPARATELY rather than by walking up from the target,
-    because vault_root_for() resolves symlinks: asking about `<vault>/🍄 brand`
-    directly answers for the repo that symlink points AT. Asking about its
-    parent answers about the vault whose top-level entry is being deleted.
+    because vault_root_for() resolves symlinks: asking about a top-level entry
+    that is itself a symlink answers for the repo it points AT. Asking about
+    its parent answers about the vault whose entry is being deleted.
 
-    Depth beyond a direct child is deliberately NOT blocked — `<vault>/⚙️
-    Meta/rules/foo.md` is the "explicit file paths" the message recommends.
+    Depth beyond a direct child is deliberately NOT blocked -- a file deep
+    inside a folder is the "explicit file paths" the message recommends.
     """
     root = vault_root_for(Path(target))
     if root is not None and _same_dir(target, root):
@@ -336,22 +500,35 @@ def _rm_target_verdict(target: str):
     return None
 
 
-def _rm_verdicts(command: str, cwd: str):
-    """Every (target, verdict) in `command` that a destructive rm would hit."""
+def _rm_verdicts(segs_text, bases):
+    """Every (target, verdict) a destructive rm in these segments would hit.
+
+    A RELATIVE operand is resolved against EVERY candidate cwd, for the same
+    fail-closed reason _cwd_candidates returns a set: if any cwd the command
+    could run in puts `rm -rf Meta` on a vault, that is the one that matters.
+    """
     found = []
     probed = 0
-    for m in _RM_RE.finditer(command):
+    seen = set()
+    for seg in segs_text:
+        m = _RM_RE.match(seg.lstrip())
+        if not m:
+            continue
         flag_blob, operand_text = m.group(1) or "", m.group(2) or ""
         if not _is_destructive_rm(flag_blob, operand_text):
             continue
-        for word in _rm_operands(operand_text, flag_blob):
-            probed += 1
-            if probed > _MAX_PATH_TOKENS:  # same stat-storm bound as above
-                return found
-            target = _resolve_operand(word, cwd)
-            verdict = _rm_target_verdict(target)
-            if verdict is not None:
-                found.append((target, verdict))
+        for word in _rm_operands(operand_text):
+            for base in (sorted(bases) or [""]):
+                probed += 1
+                if probed > _MAX_PATH_TOKENS:  # same stat-storm bound as above
+                    return found
+                target = _resolve_operand(word, base)
+                if target in seen:
+                    continue
+                seen.add(target)
+                verdict = _rm_target_verdict(target)
+                if verdict is not None:
+                    found.append((target, verdict))
     return found
 
 
@@ -361,7 +538,7 @@ def _rm_verdicts(command: str, cwd: str):
 #   _VAL_CFG -- one shell word honouring quotes: bare chars and quoted
 #               spans in any mix, so `-c name="value with spaces"` is ONE
 #               token (a bare `\S+` would stop at the space inside it).
-# (The vault folder name contains a space, so quoted forms matter.)
+# (A vault folder name can contain a space, so quoted forms matter.)
 _VAL_SP = r'(?:"[^"]*"' r"|'[^']*'" r'|\S+)'
 _VAL_EQ = r'(?:"[^"]*"' r"|'[^']*'" r'|\S*)'
 _VAL_CFG = r'(?:[^\s"\']' r'|"[^"]*"' r"|'[^']*')+"
@@ -388,10 +565,10 @@ _GIT_OPT = '|'.join([
     r'-[A-Za-z]\S*\s+',                      # any other short option (incl. -Cdir)
     r'--\S+\s+',                             # any other long option
 ])
-_GIT_OPTS_CAP = r'((?:' + _GIT_OPT + r')*)'   # capturing group: the whole options blob
+_GIT_OPTS_CAP = r'((?:' + _GIT_OPT + r')*)'   # capturing group: the options blob
 
 
-def _dash_c_target(opts_blob: str, base_cwd: str) -> str:
+def _dash_c_target(opts_blob: str, base_cwd: str, variables=None) -> str:
     """Fold any `git -C <dir>` options from a git options blob onto base_cwd,
     following git's cumulative -C semantics (each -C is relative to the
     previous one). Returns base_cwd unchanged when the blob has no -C."""
@@ -400,26 +577,36 @@ def _dash_c_target(opts_blob: str, base_cwd: str) -> str:
         raw = next((g for g in m.groups() if g is not None), None)
         if raw is None:
             continue
+        if _LIB_OK:
+            raw = expand_vars(raw, variables or {})
+        if "$" in raw:
+            # UNRESOLVED target (a var assigned outside this command, a command
+            # substitution). Folding it would join a literal `$W` onto the cwd
+            # and produce a path that resolves to no repo -- i.e. "not a vault",
+            # a silent allow. Ignoring it instead lets the cwd decide, which
+            # still blocks when that cwd IS a vault.
+            continue
         path = os.path.expanduser(raw)
         cwd = path if os.path.isabs(path) else os.path.normpath(os.path.join(cwd, path))
     return cwd
 
 
 def _targets_vault_repo(cwd: str) -> bool:
-    """True iff a git op run from `cwd` would touch the personal vault repo:
-    the main repo, or any worktree of it. Resolves the repo by identity, via
+    """True iff a git op run from `cwd` would touch a vault repo: the main
+    repo, or any worktree of it. Resolves the repo by identity, via
     `git rev-parse --git-common-dir`, so a separate repo reached through a
-    vault-namespace symlink (e.g. ~/dev/mycelium-vault) returns False.
-    Fails open (False) when the repo cannot be determined."""
+    vault-namespace symlink returns False. Fails open (False) when the repo
+    cannot be determined."""
     try:
         out = subprocess.run(
             ["git", "-C", cwd, "rev-parse", "--git-common-dir"],
             # encoding pinned, not left to the locale: this prints a PATH, and
-            # a vault path carries "⚙️ Meta" (U+FE0F, byte 0x8F unmapped in
-            # cp1252). text=True alone would raise UnicodeDecodeError inside
-            # subprocess.run on a non-UTF-8 console, before we see a byte.
+            # a vault path can carry an emoji folder name (U+FE0F, byte 0x8F
+            # unmapped in cp1252). text=True alone would raise
+            # UnicodeDecodeError inside subprocess.run on a non-UTF-8 console,
+            # before we see a byte.
             capture_output=True, text=True, encoding="utf-8", errors="replace",
-            timeout=5,
+            timeout=5, env=_GIT_CLEAN_ENV,
         )
     except Exception:
         return False
@@ -447,20 +634,21 @@ def _git_dir_arg(opts_blob: str):
 
 
 def _git_dir_is_vault(git_dir: str) -> bool:
-    """True iff an explicit --git-dir points at the personal vault repo --
-    its main .git, or a worktree gitdir whose common dir is the vault's.
-    Resolves via `git --git-dir=<x> rev-parse --git-common-dir`; falls
-    back to a realpath compare of the git dir itself."""
+    """True iff an explicit --git-dir points at a vault repo -- its main .git,
+    or a worktree gitdir whose common dir is the vault's. Resolves via
+    `git --git-dir=<x> rev-parse --git-common-dir`; falls back to a realpath
+    compare of the git dir itself."""
     git_dir = os.path.expanduser(git_dir)
     cands = [git_dir]
     try:
         out = subprocess.run(
             ["git", "--git-dir", git_dir, "rev-parse", "--git-common-dir"],
             # encoding pinned for the same reason as _targets_vault_repo above:
-            # the child prints a path, and vault paths carry non-cp1252 bytes.
+            # the child prints a path, and vault paths can carry non-cp1252 bytes.
             capture_output=True, text=True, encoding="utf-8", errors="replace",
             timeout=5,
             cwd=git_dir if os.path.isdir(git_dir) else None,
+            env=_GIT_CLEAN_ENV,
         )
         if out.returncode == 0 and out.stdout.strip():
             cands.append(os.path.join(git_dir, out.stdout.strip()))
@@ -472,13 +660,17 @@ def _git_dir_is_vault(git_dir: str) -> bool:
     return any(os.path.realpath(c) == vault_git_dir for c in cands)
 
 
-def _targets_vault(opts_blob: str, base_cwd: str) -> bool:
+def _targets_vault(opts_blob: str, base_cwd: str, variables=None) -> bool:
     """True iff a git invocation carrying this options blob, run from
-    base_cwd, would touch the personal vault repo. An explicit --git-dir
-    is authoritative; otherwise targeting follows -C / cwd. Fails open
-    (False) when the repo cannot be determined."""
-    eff_cwd = _dash_c_target(opts_blob, base_cwd)
+    base_cwd, would touch a vault repo. An explicit --git-dir is
+    authoritative; otherwise targeting follows -C / cwd. Fails open (False)
+    when the repo cannot be determined."""
+    eff_cwd = _dash_c_target(opts_blob, base_cwd, variables)
     git_dir = _git_dir_arg(opts_blob)
+    if _LIB_OK and git_dir is not None:
+        git_dir = expand_vars(git_dir, variables or {})
+        if "$" in git_dir:
+            git_dir = None      # unresolved -> let the cwd decide (see _dash_c_target)
     if git_dir is not None:
         path = os.path.expanduser(git_dir)
         if not os.path.isabs(path):
@@ -489,18 +681,26 @@ def _targets_vault(opts_blob: str, base_cwd: str) -> bool:
 
 # (regex, severity, message, scope).
 #   severity 'block' -> exit 2 ; 'nudge' -> exit 2 with softer wording.
-#   scope 'repo'      -> fire only when the op targets the vault repo. The
+#   scope 'repo'      -> fire only when the op targets a vault repo. The
 #                        regex captures the git options blob as group 1 so
 #                        targeting can follow any `git -C <dir>`.
-#   scope 'namespace' -> fire whenever the command is in the vault namespace.
+#   scope 'namespace' -> fire whenever the segment is in a vault namespace.
 #   scope 'rm-target' -> fire only when a parsed rm target resolves to a vault
 #                        root or a direct child of one. The regex is a cheap
 #                        prefilter; _rm_verdicts is what actually decides.
+#
+# Every pattern starts at `_LEAD`, and is matched with re.match against ONE
+# segment of the quote-aware split. "Is this a command start?" is therefore
+# answered structurally instead of by a regex alternation over operators, which
+# removes a whole class of phantom matches the old `(?:^|&&|...)` prefix could
+# not distinguish: `echo "later; git push"`, `git commit -m "notes; git push"`
+# and a `git push` sitting in a heredoc BODY all matched it and hard-blocked --
+# the exact false-block shape that teaches people to reach for the bypass.
 SCOPE_REPO, SCOPE_NAMESPACE, SCOPE_RM_TARGET = 'repo', 'namespace', 'rm-target'
 
 RULES = [
     (
-        r'(?:^|&&|\|\|?|;(?!;))\s*git\s+' + _GIT_OPTS_CAP + r'push\b',
+        _LEAD + r'git\s+' + _GIT_OPTS_CAP + r'push\b',
         'block',
         "git push in the vault: no remote is configured. This is a local-only snapshot repo. "
         "If you truly need to push, set up a remote first and confirm with the user. "
@@ -508,10 +708,10 @@ RULES = [
         SCOPE_REPO,
     ),
     (
-        r'(?:^|&&|\|\|?|;(?!;))\s*git\s+' + _GIT_OPTS_CAP + r'status\s*(?:$|&&|;|\|)',
+        _LEAD + r'git\s+' + _GIT_OPTS_CAP + r'status\s*$',
         'block',
-        "Unscoped `git status` in a 60K-file vault walks the full tree (~10min, locks .git/index.lock). "
-        "Pass explicit paths: git status -- \"⚙️ Meta/\" \"path/to/file.md\" "
+        "Unscoped `git status` in a large vault walks the full tree (slow, locks .git/index.lock). "
+        "Pass explicit paths: git status -- \"<folder>/\" \"path/to/file.md\" "
         "Or use `git status --short --untracked-files=no -- <path>`.",
         SCOPE_REPO,
     ),
@@ -523,14 +723,14 @@ RULES = [
         SCOPE_RM_TARGET,
     ),
     (
-        r'(?:^|&&|\|\|?|;(?!;)|\|)\s*grep\b(?!\s+--?version|\s+--?help)',
+        _LEAD + r'grep\b(?!\s+--?version|\s+--?help)',
         'nudge',
         "Prefer the Grep tool (or `rg`) over `grep` — faster, proper ignores, no full-tree walks. "
         "If you really need plain grep (e.g. piping fixed stdin), prefix with VAULT_VALIDATOR_BYPASS=1.",
         SCOPE_NAMESPACE,
     ),
     (
-        r'(?:^|&&|\|\|?|;(?!;)|\|)\s*find\s+\S+\s+-name\b',
+        _LEAD + r'find\s+\S+\s+-name\b',
         'nudge',
         "Prefer the Glob tool over `find -name` — faster and respects vault ignores. "
         "If you really need find, prefix with VAULT_VALIDATOR_BYPASS=1.",
@@ -552,59 +752,88 @@ def main():
     if not command:
         sys.exit(0)
 
-    if "VAULT_VALIDATOR_BYPASS=1" in command:
+    # A genuinely exported variable in this session disarms everything -- that
+    # is a deliberate, standing choice by the operator, not a token in a string.
+    if os.environ.get("VAULT_VALIDATOR_BYPASS") == "1":
         sys.exit(0)
 
-    cwd = os.environ.get("CLAUDE_CWD", data.get("cwd", ""))
-    cwd = _effective_cwd(command, cwd)
+    session_cwd = os.environ.get("CLAUDE_CWD", data.get("cwd", "")) or os.getcwd()
 
-    # Namespace-scoped rules fire when the command touches SOME vault's path
-    # namespace: cwd under a vault, or a vault path named in the command (so
-    # `cd /tmp && rm -rf <abs vault path>` is still caught). Computed lazily
-    # and once — every probe is a filesystem walk-up, and the overwhelming
-    # majority of Bash calls never match a namespace-scoped rule at all.
-    namespace_cache: list[bool] = []
+    # Match against CODE ONLY: heredoc bodies and comment tails are text the
+    # shell never runs, and every operator inside them is a fake boundary.
+    if _LIB_OK:
+        sanitized = strip_noncode(strip_heredoc_bodies(command))
+        segs = split_segments_with_seps(sanitized)
+    else:
+        segs = [("", command)]
+    seg_texts = [t for _, t in segs]
 
-    def in_vault_namespace() -> bool:
-        if not namespace_cache:
-            namespace_cache.append(_in_vault_namespace(command, cwd))
-        return namespace_cache[0]
+    # A SET of possible cwds, not one guess. Block if ANY member is a vault.
+    bases, variables = _cwd_candidates(segs, session_cwd)
+    if not bases:
+        bases = {os.path.expanduser(session_cwd)}
 
-    # Repo-scoped rules consult `git rev-parse` -- run it lazily, and
-    # cache by the captured git-options blob.
-    base = cwd or os.getcwd()
-    repo_cache = {}
+    # THE BYPASS IS SCOPED TO THE COMMAND IT PREFIXES, not to the whole line.
+    # Checking it once over the raw string meant a real assignment ANYWHERE
+    # disarmed every rule: `git push ; VAULT_VALIDATOR_BYPASS=1` allowed a vault
+    # push that had already run before the shell reached the token, and
+    # `git push && VAULT_VALIDATOR_BYPASS=1 <other cmd>` -- bypassing the guard
+    # for a DIFFERENT command in the chain -- silently un-gated the push too.
+    if _LIB_OK:
+        seg_bypass = segment_bypass_flags(seg_texts, "VAULT_VALIDATOR_BYPASS")
+    else:
+        seg_bypass = ["VAULT_VALIDATOR_BYPASS=1" in s for s in seg_texts]
+
+    # Repo-scoped rules consult `git rev-parse` -- run it lazily, and cache by
+    # the captured git-options blob.
+    repo_cache: dict[str, bool] = {}
 
     def opts_target_vault(opts_blob: str) -> bool:
         if opts_blob not in repo_cache:
-            repo_cache[opts_blob] = _targets_vault(opts_blob, base)
+            repo_cache[opts_blob] = any(
+                _targets_vault(opts_blob, b, variables) for b in sorted(bases)
+            )
         return repo_cache[opts_blob]
+
+    # Segments carrying the bypass are removed from consideration entirely --
+    # including from the rm target scan, which reads segments directly.
+    live = [s for i, s in enumerate(seg_texts) if not seg_bypass[i]]
 
     hits = []
     for pattern, severity, message, scope in RULES:
-        matches = list(re.finditer(pattern, command, re.MULTILINE))
-        if not matches:
-            continue
-        if scope == SCOPE_REPO:
-            fired = any(
-                opts_target_vault(m.group(1) or "")
-                for m in matches
-            )
-        elif scope == SCOPE_RM_TARGET:
-            # The regex only said "a destructive rm is in here somewhere".
-            # Naming the resolved targets is what makes the block actionable —
+        fired = False
+        detail = ""
+        if scope == SCOPE_RM_TARGET:
+            # The regex only says "a destructive rm is in here somewhere".
+            # Naming the resolved targets is what makes the block actionable --
             # and, when it is wrong, obviously wrong to the reader.
-            verdicts = _rm_verdicts(command, cwd)
+            verdicts = _rm_verdicts(live, bases)
             fired = bool(verdicts)
             if fired:
-                message += "\n  Target(s): " + "; ".join(
+                detail = "\n  Target(s): " + "; ".join(
                     f"{t} ({'vault root' if v == 'root' else 'top-level folder'})"
                     for t, v in verdicts
                 )
         else:
-            fired = in_vault_namespace()
+            for seg in live:
+                m = re.match(pattern, seg.lstrip())
+                if not m:
+                    continue
+                if scope == SCOPE_REPO:
+                    # Repo identity decides: block only when this git op really
+                    # targets a vault repo.
+                    if opts_target_vault(m.group(1) or ""):
+                        fired = True
+                else:
+                    # Namespace rules fire on a vault path in THIS segment --
+                    # the command actually being run -- not anywhere in the
+                    # whole string.
+                    if _seg_in_vault_namespace(seg, bases):
+                        fired = True
+                if fired:
+                    break
         if fired:
-            hits.append((severity, message))
+            hits.append((severity, message + detail))
 
     if hits:
         for severity, message in hits:
@@ -616,13 +845,13 @@ def main():
 
 
 if __name__ == "__main__":
-    # Windows cp1252-console safety (#313, MYC-3520). This hook's block messages
-    # quote the RESOLVED target back to the user, and a vault's top-level folders
-    # are emoji-prefixed ("⚙️ Meta"), so the crashing value arrives from the
-    # filesystem even on a machine whose command was pure ASCII. Without this,
-    # printing the reason raises UnicodeEncodeError and the block is reported as
-    # a hook error instead of a reason — on the one code path that only ever runs
-    # when live work is about to be deleted.
+    # Windows cp1252-console safety. This hook's block messages quote the
+    # RESOLVED target back to the user, and a vault's top-level folders can be
+    # emoji-prefixed, so the crashing value arrives from the filesystem even on
+    # a machine whose command was pure ASCII. Without this, printing the reason
+    # raises UnicodeEncodeError and the block is reported as a hook error
+    # instead of a reason -- on the one code path that only ever runs when live
+    # work is about to be deleted.
     for _stream in (sys.stdout, sys.stderr):
         try:
             _stream.reconfigure(encoding="utf-8")  # Python 3.7+

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1230,6 +1230,16 @@ PY_DIRECT=(
   hooks/test_block_raw_vault_git_cd.py
   # Where _floors.py looks for a vault's floor notes (emoji-prefixed folder names).
   tests/test_floors_folder_discovery.py
+  # vault-command-nudges recognised its verbs as BARE tokens at a regex
+  # alternation boundary, so `env git push`, `sudo git push`, `/usr/bin/git
+  # push`, `FOO=bar git push`, `(git push)` and `FOO=bar rm -rf <vault root>`
+  # all matched NO rule and exited 0 -- a destructive-command guard, silently
+  # unguarded on the spellings an agent actually writes. Its cwd walk was also
+  # quote-blind, so a `cd` inside a quoted string moved the guard off the vault.
+  # 18 of these 39 legs fail against the pre-fix revision; the ALLOW legs are
+  # half the suite, because the fail-closed cwd SET that fixes the walk is
+  # exactly the change that would otherwise start over-blocking.
+  hooks/test_vault_command_nudges_lead.py
 )
 dormant_py=()
 while IFS= read -r -d '' f; do


### PR DESCRIPTION
Lands the stranded `claude/vault-nudges-lead-port` work (5 commits, pushed with no PR, 5 behind main), plus one defect found while verifying it.

### Why this was stranded work, not a rewrite

The branch already existed and already carried the right fix. It was verified against an independent 16-case behavioural contract built from the private `local-machinery` copy of the same hook — 16/16 before any change here. Rewriting it would have been duplicate work against a visible claim.

### What the branch fixes

`vault-command-nudges.py` recognised its verbs as bare tokens at a regex boundary, so `env git push`, `sudo git push`, `/usr/bin/git push`, `FOO=bar git push` and `FOO=bar rm -rf <vault root>` matched no rule and exited 0. Its cwd walk was quote-blind. It also adds `_lib/shell_parse.py` as the shared parser (the four-hand-rolled-parsers problem) and a 43-case suite.

### The defect found while verifying it

With `hooks/_lib` absent, the guard **allowed** `git push` inside the vault, `git status`, and `rm -rf <vault root>`. Silently — exit 0, no stderr.

The cause is not the `_LIB_OK` block, which is correct and says FAIL CLOSED. It is the import above it: `vault_root_for` fell back to `return None`, and `None` means "no vault anywhere", so every rule that asks "is this path in a vault?" got no for free. That import runs first, so it decided the outcome. Isolated by staging `_lib` with `shell_parse.py` present and `vault_root.py` absent: still fully open.

The fallback now walks up for a Meta-suffixed folder inline — name-free, the same rule `validate-handoff-frontmatter.py` already applies in this repo. It stays inline deliberately: this is the fallback for `_lib` being unavailable, so it cannot live in `_lib`.

A partial install is the realistic cause — two installers write `~/.claude/hooks/_lib` and a client machine gets whichever landed — which is exactly when a guard has to hold.

### Why the existing degraded test could not catch it

Cases 38-39 copy `_lib/vault_root.py` INTO the degraded fixture, so they only ever removed `shell_parse.py` — the half that already failed closed. A fixture named "_lib missing" that supplies half of `_lib` is a claim about a scope it never covered. Cases 40-44 remove all of it and assert both directions. They fail 3/3 against the pre-fix hook.

### Verification

- `hooks/test_vault_command_nudges_lead.py`: 43 → 48 cases, green.
- Independent 16-case contract (rm targeting + cwd tracking + bypass): 16/16, unchanged by the fix.
- Negative controls fail first: 3/3 on the new cases, 2/2 on the rm/cwd contract against each one-way copy.

### Scope note

This does **not** close MYC-4115. That ticket's `Done =` requires all four hand-rolled parsers to import the shared module and `gh_merge.py` to drop its duplicate; this migrates one hook. Deliberately no ticket ID in the branch or title so it cannot auto-close.

Follow-up filed as MYC-4248: the same disarm-on-missing-dependency shape is measured live in `block-raw-vault-git.py` and `block-vault-git-fullwalk.py`, both of which ARE client-wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
