### PR TITLE
maintenance: alarm on a CRITICAL allowlist, not on any non-zero step

### DIFF
--- a/scripts/vault-daily-maintenance.sh
+++ b/scripts/vault-daily-maintenance.sh
@@ -167,7 +167,39 @@ log "acquired close-cascade mutex ($$)"
 # aggregators keep running when one leg dies. The change is that failures are
 # remembered, named in the log, written to a state file a SessionStart reader
 # can pick up, and reflected in the final exit code.
+# CRITICAL_STEPS -- the ONLY labels whose non-zero exit is a real failure.
+#
+# A blanket "any non-zero step" rule is WRONG here, and was briefly shipped as
+# one (b27fd6e, corrected in this change). Most legs of this pass are SURFACERS
+# that use the exit code as a findings count, so they exit non-zero while
+# perfectly healthy: aggregate-sessions and aggregate-decisions report pending
+# outcomes, relocate-watch reports residuals, close-phase-contract and
+# check-rule-conflicts report findings -- the last only since it was fixed to
+# carry a verdict at all. Alarming on those is several false reds a day, and a
+# daily red is background inside a week, which is the exact bug class this
+# accounting exists to fix.
+#
+# So the alarm is an explicit must-be-green ALLOWLIST, never a blanket rule.
+# Empty here on purpose: no leg in the substrate's own pass is unambiguously
+# must-be-green today. Add a label only when its non-zero means BROKEN rather
+# than FOUND-SOMETHING -- a security control's negative control is the
+# archetype (MYC-4116 seeds the personal vault's copy with pii-scrub-control
+# and pii-scrub-hugeline).
+CRITICAL_STEPS=()
+
+# Every failure, critical or not, for the state file and the log. Advisory by
+# design: this list does NOT gate the exit code.
 FAILED_STEPS=()
