### PR TITLE
ci: lint the repo's own Python for undefined names (nothing did)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -616,6 +616,23 @@ jobs:
       - name: phase-doc Python (no undefined names / F821)
         run: python3 scripts/check-phase-python.py
 
+      # The step above lints Python embedded in phases/*.md. THIS one lints the
+      # repo's own tracked *.py -- which nothing in CI did until it landed. The
+      # `ci` job py_compiles every tracked *.py, but py_compile parses: it cannot
+      # see a name that does not exist. `env=_GIT_CLEAN_ENV` shipped in
+      # hooks/session-lock.py on 2026-08-12 (4a2bf7c) with the constant never
+      # defined and sat on main for thirteen days (fixed 2026-08-25, 5952dac).
+      # session-lock.py is the concurrency gate and settings.json registers it
+      # behind an allow-fallback wrapper, so that NameError did not fail loudly --
+      # the hook crashed, the wrapper answered "allow", and the gate was open.
+      # Reuses the ruff installed two steps above (fail-closed), so this costs no
+      # extra install and no extra billed job.
+      - name: repo Python (no undefined names / E9,F63,F7,F82)
+        run: bash scripts/ruff-gate.sh
+
+      - name: ruff-gate negative controls (a dead linter must not read as clean)
+        run: bash scripts/ruff-gate.sh --self-test
+
   bash32-syntax:
     name: bash 3.2 syntax (macOS /bin/bash)
     runs-on: macos-latest

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -30,6 +30,14 @@
 #                           py_compile does not catch undefined names). A dedicated
 #                           lint.yml job enforces this in CI (as the shellcheck job
 #                           does); here it is best-effort, skipped without a linter.
+#   (d2) Repo Python      - scripts/ruff-gate.sh runs the SAME undefined-name check
+#                           over every tracked *.py (not just the phase docs).
+#                           Gate (a) py_compiles them, but py_compile parses and
+#                           cannot see a name that does not exist: env=_GIT_CLEAN_ENV
+#                           shipped undefined in hooks/session-lock.py and sat on
+#                           main for 13 days (2026-08-12 4a2bf7c -> 2026-08-25
+#                           5952dac) because no CI check linted hooks/*.py at all.
+#                           lint.yml runs the same script; local + CI cannot drift.
 #   (e) UTF-8 console guard - scripts/check-utf8-stdout.py fails a runnable
 #                           scripts/*.py or hooks/*.py CLI that print()s non-ASCII
 #                           (the "gear Meta" emoji, an em dash, an accented name)
@@ -1014,6 +1022,24 @@ else
   echo "    install: pip install ruff"
 fi
 
+# ---- (d2) Repo-wide Python undefined-name gate -----------------------------
+# Same linter as (d), different corpus: every tracked *.py rather than the Python
+# embedded in phases/*.md. Runs the canonical scripts/ruff-gate.sh, which lint.yml
+# also runs, so the local pre-push gate and CI cannot drift. Warn-skipped locally
+# without ruff (CI enforces it), matching (c) and (d).
+if [ -n "${GITHUB_ACTIONS:-}" ]; then
+  ruffgate_note="skipped in CI (the lint job's 'repo Python' step runs scripts/ruff-gate.sh)"
+  echo "==> (d2) repo python: $ruffgate_note"
+elif command -v ruff >/dev/null 2>&1; then
+  echo "==> (d2) repo python: bash scripts/ruff-gate.sh"
+  bash scripts/ruff-gate.sh
+  ruffgate_note="passed"
+else
+  ruffgate_note="skipped (no ruff locally; CI enforces it)"
+  echo "==> (d2) repo python: $ruffgate_note"
+  echo "    install: pip install ruff"
+fi
+
 # ---- (e) UTF-8 console guard -----------------------------------------------
 # scripts/check-utf8-stdout.py fails a runnable scripts/*.py or hooks/*.py CLI
 # that print()s non-ASCII without the UTF-8 stdout/stderr reconfigure guard - the
