### PR TITLE
check-utf8-file-io: collapse the duplicated os.open guard from #610 + #611

### DIFF
--- a/scripts/check-utf8-file-io.py
+++ b/scripts/check-utf8-file-io.py
@@ -161,26 +161,18 @@ def violations_in(path):
         if not isinstance(node, ast.Call):
             continue
         name = getattr(node.func, "id", None) or getattr(node.func, "attr", None)
-        # `os.open()` returns a file DESCRIPTOR (an int). It takes no encoding=
-        # at all and performs no text decoding, so it is not text I/O -- but it
-        # matches on the bare attribute name `open`, which made every caller a
-        # false positive. The only way to silence one was to content-pin the
-        # whole file in the baseline, which then went STALE on the next edit and
-        # re-surfaced the same false positive as a fresh FAIL.
+        # `os.open` is NOT the builtin: it returns a raw file DESCRIPTOR, has no
+        # text mode, and rejects encoding= with a TypeError. Flagging it tells
+        # the author to "pass encoding=utf-8" -- advice that breaks their code
+        # and pushes a correct call into the baseline as if it were debt. That
+        # pin then went STALE on the next edit and re-surfaced the same false
+        # positive as a fresh FAIL. The qualifier is the whole difference;
+        # `p.open()` on a Path still counts.
         if (name == "open"
                 and isinstance(node.func, ast.Attribute)
                 and getattr(node.func.value, "id", None) == "os"):
             continue
         if name not in ("open", "write_text", "read_text"):
-            continue
-        # `os.open` is NOT the builtin: it returns a raw file descriptor, has no
-        # text mode, and rejects encoding= with a TypeError. Flagging it tells
-        # the author to "pass encoding=utf-8" -- advice that breaks their code
-        # and pushes a correct call into the baseline as if it were debt. The
-        # qualifier is the whole difference; `p.open()` on a Path still counts.
-        if (name == "open"
-                and isinstance(node.func, ast.Attribute)
-                and getattr(node.func.value, "id", None) == "os"):
             continue
         if any(kw.arg == "encoding" for kw in node.keywords):
             continue


### PR DESCRIPTION
## What

PR #610 and PR #611 independently fixed the same false positive — the detector matching `os.open()` on the bare attribute name `open` — and landed **two identical guard blocks back to back**. The second is unreachable: the first already `continue`s on the same predicate.

They did not conflict textually (one block sits before the `if name not in (...)` early-continue, one after), so git merged both in silence and `merge-tree` reported clean.

Collapsed to one, keeping the stronger half of each explanation: #610's *"rejects `encoding=` with a TypeError / `p.open()` on a Path still counts"* plus #611's *"the pin then went STALE on the next edit"*.

Net **-8 lines**. No behaviour change: the predicate is byte-identical, and there is now exactly one occurrence of it.

## Verification

- self-test: still clears 5 safe forms, flags all 4 unsafe, revokes the json exemption, CRLF == LF
- real-tree scan: green over 353 files
- `ci-test` GREEN on `9c70659` — `GATE_EXIT=0`, 0 FAIL, marker written

The `except Exception` the pre-push hook flags is pre-existing; this diff adds no `except` clause, no regex, and no workflow surface.

## Bug class

`DUPLICATE-BUILD-DESPITE-VISIBLE-CLAIM`. The sibling-PR hook **did** warn that #610 touched this file. I ran a `merge-tree` conflict probe, got clean, and read that as "no overlap." A clean textual merge is not evidence of no **semantic** overlap — when a sibling PR touches the same file, read what it changes, not just whether it collides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
