### PR TITLE
exit codes: a killed linter is not a finding, and a failed maintenance leg is not a success

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -548,6 +548,13 @@ jobs:
       - name: ensure shellcheck present
         run: command -v shellcheck >/dev/null || { sudo apt-get update && sudo apt-get install -y shellcheck; }
 
+      # A signal death and a lint finding used to be the same exit here, so a
+      # shellcheck the kernel killed reported "found issues" and a reader went
+      # hunting for a defect that did not exist (MYC-4259). These controls shim
+      # a fake shellcheck to drive each documented status.
+      - name: shellcheck exit-code negative controls (a killed linter is not a finding)
+        run: bash scripts/shellcheck.sh --self-test
+
       - name: shellcheck (.sh, -S warning)
         run: bash scripts/shellcheck.sh
 

--- a/scripts/check-exit-contract.py
+++ b/scripts/check-exit-contract.py
@@ -258,7 +258,6 @@ UNDECLARED_BASELINE: set[str] = {
     "scripts/update-check.ps1",
     "scripts/vault-backup.ps1",
     "scripts/vault-classify-untyped.py",
-    "scripts/vault-daily-maintenance.sh",
     "scripts/vault-hygiene.py",
     "scripts/vault-insight-engine.py",
     "scripts/vault-metadata-extract.py",
@@ -268,7 +267,7 @@ UNDECLARED_BASELINE: set[str] = {
     "scripts/worktree-archive-prep.py",
     "scripts/write-hook.sh",
 }
-UNDECLARED_MAX = 101
+UNDECLARED_MAX = 100
 
 
 def _tracked_scripts() -> tuple[list[Path], int]:

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -287,6 +287,7 @@ INTEGRATION_TESTS=(
   test_resource_aware_session_close
   test_vault_lock_separated_gitdir
   test_cloud_sync_guard
+  test_daily_maintenance_exit_code
   test_cloud_safe_file_walkers
   test_delegated_task_needs_source
   test_cloud_sync_offer

--- a/scripts/shellcheck.sh
+++ b/scripts/shellcheck.sh
@@ -35,6 +35,59 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
 
+# --- negative controls (MYC-4259) -------------------------------------------
+# A signal death and a lint finding used to be indistinguishable here: every
+# non-zero shellcheck status printed "found issues" and exited 1. These shim a
+# fake `shellcheck` onto PATH so each documented status can be driven directly,
+# and assert this script's OWN exit for each. Without the kill case the
+# classification below is untested on the one input that motivated it.
+if [ "${1:-}" = "--self-test" ]; then
+  st_fail=0
+  st_tmp="$(mktemp -d)"
+  trap 'rm -rf "$st_tmp"' EXIT
+  mkdir -p "$st_tmp/bin"
+
+  st_case() { # st_case <label> <fake-rc> <expected-this-script-rc>
+    local label="$1" fake="$2" want="$3" got
+    # `shellcheck --version` is called before the scan, so the shim must answer
+    # it with a plausible version and only then honour the injected status.
+    cat > "$st_tmp/bin/shellcheck" <<SHIM
+#!/bin/sh
+case "\$1" in --version) echo "ShellCheck - shell script analysis tool"; echo "version: 0.0.0-fake"; exit 0;; esac
+exit $fake
+SHIM
+    chmod +x "$st_tmp/bin/shellcheck"
+    # `set -e` is active: without disabling it, the FIRST probe that returns
+    # non-zero would abort the self-test and the remaining cases -- including
+    # the kill case this exists for -- would never run, while the suite looked
+    # like it had simply stopped early.
+    set +e
+    PATH="$st_tmp/bin:$PATH" bash "$0" >/dev/null 2>&1
+    got=$?
+    set -e
+    if [ "$got" != "$want" ]; then
+      echo "  FAIL [$label] fake shellcheck rc=$fake -> this script exited $got, expected $want"
+      st_fail=1
+    else
+      echo "  ok   [$label] fake shellcheck rc=$fake -> exit $got"
+    fi
+  }
+
+  st_case "clean"                0   0
+  st_case "real findings"        1   1
+  st_case "could-not-process"    2   2
+  st_case "SIGKILL (OOM shape)"  137 2
+  st_case "SIGTERM"              143 2
+
+  if [ "$st_fail" -ne 0 ]; then
+    echo "shellcheck.sh self-test FAILED" >&2
+    exit 1
+  fi
+  echo "OK - self-test: findings (1) and a killed/failed linter (2) are distinct exits."
+  exit 0
+fi
+
+
 if ! command -v shellcheck >/dev/null 2>&1; then
   echo "::error::shellcheck not installed." >&2
   echo "  macOS:         brew install shellcheck" >&2
@@ -66,12 +119,37 @@ echo "==> shellcheck -S $SEVERITY over ${#files[@]} tracked *.sh  [$(shellcheck 
 fmt="tty"
 [ -n "${GITHUB_ACTIONS:-}" ] && fmt="gcc"
 
-if shellcheck -S "$SEVERITY" -f "$fmt" "${files[@]}"; then
+# Classify shellcheck's status instead of treating every non-zero as "found
+# issues" (MYC-4259). shellcheck documents 0 = clean and 1 = findings; anything
+# else means the TOOL did not deliver a verdict -- 2 for a file it could not
+# process, and 128+N when the kernel killed it (137 = SIGKILL, the OOM shape on
+# a loaded runner). Reporting a signal death as a lint finding sends the reader
+# hunting for a defect that does not exist, and the adjacent shape is worse: a
+# "no findings" line over a run that never actually linted anything.
+#
+# Exit 2 for could-not-evaluate, deliberately distinct from 1 = real findings,
+# so a caller can tell "your code is bad" from "the linter died".
+set +e
+shellcheck -S "$SEVERITY" -f "$fmt" "${files[@]}"
+sc_rc=$?
+set -e
+
+if [ "$sc_rc" -eq 0 ]; then
   echo "    OK - no shellcheck findings at -S $SEVERITY"
-else
+elif [ "$sc_rc" -eq 1 ]; then
   echo "FAILED: shellcheck found issues at -S $SEVERITY." >&2
   echo "Fix them, or - for a genuine false-positive - add an inline shellcheck" >&2
   echo "disable directive with a one-line reason at the source line." >&2
   echo "Do NOT lower the severity gate to hide a finding (see this script's header)." >&2
   exit 1
+elif [ "$sc_rc" -gt 128 ]; then
+  echo "UNEVALUATED: shellcheck was KILLED by signal $((sc_rc - 128)) (exit $sc_rc)." >&2
+  echo "It did not finish, so NOTHING was linted -- this is not a finding and it" >&2
+  echo "is not a pass. On a loaded runner this is usually the OOM killer." >&2
+  exit 2
+else
+  echo "UNEVALUATED: shellcheck exited $sc_rc, which is neither clean (0) nor" >&2
+  echo "findings (1). It could not process one or more files, so the scan is" >&2
+  echo "incomplete and its silence means nothing." >&2
+  exit 2
 fi

--- a/scripts/vault-daily-maintenance.sh
+++ b/scripts/vault-daily-maintenance.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# exit-contract: ENFORCING
+
 # vault-daily-maintenance.sh - heavy vault maintenance, kept OFF the interactive
 # session-close path.
 #
@@ -156,13 +158,27 @@ if ! close_mutex_acquire 60; then
 fi
 log "acquired close-cascade mutex ($$)"
 
+# Every step's status used to be logged and then DISCARDED: this script exited
+# 0 unconditionally, so a step that had been failing for weeks reported success
+# to launchd every night and to anyone reading `launchctl list`. A runner that
+# cannot fail cannot tell you its steps are failing (MYC-4116).
+#
+# Steps still never ABORT the pass -- that part was right, and is why the
+# aggregators keep running when one leg dies. The change is that failures are
+# remembered, named in the log, written to a state file a SessionStart reader
+# can pick up, and reflected in the final exit code.
+FAILED_STEPS=()
+
 run() {
-  # run <label> <command...> - runs at low priority, logs a tail, never aborts.
+  # run <label> <command...> - runs at low priority, logs a tail, never aborts,
+  # and REMEMBERS a non-zero status for the summary + exit code.
   local label="$1"; shift
   local out rc
   out=$(nice -n 10 "$@" 2>&1); rc=$?
   printf '%s\n' "$out" | tail -3
   log "[$label] rc=$rc :: $(printf '%s\n' "$out" | tail -1)"
+  [ "$rc" -ne 0 ] && FAILED_STEPS+=("$label(rc=$rc)")
+  return 0
 }
 
 # === RECONCILE (data safety): aggregators + commit deferred close artifacts ===
@@ -342,5 +358,29 @@ if [ "${ABS_NO_AUTO_GC:-0}" != "1" ] && [ -n "${GC_SEEN_MARKER:-}" ] && [ ! -f "
 fi
 
 close_mutex_release
+
+# Report failed steps to three surfaces that fail differently: the log (a human
+# tailing it), a state file (a SessionStart reader), and the exit code (launchd,
+# cron MAILTO, a hand run). The plist is StartCalendarInterval-only with no
+# KeepAlive/SuccessfulExit, so a non-zero exit records status without provoking
+# a restart loop.
+MAINT_STATE_DIR="${HOME}/.claude/state"
+MAINT_STATE="$MAINT_STATE_DIR/vault-daily-maintenance-last.json"
+mkdir -p "$MAINT_STATE_DIR" 2>/dev/null || true
+{
+  printf '{"finished_at":"%s","failed_count":%d,"failed_steps":[' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${#FAILED_STEPS[@]}"
+  for i in "${!FAILED_STEPS[@]}"; do
+    [ "$i" -gt 0 ] && printf ','
+    printf '"%s"' "${FAILED_STEPS[$i]}"
+  done
+  printf ']}\n'
+} > "$MAINT_STATE" 2>/dev/null || true
+
+if [ "${#FAILED_STEPS[@]}" -gt 0 ]; then
+  log "=== vault-daily-maintenance COMPLETED WITH ${#FAILED_STEPS[@]} FAILED STEP(S): ${FAILED_STEPS[*]} @ $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+  exit 1
+fi
+
 log "=== vault-daily-maintenance COMPLETE @ $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
 exit 0

--- a/tests/integration/test_daily_maintenance_exit_code.sh
+++ b/tests/integration/test_daily_maintenance_exit_code.sh
@@ -17,6 +17,15 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# HOME alone does NOT sandbox on Windows: ntpath.expanduser reads USERPROFILE and
+# ignores HOME, so a bare `HOME=... bash ...` here would write this test's state
+# file into the developer's REAL ~/.claude on Git Bash. That exact class once
+# rewrote a real settings.json and denied every tool call in later sessions
+# (MYC-3536). The shared helper sets HOME + USERPROFILE and neutralises the
+# HOMEDRIVE/HOMEPATH fallback; scripts/ci.sh has a guard that fails this file if
+# it drifts back to a bare HOME= redirect, and that guard is what caught it.
+# shellcheck source=tests/integration/lib/sandbox_home.sh
+. "$SCRIPT_DIR/lib/sandbox_home.sh"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 TARGET="$REPO_ROOT/scripts/vault-daily-maintenance.sh"
 FAILED=0
@@ -66,7 +75,7 @@ build_harness <<'STEPS'
 run "deliberately-failing-leg" false
 STEPS
 set +e
-HOME="$tmp/home1" bash "$tmp/h.sh" > "$tmp/o1" 2>&1
+run_sandboxed "$tmp/home1" bash "$tmp/h.sh" > "$tmp/o1" 2>&1
 rc1=$?
 set -e
 if [ "$rc1" -eq 0 ]; then
@@ -90,7 +99,7 @@ build_harness <<'STEPS'
 run "healthy-leg" true
 STEPS
 set +e
-HOME="$tmp/home2" bash "$tmp/h.sh" > "$tmp/o2" 2>&1
+run_sandboxed "$tmp/home2" bash "$tmp/h.sh" > "$tmp/o2" 2>&1
 rc2=$?
 set -e
 if [ "$rc2" -ne 0 ]; then
@@ -107,7 +116,7 @@ run "first-leg-fails" false
 run "second-leg-still-runs" true
 STEPS
 set +e
-HOME="$tmp/home3" bash "$tmp/h.sh" > "$tmp/o3" 2>&1
+run_sandboxed "$tmp/home3" bash "$tmp/h.sh" > "$tmp/o3" 2>&1
 rc3=$?
 set -e
 grep -q 'second-leg-still-runs' "$tmp/o3" \

--- a/tests/integration/test_daily_maintenance_exit_code.sh
+++ b/tests/integration/test_daily_maintenance_exit_code.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Negative control for MYC-4116: scripts/vault-daily-maintenance.sh used to log
+# every step's exit code and then DISCARD it, ending in an unconditional
+# `exit 0`. A leg that had been failing for weeks reported success to launchd
+# every night, so the one surface anyone checks said the job was healthy.
+#
+# WHAT THIS PROVES, AND WHAT IT DOES NOT
+#   It exercises the REAL `run()` definition and the REAL summary block, lifted
+#   verbatim out of the shipped script rather than retyped here -- a control
+#   built from a copy of the logic proves only that the copy works. The
+#   extraction is asserted, so if either block is renamed or moved this test
+#   goes RED rather than silently testing nothing.
+#
+#   It does NOT boot the whole maintenance pass (that needs a real vault, the
+#   close mutex, and git). The claim is scoped to the accounting and the exit
+#   predicate, which is exactly what MYC-4116 was about.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TARGET="$REPO_ROOT/scripts/vault-daily-maintenance.sh"
+FAILED=0
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+fail() { echo "  FAIL: $*" >&2; FAILED=1; }
+ok()   { echo "  ok   $*"; }
+
+[ -f "$TARGET" ] || { echo "FAIL: $TARGET missing" >&2; exit 1; }
+
+# --- lift the two real blocks out of the shipped script ---------------------
+# `run()` ... its closing brace, and the summary block from MAINT_STATE_DIR to
+# the final `exit 0`. Both extractions are asserted below: an empty lift means
+# the block moved, and a control that tests an empty string always passes.
+run_block="$(awk '/^run\(\) \{/,/^\}/' "$TARGET")"
+summary_block="$(awk '/^MAINT_STATE_DIR=/,/^exit 0$/' "$TARGET")"
+
+if ! printf '%s' "$run_block" | grep -q 'FAILED_STEPS+='; then
+  fail "could not lift run() with its FAILED_STEPS accounting -- the block moved,"
+  fail "so this control would have tested nothing. Fix the extraction, not the assert."
+  exit 1
+fi
+if ! printf '%s' "$summary_block" | grep -q 'exit 1'; then
+  fail "could not lift the summary block with its non-zero exit -- extraction is stale."
+  exit 1
+fi
+ok "lifted run() + summary block from the shipped script (not retyped)"
+
+# --- harness: the real blocks, with the vault/mutex setup stubbed out -------
+build_harness() { # build_harness <steps...>  -> a runnable script at $tmp/h.sh
+  {
+    echo '#!/usr/bin/env bash'
+    echo 'set -uo pipefail'
+    echo 'log() { printf "%s\n" "$*"; }'
+    echo 'FAILED_STEPS=()'
+    printf '%s\n' "$run_block"
+    cat                      # caller pipes in the step invocations
+    printf '%s\n' "$summary_block"
+  } > "$tmp/h.sh"
+  chmod +x "$tmp/h.sh"
+}
+
+# CASE 1 -- a FAILING step must reach the exit code. This is the defect.
+build_harness <<'STEPS'
+run "deliberately-failing-leg" false
+STEPS
+set +e
+HOME="$tmp/home1" bash "$tmp/h.sh" > "$tmp/o1" 2>&1
+rc1=$?
+set -e
+if [ "$rc1" -eq 0 ]; then
+  fail "a failing step still exited 0 -- the swallow is back (MYC-4116)"
+else
+  ok "failing step -> exit $rc1"
+fi
+grep -q 'FAILED STEP' "$tmp/o1" || fail "the log line does not name the failed step"
+if [ -f "$tmp/home1/.claude/state/vault-daily-maintenance-last.json" ]; then
+  grep -q 'deliberately-failing-leg' \
+    "$tmp/home1/.claude/state/vault-daily-maintenance-last.json" \
+    || fail "state file does not name the failed step"
+  ok "state file names the failed step"
+else
+  fail "no state file written for a failed run"
+fi
+
+# CASE 2 -- the inverse. Without this, a harness that exited non-zero for ANY
+# reason would satisfy CASE 1 and the control would be theatre.
+build_harness <<'STEPS'
+run "healthy-leg" true
+STEPS
+set +e
+HOME="$tmp/home2" bash "$tmp/h.sh" > "$tmp/o2" 2>&1
+rc2=$?
+set -e
+if [ "$rc2" -ne 0 ]; then
+  fail "an all-green pass exited $rc2, expected 0 -- CASE 1 may be passing for the wrong reason"
+else
+  ok "all-green pass -> exit 0"
+fi
+
+# CASE 3 -- a failing step must NOT abort the remaining steps. That behaviour
+# was correct before and is the reason run() swallows rather than `set -e`s;
+# breaking it while fixing the exit code would trade one defect for a worse one.
+build_harness <<'STEPS'
+run "first-leg-fails" false
+run "second-leg-still-runs" true
+STEPS
+set +e
+HOME="$tmp/home3" bash "$tmp/h.sh" > "$tmp/o3" 2>&1
+rc3=$?
+set -e
+grep -q 'second-leg-still-runs' "$tmp/o3" \
+  || fail "a failing leg aborted the pass -- later legs must still run"
+[ "$rc3" -ne 0 ] || fail "mixed pass should still exit non-zero"
+ok "a failing leg does not abort the legs after it (exit $rc3)"
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "test_daily_maintenance_exit_code: FAILED" >&2
+  exit 1
+fi
+echo "test_daily_maintenance_exit_code: OK"


### PR DESCRIPTION
Follow-up to #619. Two open tickets in the same family, both measured rather than assumed.

## MYC-4259 — a killed linter is not a lint finding

`scripts/shellcheck.sh` treated EVERY non-zero shellcheck status as "found issues" and exited 1. shellcheck documents `0` = clean and `1` = findings; anything else means the tool did not deliver a verdict — `2` for a file it could not process, `128+N` when the kernel killed it (`137` = SIGKILL, the OOM shape on a loaded runner).

Reporting a signal death as a lint finding sends the reader hunting for a defect that does not exist. The adjacent shape is worse: a clean line over a run that linted nothing. Now classified — `1` = real findings, `2` = could-not-evaluate.

## MYC-4116 — a failed maintenance leg is not a success

`scripts/vault-daily-maintenance.sh` logged each step's exit code and then discarded it, ending in an unconditional `exit 0`. A leg failing for weeks reported success to launchd every night, and `launchctl list` is the one surface anyone checks.

Failures are now remembered, named in the log, written to `~/.claude/state/vault-daily-maintenance-last.json` for a SessionStart reader, and reflected in the exit code.

Steps still never ABORT the pass — that was correct, and is why `run()` swallows rather than `set -e`s, so a failing leg does not stop the legs after it. The plist is `StartCalendarInterval`-only with no `KeepAlive`/`SuccessfulExit`, checked before making the exit non-zero, so this records status without provoking a restart loop.

## Controls

**`shellcheck.sh --self-test`** shims a fake `shellcheck` onto PATH and drives each documented status, asserting this script's own exit for each: `0 → 0`, `1 → 1`, `2 → 2`, `137 → 2`, `143 → 2`. Mutation-proven: collapsing the classification back to "any non-zero → exit 1" fails the could-not-process, SIGKILL and SIGTERM cases by name.

**`tests/integration/test_daily_maintenance_exit_code.sh`** lifts the REAL `run()` and summary block out of the shipped script rather than retyping them, and asserts the extraction succeeded — a control built from a copy proves only that the copy works. Three cases: a failing step reaches the exit, an all-green pass still exits 0 (so case 1 cannot pass for the wrong reason), and a failing leg does not abort the legs after it.

Mutation-proven at the intended site. Two mutations tripped the extraction guard rather than the behaviour, so a third was run that leaves the `FAILED_STEPS+=` token intact and inverts the condition — extraction still succeeds, and the suite fails with *"a failing step still exited 0 — the swallow is back (MYC-4116)"*.

## A guard caught this PR's own test

The first full gate run went RED on `test_home_sandbox_hermeticity.sh`:

> `FAIL HOME-only sandbox :: 3 site(s) redirect HOME without USERPROFILE, so on Windows they run against the REAL ~/.claude`

The new control redirected `HOME` at three sites without `USERPROFILE`. On Git Bash `ntpath.expanduser` reads `USERPROFILE` and ignores `HOME` entirely, so on Windows the test would have written its state file into the developer's real `~/.claude` — the class that already cost a rewritten `settings.json` pointing 95 of 111 hook entries into a deleted worktree, denying every tool call in later sessions (MYC-3536).

macOS cannot observe that failure at all: `HOME` works there, so the test was green by construction on the machine that wrote it. Converted all three sites to `run_sandboxed` from the shared helper, which sets `HOME` + `USERPROFILE` and neutralises the `HOMEDRIVE`/`HOMEPATH` fallback.

## Wiring

`shellcheck.sh --self-test` into `lint.yml` as a step before the gate; the integration test into `ci.sh`'s list. `vault-daily-maintenance.sh` now declares `exit-contract: ENFORCING` and its row is burned off the `check-exit-contract` baseline, which drops **101 → 100** with the cap following it down — the first real exercise of that ratchet's shrink path.

## Verification

Local canonical gate GREEN (`GATE_EXIT=0`, marker `642217fc.ok`): py_compile 400 files, **139** integration tests (138 + this PR's), 31 script suites, 29 hook suites, shellcheck, phase-doc python, utf8 console guard, hook block-protocol, vault-root reads. Both new controls confirmed to have run inside that gate, not merely standalone.

The gate declined twice before this (exit 3) with the box at load 55–61 on 10 cores — a refusal to measure, correctly, not a red. Re-run with `CI_PARITY_LOAD_BYPASS=1`, which skips only the load pre-check and still runs everything.

## Not claimed

- The daily-maintenance control is scoped to the accounting and the exit predicate. It does not boot the whole maintenance pass, which needs a real vault, the close mutex, and git.
- The Windows fix is verified by the repo's static guard, not by executing on Windows.
- 100 scripts remain undeclared on the exit-contract baseline (MYC-4261), and the gate is absent from both paid repos (MYC-4262).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
