### PR TITLE
shellcheck: refuse an empty enumeration instead of passing it

### DIFF
--- a/scripts/shellcheck.sh
+++ b/scripts/shellcheck.sh
@@ -78,7 +78,17 @@ SHIM
   # production reaches this state via a broken pathspec or an empty checkout.
   st_empty="$st_tmp/emptyrepo"
   mkdir -p "$st_empty"
-  ( cd "$st_empty" && git init -q . && git commit -q --allow-empty -m init ) >/dev/null 2>&1
+  # `git init` ONLY -- no commit. A commit needs user.name/user.email, which a
+  # developer box has globally and a CI runner does not: the first version of
+  # this control ran `git commit --allow-empty`, died with git's exit 128 under
+  # `set -e`, and so passed locally while failing in CI (PR #625, run at
+  # 03:29:41Z). `git ls-files` returns nothing in a repo with no commits, which
+  # is the only property this fixture needs.
+  if ! ( cd "$st_empty" && git init -q . ) >/dev/null 2>&1; then
+    echo "  FAIL [empty enumeration] could not create the fixture repo -- the"
+    echo "       control did not run, which is not a pass."
+    st_fail=1
+  fi
   # The script resolves REPO_ROOT from its OWN location and cd's there, so
   # running the real one from another cwd still scans THIS repo. Copy it into
   # the empty repo so its own resolution lands on a tree with no tracked *.sh.

--- a/scripts/shellcheck.sh
+++ b/scripts/shellcheck.sh
@@ -73,6 +73,29 @@ SHIM
     fi
   }
 
+  # The empty-enumeration refusal. Driven by pointing the scan at a directory
+  # with no tracked *.sh, so `git ls-files` legitimately returns nothing --
+  # production reaches this state via a broken pathspec or an empty checkout.
+  st_empty="$st_tmp/emptyrepo"
+  mkdir -p "$st_empty"
+  ( cd "$st_empty" && git init -q . && git commit -q --allow-empty -m init ) >/dev/null 2>&1
+  # The script resolves REPO_ROOT from its OWN location and cd's there, so
+  # running the real one from another cwd still scans THIS repo. Copy it into
+  # the empty repo so its own resolution lands on a tree with no tracked *.sh.
+  mkdir -p "$st_empty/scripts"
+  cp "$REPO_ROOT/scripts/shellcheck.sh" "$st_empty/scripts/shellcheck.sh"
+  set +e
+  ( cd "$st_empty" && PATH="$st_tmp/bin:$PATH" bash scripts/shellcheck.sh ) >/dev/null 2>&1
+  st_got=$?
+  set -e
+  if [ "$st_got" -ne 2 ]; then
+    echo "  FAIL [empty enumeration] expected exit 2 (UNEVALUATED), got $st_got."
+    echo "       A scan of zero files is not a clean tree."
+    st_fail=1
+  else
+    echo "  ok   [empty enumeration] zero tracked *.sh -> exit 2, not a pass"
+  fi
+
   st_case "clean"                0   0
   st_case "real findings"        1   1
   st_case "could-not-process"    2   2
@@ -83,7 +106,7 @@ SHIM
     echo "shellcheck.sh self-test FAILED" >&2
     exit 1
   fi
-  echo "OK - self-test: findings (1) and a killed/failed linter (2) are distinct exits."
+  echo "OK - self-test: findings (1), a killed/failed linter (2), and an empty enumeration (2) are all distinct from a clean pass (0)."
   exit 0
 fi
 
@@ -108,8 +131,18 @@ done < <(git ls-files -z -- '*.sh')
 
 # Empty-array expansion under `set -u` errors on bash 3.2 / 4.3; guard it.
 if [ "${#files[@]}" -eq 0 ]; then
-  echo "no tracked *.sh found - nothing to check"
-  exit 0
+  # REFUSE, do not pass. This repo tracks ~200 *.sh, so an empty enumeration
+  # means the selection broke -- a bad pathspec, a detached/empty checkout, a
+  # `git ls-files` that failed -- never that the work is clean. Exiting 0 here
+  # reported a clean lint over a scan that never happened, which is the same
+  # shape as the killed-linter case below: nothing ran, and the caller was told
+  # everything was fine. "Nothing compared is not parity"
+  # (check-paired-implementations.py). Exit 2 = could-not-evaluate, matching the
+  # classification below so a caller can tell it from real findings (1).
+  echo "UNEVALUATED: zero tracked *.sh found. This repo tracks many, so an" >&2
+  echo "empty file list means the SELECTION failed, not that the tree is" >&2
+  echo "clean. Nothing was linted -- this is not a pass." >&2
+  exit 2
 fi
 
 echo "==> shellcheck -S $SEVERITY over ${#files[@]} tracked *.sh  [$(shellcheck --version | awk '/^version:/{print $2}')]"


### PR DESCRIPTION
Completes the second half of MYC-4259's `Done =`. #623 shipped the first half (a killed linter is classified as could-not-evaluate rather than as findings) and left this one: **"an empty file list refuses."**

## The defect

`scripts/shellcheck.sh` printed `no tracked *.sh found - nothing to check` and exited **0**.

This repo tracks ~200 `*.sh`. An empty enumeration therefore means the *selection* broke — a bad pathspec, an empty or detached checkout, a `git ls-files` that failed — never that the tree is clean. Exiting 0 there reported a clean lint over a scan that never happened, which is the same shape as the killed-linter case one branch below it: nothing ran, and the caller was told everything was fine.

Now `exit 2`, matching the could-not-evaluate class introduced in #623, so a caller can still tell it from real findings (`1`).

The rule it now follows is the repo's own, borrowed from `check-paired-implementations.py`: *nothing compared is not parity.*

## Control

A git repo containing no tracked `*.sh`, driven end-to-end through the script.

The first version of this control **passed for the wrong reason**, and that is worth recording. `shellcheck.sh` resolves `REPO_ROOT` from its own location and `cd`s there, so invoking the real script from another working directory still scans *this* repo — the probe never reached the branch under test and reported exit 0 against an expectation of 2. It now copies the script into the empty repo so its own resolution lands on the empty tree.

Mutation-proven: reverting the refusal to `exit 0` fails the control by name —

```
FAIL [empty enumeration] expected exit 2 (UNEVALUATED), got 0.
```

Full self-test on this branch:

```
ok   [empty enumeration] zero tracked *.sh -> exit 2, not a pass
ok   [clean] fake shellcheck rc=0 -> exit 0
ok   [real findings] fake shellcheck rc=1 -> exit 1
ok   [could-not-process] fake shellcheck rc=2 -> exit 2
ok   [SIGKILL (OOM shape)] fake shellcheck rc=137 -> exit 2
ok   [SIGTERM] fake shellcheck rc=143 -> exit 2
```

## Verification

Local canonical gate GREEN (`GATE_EXIT=0`, marker `ee8b0762.ok`). The real gate still exits 0 on this repo, so the refusal does not fire on a healthy tree.

## Not claimed

MYC-4259's `Done =` has a fourth item this PR does **not** cover: sweeping sibling wrappers in `scripts/` that map a child process's non-zero exit onto a domain verdict. That is a distinct sweep across other files and is tracked separately rather than being quietly absorbed here.

The empty-enumeration case is driven by a genuinely empty git repo, not by simulating a `git ls-files` failure — the refusal is proven, a broken-pathspec failure in situ is not reproduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