@@ -1357,4 +1383,4 @@ done
 echo "    OK - ${#PY_DIRECT[@]} hooks/+tests/ direct suite(s) passed; dormancy invariant clean"
 
 echo
-echo "All gates passed: py_compile ($count file(s)) + ${#INTEGRATION_TESTS[@]} integration tests + $unit_count scripts/ + ${#PY_DIRECT[@]} hooks/tests unit suite(s) + shellcheck [$shellcheck_note] + phase-doc python [$phasepy_note] + utf8 console guard [$utf8_note] + hook block-protocol [passed] + vault-root reads [passed] + home-hook deploy [passed] + subprocess decode [passed] + py3.9 annotation parity [passed] + ps1 encoding [passed]."
+echo "All gates passed: py_compile ($count file(s)) + ${#INTEGRATION_TESTS[@]} integration tests + $unit_count scripts/ + ${#PY_DIRECT[@]} hooks/tests unit suite(s) + shellcheck [$shellcheck_note] + phase-doc python [$phasepy_note] + repo python [$ruffgate_note] + utf8 console guard [$utf8_note] + hook block-protocol [passed] + vault-root reads [passed] + home-hook deploy [passed] + subprocess decode [passed] + py3.9 annotation parity [passed] + ps1 encoding [passed]."

--- a/scripts/ruff-gate.sh
+++ b/scripts/ruff-gate.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# exit-contract: ENFORCING
+
+#
+# scripts/ruff-gate.sh - the canonical, locally-runnable undefined-name gate for
+# every tracked *.py in ai-brain-starter. ONE command, shared by two callers so
+# they can never drift:
+#
+#   1. .github/workflows/lint.yml  - a step in the `lint` job (ruff is installed
+#                                    fail-closed two steps above).
+#   2. scripts/ci.sh               - section (d2), so the local pre-push gate
+#                                    (~/.local/bin/ci-test) runs the SAME check.
+#
+# Why this exists. Until this gate landed, NO CI check linted this repo's own
+# *.py for undefined names. Gate (a) py_compiles every tracked *.py, but
+# py_compile parses -- it cannot see a name that does not exist. The only ruff
+# F821 in CI was scripts/check-phase-python.py, scoped to Python blocks embedded
+# in phases/*.md. So the ~400 tracked *.py -- including hooks/ that execute on
+# every install -- had a syntax check and nothing more.
+#
+# The gap shipped. `env=_GIT_CLEAN_ENV` landed in hooks/session-lock.py on
+# 2026-08-12 (4a2bf7c) with the constant never defined, and sat on main for
+# THIRTEEN DAYS until 5952dac defined it on 2026-08-25. Nothing in CI could see
+# it. hooks/check-py-import-precommit.py catches exactly this class and is
+# tested by tests/integration/test_session_coordination_guards.sh -- but it is a
+# commit-time hook on a developer's machine, so it only fires where it happens
+# to be registered, and it fails OPEN when ruff is absent. A guard the repo
+# ships, tests, and never points at itself is not coverage.
+#
+# session-lock.py is the concurrency gate, and settings.json registers it behind
+# an allow-fallback wrapper. A NameError there does not fail loudly: the hook
+# crashes, the wrapper answers "allow", and the gate is silently open.
+#
+# Severity gate: E9,F63,F7,F82 -- ruff's standard error set (syntax errors,
+# undefined names, and the always-true assert/comparison class). This is the
+# real ship/hold boundary, NOT the strictest signal: the full `F` ruleset
+# reports 138 findings on this tree today (mostly unused imports/locals), and a
+# gate that lands red just teaches people to bypass it
+# (over-strict-verification-teaches-bypass). Raise the floor later, on purpose,
+# once a baseline supports it:
+#     RUFF_GATE_SELECT=F bash scripts/ruff-gate.sh
+#
+# A genuine false-positive is silenced at the source with `# noqa: <rule>` and a
+# one-line reason -- never by narrowing the select for every file.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+SELECT="${RUFF_GATE_SELECT:-E9,F63,F7,F82}"
+
+# --- negative controls -------------------------------------------------------
+# A linter that dies and a linter that finds nothing both print no findings. The
+# classification below exists to tell them apart, and without these controls it
+# would be untested on the only inputs that motivated it. Each case shims a fake
+# `ruff` onto PATH, drives one documented status, and asserts THIS script's exit.
+if [ "${1:-}" = "--self-test" ]; then
+  st_fail=0
+  st_tmp="$(mktemp -d)"
+  trap 'rm -rf "$st_tmp"' EXIT
+  mkdir -p "$st_tmp/bin"
+
+  st_case() { # st_case <label> <fake-rc> <expected-this-script-rc>
+    local label="$1" fake="$2" want="$3" got
+    # `ruff --version` runs before the scan, so the shim must answer it first
+    # and only then honour the injected status.
+    cat > "$st_tmp/bin/ruff" <<SHIM
+#!/bin/sh
+case "\$1" in --version) echo "ruff 0.0.0-fake"; exit 0;; esac
+exit $fake
+SHIM
+    chmod +x "$st_tmp/bin/ruff"
+    # `set -e` is active: without disabling it the FIRST non-zero probe would
+    # abort the self-test and the remaining cases -- including the kill case
+    # this exists for -- would never run, while the suite looked like it simply
+    # stopped early.
+    set +e
+    PATH="$st_tmp/bin:$PATH" bash "$0" >/dev/null 2>&1
+    got=$?
+    set -e
+    if [ "$got" != "$want" ]; then
+      echo "  FAIL [$label] fake ruff rc=$fake -> this script exited $got, expected $want"
+      st_fail=1
+    else
+      echo "  ok   [$label] fake ruff rc=$fake -> exit $got"
+    fi
+  }
+
+  # The empty-enumeration refusal. Driven by pointing the scan at a repo with no
+  # tracked *.py, which production reaches via a broken pathspec or an empty
+  # checkout -- never because the work is clean. `git init` ONLY: a commit needs
+  # user.name/user.email, which a dev box has globally and a CI runner does not,
+  # and `git ls-files` already returns nothing in a repo with no commits.
+  st_empty="$st_tmp/emptyrepo"
+  mkdir -p "$st_empty/scripts"
+  if ! ( cd "$st_empty" && git init -q . ) >/dev/null 2>&1; then
+    echo "  FAIL [empty enumeration] could not create the fixture repo -- the"
+    echo "       control did not run, which is not a pass."
+    st_fail=1
+  fi
+  # This script resolves REPO_ROOT from its OWN location, so it must be copied
+  # into the fixture for that resolution to land on the empty tree.
+  cp "$REPO_ROOT/scripts/ruff-gate.sh" "$st_empty/scripts/ruff-gate.sh"
+  set +e
+  ( cd "$st_empty" && PATH="$st_tmp/bin:$PATH" bash scripts/ruff-gate.sh ) >/dev/null 2>&1
+  st_got=$?
+  set -e
+  if [ "$st_got" -ne 2 ]; then
+    echo "  FAIL [empty enumeration] expected exit 2 (UNEVALUATED), got $st_got."
+    echo "       A scan of zero files is not a clean tree."
+    st_fail=1
+  else
+    echo "  ok   [empty enumeration] zero tracked *.py -> exit 2, not a pass"
+  fi
+
+  st_case "clean"                0   0
+  st_case "real findings"        1   1
+  st_case "could-not-process"    2   2
+  st_case "SIGKILL (OOM shape)"  137 2
+  st_case "SIGTERM"              143 2
+
+  if [ "$st_fail" -ne 0 ]; then
+    echo "ruff-gate.sh self-test FAILED" >&2
+    exit 1
+  fi
+  echo "OK - self-test: findings (1), a killed/failed linter (2), and an empty enumeration (2) are all distinct from a clean pass (0)."
+  exit 0
+fi
+
+if ! command -v ruff >/dev/null 2>&1; then
+  echo "::error::ruff not installed." >&2
+  echo "  pipx install ruff   (or)   python3 -m pip install --user ruff" >&2
+  exit 1
+fi
+
+# Collect every tracked *.py. git ls-files is the source of truth -- the SAME
+# corpus ci.sh gate (a) py_compiles, so the two cannot disagree about what
+# "every tracked *.py" means. It excludes .git/, node_modules/ and untracked
+# cruft for free, and -z is NUL-delimited so paths with spaces / emoji survive.
+# Built bash-3.2-safe (macOS ships bash 3.2): no `mapfile -d`, just read+append.
+files=()
+while IFS= read -r -d '' f; do
+  files+=("$f")
+done < <(git ls-files -z -- '*.py')
+
+# Empty-array expansion under `set -u` errors on bash 3.2 / 4.3; guard it.
+if [ "${#files[@]}" -eq 0 ]; then
+  # REFUSE, do not pass. This repo tracks ~400 *.py, so an empty enumeration
+  # means the SELECTION broke -- a bad pathspec, a detached/empty checkout, a
+  # `git ls-files` that failed -- never that the work is clean. Exiting 0 here
+  # would report a clean lint over a scan that never happened, the same shape as
+  # the killed-linter case below: nothing ran, and the caller was told it was
+  # fine. Exit 2 = could-not-evaluate, distinct from 1 = real findings.
+  echo "UNEVALUATED: zero tracked *.py found. This repo tracks many, so an" >&2
+  echo "empty file list means the SELECTION failed, not that the tree is" >&2
+  echo "clean. Nothing was linted -- this is not a pass." >&2
+  exit 2
+fi
+
+echo "==> ruff --select $SELECT over ${#files[@]} tracked *.py  [$(ruff --version | awk '{print $2}')]"
+
+# GitHub Actions renders one annotation per finding from the github format; an
+# interactive run gets ruff's readable default.
+fmt="full"
+[ -n "${GITHUB_ACTIONS:-}" ] && fmt="github"
+
+# Classify ruff's status instead of treating every non-zero as "found issues".
+# ruff documents 0 = clean and 1 = findings; anything else means the TOOL did
+# not deliver a verdict -- 2 for a CLI/config error, and 128+N when the kernel
+# killed it (137 = SIGKILL, the OOM shape on a loaded runner). Reporting a
+# signal death as a lint finding sends the reader hunting a defect that does not
+# exist; the adjacent shape is worse -- a "no findings" line over a run that
+# never linted anything.
+set +e
+ruff check --select "$SELECT" --no-cache --output-format="$fmt" -- "${files[@]}"
+rf_rc=$?
+set -e
+
+if [ "$rf_rc" -eq 0 ]; then
+  echo "    OK - no ruff findings at --select $SELECT"
+elif [ "$rf_rc" -eq 1 ]; then
+  echo "FAILED: ruff found issues at --select $SELECT." >&2
+  echo "These are undefined names, syntax errors, and always-true asserts --" >&2
+  echo "runtime bugs, not style. Fix them, or for a genuine false-positive add" >&2
+  echo "a '# noqa: <rule>' comment with a one-line reason at the source line." >&2
+  echo "Do NOT narrow the select to hide a finding (see this script's header)." >&2
+  exit 1
+elif [ "$rf_rc" -gt 128 ]; then
+  echo "UNEVALUATED: ruff was KILLED by signal $((rf_rc - 128)) (exit $rf_rc)." >&2
+  echo "It did not finish, so NOTHING was linted -- this is not a finding and it" >&2
+  echo "is not a pass. On a loaded runner this is usually the OOM killer." >&2
+  exit 2
+else
+  echo "UNEVALUATED: ruff exited $rf_rc, which is neither clean (0) nor findings" >&2
+  echo "(1). It could not run -- a bad --select, a config error, a missing file --" >&2
+  echo "so the scan is incomplete and its silence means nothing." >&2
+  exit 2
+fi