+# The subset that must be green. This one DOES gate the exit code.
+FAILED_CRITICAL=()
+
+_is_critical() {
+  local needle="$1" c
+  for c in ${CRITICAL_STEPS+"${CRITICAL_STEPS[@]}"}; do
+    [ "$c" = "$needle" ] && return 0
+  done
+  return 1
+}
 
 run() {
   # run <label> <command...> - runs at low priority, logs a tail, never aborts,
@@ -177,7 +209,10 @@ run() {
   out=$(nice -n 10 "$@" 2>&1); rc=$?
   printf '%s\n' "$out" | tail -3
   log "[$label] rc=$rc :: $(printf '%s\n' "$out" | tail -1)"
-  [ "$rc" -ne 0 ] && FAILED_STEPS+=("$label(rc=$rc)")
+  if [ "$rc" -ne 0 ]; then
+    FAILED_STEPS+=("$label(rc=$rc)")
+    _is_critical "$label" && FAILED_CRITICAL+=("$label(rc=$rc)")
+  fi
   return 0
 }
 
@@ -370,15 +405,25 @@ mkdir -p "$MAINT_STATE_DIR" 2>/dev/null || true
 {
   printf '{"finished_at":"%s","failed_count":%d,"failed_steps":[' \
     "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${#FAILED_STEPS[@]}"
-  for i in "${!FAILED_STEPS[@]}"; do
+  for i in ${FAILED_STEPS+"${!FAILED_STEPS[@]}"}; do
     [ "$i" -gt 0 ] && printf ','
     printf '"%s"' "${FAILED_STEPS[$i]}"
+  done
+  printf '],"failed_critical":['
+  for i in ${FAILED_CRITICAL+"${!FAILED_CRITICAL[@]}"}; do
+    [ "$i" -gt 0 ] && printf ','
+    printf '"%s"' "${FAILED_CRITICAL[$i]}"
   done
   printf ']}\n'
 } > "$MAINT_STATE" 2>/dev/null || true
 
+# Advisory failures are LOGGED but never gate the exit -- see CRITICAL_STEPS.
 if [ "${#FAILED_STEPS[@]}" -gt 0 ]; then
-  log "=== vault-daily-maintenance COMPLETED WITH ${#FAILED_STEPS[@]} FAILED STEP(S): ${FAILED_STEPS[*]} @ $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+  log "=== vault-daily-maintenance: ${#FAILED_STEPS[@]} non-zero step(s) (advisory; most are findings counts): ${FAILED_STEPS[*]} ==="
+fi
+
+if [ "${#FAILED_CRITICAL[@]}" -gt 0 ]; then
+  log "=== vault-daily-maintenance FAILED ${#FAILED_CRITICAL[@]} CRITICAL STEP(S): ${FAILED_CRITICAL[*]} @ $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
   exit 1
 fi
 

--- a/tests/integration/test_daily_maintenance_exit_code.sh
+++ b/tests/integration/test_daily_maintenance_exit_code.sh
@@ -42,9 +42,15 @@ ok()   { echo "  ok   $*"; }
 # `run()` ... its closing brace, and the summary block from MAINT_STATE_DIR to
 # the final `exit 0`. Both extractions are asserted below: an empty lift means
 # the block moved, and a control that tests an empty string always passes.
+crit_block="$(awk '/^_is_critical\(\) \{/,/^\}/' "$TARGET")"
 run_block="$(awk '/^run\(\) \{/,/^\}/' "$TARGET")"
 summary_block="$(awk '/^MAINT_STATE_DIR=/,/^exit 0$/' "$TARGET")"
 
+if ! printf '%s' "$crit_block" | grep -q 'CRITICAL_STEPS'; then
+  fail "could not lift _is_critical() -- the allowlist machinery moved, so the"
+  fail "advisory-vs-critical cases below would prove nothing."
+  exit 1
+fi
 if ! printf '%s' "$run_block" | grep -q 'FAILED_STEPS+='; then
   fail "could not lift run() with its FAILED_STEPS accounting -- the block moved,"
   fail "so this control would have tested nothing. Fix the extraction, not the assert."
@@ -62,7 +68,10 @@ build_harness() { # build_harness <steps...>  -> a runnable script at $tmp/h.sh
     echo '#!/usr/bin/env bash'
     echo 'set -uo pipefail'
     echo 'log() { printf "%s\n" "$*"; }'
+    echo "CRITICAL_STEPS=(${HARNESS_CRITICAL:-})"
     echo 'FAILED_STEPS=()'
+    echo 'FAILED_CRITICAL=()'
+    printf '%s\n' "$crit_block"
     printf '%s\n' "$run_block"
     cat                      # caller pipes in the step invocations
     printf '%s\n' "$summary_block"
@@ -70,7 +79,9 @@ build_harness() { # build_harness <steps...>  -> a runnable script at $tmp/h.sh
   chmod +x "$tmp/h.sh"
 }
 
-# CASE 1 -- a FAILING step must reach the exit code. This is the defect.
+# CASE 1 -- a failing CRITICAL step must reach the exit code. This is the defect
+# MYC-4116 was filed for.
+HARNESS_CRITICAL='"deliberately-failing-leg"'
 build_harness <<'STEPS'
 run "deliberately-failing-leg" false
 STEPS
@@ -79,11 +90,11 @@ run_sandboxed "$tmp/home1" bash "$tmp/h.sh" > "$tmp/o1" 2>&1
 rc1=$?
 set -e
 if [ "$rc1" -eq 0 ]; then
-  fail "a failing step still exited 0 -- the swallow is back (MYC-4116)"
+  fail "a failing CRITICAL step still exited 0 -- the swallow is back (MYC-4116)"
 else
-  ok "failing step -> exit $rc1"
+  ok "failing CRITICAL step -> exit $rc1"
 fi
-grep -q 'FAILED STEP' "$tmp/o1" || fail "the log line does not name the failed step"
+grep -q 'CRITICAL STEP' "$tmp/o1" || fail "the log line does not name the failed critical step"
 if [ -f "$tmp/home1/.claude/state/vault-daily-maintenance-last.json" ]; then
   grep -q 'deliberately-failing-leg' \
     "$tmp/home1/.claude/state/vault-daily-maintenance-last.json" \
@@ -95,6 +106,7 @@ fi
 
 # CASE 2 -- the inverse. Without this, a harness that exited non-zero for ANY
 # reason would satisfy CASE 1 and the control would be theatre.
+HARNESS_CRITICAL='"healthy-leg"'
 build_harness <<'STEPS'
 run "healthy-leg" true
 STEPS
@@ -111,6 +123,7 @@ fi
 # CASE 3 -- a failing step must NOT abort the remaining steps. That behaviour
 # was correct before and is the reason run() swallows rather than `set -e`s;
 # breaking it while fixing the exit code would trade one defect for a worse one.
+HARNESS_CRITICAL='"first-leg-fails"'
 build_harness <<'STEPS'
 run "first-leg-fails" false
 run "second-leg-still-runs" true
@@ -123,6 +136,34 @@ grep -q 'second-leg-still-runs' "$tmp/o3" \
   || fail "a failing leg aborted the pass -- later legs must still run"
 [ "$rc3" -ne 0 ] || fail "mixed pass should still exit non-zero"
 ok "a failing leg does not abort the legs after it (exit $rc3)"
+
+# CASE 4 -- an ADVISORY failure must NOT red. Most legs of the real pass are
+# surfacers whose non-zero is a findings count (aggregate-sessions,
+# relocate-watch, check-rule-conflicts...). A blanket rule shipped briefly in
+# b27fd6e and would have reported failure EVERY day, which is how a real alarm
+# becomes background. This is the case that keeps the allowlist honest.
+HARNESS_CRITICAL=''            # nothing is critical
+build_harness <<'STEPS'
+run "surfacer-with-findings" false
+STEPS
+set +e
+run_sandboxed "$tmp/home4" bash "$tmp/h.sh" > "$tmp/o4" 2>&1
+rc4=$?
+set -e
+if [ "$rc4" -ne 0 ]; then
+  fail "a NON-critical failing step exited $rc4 -- a blanket rule is back, and"
+  fail "the real pass has several legs that exit non-zero while healthy."
+else
+  ok "advisory (non-critical) failure -> exit 0, logged but not alarmed"
+fi
+grep -q 'surfacer-with-findings' "$tmp/o4" \
+  || fail "an advisory failure must still be RECORDED even though it does not red"
+if [ -f "$tmp/home4/.claude/state/vault-daily-maintenance-last.json" ]; then
+  grep -q '"failed_critical":\[\]' \
+    "$tmp/home4/.claude/state/vault-daily-maintenance-last.json" \
+    || fail "failed_critical should be empty for an advisory-only failure"
+  ok "state file separates failed_steps from an empty failed_critical"
+fi
 
 if [ "$FAILED" -ne 0 ]; then
   echo "test_daily_maintenance_exit_code: FAILED" >&2


### PR DESCRIPTION
**Corrects a defect I shipped in `b27fd6e` (#623).**

## What went wrong

#623 made `scripts/vault-daily-maintenance.sh` exit non-zero when **any** step failed. MYC-4116 states in its own body that a blanket rule is the wrong design, and it is right — it had already measured that several legs of this pass exit non-zero **while perfectly healthy**, because they use the exit code as a findings count.

In the substrate's 15 legs that includes `aggregate-sessions`, `aggregate-decisions`, `relocate-watch` and `close-phase-contract` — plus `check-rule-conflicts`, which only started carrying a verdict at all because **#619 gave it one**.

So two of my own changes interacted: #619 taught a leg to report findings through its exit code, and #623 then alarmed on it. The daily job would have reported failure every single day. A daily red is background inside a week, which is exactly the bug class MYC-4116 is filed under (`GUARD-LEFT-RED-BECOMES-BACKGROUND`). The fix was worse than the defect it replaced.

I found this by reading the ticket's `Done =` before closing it — not from any test.

## The design MYC-4116 actually specifies

| | |
|---|---|
| `CRITICAL_STEPS` | explicit must-be-green allowlist. **Empty in the substrate on purpose** — no leg here is unambiguously must-be-green — with the criterion for adding one written down beside it. |
| `FAILED_STEPS` | every failure, logged and written to the state file. **Advisory: does not gate the exit.** |
| `FAILED_CRITICAL` | the subset on the allowlist. **This gates the exit.** |
| state file | gains `failed_critical` alongside `failed_steps`; existing keys preserved, since MYC-549's starvation logic reads them. |

The criterion, in the file: add a label only when its non-zero means BROKEN rather than FOUND-SOMETHING. A security control's negative control is the archetype — MYC-4116 seeds the personal vault's copy with `pii-scrub-control` and `pii-scrub-hugeline`.

## Control

`tests/integration/test_daily_maintenance_exit_code.sh` gains **CASE 4**, the case this fix exists for: a non-critical failure must exit 0 while still being **recorded**, and `failed_critical` must be empty. It also now lifts `_is_critical()` from the shipped script alongside `run()`, with the extraction asserted, so the allowlist machinery cannot move without the test going red.

Mutation-proven — restoring the blanket rule fails it by name:

```
FAIL: a NON-critical failing step exited 1 -- a blanket rule is back, and
FAIL: the real pass has several legs that exit non-zero while healthy.
```

Full suite on this branch:

```
ok   lifted run() + summary block from the shipped script (not retyped)
ok   failing CRITICAL step -> exit 1
ok   state file names the failed step
ok   all-green pass -> exit 0
ok   a failing leg does not abort the legs after it (exit 1)
ok   advisory (non-critical) failure -> exit 0, logged but not alarmed
ok   state file separates failed_steps from an empty failed_critical
```

## Verification

Local canonical gate GREEN (`GATE_EXIT=0`, marker `4fc6d7b4.ok`).

## MYC-4116 stays OPEN

This is a correction, not the ticket. Its `Done =` additionally requires the surfacer (`surface-stale-automation-failures.py`) to emit `failed_critical` **independently of the starvation branch** — its early `return []` is the actual bug — plus a `local-machinery` ship and a fresh-install smoke. None of that is here.

## Not claimed

The empty `CRITICAL_STEPS` means the substrate's own pass cannot currently go red on a step. That is deliberate and declared, not an oversight — but it does mean the exit-code half of this mechanism is exercised only by the control until a genuine must-be-green leg exists here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
