### PR TITLE
hooks: close the recognition-layer bypass in the two LIVE vault git guards

### DIFF
--- a/hooks/_lib/shell_parse.py
+++ b/hooks/_lib/shell_parse.py
@@ -30,11 +30,13 @@ fail-open/fail-closed decisions, which differ by guard.
 
 from __future__ import annotations
 
+import os
 import re
 import shlex
 
 __all__ = [
     "ASSIGN_RE",
+    "cwd_candidates",
     "ENV_ASSIGN_RE",
     "WRAPPER_PREFIXES",
     "expand_vars",
@@ -301,3 +303,128 @@ def segment_bypass_flags(segments, var, value="1"):
             here = True
         flags.append(here)
     return flags
+
+
+_GLOB_CHARS = set("*?[")
+
+
+def _cd_operand(rest):
+    """The single directory operand of a `cd`, or None when unresolvable.
+
+    None means "this cd may have gone somewhere I cannot name", which callers
+    must treat as AMBIGUOUS (keep the previous cwd in play), never as "no cd
+    happened". `cd -` (OLDPWD, which this process cannot know) and a
+    multi-operand `cd` land here on purpose -- resolving `cd -` to HOME by
+    discarding the "-" as a flag is a fail-open dressed as a confident answer.
+    """
+    if "-" in rest[1:]:
+        return None
+    operands = [t for t in rest[1:] if not t.startswith("-")]
+    if not operands:
+        return os.path.expanduser("~")          # bare `cd` -> HOME
+    if len(operands) > 1:
+        return None
+    return operands[0]
+
+
+def cwd_candidates(segs, base):
+    """Every cwd a command could run in, plus the literal `VAR=` assignments.
+
+    Returns ``(set_of_cwds, variables)``. A guard blocks when ANY member is a
+    directory it protects.
+
+    FAIL-CLOSED BY CONSTRUCTION, and that is the whole point. A single
+    "effective cwd" forces a guess at each ambiguity, and every wrong guess in
+    the walks this replaces pointed the same way -- off the protected tree, i.e.
+    open. Measured shapes that a single-guess walk let through:
+
+        W=<protected>; cd "$W" && git push   -- `$W` never expanded
+        echo "hi; cd /tmp" && git push       -- `cd` cut out of a QUOTED string
+        cd /tmp || git push                  -- `||` treated as unconditional
+
+    Ambiguity UNIONS instead of overwriting, so the protected path stays in the
+    set and the block stands. The cost is a possible over-block on a genuinely
+    ambiguous command, which is loud and bypassable; the old cost was a silent
+    allow on the exact command the guard exists to stop.
+
+    This also subsumes the "ignore a `cd` whose target does not exist" clause
+    some callers carried: unioning cannot move the set OFF the protected tree,
+    so a bogus `cd` can no longer disarm a guard that fails open on an
+    unresolvable repo.
+
+    `segs` is the output of split_segments_with_seps on ALREADY-SANITIZED text
+    (heredoc bodies and comment tails stripped) -- both carry operators that
+    would otherwise forge segment boundaries.
+    """
+    base = os.path.expanduser(base) if base else ""
+    cur = {base} if base else set()
+    variables = {}
+
+    depth = 0
+    for idx, (sep, seg) in enumerate(segs):
+        # `(` and `)` arrive as separators, so paren depth is a running count --
+        # and it covers BOTH `( cd X ; ... )` and `$( cd X && ... )`, because a
+        # command substitution opens the same paren. A cd below the top level
+        # changes only the SUBSHELL's cwd and is invisible to the parent.
+        # Tracking only the separator IMMEDIATELY after the cd was not enough:
+        # in `(cd /tmp; true) && git push` the cd is followed by `;`, so it
+        # looked top-level and escaped its own subshell.
+        # A brace group is deliberately NOT counted: `{ cd X; }` runs in the
+        # CURRENT shell and its cd really does move the caller.
+        if sep == "(":
+            depth += 1
+        elif sep == ")":
+            depth = max(0, depth - 1)
+        if depth > 0:
+            continue
+        toks = tokens(seg.strip())
+        if not toks:
+            continue
+        k = 1 if toks[0] == "export" else 0
+        while k < len(toks) and ASSIGN_RE.match(toks[k]):
+            name, _, val = toks[k].partition("=")
+            variables[name] = expand_vars(val, variables)
+            k += 1
+        while k < len(toks) and toks[k] in WRAPPER_PREFIXES:
+            k += 1
+        rest = toks[k:]
+        if not rest or rest[0] != "cd":
+            continue
+
+        raw = _cd_operand(rest)
+        target = expand_vars(raw, variables) if raw else None
+        # An unexpanded `$`, a command substitution or a glob is a target that
+        # cannot be named -- treat as unresolved rather than resolving it wrongly.
+        if target and ("$" in target or set(target) & _GLOB_CHARS):
+            target = None
+
+        if target is None:
+            moved = set()                      # unknown destination
+        else:
+            t = os.path.expanduser(target)
+            moved = ({t} if os.path.isabs(t)
+                     else {os.path.normpath(os.path.join(b, t)) for b in (cur or {""})})
+
+        # The operator JOINING this cd to what follows decides whether the cd is
+        # in effect for it. See split_segments_with_seps for the full table.
+        nxt = segs[idx + 1][0] if idx + 1 < len(segs) else ""
+        if not moved:
+            continue                           # destination unknown -> keep old cwd
+        if nxt == "&&":
+            # The right-hand side runs IF AND ONLY IF the cd succeeded, so where
+            # it runs is not in doubt. No existence check: an earlier segment may
+            # legitimately create the directory (`git worktree add W && cd W`).
+            cur = moved
+        elif nxt in (";", "\n", ""):
+            # `cd X ; cmd` runs cmd in X when the cd succeeds and in the OLD cwd
+            # when it fails. That is DECIDABLE, not a coin flip: a cd fails when
+            # the target is not a directory. Deciding it matters -- unioning
+            # unconditionally would keep the protected path in the set for the
+            # everyday `cd /repo` + newline + command shape and false-block every
+            # one of them, which is precisely what teaches the bypass.
+            if all(os.path.isdir(m) for m in moved):
+                cur = moved
+            else:
+                cur = cur | {m for m in moved if os.path.isdir(m)}
+        # "||", "|", "&", "(", ")" -> the next command runs in the OLD cwd.
+    return cur, variables

--- a/hooks/block-raw-vault-git.py
+++ b/hooks/block-raw-vault-git.py
@@ -54,6 +54,23 @@ except Exception:  # fail-open: never block a git op on an import error
     def vault_root_for(target: Path):  # type: ignore
         return None
 
+# The quote-aware splitter, the `$VAR` expander and the heredoc/comment
+# strippers are CANONICAL in _lib.shell_parse. This guard hand-rolled its own
+# `cd` walk and inherited every fail-open that copy had.
+try:
+    from _lib.shell_parse import (  # noqa: E402
+        cwd_candidates, expand_vars, segment_bypass_flags,
+        split_segments_with_seps, strip_heredoc_bodies, strip_noncode,
+    )
+    _LIB_OK = True
+except Exception:
+    # FAIL CLOSED. This guard's job is to STOP a raw vault git op, so a degraded
+    # parse keeps the session cwd as the only candidate -- which still blocks the
+    # common case and at worst over-blocks (visible, bypassable) instead of
+    # silently letting a raw vault op through (invisible).
+    _LIB_OK = False
+
+
 
 def _vault_git_dir_for(target: str) -> str | None:
     """realpath of the `.git` of the vault governing `target`, or None.
@@ -86,35 +103,19 @@ def _vault_git_dir_for(target: str) -> str | None:
     return os.path.realpath(os.path.join(str(root), ".git"))
 
 
-def _effective_cwd(command: str, initial: str) -> str:
-    """Resolve cwd after any `cd <path>` in the command string.
-
-    A NEWLINE separates statements exactly like `;` does. Splitting only on
-    `&&`/`||`/`;` left a newline-separated script as ONE chunk, and the
-    `re.match` below anchors at the chunk start -- so a `cd` was seen only
-    when it was the very first token of the whole command. Any statement
-    before it (`set -e`, an echo, a var assignment) made the `cd` invisible
-    and this hook resolved the HARNESS cwd instead. That disabled the guard
-    outright: from an unrelated repo, `set -e` + `cd <vault>` + a raw
-    `git add` reached the vault with no mutex.
-
-    A `cd` whose target is not an existing directory is IGNORED rather than
-    applied. `_targets_vault_repo` fails OPEN when it cannot resolve a repo,
-    so honouring a bogus path (a `cd` quoted inside a heredoc body or an echo)
-    would silently turn a blocked vault op into an allowed one -- the newline
-    split makes such lines reachable, so this clause is load-bearing, not
-    defensive dressing.
-    """
-    cwd = os.path.expanduser(initial) if initial else ""
-    for chunk in re.split(r"\s*(?:&&|\|\||;|\n)\s*", command):
-        chunk = chunk.strip()
-        m = re.match(r"cd\s+(?:\"([^\"]+)\"|'([^']+)'|(\S+))", chunk)
-        if m:
-            new_path = os.path.expanduser(next(g for g in m.groups() if g is not None))
-            cand = new_path if os.path.isabs(new_path) else os.path.normpath(os.path.join(cwd, new_path))
-            if os.path.isdir(cand):
-                cwd = cand
-    return cwd
+# What may sit between a command start and its verb without changing which
+# program runs: transparent wrappers (with their own bounded options, so
+# `sudo -u root git ...` is seen), one-shot `VAR=` assignments in ANY case, an
+# explicit path to the binary, and a brace-group opener. Matching a bare `git`
+# token at a regex boundary instead let `env git commit`, `sudo git commit`,
+# `/usr/bin/git commit`, `command git commit`, lowercase `foo=1 git commit` and
+# `(git commit)` all run completely unguarded -- measured exit 0 against a
+# proven positive control.
+_ASSIGN_TOK = r'[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|\'[^\']*\'|\S*)'
+_WRAPPER_TOK = r'(?:env|command|exec|builtin|nohup|sudo|time)'
+_LEAD = (r'\s*(?:[({]\s+)*'
+         r'(?:' + _ASSIGN_TOK + r'\s+|' + _WRAPPER_TOK + r'\s+(?:\S+\s+){0,3})*'
+         r'(?:\S*/)?')
 
 
 # A git option's value argument:
@@ -153,7 +154,7 @@ _GIT_OPT = '|'.join([
 _GIT_OPTS_CAP = r'((?:' + _GIT_OPT + r')*)'   # capturing group: the whole options blob
 
 
-def _dash_c_target(opts_blob: str, base_cwd: str) -> str:
+def _dash_c_target(opts_blob: str, base_cwd: str, variables=None) -> str:
     """Fold any `git -C <dir>` options from a git options blob onto base_cwd,
     following git's cumulative -C semantics (each -C is relative to the
     previous one). Returns base_cwd unchanged when the blob has no -C."""
@@ -161,6 +162,13 @@ def _dash_c_target(opts_blob: str, base_cwd: str) -> str:
     for m in re.finditer(r'-C\s*(?:"([^"]*)"|\'([^\']*)\'|(\S+))', opts_blob):
         raw = next((g for g in m.groups() if g is not None), None)
         if raw is None:
+            continue
+        if _LIB_OK:
+            raw = expand_vars(raw, variables or {})
+        if "$" in raw:
+            # UNRESOLVED target. Folding it would join a literal `$W` onto the
+            # cwd and produce a path that resolves to no repo -- i.e. "not the
+            # vault", a silent allow. Let the cwd decide instead.
             continue
         path = os.path.expanduser(raw)
         cwd = path if os.path.isabs(path) else os.path.normpath(os.path.join(cwd, path))
@@ -226,12 +234,12 @@ def _git_dir_is_vault(git_dir: str) -> bool:
     return any(os.path.realpath(c) == vault_git_dir for c in cands)
 
 
-def _targets_vault(opts_blob: str, base_cwd: str) -> bool:
+def _targets_vault(opts_blob: str, base_cwd: str, variables=None) -> bool:
     """True iff a git invocation carrying this options blob, run from
     base_cwd, would touch the personal vault repo. An explicit --git-dir
     is authoritative; otherwise targeting follows -C / cwd. Fails open
     (False) when the repo cannot be determined."""
-    eff_cwd = _dash_c_target(opts_blob, base_cwd)
+    eff_cwd = _dash_c_target(opts_blob, base_cwd, variables)
     git_dir = _git_dir_arg(opts_blob)
     if git_dir is not None:
         path = os.path.expanduser(git_dir)
@@ -253,40 +261,75 @@ except Exception:
 
 command = data.get("tool_input", {}).get("command", "")
 
-if "GIT_VAULT_BYPASS=1" in command or "vault-safe-commit.sh" in command:
+# The wrapper allowance stays whole-command: it is the sanctioned path this
+# hook's own message tells people to use, and narrowing it would break the
+# escape hatch rather than the bypass.
+if "vault-safe-commit.sh" in command:
     sys.exit(0)
 
-# Find every `git <subcommand>` invocation at a command-start position
-# (line start, or after &&, ||, ;, |). Ignore mentions inside quoted strings
-# by only matching the first token after separators. Group 1 captures the
-# git options blob (incl. any `-C <dir>`); group 2 the subcommand.
+# A genuinely exported variable is a deliberate standing choice by the operator.
+if os.environ.get("GIT_VAULT_BYPASS") == "1":
+    sys.exit(0)
+
+# Match PER SEGMENT against a quote-aware split, so "is this a command start?"
+# is answered structurally instead of by a regex alternation over operators.
+# That removes the phantom matches the old boundary could not tell apart -- a
+# `git add -A` inside `echo "..."` or a heredoc BODY used to match and hard-block
+# -- and it makes a subshell `(git commit)` visible, which the old pattern
+# missed entirely. Group 1 is the git options blob, group 2 the subcommand.
 pattern = re.compile(
-    r'(?:^|&&|\|\|?|;(?!;))\s*'        # command boundary
-    r'(?:[A-Z_][A-Z0-9_]*=\S+\s+)*'    # optional env assignments
-    r'git\s+'                          # git
-    + _GIT_OPTS_CAP +                  # group 1: git options (-C dir, --git-dir=..., ...)
-    r'([a-z][a-z-]*)',                 # group 2: subcommand
-    re.MULTILINE,
+    _LEAD
+    + r'git\s+'
+    + _GIT_OPTS_CAP
+    + r'([a-z][a-z-]*)'
 )
 
-hits = [(m.group(1) or "", m.group(2)) for m in pattern.finditer(command)]
-mutating = [(opts, sub) for opts, sub in hits if sub in MUTATING]
+cwd = os.environ.get("CLAUDE_CWD", data.get("cwd", "")) or os.getcwd()
+
+# Heredoc bodies and comment tails are text the shell never runs, yet both carry
+# operators that forge segment boundaries. Strip before splitting.
+if _LIB_OK:
+    sanitized = strip_noncode(strip_heredoc_bodies(command))
+    segs = split_segments_with_seps(sanitized)
+else:
+    segs = [("", command)]
+seg_texts = [t for _, t in segs]
+
+# A SET of possible cwds, not one guess. Block if ANY member is the vault.
+if _LIB_OK:
+    bases, variables = cwd_candidates(segs, cwd)
+else:
+    bases, variables = set(), {}
+if not bases:
+    bases = {os.path.expanduser(cwd)}
+
+# THE BYPASS IS SCOPED TO THE COMMAND IT PREFIXES. Checking `"GIT_VAULT_BYPASS=1"
+# in command` meant a real assignment ANYWHERE disarmed the guard, so
+# `git add -A ; GIT_VAULT_BYPASS=1` allowed a raw vault op that had already run.
+if _LIB_OK:
+    seg_bypass = segment_bypass_flags(seg_texts, "GIT_VAULT_BYPASS")
+else:
+    seg_bypass = ["GIT_VAULT_BYPASS=1" in t for t in seg_texts]
+live = [t for i, t in enumerate(seg_texts) if not seg_bypass[i]]
+
+mutating = []
+for seg in live:
+    m = pattern.match(seg.lstrip())
+    if m and m.group(2) in MUTATING:
+        mutating.append((m.group(1) or "", m.group(2)))
 if not mutating:
     sys.exit(0)
 
 # A mutating git subcommand is present. Resolve which repo each invocation
 # targets -- only the vault repo (or a worktree of it) gets funneled through
-# the wrapper. `git -C <dir>` retargets the op, so fold it onto the cwd.
-cwd = os.environ.get("CLAUDE_CWD", data.get("cwd", ""))
-base_cwd = _effective_cwd(command, cwd) or os.getcwd()
-
+# the wrapper. `git -C <dir>` retargets the op, so fold it onto each candidate.
 blocked = []
 seen = {}
-for opts, sub in mutating:
+for opts, sub_name in mutating:
     if opts not in seen:
-        seen[opts] = _targets_vault(opts, base_cwd)
+        seen[opts] = any(_targets_vault(opts, b, variables) for b in sorted(bases))
     if seen[opts]:
-        blocked.append(sub)
+        blocked.append(sub_name)
 if not blocked:
     sys.exit(0)
 

--- a/hooks/block-vault-git-fullwalk.py
+++ b/hooks/block-vault-git-fullwalk.py
@@ -46,6 +46,19 @@ except Exception:  # fail-open: never block a git op on an import error
     def vault_root_for(target: Path):  # type: ignore
         return None
 
+# Shared, quote-aware command parsing. This guard hand-rolled its own `cd` walk
+# and inherited every fail-open that copy had.
+try:
+    from _lib.shell_parse import (  # noqa: E402
+        cwd_candidates, expand_vars, split_segments_with_seps,
+        strip_heredoc_bodies, strip_noncode,
+    )
+    _LIB_OK = True
+except Exception:
+    # FAIL CLOSED: keep the session cwd as the only candidate rather than
+    # widening to "allow".
+    _LIB_OK = False
+
 
 def _vault_git_dir_for(target: str) -> str | None:
     """realpath of the `.git` of the vault governing `target`, or None.
