### PR TITLE
schema: declare the umbrella frontmatter keys and require their anchor (MYC-4238)

### DIFF
--- a/templates/schemas/skill.json
+++ b/templates/schemas/skill.json
@@ -3,7 +3,10 @@
   "title": "Skill frontmatter",
   "type": "object",
   "_comment": "Schema for skill primitives. A skill is a STRUCTURED executable object, not just SKILL.md prose. Declares tool_access (allowed tools), policy_constraints (rules + exception handling), required_inputs (what callers must pass), and output_shape (what callers receive). Validator: hooks/validate-skill-frontmatter.py blocks malformed Write/Edit at skills/**/SKILL.md. Bypass: SKILL_VALIDATION_BYPASS=1. Includes the cross-type frontmatter contract (provenance, confidence, freshness_days, last_verified, source_count) shared across all 6 typed memory primitives.",
-  "required": ["type", "name"],
+  "required": [
+    "type",
+    "name"
+  ],
   "properties": {
     "type": {
       "type": "string",
@@ -27,14 +30,18 @@
     },
     "tool_access": {
       "type": "array",
-      "items": {"type": "string"},
+      "items": {
+        "type": "string"
+      },
       "description": "Whitelist of tool names this skill is permitted to call. Empty array means the skill takes no tool actions (pure prose/analysis). Names match the canonical tool ids (Read, Write, Edit, Bash, Grep, Glob, etc.) or MCP tool ids (mcp__server__tool)."
     },
     "policy_constraints": {
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["rule"],
+        "required": [
+          "rule"
+        ],
         "properties": {
           "rule": {
             "type": "string",
@@ -52,7 +59,10 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["name", "type"],
+        "required": [
+          "name",
+          "type"
+        ],
         "properties": {
           "name": {
             "type": "string",
@@ -85,11 +95,26 @@
         "properties": {
           "source_type": {
             "type": "string",
-            "enum": ["slack", "email", "notion", "gdoc", "whatsapp", "calendar", "claude-session", "manual"]
+            "enum": [
+              "slack",
+              "email",
+              "notion",
+              "gdoc",
+              "whatsapp",
+              "calendar",
+              "claude-session",
+              "manual"
+            ]
           },
-          "source_id": {"type": "string"},
-          "source_url": {"type": "string"},
-          "captured_at": {"type": "string"}
+          "source_id": {
+            "type": "string"
+          },
+          "source_url": {
+            "type": "string"
+          },
+          "captured_at": {
+            "type": "string"
+          }
         }
       },
       "description": "List of independent sources that back this skill definition."
@@ -113,7 +138,34 @@
       "type": "integer",
       "minimum": 0,
       "description": "How many independent sources back this skill definition."
+    },
+    "umbrella": {
+      "type": "boolean",
+      "description": "True when this skill is a ROUTING UMBRELLA \u2014 a top-level lane the session map offers. This frontmatter field is the single source of truth for umbrella-ness: hooks/_lib/umbrella_map.py RENDERS the session map from it and enumerates no skill names, which is what keeps the map correct on an install whose skill set we have never seen. Anything else that lists umbrellas describes this field; it does not define it."
+    },
+    "umbrella_group": {
+      "type": "string",
+      "description": "Heading this umbrella renders under in the session map (e.g. 'Operating layer'). Groups are ordered by their earliest member's umbrella_order, so group order is declared by the skills themselves. Defaults to 'Skills'."
+    },
+    "umbrella_order": {
+      "type": "integer",
+      "description": "Sort key within the session map, lower first. Defaults to 50. Must be an integer: a non-integer silently falls back to the default and the map's ordering is quietly wrong."
+    },
+    "umbrella_domain": {
+      "type": "string",
+      "description": "One-line 'what this umbrella covers', shown beside the name. Defaults to the first sentence of `description`."
     }
   },
-  "additionalProperties": true
+  "additionalProperties": true,
+  "dependencies": {
+    "umbrella_group": [
+      "umbrella"
+    ],
+    "umbrella_order": [
+      "umbrella"
+    ],
+    "umbrella_domain": [
+      "umbrella"
+    ]
+  }
 }


### PR DESCRIPTION
Part of MYC-4238 — https://linear.app/myceliumai/issue/MYC-4238
Follows #612, which shipped `hooks/_lib/umbrella_map.py`.

## Why

`hooks/_lib/umbrella_map.py` renders the session umbrella map from `umbrella: true` in each installed `SKILL.md`. Those keys were **undeclared** in `templates/schemas/skill.json`, so the already-wired validator (`hooks/validate-skill-frontmatter.py`, PreToolUse on `Write|Edit|MultiEdit`) had nothing to check them against, and every malformed declaration passed.

## What this adds

The four keys with their types, plus a Draft-07 `dependencies` rule: `umbrella_group` / `umbrella_order` / `umbrella_domain` each **require** `umbrella`.

That dependency is the point. The failure it catches is silent — write `umbrela: true` (or omit it), keep the three companion keys, and the file still parses, still reads like a declaration, and simply is not an umbrella. Indistinguishable from never having tried. `umbrella_order` gets a type for the same reason: a non-integer silently falls back to the default and the map's ordering is quietly wrong rather than rejected.

**No new artifact and no new hook.** This extends a validator that already ships and is already wired, so it reaches a client install without adding SessionStart fan-out.

## Verification

- All **13** real umbrella declarations validate with zero umbrella-related errors.
- Five malformed shapes each rejected: companions-without-anchor, `umbrella_order` as string, as float, `umbrella` as string, `umbrella_group` as list.
- **Control on the control:** a well-formed declaration is NOT flagged — so the check can actually distinguish the two rather than rejecting everything.

`additionalProperties` was already `true`, so this is additive: it constrains the keys where present and changes nothing else.

## Scope note

While verifying this I measured that **31 of the substrate's 36 skills lack `type: skill`**, which the schema lists in `required` — so the same validator currently denies edits to shipped skills. That is pre-existing and untouched here; filed separately as MYC-4249, because the fix needs a decision about whether `type` is a settled contract or an in-flight migration.
