### PR TITLE
fix(floors): a Floor written as a wikilink matched nothing, and the check that should have caught it was skipping itself

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,17 @@ description: What's new in AI Brain Starter — plain English, no jargon
 
 ---
 
+## 2026-08-30: floors written as links now count as floors
+
+**Who this affects:** anyone who connects journal entries to their Floors in Obsidian's graph by writing the floor as a link — `floor: "[[Acceptance]]"` instead of plain text. Plain-text floors are unaffected.
+
+Obsidian's graph draws exactly one thing: links. An entry that records its floor as plain text is joined to nothing, so writing floors as links is the way the 34-floor system actually appears connected in the graph. Doing that broke two things here, quietly:
+
+- **A link was being read as a list.** `[[Acceptance|Aceptación]]` opens and closes with a bracket, exactly like an inline YAML list, so it was split as one — handing back a name one bracket short that matched nothing in the floor scale. On a vault that had just switched to links, every single entry was reported as off the scale. A link is one value, never a list.
+- **Floor names now compare through link syntax.** `[[Acceptance|Aceptación]]`, `Aceptación` and `Acceptance` all resolve to the same floor. The journal index still stores the plain name, so `/weekly` and `/patterns` read exactly what they read before.
+
+This builds on the 2026-08-25 fix below, which taught the checker to find your floor notes folder in the first place — that fix found the notes, this one lets linked entries match them.
+
 ## 2026-08-25: the check on your journal's floor labels was never running
 
 **Who this affects:** anyone whose vault folders have emoji in their names and are in English — which is the default this project sets up.

--- a/scripts/_floors.py
+++ b/scripts/_floors.py
@@ -64,11 +64,30 @@ def strip_accents(s):
                    if unicodedata.category(c) != "Mn")
 
 
+_WIKILINK = re.compile(r"^\[\[([^\]|#]+)(?:\|([^\]]+))?\]\]$")
+
+
+def strip_wikilink(s):
+    """`[[Acceptance|Aceptación]]` -> `Aceptación`; `[[Joy]]` -> `Joy`.
+
+    Floor values are wikilinks in frontmatter on purpose: a plain string
+    draws no graph edge, so writing the floor as text silently disconnects
+    the entire floor system from the vault. Every consumer that compares or
+    indexes a floor name has to see through the link syntax first.
+    Non-links pass through unchanged.
+    """
+    if not isinstance(s, str):
+        return s
+    m = _WIKILINK.match(s.strip().strip('"').strip("'"))
+    return (m.group(2) or m.group(1)).strip() if m else s
+
+
 def normalise_name(s):
-    """Floor names compare accent-insensitively and case-insensitively."""
+    """Floor names compare accent-insensitively, case-insensitively, and
+    through wikilink syntax."""
     if s is None:
         return ""
-    return strip_accents(str(s).strip().lower())
+    return strip_accents(strip_wikilink(str(s)).strip().lower())
 
 
 def folder_key(name):
@@ -149,6 +168,13 @@ def parse_inline_list(v):
     s = str(v).strip()
     if not s or s.lower() in ("null", "none", '""', "[]"):
         return []
+    # A wikilink opens and closes with a bracket too, and splitting one as a
+    # flow list drops a bracket and hands back a name that matches nothing:
+    # `[[Willingness|Voluntad]]` came back as `[Willingness|Voluntad]` and every
+    # entry was reported as off the floor scale. It is one value, never a list.
+    unquoted = s.strip("'\"").strip()
+    if unquoted.startswith("[[") and unquoted.endswith("]]"):
+        return [unquoted]
     if s.startswith("[") and s.endswith("]"):
         inner = s[1:-1].strip()
         if not inner:

--- a/scripts/build-journal-index.py
+++ b/scripts/build-journal-index.py
@@ -68,7 +68,7 @@ from _meta_resolver import find_meta_dir  # noqa: E402
 # reach the ONE audited primitive, or the guarantee is only as good as the copy.
 # safe_read.py is stdlib-only, so mirroring it costs the vault nothing.
 from _lib.safe_read import safe_read_text  # noqa: E402
-from _floors import Floors  # noqa: E402
+from _floors import Floors, strip_wikilink  # noqa: E402
 
 # Read bounds for the shared safe_read primitive. Journal frontmatter sits in
 # the first lines; safe_read hands back the whole (size-capped) file. 1 MB is
@@ -268,11 +268,14 @@ def main():
                     "date": meta["creationDate"][:10],
                 }
                 if "floor" in meta:
-                    entry["floor"] = meta["floor"]
+                    entry["floor"] = strip_wikilink(meta["floor"])
                 if "floor_level" in meta:
-                    entry["floor_level"] = meta["floor_level"]
+                    entry["floor_level"] = strip_wikilink(meta["floor_level"])
                 if "floor_arc" in meta:
-                    entry["floor_arc"] = _parse_inline_list(meta["floor_arc"])
+                    _arc = _parse_inline_list(meta["floor_arc"])
+                    entry["floor_arc"] = (
+                        [strip_wikilink(x) for x in _arc]
+                        if isinstance(_arc, list) else strip_wikilink(_arc))
                 entries.append(entry)
                 inconsistencies.extend(
                     floors.check(meta, label=os.path.relpath(fpath, journal_dir)))

--- a/scripts/test_floors_wikilink.py
+++ b/scripts/test_floors_wikilink.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Floors written as wikilinks must resolve exactly like plain names.
+
+A floor recorded as `floor: Aceptación` draws NO edge in the Obsidian graph —
+frontmatter has to carry `floor: "[[Acceptance|Aceptación]]"` for the link to
+exist. On a real vault that change made every entry fail the consistency check:
+`parse_inline_list` saw a value that opened and closed with a bracket, split it
+as a YAML flow list, and handed back `[Acceptance|Aceptación]` — one bracket
+short and matching nothing in the scale.
+
+This locks in both halves: a wikilink is ONE value, and name comparison sees
+through the link syntax. Auto-discovered by scripts/ci.sh via test_*.py.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+MODULE = ROOT / "scripts" / "_floors.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("_floors", MODULE)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _write(path, frontmatter):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = ["---"]
+    for key, value in frontmatter.items():
+        lines.append("{}: {}".format(key, value))
+    lines += ["---", "", "body"]
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def _fail(label, got, want):
+    print("FAIL: {} — got {!r}, want {!r}".format(label, got, want))
+    return False
+
+
+def test_strip_wikilink():
+    m = _load_module()
+    cases = [
+        ('[[Acceptance|Aceptación]]', "Aceptación"),
+        ("[[Joy]]", "Joy"),
+        ('"[[Willingness|Voluntad]]"', "Voluntad"),
+        ("Razón", "Razón"),          # plain names pass through untouched
+        ("middle", "middle"),
+        ("[a, b]", "[a, b]"),        # a real flow list is not a link
+    ]
+    ok = True
+    for raw, want in cases:
+        got = m.strip_wikilink(raw)
+        if got != want:
+            ok = _fail("strip_wikilink({!r})".format(raw), got, want) and False
+    if None is not m.strip_wikilink(None):
+        ok = _fail("strip_wikilink(None)", m.strip_wikilink(None), None) and False
+    if ok:
+        print("OK: wikilink syntax stripped; plain values and real lists untouched")
+    return ok
+
+
+def test_wikilink_is_one_value():
+    """The regression itself: a link must not be split as a flow list."""
+    m = _load_module()
+    ok = True
+    got = m.parse_inline_list('[[Willingness|Voluntad]]')
+    if got != ["[[Willingness|Voluntad]]"]:
+        ok = _fail("parse_inline_list(wikilink)", got, ["[[Willingness|Voluntad]]"])
+    got = m.landed_floor({"floor": '"[[Acceptance|Aceptación]]"'})
+    if m.normalise_name(got) != "aceptacion":
+        ok = _fail("landed_floor -> normalise_name", m.normalise_name(got), "aceptacion")
+    got = m.parse_inline_list("[Fear, Hope]")
+    if got != ["Fear", "Hope"]:
+        ok = _fail("parse_inline_list(real list)", got, ["Fear", "Hope"])
+    if ok:
+        print("OK: a wikilink is one value; genuine flow lists still split")
+    return ok
+
+
+def _vault(root):
+    """Emoji-decorated English folder — the layout the exact-path list missed."""
+    for name, number, tier in (
+        ("Acceptance", 23, "middle"),
+        ("Willingness", 22, "middle"),
+        ("Compassion", 26, "high"),
+    ):
+        _write(root / "📝 Notes" / "Floors" / "{}.md".format(name),
+               {"floor_number": number, "floor_tier": tier,
+                "aliases": "[{}, {}]".format(name.lower(), "aceptación"
+                                             if name == "Acceptance" else "voluntad"
+                                             if name == "Willingness" else "compasión")})
+
+
+def test_decorated_folder_is_found():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _vault(root)
+        floors = _load_module().Floors(root)
+        if not floors:
+            print("FAIL: floor notes under '📝 Notes/Floors' were not found")
+            return False
+        if floors.num('[[Acceptance|Aceptación]]') != 23:
+            return _fail("num(wikilink)", floors.num('[[Acceptance|Aceptación]]'), 23)
+        print("OK: emoji-decorated parent folder discovered; wikilink resolves to its number")
+        return True
+
+
+def test_check_accepts_wikilinks():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _vault(root)
+        floors = _load_module().Floors(root)
+        clean = {
+            "floor": '"[[Acceptance|Aceptación]]"',
+            "floor_level": "middle",
+            "floor_arc": '["[[Compassion|Compasión]]", "[[Acceptance|Aceptación]]"]',
+        }
+        issues = floors.check(clean, label="clean.md")
+        if issues:
+            print("FAIL: a consistent wikilink entry was flagged: {}".format(issues))
+            return False
+        wrong_tier = dict(clean, floor_level="high")
+        if not floors.check(wrong_tier, label="wrong.md"):
+            print("FAIL: a wrong tier went unreported behind link syntax")
+            return False
+        print("OK: consistent wikilink entries pass; real contradictions still caught")
+        return True
+
+
+def main() -> int:
+    ok = test_strip_wikilink()
+    ok = test_wikilink_is_one_value() and ok
+    ok = test_decorated_folder_is_found() and ok
+    ok = test_check_accepts_wikilinks() and ok
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")
+        except (AttributeError, ValueError):
+            pass
+    sys.exit(main())