### PR DESCRIPTION
## What

Adds `scripts/ruff-gate.sh`, run from two callers: a step in the `lint` job, and section (d2) of `scripts/ci.sh`.

## Why

**No CI check linted this repo's own `*.py` for undefined names.** The `ci` job `py_compile`s every tracked `*.py`, but `py_compile` *parses* — it cannot see a name that does not exist. The only ruff `F821` in CI was `check-phase-python.py`, scoped to Python blocks embedded in `phases/*.md`. So ~400 tracked `*.py`, including the `hooks/` that execute on every install, had a syntax check and nothing more.

The gap shipped. `env=_GIT_CLEAN_ENV` landed in `session-lock.py` on 2026-08-12 (`4a2bf7c`) with the constant never defined, and sat on `main` for **thirteen days** until `5952dac` defined it on 2026-08-25.

It would not have failed loudly. `session-lock.py` is the concurrency gate, and `settings.json` registers it behind an allow-fallback wrapper. A `NameError` there means the hook crashes, the wrapper answers `allow`, and the gate is silently open.

**The trap worth naming:** this repo already ships the right guard — `check-py-import-precommit.py` runs `ruff --select F821` over staged files — and already tests it (`test_session_coordination_guards.sh` plants an undefined name and asserts `rc=2`). Every artifact read green. But it is a *commit-time hook on a developer's machine*: it fires only where it happens to be registered, and it fails **open** when ruff is absent. A guard the repo ships, tests, and never points at itself is not coverage. Bug class SCAN-SCOPE-BLIND-SPOT, channel form.

