### PR TITLE
gitignore: the prune log dirties the install and stalls its auto-update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,10 @@ hooks/.secret-scan.lock
 # are already ignored; this covers the exported message content too, so a user
 # can never stage their own WhatsApp history into a public fork.
 /🤖 AI Chats/
+
+# scripts/worktree-prune.sh defaults LOG_DIR to `$SCRIPT_DIR/../logs`, i.e. the
+# repo's OWN checkout. Every install that runs it dirties its own clone, and a
+# dirty clone BLOCKS the ff-only auto-update — so the install silently stops
+# receiving substrate updates. Measured on the deployed checkout at
+# ~/.claude/skills/ai-brain-starter: untracked logs/ present, update blocked.
+/logs/


### PR DESCRIPTION
`scripts/worktree-prune.sh` defaults `LOG_DIR` to `$SCRIPT_DIR/../logs` — the repo's own checkout. Every install that runs it writes an untracked `logs/worktree-prune.log` into its own clone, the clone goes dirty, and a dirty clone is what blocks the ff-only auto-update. The install then silently stops receiving substrate updates, with nothing reporting it.

Measured on the deployed checkout at `~/.claude/skills/ai-brain-starter`: the untracked `logs/` was its only diff, and the session-start drift warning had been firing on it repeatedly.

`/logs/` was already present in `.gitignore` as TEXT, inside a comment about a script writing `"⚙️ Meta/logs/"` — so a substring check reports it as covered while git does not. Confirmed with git's own authority instead: `git check-ignore` exits 1 (not ignored) before, matches `.gitignore:66` after.

The log belongs beside the script. It just must not make the tree dirty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