### PR DESCRIPTION
## What does this PR do?

Makes floors written as wikilinks — `floor: "[[Acceptance|Aceptación]]"` — resolve exactly like plain-text floors, in the consistency check and in the journal index.

*(Rebased 2026-08-30 onto main. An earlier draft also fixed the emoji-folder discovery gap; #599 landed the better version of that first, so this branch now builds on it and carries only the wikilink half. Plain-text floors are unaffected.)*

## Why

Obsidian's graph draws links and nothing else. An entry that records `floor: Acceptance` as plain text is joined to no floor at all — on my vault the entire 34-floor system sat in the graph as an island. Writing floors as links is what connects them, and it surfaced two problems:

**1. A wikilink was parsed as an inline list.**

`[[Acceptance|Aceptación]]` opens and closes with a bracket, exactly like a YAML flow list, so `parse_inline_list` split it and returned `[Acceptance|Aceptación]` — one bracket short, matching nothing in the scale. With #599's discovery fix in place, the newly-awake consistency check reported every one of my 14 linked entries as `not in the vault's floor scale`. A wikilink is one value; genuine flow lists (`[Fear, Hope]`) still split.

**2. Name comparison now sees through link syntax.**

New `strip_wikilink()`, used inside `normalise_name()` — the single chokepoint every floor lookup already flows through — so `[[Acceptance|Aceptación]]`, `Aceptación` and `Acceptance` all resolve to floor 23. `build-journal-index.py` uses the same primitive, so the index keeps storing the **plain** name and `/weekly` / `/patterns` read exactly what they read before.

## Verification

Against a real vault (34 floor notes, 14 linked journal entries, Spanish display names on English note titles):

```
$ python scripts/build-journal-index.py --vault-root .
Indexed 14 entries → journal-index.json
```

Zero inconsistencies — and the negative control still bites: a deliberately wrong `floor_level` behind a wikilink is reported (`floor_level 'high' but the vault declares [[Acceptance|Aceptación]] (23) as 'middle'`). The fix resolves links; it does not make the validator permissive.

Adds `scripts/test_floors_wikilink.py` — 4 cases: link stripping, link-is-not-a-list, discovery of an emoji-decorated folder (through #599's `discover_floor_dirs`), and that negative control. `test_floors.py`, both journal-index suites, and `tests/test_floors_folder_discovery.py` all pass on the rebased branch (the folder-discovery suite needs `PYTHONUTF8=1` on a Windows cp1252 console — its emoji output, not its logic; passes clean on ubuntu).

**On the full `ci.sh` gate:** it fails on my Windows machine identically on a clean `origin/main` (a `charmap` decode in `test_session_start_announces_memory_index`) — pre-existing, unrelated, left alone; happy to file it separately.

## Which file(s) changed?

- [x] Other: `scripts/_floors.py`, `scripts/build-journal-index.py`, `scripts/test_floors_wikilink.py` (new)
- [x] `docs/CHANGELOG.md`

## Is this a breaking change?

- [x] No

## Did you update `docs/CHANGELOG.md`?

- [x] Yes

## Checklist

- [x] No personal data, vault paths, or API keys included
- [x] The pattern is universal (works for any user, not just one setup)
- [x] SKILL.md changes don't break the existing phase flow — no SKILL.md changes
- [x] Tested manually (real vault + 4 new automated cases + 4 existing suites)