## Design

Mirrors `shellcheck.sh` deliberately — one canonical command, two callers, so the local pre-push gate and CI cannot drift.

**Three states, not two.** `0` clean, `1` real findings, `2` UNEVALUATED. A linter that dies and a linter that finds nothing both print no findings, so a killed ruff (`128+N`, the OOM shape on a loaded runner) and an empty enumeration both exit `2`. A scan of zero files is not a clean tree: this repo tracks ~400 `*.py`, so an empty list means the *selection* broke, never that the work is clean.

**Select is `E9,F63,F7,F82`, measured rather than guessed** — ruff's standard error set (syntax errors, undefined names, always-true asserts). On this tree that set is clean, while the full `F` ruleset reports **138** findings, mostly unused imports and locals. Landing red would only teach people to bypass the gate. Raise the floor later on purpose with `RUFF_GATE_SELECT=F`.

**Costs nothing extra** — a step in the existing `lint` job reusing the fail-closed ruff installed two steps above. No new billed job, no second install, per this workflow's own "add a STEP here, not a job".

## Review-risky areas

- The gate now runs on every PR. If `git ls-files` ever returns nothing it exits `2` rather than passing — intentional, and covered by a negative control.
- `--output-format=github` is used only under `GITHUB_ACTIONS`; that branch was exercised locally rather than left to first contact with CI.