@@ -79,16 +92,19 @@ def _vault_git_dir_for(target: str) -> str | None:
     return os.path.realpath(os.path.join(str(root), ".git"))
 
 
-def _effective_cwd(command: str, initial: str) -> str:
-    """Resolve cwd after any leading `cd <path>` commands in the command string."""
-    cwd = os.path.expanduser(initial) if initial else ""
-    for chunk in re.split(r"\s*(?:&&|\|\||;)\s*", command):
-        chunk = chunk.strip()
-        m = re.match(r"cd\s+(?:\"([^\"]+)\"|'([^']+)'|(\S+))", chunk)
-        if m:
-            new_path = os.path.expanduser(next(g for g in m.groups() if g is not None))
-            cwd = new_path if os.path.isabs(new_path) else os.path.normpath(os.path.join(cwd, new_path))
-    return cwd
+# What may sit between a command start and its verb without changing which
+# program runs: transparent wrappers (with their own bounded options, so
+# `sudo -u root git add -A` is seen), one-shot `VAR=` assignments in ANY case,
+# an explicit path to the binary, and a brace-group opener. Matching a bare
+# `git` token at a regex boundary instead let `env git add -A`, `sudo git add
+# -A`, `/usr/bin/git add -A`, `command git add -A`, lowercase `foo=1 git add -A`
+# and `(git add -A)` run completely unguarded -- measured exit 0 against a
+# proven positive control.
+_ASSIGN_TOK = r'[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|\'[^\']*\'|\S*)'
+_WRAPPER_TOK = r'(?:env|command|exec|builtin|nohup|sudo|time)'
+_LEAD = (r'\s*(?:[({]\s+)*'
+         r'(?:' + _ASSIGN_TOK + r'\s+|' + _WRAPPER_TOK + r'\s+(?:\S+\s+){0,3})*'
+         r'(?:\S*/)?')
 
 
 # A git option's value argument:
@@ -127,7 +143,7 @@ _GIT_OPT = '|'.join([
 _GIT_OPTS_CAP = r'((?:' + _GIT_OPT + r')*)'   # capturing group: the whole options blob
 
 
-def _dash_c_target(opts_blob: str, base_cwd: str) -> str:
+def _dash_c_target(opts_blob: str, base_cwd: str, variables=None) -> str:
     """Fold any `git -C <dir>` options from a git options blob onto base_cwd,
     following git's cumulative -C semantics (each -C is relative to the
     previous one). Returns base_cwd unchanged when the blob has no -C."""
@@ -135,6 +151,12 @@ def _dash_c_target(opts_blob: str, base_cwd: str) -> str:
     for m in re.finditer(r'-C\s*(?:"([^"]*)"|\'([^\']*)\'|(\S+))', opts_blob):
         raw = next((g for g in m.groups() if g is not None), None)
         if raw is None:
+            continue
+        if _LIB_OK:
+            raw = expand_vars(raw, variables or {})
+        if "$" in raw:
+            # UNRESOLVED target: folding a literal `$W` onto the cwd yields a
+            # path that resolves to no repo -- "not the vault", a silent allow.
             continue
         path = os.path.expanduser(raw)
         cwd = path if os.path.isabs(path) else os.path.normpath(os.path.join(cwd, path))
@@ -150,7 +172,13 @@ def _targets_vault_repo(cwd: str) -> bool:
     try:
         out = subprocess.run(
             ["git", "-C", cwd, "rev-parse", "--git-common-dir"],
-            capture_output=True, text=True, timeout=5,
+            # encoding pinned, not left to the locale: this prints a PATH, and a
+            # vault path can carry an emoji folder name (U+FE0F, byte 0x8F
+            # unmapped in cp1252). text=True alone raises UnicodeDecodeError
+            # inside subprocess.run on a non-UTF-8 console, before we see a byte
+            # -- and this guard then fails open on the machine it never ran on.
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            timeout=5,
         )
     except Exception:
         return False
@@ -187,7 +215,10 @@ def _git_dir_is_vault(git_dir: str) -> bool:
     try:
         out = subprocess.run(
             ["git", "--git-dir", git_dir, "rev-parse", "--git-common-dir"],
-            capture_output=True, text=True, timeout=5,
+            # encoding pinned for the same reason as the call above: the child
+            # prints a path, and vault paths carry non-cp1252 bytes.
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            timeout=5,
             cwd=git_dir if os.path.isdir(git_dir) else None,
         )
         if out.returncode == 0 and out.stdout.strip():
@@ -200,12 +231,12 @@ def _git_dir_is_vault(git_dir: str) -> bool:
     return any(os.path.realpath(c) == vault_git_dir for c in cands)
 
 
-def _targets_vault(opts_blob: str, base_cwd: str) -> bool:
+def _targets_vault(opts_blob: str, base_cwd: str, variables=None) -> bool:
     """True iff a git invocation carrying this options blob, run from
     base_cwd, would touch the personal vault repo. An explicit --git-dir
     is authoritative; otherwise targeting follows -C / cwd. Fails open
     (False) when the repo cannot be determined."""
-    eff_cwd = _dash_c_target(opts_blob, base_cwd)
+    eff_cwd = _dash_c_target(opts_blob, base_cwd, variables)
     git_dir = _git_dir_arg(opts_blob)
     if git_dir is not None:
         path = os.path.expanduser(git_dir)
@@ -223,34 +254,56 @@ except Exception:
 command = data.get("tool_input", {}).get("command", "")
 
 # Block git add -A / --all / bare dot.
-# Only match at command-start positions (line start, after &&, ;, or |)
-# to avoid false positives inside commit messages, heredocs, or comments.
-# Group 1 captures the git options blob (incl. any `-C <dir>`); group 2
-# the dangerous argument.
-# Does NOT match: git add ./relative/path, git add .gitignore, or
-#   mentions of "git add -A" inside quoted strings/heredocs.
+# Matched PER SEGMENT against a quote-aware split, so command-start is decided
+# structurally rather than by a regex alternation over operators. That keeps the
+# old false-positive protection (a mention inside a commit message, a heredoc
+# BODY or a comment tail is no longer even in the input) while ALSO seeing the
+# spellings the alternation missed entirely -- a subshell, a brace group, a
+# wrapper, an assignment prefix, an explicit path to the binary.
+# Still does NOT match: `git add ./relative/path` or `git add .gitignore`.
+# The lone-dot arm no longer lists `&&`/`;`/`|` as terminators: the splitter has
+# already removed every unquoted separator, so end-of-segment IS the terminator.
 DANGEROUS = re.compile(
-    r'(?:^|&&|;(?!;)|\|\|?)\s*git\s+'
-    + _GIT_OPTS_CAP +                       # group 1: git options blob
-    r'add\s+('                              # group 2: the dangerous argument
-    r'-A\b'
-    r'|--all\b'
-    r'|\.\s*(?:$|&&|;|2>|>>|>|\|)'          # lone dot (not ./path or .gitignore)
-    r')',
-    re.MULTILINE
+    _LEAD
+    + r'git\s+'
+    + _GIT_OPTS_CAP                         # group 1: git options blob
+    + r'add\s+('                            # group 2: the dangerous argument
+      r'-A\b'
+      r'|--all\b'
+      r'|\.\s*(?:$|2>|>>|>)'                 # lone dot (not ./path or .gitignore)
+      r')'
 )
 
-matches = list(DANGEROUS.finditer(command))
+cwd = os.environ.get("CLAUDE_CWD", data.get("cwd", "")) or os.getcwd()
+
+# Heredoc bodies and comment tails are text the shell never runs, yet both carry
+# operators that would forge segment boundaries. Strip before splitting.
+if _LIB_OK:
+    segs = split_segments_with_seps(strip_noncode(strip_heredoc_bodies(command)))
+else:
+    segs = [("", command)]
+
+matches = []
+for _sep, seg in segs:
+    m = DANGEROUS.match(seg.lstrip())
+    if m:
+        matches.append(m)
 if not matches:
     sys.exit(0)
 
-# A full-tree `git add` is present. Resolve which repo each invocation
-# targets -- the 60K walk only hurts the vault repo; ~/dev/* repos stage
-# instantly. `git -C <dir>` retargets the op, so fold it onto the cwd.
-cwd = os.environ.get("CLAUDE_CWD", data.get("cwd", ""))
-base_cwd = _effective_cwd(command, cwd) or os.getcwd()
+# A full-tree `git add` is present. Resolve which repo each invocation targets --
+# the full walk only hurts the vault repo. `git -C <dir>` retargets the op, so
+# fold it onto every candidate cwd. A SET, not one guess: block if ANY member is
+# the vault (see cwd_candidates for the fail-closed rationale).
+if _LIB_OK:
+    bases, variables = cwd_candidates(segs, cwd)
+else:
+    bases, variables = set(), {}
+if not bases:
+    bases = {os.path.expanduser(cwd)}
 
-if not any(_targets_vault(m.group(1) or "", base_cwd) for m in matches):
+if not any(_targets_vault(m.group(1) or "", b, variables)
+           for m in matches for b in sorted(bases)):
     sys.exit(0)
 
 print(

--- a/hooks/test_live_vault_git_guards_lead.py
+++ b/hooks/test_live_vault_git_guards_lead.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Controls for the recognition layer of the two LIVE vault git guards.
+
+block-raw-vault-git.py and block-vault-git-fullwalk.py are the hooks a user
+actually runs: both activate through the phase-doc channel and are wired in
+hooks.json. vault-command-nudges.py, which carries the same two rules, is
+documented-dormant. So this suite is the one that covers the deployed surface,
+and hooks/test_vault_command_nudges_lead.py covers the dormant sibling.
+
+Every BLOCK leg here was measured EXITING 0 before the fix, each against a
+proven positive control (a bare `git commit -m x` and a bare `git add -A` from
+a vault cwd both exit 2). Both hooks recognised their verb as a BARE token at a
+boundary alternation that admitted only UPPERCASE assignments, and both resolved
+cwd with a quote-blind split whose `cd` match anchored at chunk start:
+
+    env / sudo / command / /usr/bin/git <verb>      -> 0
+    foo=1 git <verb>          (lowercase assign)    -> 0
+    (git <verb>)              (subshell)            -> 0
+    cd /nonexistent || git add -A                   -> 0
+
+The ALLOW legs are half the point. These guards sit in front of the commands
+people run constantly, and the fail-closed cwd candidate SET is exactly the kind
+of change that starts over-blocking -- which is what teaches people to reach for
+the bypass. A hook that returned 2 unconditionally fails this suite.
+
+A vault is "a directory with a Meta-suffixed folder above it"
+(hooks/_lib/vault_root.py), so a tmpdir with `Meta/` and a `git init` is a real
+one. VAULT_ROOT is pointed somewhere ELSE on purpose: these rules must resolve
+the vault PER TARGET, and a regression that only reads $VAULT_ROOT must not pass.
+
+Stdlib only. Exit 0 = all pass.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+HOOKS = os.path.dirname(os.path.abspath(__file__))
+RAW = os.path.join(HOOKS, "block-raw-vault-git.py")
+FULLWALK = os.path.join(HOOKS, "block-vault-git-fullwalk.py")
+
+PASS = 0
+FAIL = 0
+
+
+def run(hook, command, cwd, env=None):
+    """Exit code of one hook for one crafted PreToolUse payload.
+
+    The hook only PARSES the string -- nothing is executed by a shell, which is
+    why a `git add -A` case is safe to assert on.
+    """
+    payload = json.dumps({"tool_name": "Bash", "cwd": cwd,
+                          "tool_input": {"command": command}})
+    # USERPROFILE is set alongside HOME, never instead of it: Path.home() reads
+    # USERPROFILE on Windows, so a HOME-only redirect would silently run the
+    # child against the REAL ~/.claude there while looking sandboxed on POSIX.
+    home = os.environ.get("HOME") or os.environ.get("USERPROFILE") or tempfile.gettempdir()
+    base = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": home,
+        "USERPROFILE": home,
+        "VAULT_ROOT": os.path.join(tempfile.gettempdir(), "lvg-not-a-vault"),
+        "SYSTEMROOT": os.environ.get("SYSTEMROOT", ""),   # git needs it on Windows
+    }
+    if env:
+        base.update(env)
+    # encoding pinned, not left to the locale: vault paths can carry non-ASCII
+    # folder names. Enforced repo-wide by scripts/check-utf8-subprocess.py.
+    proc = subprocess.run([sys.executable, hook], input=payload,
+                          capture_output=True, text=True, encoding="utf-8",
+                          errors="replace", env=base, timeout=60)
+    return proc.returncode
+
+
+def check(want_block, label, hook, command, cwd, env=None):
+    global PASS, FAIL
+    rc = run(hook, command, cwd, env=env)
+    got = (rc == 2)
+    if got == want_block:
+        PASS += 1
+        print(f"PASS  {label} :: {'BLOCK' if got else 'allow'}")
+    else:
+        FAIL += 1
+        print(f"FAIL  {label} :: got rc={rc} ({'BLOCK' if got else 'allow'}), "
+              f"wanted {'BLOCK' if want_block else 'allow'}")
+
+
+def git(*args, cwd):
+    subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True,
+                   encoding="utf-8", errors="replace", check=False)
+
+
+TMP = tempfile.mkdtemp(prefix="lvg-lead-")
+try:
+    VAULT = os.path.join(TMP, "brain")
+    os.makedirs(os.path.join(VAULT, "Meta"))
+    git("init", "-q", cwd=VAULT)
+
+    PLAIN = os.path.join(TMP, "plain", "repo")   # no Meta anywhere above it
+    os.makedirs(PLAIN)
+    git("init", "-q", cwd=PLAIN)
+
+    print("--- block-raw-vault-git: recognition layer ---")
+    check(True,  "01. bare `git commit`     [POSITIVE CONTROL]", RAW,
+          "git commit -m x", VAULT)
+    check(True,  "02. env wrapper", RAW, "env git commit -m x", VAULT)
+    check(True,  "03. sudo wrapper", RAW, "sudo git commit -m x", VAULT)
+    check(True,  "04. wrapper with its own flag+value", RAW,
+          "sudo -u root git commit -m x", VAULT)
+    check(True,  "05. absolute path to the binary", RAW,
+          "/usr/bin/git commit -m x", VAULT)
+    check(True,  "06. command wrapper", RAW, "command git commit -m x", VAULT)
+    check(True,  "07. LOWERCASE assignment prefix", RAW,
+          "foo=1 git commit -m x", VAULT)
+    check(True,  "08. subshell", RAW, "(git commit -m x)", VAULT)
+    check(True,  "09. brace group (runs in the CURRENT shell)", RAW,
+          "{ git commit -m x; }", VAULT)
+    check(True,  "10. `$VAR` cd, never expanded before", RAW,
+          f'W={VAULT}; cd "$W" && git add .', TMP)
+    check(True,  "11. `cd` inside a QUOTED string is not a cd", RAW,
+          'echo "hi; cd /tmp" && git commit -m x', VAULT)
+
+    print("--- block-raw-vault-git: ALLOW legs ---")
+    check(False, "12. non-vault repo         [NEGATIVE CONTROL]", RAW,
+          "git commit -m x", PLAIN)
+    check(False, "13. read-only git is not mutating", RAW,
+          "git log --oneline -1", VAULT)
+    check(False, "14. the sanctioned wrapper is still allowed", RAW,
+          'bash "Meta/scripts/vault-safe-commit.sh" "msg" a.md', VAULT)
+    check(False, "15. inline bypass on the segment", RAW,
+          "GIT_VAULT_BYPASS=1 git commit -m x", VAULT)
+    check(False, "16. exported bypass", RAW, "git commit -m x", VAULT,
+          env={"GIT_VAULT_BYPASS": "1"})
+    check(False, "17. verb quoted as an argument", RAW,
+          'echo "later; git commit -m x"', VAULT)
+    check(False, "18. verb inside a heredoc BODY", RAW,
+          'cat > n.md <<\'XX\'\ngit commit -m x\nXX\n', VAULT)
+    # A bare trailing assignment sets only a SHELL variable -- unexported, so it
+    # never reaches a child's environment and cannot be a bypass for one. The
+    # op it "bypasses" has already run by the time the shell reaches the token.
+    check(True,  "19. trailing bypass does NOT disarm a prior op", RAW,
+          "git commit -m x ; GIT_VAULT_BYPASS=1", VAULT)
+
+    print("--- block-vault-git-fullwalk: recognition layer ---")
+    check(True,  "20. bare `git add -A`     [POSITIVE CONTROL]", FULLWALK,
+          "git add -A", VAULT)
+    check(True,  "21. env wrapper", FULLWALK, "env git add -A", VAULT)
+    check(True,  "22. sudo wrapper", FULLWALK, "sudo git add -A", VAULT)
+    check(True,  "23. wrapper with its own flag+value", FULLWALK,
+          "sudo -u root git add -A", VAULT)
+    check(True,  "24. absolute path to the binary", FULLWALK,
+          "/usr/bin/git add -A", VAULT)
+    check(True,  "25. LOWERCASE assignment prefix", FULLWALK,
+          "foo=1 git add -A", VAULT)
+    check(True,  "26. subshell", FULLWALK, "(git add -A)", VAULT)
+    check(True,  "27. brace group", FULLWALK, "{ git add -A; }", VAULT)
+    check(True,  "28. `||` is not an unconditional cd", FULLWALK,
+          "cd /nonexistent-xyz || git add -A", VAULT)
+    check(True,  "29. `git add --all`", FULLWALK, "git add --all", VAULT)
+    check(True,  "30. lone dot", FULLWALK, "git add .", VAULT)
+    check(True,  "31. lone dot with a redirect", FULLWALK,
+          "git add . 2>/dev/null", VAULT)
+
+    print("--- block-vault-git-fullwalk: ALLOW legs ---")
+    check(False, "32. non-vault repo         [NEGATIVE CONTROL]", FULLWALK,
+          "git add -A", PLAIN)
+    check(False, "33. `git add ./relative/path` is not a lone dot", FULLWALK,
+          "git add ./relative/path", VAULT)
+    check(False, "34. `git add .gitignore` is not a lone dot", FULLWALK,
+          "git add .gitignore", VAULT)
+    check(False, "35. explicit paths are the recommended form", FULLWALK,
+          'git add "Meta/file.md"', VAULT)
+    check(False, "36. mention inside a commit message", FULLWALK,
+          'git commit -m "ran git add -A once"', VAULT)
+    check(False, "37. inside a heredoc BODY", FULLWALK,
+          'cat > n.md <<\'XX\'\ngit add -A\nXX\n', VAULT)
+    check(False, "38. quoted as an argument", FULLWALK,
+          'echo "later; git add -A"', VAULT)
+    check(False, "39. `cd <non-vault> && git add -A` from a vault cwd", FULLWALK,
+          f'cd "{PLAIN}" && git add -A', VAULT)
+
+    print("--- degraded mode: a missing _lib must FAIL CLOSED, both hooks ---")
+    degraded = os.path.join(TMP, "degraded")
+    os.makedirs(os.path.join(degraded, "_lib"))
+    # Copied file-by-file, NOT with shutil.copytree: copytree owns its own
+    # recursion and reads content internally, which
+    # scripts/check-cloud-safe-file-walkers.py flags fleet-wide unless it
+    # reaches the shared safe_read primitive. Naming the files is also the more
+    # precise fixture -- it proves shell_parse.py is the ONLY thing absent.
+    for rel in ("block-raw-vault-git.py", "block-vault-git-fullwalk.py",
+                "_lib/__init__.py", "_lib/vault_root.py"):
+        parts = rel.split("/")
+        shutil.copy2(os.path.join(HOOKS, *parts), os.path.join(degraded, *parts))
+    d_raw = os.path.join(degraded, "block-raw-vault-git.py")
+    d_full = os.path.join(degraded, "block-vault-git-fullwalk.py")
+    check(True,  "40. raw guard still blocks in the vault", d_raw,
+          "git commit -m x", VAULT)
+    check(False, "41. raw guard still allows outside it", d_raw,
+          "git commit -m x", PLAIN)
+    check(True,  "42. fullwalk still blocks in the vault", d_full,
+          "git add -A", VAULT)
+    check(False, "43. fullwalk still allows outside it", d_full,
+          "git add -A", PLAIN)
+finally:
+    shutil.rmtree(TMP, ignore_errors=True)
+
+print()
+print(f"=== summary: {PASS} passed, {FAIL} failed ===")
+sys.exit(1 if FAIL else 0)

--- a/hooks/test_vault_command_nudges_lead.py
+++ b/hooks/test_vault_command_nudges_lead.py
@@ -149,6 +149,17 @@ try:
     print("--- rm -rf: _RM_LEAD covered wrappers but NOT these two ---")
     check(True,  "16. assignment prefix on rm",
           f'FOO=bar rm -rf "{VAULT}"', TMP)
+    # 16a/16b/16c: an operand carrying `$VAR`. This guard hard-blocked its own
+    # author on `N=/some/path; rm -rf "$N"` -- the literal `$N` was joined onto
+    # the cwd and `<cwd>/$N`, a path that exists nowhere, landed one level under
+    # a vault root and was reported as a top-level folder. A block naming a
+    # non-existent path is the shape that reads as broken and teaches the bypass.
+    check(False, "16a. $VAR expanding to a NON-vault must not block",
+          f'W={PLAIN}; rm -rf "$W"', TMP)
+    check(True,  "16b. $VAR expanding TO a vault must still block",
+          f'W={VAULT}; rm -rf "$W"', TMP)
+    check(False, "16c. an unresolvable $VAR is skipped, never invented",
+          'rm -rf "$SOMETHING_NEVER_SET"', TMP)
     check(True,  "17. absolute path to rm",
           f'/bin/rm -rf "{VAULT}"', TMP)
     check(True,  "17a. wrapper flag+value on rm (sudo -u root rm)",

--- a/hooks/vault-command-nudges.py
+++ b/hooks/vault-command-nudges.py
@@ -538,12 +538,27 @@ def _rm_target_verdict(target: str):
     return None
 
 
-def _rm_verdicts(segs_text, bases):
+def _rm_verdicts(segs_text, bases, variables=None):
     """Every (target, verdict) a destructive rm in these segments would hit.
 
     A RELATIVE operand is resolved against EVERY candidate cwd, for the same
     fail-closed reason _cwd_candidates returns a set: if any cwd the command
     could run in puts `rm -rf Meta` on a vault, that is the one that matters.
+
+    An operand carrying `$VAR` is EXPANDED from assignments seen earlier in the
+    same command, and SKIPPED when it still cannot be named. Without that, a
+    literal `$N` was joined onto the cwd and the result -- `<cwd>/$N`, a path
+    that exists nowhere -- landed one level under a vault root and was reported
+    as a top-level folder. This guard hard-blocked its own author that way, on
+    `N=/some/path; rm -rf "$N"` where the assignment is right there in the same
+    command. A block naming a path that does not exist is the exact shape that
+    reads as broken and teaches VAULT_VALIDATOR_BYPASS=1.
+
+    Skipping an operand that is STILL unresolved after expansion (a var set in
+    an earlier shell, a command substitution) is a deliberate narrow fail-open:
+    the alternative is asserting a concrete verdict about a path we cannot name,
+    which is how the false block above happened. The cwd walk already makes the
+    same call for `cd` targets.
     """
     found = []
     probed = 0
@@ -556,6 +571,10 @@ def _rm_verdicts(segs_text, bases):
         if not _is_destructive_rm(flag_blob, operand_text):
             continue
         for word in _rm_operands(operand_text):
+            if _LIB_OK:
+                word = expand_vars(word, variables or {})
+            if "$" in word:
+                continue          # unresolvable target -- do not invent one
             for base in (sorted(bases) or [""]):
                 probed += 1
                 if probed > _MAX_PATH_TOKENS:  # same stat-storm bound as above
@@ -845,7 +864,7 @@ def main():
             # The regex only says "a destructive rm is in here somewhere".
             # Naming the resolved targets is what makes the block actionable --
             # and, when it is wrong, obviously wrong to the reader.
-            verdicts = _rm_verdicts(live, bases)
+            verdicts = _rm_verdicts(live, bases, variables)
             fired = bool(verdicts)
             if fired:
                 detail = "\n  Target(s): " + "; ".join(

--- a/phases/phase-05-context-layer.md
+++ b/phases/phase-05-context-layer.md
@@ -177,7 +177,7 @@ cp ~/.claude/skills/ai-brain-starter/hooks/block-vault-git-fullwalk.py ~/.claude
 cp ~/.claude/skills/ai-brain-starter/hooks/permission-denied.py ~/.claude/hooks/
 ```
 
-The two git-guard hooks read their vault path from the `VAULT_ROOT` environment variable; if unset, they no-op safely. Set it in `~/.zshrc` or `~/.claude/settings.json` pointing at your vault root. Emergency bypass for blocked git commands: `GIT_VAULT_BYPASS=1 git ...`.
+The two git-guard hooks DETECT the vault from the path each command targets — any ancestor directory holding a `Meta`-suffixed folder counts — so they protect every vault on the machine, not one. `VAULT_ROOT` is only a fallback for when detection finds nothing; setting it is optional and it does NOT scope them to a single vault. **Leaving it unset does not disable them**: if you keep notes in a folder with a `Meta` subfolder, these hooks will fire there. Emergency bypass for blocked git commands: `GIT_VAULT_BYPASS=1 git ...` — that prefix applies to the command it prefixes, not to the whole line, and `export GIT_VAULT_BYPASS=1` disarms them for the session.
 
 Tell them: "Done. From now on, the first thing I do every session is read your files — automatically, before I say anything. And whenever you ask something strategic, I'll pull your current priorities and open items into context before I respond. If there's an update to the skill, I'll pull it and apply it automatically — you'll just see a quick note about what changed."
 

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1320,6 +1320,14 @@ PY_DIRECT=(
   # half the suite, because the fail-closed cwd SET that fixes the walk is
   # exactly the change that would otherwise start over-blocking.
   hooks/test_vault_command_nudges_lead.py
+  # The same recognition-layer defect in the two guards a user actually RUNS.
+  # vault-command-nudges is documented-dormant (0 matches in hooks.json);
+  # block-raw-vault-git and block-vault-git-fullwalk activate through the
+  # phase-doc channel and are wired, so this is the suite covering the deployed
+  # surface. 23 of its 43 legs fail against the pre-fix revision. Half are ALLOW
+  # legs -- these guards sit in front of commands people run constantly, and the
+  # fail-closed cwd SET is exactly the change that would start over-blocking.
+  hooks/test_live_vault_git_guards_lead.py
 )
 dormant_py=()
 while IFS= read -r -d '' f; do

--- a/scripts/utf8-subprocess-baseline.txt
+++ b/scripts/utf8-subprocess-baseline.txt
@@ -4,7 +4,6 @@
 # Fix by adding: encoding="utf-8", errors="replace"
 e2f343536da6ef508c45d335a9d2fbe9977f40aaa152f5c86913ddeb82f9c531 hooks/_lib/git_locks.py
 987aca2ae82229a42d29a8c89fed690e9de7e6fad4182dea564bc92557a81922 hooks/auto-capture-public-ships.py
-851421a1c5ac1daa0fae7effa71f06e08330cd4ec9edd9909b6fea8626ad0140 hooks/block-vault-git-fullwalk.py
 9cbf3bb52c04fd00a41852d12baf7640f9212db9b5a34aaac2247ee6abb4312f hooks/check-py-import-precommit.py
 25d963d25e1e2e6844a35133bbad1d0aad8d03de424e29d4a406a67cb1d4c1cb hooks/check-rule-conflicts-on-write.py
 85006d7e25f42ba787b2ce616bd1c71590c3990f89f3153a6f958156c93029ed hooks/coach-auto-prescribe-on-journal.py


### PR DESCRIPTION
## Why this exists after #616

#616 landed the recognition-layer fix for `hooks/vault-command-nudges.py`. That hook is
**documented-dormant** — 0 matches in `hooks.json`, budget-blocked at PreToolUse:Bash 9/9, and
`scripts/check-hook-activation.py` records that its rules are delivered by two other hooks.

Those two — `block-raw-vault-git.py` and `block-vault-git-fullwalk.py` — activate through the
phase-doc channel and **are** wired. Both carried the identical defect. So after #616 the fix was
on main and the shipped guards were still open.

Measured before, each against a proven positive control (a bare `git commit -m x` and a bare
`git add -A` from a vault cwd both exit `2`). Every one of these exited **0**:

```
env git <verb>        sudo git <verb>       command git <verb>     /usr/bin/git <verb>
sudo -u root git <verb>                     foo=1 git <verb>   (LOWERCASE assignment)
(git <verb>)  subshell                      { git <verb>; }    brace group
cd /nonexistent || git add -A               W=<vault>; cd "$W" && git add .
```

Both recognised the verb as a BARE token at a boundary alternation that admitted only
UPPERCASE assignments, and both resolved cwd with a quote-blind `re.split` whose `cd` match
anchored at chunk start.

## What changed

- Both hooks now read segments from the shared quote-aware splitter, carry `_LEAD` (transparent
  wrappers **with their own bounded options**, assignments in any case, an explicit path to the
  binary, a brace-group opener), and resolve cwd through a candidate **set**.
- `cwd_candidates` moves **into** `_lib/shell_parse.py` instead of becoming a third inline copy.
  This repo already names "four hooks, four parsers, four different bugs" as a bug class, so a
  third copy would have been the defect rather than the fix. `vault-command-nudges.py` is
  switched over in the same commit — one implementation.
- That shared walk **subsumes** `block-raw-vault-git`'s deliberate "ignore a `cd` whose target
  does not exist" clause. It existed because `_targets_vault_repo` fails OPEN, so a bogus `cd`
  could move the guard off the vault. Unioning cannot move the set off: with `&&` the `cd` must
  have succeeded for the next command to run, with `;` the isdir check decides, and an
  unresolvable target keeps the old cwd. The clause is gone because it is unreachable, not
  because it was overlooked.
- `block-raw-vault-git`'s bypass is now scoped to the segment it prefixes, and an **exported**
  var is honoured as a standing operator choice. The `vault-safe-commit.sh` allowance stays
  whole-command on purpose — it is the sanctioned path the block message itself names.

## A false block this branch hit live

`_rm_verdicts` never expanded `$VAR` in an **operand**. So `N=/some/path; rm -rf "$N"` — with the
assignment right there in the same command — joined the literal `$N` onto the cwd. `<cwd>/$N`
exists nowhere, landed one level under a vault root, and was reported as a top-level folder. The
guard refused a worktree cleanup and printed a path that does not exist.

That is the exact shape that reads as broken and teaches `VAULT_VALIDATOR_BYPASS=1`. Operands are
now expanded from assignments seen in the same command; one still unresolvable after expansion is
**skipped rather than invented**. `W=<vault>; rm -rf "$W"` still blocks, because it expands *to* a
vault — pinned as its own leg.

## utf-8 on the fullwalk guard

Its two `git rev-parse` calls decoded with the locale encoding. Both callers read an exception as
"cannot resolve the repo", which fails **OPEN** — so on a non-UTF-8 Windows console that guard
silently stopped guarding on exactly the emoji-bearing vault paths it protects. Pinned at both
sites; the baseline row is removed via the tool's own `--write-baseline`, a one-line diff.

## Docs

`phases/phase-05-context-layer.md` told users these hooks "read their vault path from the
`VAULT_ROOT` environment variable; if unset, they no-op safely." Both halves are false since
per-target detection landed. A user who follows that sentence believes the guards are inert and
then gets a hard block in any notes folder with a `Meta` subfolder. Being told a guard is off
while it is on is worse than either state alone.

## Tests

`hooks/test_live_vault_git_guards_lead.py` — 43 legs, registered in `ci.sh` `PY_DIRECT` so it
cannot ship dormant. Proven to **discriminate**: 23 fail against the pre-fix revision.

Roughly half are ALLOW legs, because these guards sit in front of commands people run constantly
and the fail-closed cwd set is exactly the change that would start over-blocking: a read-only
`git log`, the sanctioned `vault-safe-commit.sh` path, both bypass forms,
`git add ./relative/path`, `git add .gitignore`, a verb named in a commit message, a verb in a
heredoc **body**, a verb quoted as an argument, and the same verb from a non-vault repo.

One leg asserts a **tightening**, not a capability: a trailing `; GIT_VAULT_BYPASS=1` must NOT
disarm an op that has already run. A bare assignment sets only a shell variable — unexported, it
never reaches a child's environment.

Also pins fail-closed on both hooks: a copy with `_lib/shell_parse.py` removed must still block in
the vault and still allow outside it.

`test_vault_command_nudges_lead.py` gains 3 legs for the `$VAR` operand cases (48 → 51).

## Deliberately not in this PR

- **Nested shells still bypass all three** — `bash -c`, `sh -c`, `xargs`, `find -exec`. Measured
  with positive controls, posted to MYC-3540. Not fixable by "also parse quoted strings" without
  breaking the mention-vs-use rule (MYC-1269).
- **`_GIT_CLEAN_ENV` not ported** to these two, so a leaked `GIT_DIR` can retarget their
  repo-identity resolution. Recorded on MYC-3280, which already owns that port.
- **Not wired into `hooks.json`.** Two of `vault-command-nudges`'s rules are `nudge`-severity but
  still `exit 2`; wiring as-is would block every `grep` in a vault. That scope call is MYC-3554's.

Full `ci-test` GREEN (marker `cd9e6ff9.ok`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