## Verification

- `--self-test`: six negative controls green — clean, findings, could-not-process, SIGKILL, SIGTERM, empty-enumeration.
- **Red on the real defect:** reproducing `4a2bf7c` (removing the `_GIT_CLEAN_ENV` definition, keeping the use sites) drives the gate to exit `1` naming all **3** use sites; restoring returns exit `0` with the tree byte-identical.
- CI-only branch exercised locally with `GITHUB_ACTIONS=true`: exit `0`, and `--output-format=github` renders `::error` annotations on ruff 0.15.15.
- `lint.yml` parses with PyYAML; `ci.sh` passes `bash -n`.
- Full canonical gate green: `py_compile` (403 files) + 139 integration tests + 31 `scripts/` + 31 `hooks/tests` suites + shellcheck + phase-doc python + repo python + utf8 + block-protocol + vault-root + home-hook + subprocess decode + py3.9 parity + ps1 encoding.

## Scope

Partial for MYC-572 (the `.py` half). The PSScriptAnalyzer `.ps1` half of that ticket is untouched and stays open.

Deliberately **not** changed: the `ci` job's `pipx install ruff || ... || true`. It looks like a fail-open but is deliberate and tested — `test_session_coordination_guards.sh` asserts *both* branches (ruff present → must block `rc=2`; absent → must fail-open `rc=0`). Removing it would be a regression, not a hardening.

Drafted with Claude Code; gate run and doubt-pass completed before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
