### PR TITLE
ci: analyze the repo's PowerShell, not just its encoding

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -633,6 +633,25 @@ jobs:
       - name: ruff-gate negative controls (a dead linter must not read as clean)
         run: bash scripts/ruff-gate.sh --self-test
 
+      # The .ps1 half of the same gap. `.ps1 encoding` above checks BOM + em
+      # dashes, and the pwsh parse step checks syntax -- neither looks at
+      # semantics, on the platform (Windows install) with the fewest local eyes.
+      # Deliberately a curated RULE list, not a severity floor: `-Severity
+      # Warning` would land 318 findings red on day one, 251 of them
+      # PSAvoidUsingWriteHost, which is the CORRECT call in an installer that
+      # talks to a human. See scripts/psscriptanalyzer.sh for the measurement.
+      # The module install has no `|| true`: a gate that cannot run must not
+      # report clean, same reasoning as the ruff install above.
+      - name: install PSScriptAnalyzer (the .ps1 analyzer this gate needs)
+        shell: pwsh
+        run: Install-Module -Name PSScriptAnalyzer -Repository PSGallery -Scope CurrentUser -Force -AcceptLicense
+
+      - name: repo PowerShell (security + real-bug rules over tracked *.ps1)
+        run: bash scripts/psscriptanalyzer.sh
+
+      - name: psscriptanalyzer negative controls (a dead analyzer must not read as clean)
+        run: bash scripts/psscriptanalyzer.sh --self-test
+
   bash32-syntax:
     name: bash 3.2 syntax (macOS /bin/bash)
     runs-on: macos-latest

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -22,6 +22,16 @@
 #                           when running inside GitHub Actions (the dedicated job
 #                           already covers it); locally it is warn-and-skipped
 #                           when the shellcheck binary is absent (CI enforces it).
+#   (c2) PowerShell       - scripts/psscriptanalyzer.sh runs PSScriptAnalyzer over
+#                           every tracked *.ps1 with a curated security + real-bug
+#                           rule list. The .ps1 sibling of (c): until it landed,
+#                           .ps1 had an ENCODING check (BOM / em dash) and a PARSE
+#                           check and nothing semantic, on the Windows install path.
+#                           A severity floor was measured and rejected: -Severity
+#                           Warning is 318 findings on this tree, 251 of them
+#                           PSAvoidUsingWriteHost, which is correct in an installer.
+#                           Parse errors still fail it -- an -IncludeRule list does
+#                           not suppress ParseError findings.
 #   (d) Phase-doc Python  - scripts/check-phase-python.py extracts every Python
 #                           block from phases/*.md and runs the undefined-name
 #                           check (ruff F821). Catches a bare-identifier typo in
@@ -1001,6 +1011,23 @@ else
   echo "    install: brew install shellcheck  (macOS)  /  sudo apt-get install -y shellcheck  (Debian/Ubuntu)"
 fi
 
+# ---- (c2) PowerShell static analysis ---------------------------------------
+# Runs the SAME canonical gate as the lint job's 'repo PowerShell' step, so the
+# local pre-push gate and CI cannot drift on .ps1 quality. Warn-skipped locally
+# when pwsh or the module is absent (CI enforces it), matching (c) and (d).
+if [ -n "${GITHUB_ACTIONS:-}" ]; then
+  pssa_note="skipped in CI (the lint job's 'repo PowerShell' step runs scripts/psscriptanalyzer.sh)"
+  echo "==> (c2) powershell: $pssa_note"
+elif command -v pwsh >/dev/null 2>&1; then
+  echo "==> (c2) powershell: bash scripts/psscriptanalyzer.sh"
+  bash scripts/psscriptanalyzer.sh
+  pssa_note="passed"
+else
+  pssa_note="skipped (pwsh not installed locally; CI enforces it)"
+  echo "==> (c2) powershell: $pssa_note"
+  echo "    install: brew install --cask powershell  (macOS)"
+fi
+
 # ---- (d) Phase-doc Python undefined-name gate ------------------------------
 # The Phase 2 plugin installer and Phase 10a graph-config block are python3
 # heredocs / ```python fences inside Markdown, so gate (a) py_compile never sees
@@ -1383,4 +1410,4 @@ done
 echo "    OK - ${#PY_DIRECT[@]} hooks/+tests/ direct suite(s) passed; dormancy invariant clean"
 
 echo
-echo "All gates passed: py_compile ($count file(s)) + ${#INTEGRATION_TESTS[@]} integration tests + $unit_count scripts/ + ${#PY_DIRECT[@]} hooks/tests unit suite(s) + shellcheck [$shellcheck_note] + phase-doc python [$phasepy_note] + repo python [$ruffgate_note] + utf8 console guard [$utf8_note] + hook block-protocol [passed] + vault-root reads [passed] + home-hook deploy [passed] + subprocess decode [passed] + py3.9 annotation parity [passed] + ps1 encoding [passed]."
+echo "All gates passed: py_compile ($count file(s)) + ${#INTEGRATION_TESTS[@]} integration tests + $unit_count scripts/ + ${#PY_DIRECT[@]} hooks/tests unit suite(s) + shellcheck [$shellcheck_note] + powershell [$pssa_note] + phase-doc python [$phasepy_note] + repo python [$ruffgate_note] + utf8 console guard [$utf8_note] + hook block-protocol [passed] + vault-root reads [passed] + home-hook deploy [passed] + subprocess decode [passed] + py3.9 annotation parity [passed] + ps1 encoding [passed]."

--- a/scripts/psscriptanalyzer.sh
+++ b/scripts/psscriptanalyzer.sh
@@ -161,6 +161,33 @@ SHIM
     echo "  SKIP [parse error] pwsh absent -- this control did NOT run"
   fi
 
+  # A file tracked in the index but MISSING from disk makes the analyzer throw.
+  # That must classify as UNEVALUATED (2), never as findings (1): an uncaught
+  # throw exits 1, and reporting a dead analyzer as bad code is the exact
+  # confusion this script's three-state contract exists to prevent.
+  if command -v pwsh >/dev/null 2>&1; then
+    st_gone="$st_tmp/gonerepo"
+    mkdir -p "$st_gone/scripts"
+    ( cd "$st_gone" && git init -q . ) >/dev/null 2>&1
+    printf '\xef\xbb\xbfWrite-Output "ok"\n' > "$st_gone/scripts/vanishes.ps1"
+    cp "$REPO_ROOT/scripts/psscriptanalyzer.sh" "$st_gone/scripts/psscriptanalyzer.sh"
+    ( cd "$st_gone" && git update-index --add scripts/vanishes.ps1 ) >/dev/null 2>&1
+    rm -f "$st_gone/scripts/vanishes.ps1"
+    set +e
+    ( cd "$st_gone" && bash scripts/psscriptanalyzer.sh ) >/dev/null 2>&1
+    st_gone_rc=$?
+    set -e
+    if [ "$st_gone_rc" -ne 2 ]; then
+      echo "  FAIL [analyzer throws] tracked-but-missing *.ps1 exited $st_gone_rc, expected 2."
+      echo "       A crashed analyzer must not be reported as a lint finding."
+      st_fail=1
+    else
+      echo "  ok   [analyzer throws] tracked-but-missing *.ps1 -> exit 2, not findings"
+    fi
+  else
+    echo "  SKIP [analyzer throws] pwsh absent -- this control did NOT run"
+  fi
+
   if [ "$st_fail" -ne 0 ]; then
     echo "psscriptanalyzer.sh self-test FAILED" >&2
     exit 1
@@ -227,7 +254,19 @@ $files = [System.IO.File]::ReadAllLines($FileList) | Where-Object { $_ }
 $ver = (Get-Module -ListAvailable PSScriptAnalyzer | Select-Object -First 1).Version
 Write-Output "==> PSScriptAnalyzer over $($files.Count) tracked *.ps1, $($rules.Count) enforced rule(s)  [$ver]"
 $found = @()
-foreach ($f in $files) { $found += Invoke-ScriptAnalyzer -Path $f -IncludeRule $rules }
+# The scan is wrapped because an UNCAUGHT terminating error exits 1, which the
+# caller reads as "found issues" -- mislabelling a dead analyzer as bad code and
+# sending the reader hunting a defect that does not exist. A file tracked in the
+# index but missing from disk throws ItemNotFoundException here, and so does an
+# unreadable or mangled path. Exit 3 = could-not-evaluate, which the caller maps
+# to UNEVALUATED instead.
+try {
+  foreach ($f in $files) { $found += Invoke-ScriptAnalyzer -Path $f -IncludeRule $rules }
+} catch {
+  [Console]::Error.WriteLine("SCAN FAILED: $($_.Exception.GetType().Name): $($_.Exception.Message)")
+  [Console]::Error.WriteLine("The analyzer did not finish, so the tree was NOT verified.")
+  exit 3
+}
 if ($found.Count -eq 0) { exit 0 }
 foreach ($d in $found) {
   if ($env:GITHUB_ACTIONS) {

--- a/scripts/psscriptanalyzer.sh
+++ b/scripts/psscriptanalyzer.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+# exit-contract: ENFORCING
+
+#
+# scripts/psscriptanalyzer.sh - the canonical, locally-runnable PSScriptAnalyzer
+# gate for every tracked *.ps1 in ai-brain-starter. ONE command, shared by two
+# callers so they can never drift:
+#
+#   1. .github/workflows/lint.yml  - a step in the `lint` job.
+#   2. scripts/ci.sh               - section (c2), so the local pre-push gate
+#                                    (~/.local/bin/ci-test) runs the SAME check.
+#
+# Completes the .ps1 half of the syntax-check-only gap that scripts/shellcheck.sh
+# closed for *.sh and scripts/ruff-gate.sh closed for *.py. Until this landed,
+# .ps1 was checked for ENCODING (check-ps1-encoding.sh: UTF-8 BOM, no em dash)
+# and PARSE only. Nothing looked at semantics -- and .ps1 is the Windows install
+# path, the platform with the fewest local eyes on it.
+#
+# WHY A CURATED RULE LIST AND NOT A SEVERITY FLOOR. shellcheck.sh gates at
+# `-S warning` because shellcheck's warning tier is mostly correctness. PSSA's
+# is not, and the numbers are not close. Measured over the 17 tracked *.ps1
+# when this gate was written:
+#
+#     Warning      317   (251 of them PSAvoidUsingWriteHost)
+#     Information   18
+#     Error          1
+#
+# A `-Severity Warning` gate would therefore land 318 findings RED on day one,
+# and the single largest rule in it is WRONG for this repo: these are installers
+# and CLIs whose whole job is talking to a human, so Write-Host is the correct
+# call, not a defect. Landing red like that only teaches people to bypass the
+# gate (over-strict-verification-teaches-bypass). So the contract is an explicit
+# RULE LIST -- security and real-bug rules -- every one of which is green on this
+# tree. That is auditable in a way "-Severity Warning" is not: you can read
+# exactly what is enforced, and adding a file cannot silently change it.
+#
+# The one Error-severity finding was adjudicated at the source, not gate-wide:
+# vault-backup.ps1's Store-Passphrase carries a SuppressMessageAttribute with a
+# justification, because it converts a just-typed passphrase INTO DPAPI (the very
+# next line writes the encrypted blob). Any OTHER file that genuinely leaks a
+# plaintext secret still reds this gate.
+#
+# PARSE ERRORS ARE STILL CAUGHT. An `-IncludeRule` list does not suppress them:
+# PSSA reports ParseError findings regardless of the rule filter (verified, and
+# covered by a negative control below). So a syntax error in any tracked *.ps1
+# fails this gate even though no syntax rule is named in the list.
+#
+# Read the list as what it enforces, not as a claim about the repo. Example:
+# PSAvoidUsingBrokenHashAlgorithms is green here, and vault-backup.ps1 still uses
+# MD5 for a filename slug -- the rule matches the Get-FileHash cmdlet form, not a
+# raw .NET type. It is in the list to keep the cmdlet form out, nothing more.
+#
+# Widen locally without editing the contract:
+#     PSSA_INCLUDE_EXTRA='PSAvoidUsingEmptyCatchBlock' bash scripts/psscriptanalyzer.sh
+#
+# A genuine false-positive is silenced at the SOURCE with a
+# SuppressMessageAttribute carrying a Justification -- never by dropping a rule
+# from the list for every file.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# The enforced contract. Every name is verified to RESOLVE against the installed
+# PSScriptAnalyzer before the scan runs: a renamed or removed rule would
+# otherwise sit in this list matching nothing while the gate still reported
+# clean, which is the silent-no-op failure this repo treats as worse than no gate.
+PSSA_RULES="PSAvoidUsingInvokeExpression,PSAvoidUsingConvertToSecureStringWithPlainText,PSAvoidUsingPlainTextForPassword,PSAvoidUsingUsernameAndPasswordParams,PSUsePSCredentialType,PSAvoidUsingBrokenHashAlgorithms,PSAvoidUsingComputerNameHardcoded,PSPossibleIncorrectComparisonWithNull,PSPossibleIncorrectUsageOfAssignmentOperator,PSPossibleIncorrectUsageOfRedirectionOperator,PSAvoidGlobalVars,PSAvoidDefaultValueSwitchParameter,PSReservedCmdletChar,PSReservedParams,PSUseCmdletCorrectly,PSUseProcessBlockForPipelineCommand,PSShouldProcess,PSMissingModuleManifestField,PSAvoidUsingDeprecatedManifestFields,PSAvoidNullOrEmptyHelpMessageAttribute,PSUseLiteralInitializerForHashtable"
+[ -n "${PSSA_INCLUDE_EXTRA:-}" ] && PSSA_RULES="${PSSA_RULES},${PSSA_INCLUDE_EXTRA}"
+
+# --- negative controls -------------------------------------------------------
+# An analyzer that dies and an analyzer that finds nothing both print no
+# findings. The classification below exists to tell them apart; without these
+# controls it is untested on exactly the inputs that motivated it. Each case
+# shims a fake `pwsh` onto PATH and asserts THIS script's exit.
+if [ "${1:-}" = "--self-test" ]; then
+  st_fail=0
+  st_tmp="$(mktemp -d)"
+  trap 'rm -rf "$st_tmp"' EXIT
+  mkdir -p "$st_tmp/bin"
+
+  st_case() { # st_case <label> <fake-rc> <expected-this-script-rc>
+    local label="$1" fake="$2" want="$3" got
+    cat > "$st_tmp/bin/pwsh" <<SHIM
+#!/bin/sh
+case "\$1" in --version) echo "PowerShell 0.0.0-fake"; exit 0;; esac
+exit $fake
+SHIM
+    chmod +x "$st_tmp/bin/pwsh"
+    # `set -e` is active: without disabling it the FIRST non-zero probe would
+    # abort the self-test and the remaining cases -- including the kill case
+    # this exists for -- would never run, while the suite looked like it had
+    # simply stopped early.
+    set +e
+    PATH="$st_tmp/bin:$PATH" bash "$0" >/dev/null 2>&1
+    got=$?
+    set -e
+    if [ "$got" != "$want" ]; then
+      echo "  FAIL [$label] fake pwsh rc=$fake -> this script exited $got, expected $want"
+      st_fail=1
+    else
+      echo "  ok   [$label] fake pwsh rc=$fake -> exit $got"
+    fi
+  }
+
+  # Empty-enumeration refusal. Production reaches this via a broken pathspec or
+  # an empty checkout -- never because the work is clean. `git init` ONLY: a
+  # commit needs user.name/user.email, which a dev box has globally and a CI
+  # runner does not, and `git ls-files` already returns nothing without commits.
+  st_empty="$st_tmp/emptyrepo"
+  mkdir -p "$st_empty/scripts"
+  if ! ( cd "$st_empty" && git init -q . ) >/dev/null 2>&1; then
+    echo "  FAIL [empty enumeration] could not create the fixture repo -- the"
+    echo "       control did not run, which is not a pass."
+    st_fail=1
+  fi
+  cp "$REPO_ROOT/scripts/psscriptanalyzer.sh" "$st_empty/scripts/psscriptanalyzer.sh"
+  set +e
+  ( cd "$st_empty" && PATH="$st_tmp/bin:$PATH" bash scripts/psscriptanalyzer.sh ) >/dev/null 2>&1
+  st_got=$?
+  set -e
+  if [ "$st_got" -ne 2 ]; then
+    echo "  FAIL [empty enumeration] expected exit 2 (UNEVALUATED), got $st_got."
+    echo "       A scan of zero files is not a clean tree."
+    st_fail=1
+  else
+    echo "  ok   [empty enumeration] zero tracked *.ps1 -> exit 2, not a pass"
+  fi
+
+  st_case "clean"                 0   0
+  st_case "real findings"         1   1
+  st_case "unresolvable rule"     3   2
+  st_case "analyzer error"        4   2
+  st_case "SIGKILL (OOM shape)" 137   2
+  st_case "SIGTERM"             143   2
+
+  # A syntax error must fail this gate even though the contract names no syntax
+  # rule -- the property the curated list depends on. Uses the REAL pwsh; skipped
+  # with a loud note (never a silent pass) when pwsh is unavailable. The fixture
+  # stages via `update-index` (plumbing) so no porcelain staging runs here.
+  if command -v pwsh >/dev/null 2>&1; then
+    st_bad="$st_tmp/badrepo"
+    mkdir -p "$st_bad/scripts"
+    ( cd "$st_bad" && git init -q . ) >/dev/null 2>&1
+    printf '\xef\xbb\xbffunction Broken {\n  if ($a -eq 1) {\n    Write-Output "x"\n' > "$st_bad/scripts/broken.ps1"
+    cp "$REPO_ROOT/scripts/psscriptanalyzer.sh" "$st_bad/scripts/psscriptanalyzer.sh"
+    ( cd "$st_bad" && git update-index --add scripts/broken.ps1 ) >/dev/null 2>&1
+    set +e
+    ( cd "$st_bad" && bash scripts/psscriptanalyzer.sh ) >/dev/null 2>&1
+    st_syn=$?
+    set -e
+    if [ "$st_syn" -ne 1 ]; then
+      echo "  FAIL [parse error] a *.ps1 with a syntax error exited $st_syn, expected 1."
+      echo "       An -IncludeRule list must NOT suppress ParseError findings."
+      st_fail=1
+    else
+      echo "  ok   [parse error] syntax error reds the gate despite the curated list"
+    fi
+  else
+    echo "  SKIP [parse error] pwsh absent -- this control did NOT run"
+  fi
+
+  if [ "$st_fail" -ne 0 ]; then
+    echo "psscriptanalyzer.sh self-test FAILED" >&2
+    exit 1
+  fi
+  echo "OK - self-test: findings (1), a killed/unusable analyzer (2), and an empty enumeration (2) are all distinct from a clean pass (0)."
+  exit 0
+fi
+
+if ! command -v pwsh >/dev/null 2>&1; then
+  echo "::error::pwsh (PowerShell 7+) not installed." >&2
+  echo "  macOS:         brew install --cask powershell" >&2
+  echo "  Debian/Ubuntu: https://learn.microsoft.com/powershell/scripting/install/install-ubuntu" >&2
+  exit 1
+fi
+
+# Collect every tracked *.ps1. git ls-files is the source of truth -- the SAME
+# corpus check-ps1-encoding.sh reads, so the two cannot disagree about what
+# "every tracked *.ps1" means. -z is NUL-delimited so paths with spaces survive.
+# Built bash-3.2-safe (macOS ships bash 3.2): no `mapfile -d`, just read+append.
+files=()
+while IFS= read -r -d '' f; do
+  files+=("$f")
+done < <(git ls-files -z -- '*.ps1')
+
+if [ "${#files[@]}" -eq 0 ]; then
+  # REFUSE, do not pass. This repo tracks 17 *.ps1, so an empty enumeration
+  # means the SELECTION broke -- a bad pathspec, an empty checkout, a failed
+  # `git ls-files` -- never that the work is clean. Exiting 0 here would report
+  # a clean scan over a run that never happened.
+  echo "UNEVALUATED: zero tracked *.ps1 found. This repo tracks several, so an" >&2
+  echo "empty file list means the SELECTION failed, not that the tree is clean." >&2
+  echo "Nothing was analyzed -- this is not a pass." >&2
+  exit 2
+fi
+
+# The analyzer runs from a FILE rather than -Command: the rule list and the
+# GitHub annotation format both contain characters that do not survive being
+# quoted through two shells intact.
+helper="$(mktemp -t pssa-gate.XXXXXX)"
+mv "$helper" "$helper.ps1"; helper="$helper.ps1"
+listfile="$(mktemp -t pssa-files.XXXXXX)"
+cleanup_all() { rm -f "$helper" "$listfile"; }
+trap cleanup_all EXIT
+
+cat > "$helper" <<'HELPER'
+param([string]$RuleCsv, [string]$FileList)
+$ErrorActionPreference = 'Stop'
+try { Import-Module PSScriptAnalyzer -ErrorAction Stop } catch {
+  [Console]::Error.WriteLine("PSScriptAnalyzer module not available: $($_.Exception.Message)")
+  exit 3
+}
+$rules = $RuleCsv.Split(',') | Where-Object { $_ }
+# Fail LOUD on a rule name the installed analyzer does not know. A stale name in
+# the contract would sit there matching nothing while the gate reported clean --
+# the scope silently shrinks and the green looks identical.
+$known = (Get-ScriptAnalyzerRule).RuleName
+$bad = @($rules | Where-Object { $_ -notin $known })
+if ($bad.Count -gt 0) {
+  [Console]::Error.WriteLine("UNRESOLVABLE RULE NAME(S): " + ($bad -join ', '))
+  [Console]::Error.WriteLine("These would match nothing and the scan would still report clean.")
+  exit 3
+}
+$files = [System.IO.File]::ReadAllLines($FileList) | Where-Object { $_ }
+$ver = (Get-Module -ListAvailable PSScriptAnalyzer | Select-Object -First 1).Version
+Write-Output "==> PSScriptAnalyzer over $($files.Count) tracked *.ps1, $($rules.Count) enforced rule(s)  [$ver]"
+$found = @()
+foreach ($f in $files) { $found += Invoke-ScriptAnalyzer -Path $f -IncludeRule $rules }
+if ($found.Count -eq 0) { exit 0 }
+foreach ($d in $found) {
+  if ($env:GITHUB_ACTIONS) {
+    Write-Output ("::error file={0},line={1}::{2}: {3}" -f $d.ScriptPath, $d.Line, $d.RuleName, $d.Message)
+  } else {
+    Write-Output ("{0}:{1} [{2}] {3}" -f $d.ScriptName, $d.Line, $d.RuleName, $d.Message)
+  }
+}
+exit 1
+HELPER
+
+printf '%s\n' "${files[@]}" > "$listfile"
+
+# Classify pwsh's status instead of treating every non-zero as "found issues".
+# The helper returns 0 = clean, 1 = findings, 3 = it could not evaluate (module
+# missing, or a rule name that no longer resolves). Anything else means the
+# process itself did not deliver a verdict -- 128+N when the kernel killed it
+# (137 = SIGKILL, the OOM shape on a loaded runner). Reporting a signal death as
+# a lint finding sends the reader hunting a defect that does not exist; the
+# adjacent shape is worse -- a "no findings" line over a scan that never ran.
+set +e
+pwsh -NoProfile -NonInteractive -File "$helper" -RuleCsv "$PSSA_RULES" -FileList "$listfile"
+ps_rc=$?
+set -e
+
+if [ "$ps_rc" -eq 0 ]; then
+  echo "    OK - no PSScriptAnalyzer findings in the enforced rule set"
+elif [ "$ps_rc" -eq 1 ]; then
+  echo "FAILED: PSScriptAnalyzer found issues in the enforced rule set." >&2
+  echo "These are security and real-bug rules, plus any syntax error. Fix them," >&2
+  echo "or for a genuine false-positive add a SuppressMessageAttribute WITH a" >&2
+  echo "Justification at the source. Do NOT drop a rule from the list in this" >&2
+  echo "script to hide a finding (see its header)." >&2
+  exit 1
+elif [ "$ps_rc" -eq 3 ]; then
+  echo "UNEVALUATED: the analyzer could not run its contract (see stderr above)." >&2
+  echo "Either PSScriptAnalyzer is not installed, or a rule name in this script no" >&2
+  echo "longer resolves. Nothing was verified -- this is not a pass." >&2
+  exit 2
+elif [ "$ps_rc" -gt 128 ]; then
+  echo "UNEVALUATED: pwsh was KILLED by signal $((ps_rc - 128)) (exit $ps_rc)." >&2
+  echo "It did not finish, so NOTHING was analyzed -- this is not a finding and it" >&2
+  echo "is not a pass. On a loaded runner this is usually the OOM killer." >&2
+  exit 2
+else
+  echo "UNEVALUATED: pwsh exited $ps_rc, which is none of clean (0), findings (1)," >&2
+  echo "or could-not-evaluate (3). The scan is incomplete and its silence means" >&2
+  echo "nothing." >&2
+  exit 2
+fi

--- a/scripts/vault-backup.ps1
+++ b/scripts/vault-backup.ps1
@@ -90,7 +90,16 @@ function Slug-For { param([string]$p)
 }
 
 # Passphrase at rest via DPAPI (current-user scoped). Never plaintext on disk.
-function Store-Passphrase { param([string]$slug, [string]$plain)
+function Store-Passphrase {
+  # PSScriptAnalyzer flags ConvertTo-SecureString -AsPlainText as leaking a
+  # secret. Here it does the opposite: the passphrase arrives as a plain
+  # string (the user just typed it), and this is the ONLY API path that gets
+  # it into DPAPI -- the very next line, ConvertFrom-SecureString, is what
+  # produces the encrypted standard string the rule asks for, and that blob
+  # is what reaches disk. The plaintext never leaves memory. Suppressed
+  # here rather than gate-wide so any OTHER file that does leak one still reds.
+  [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '', Justification = 'Plaintext is the user-typed passphrase being sealed INTO DPAPI; ConvertFrom-SecureString on the next line is what is written to disk.')]
+  param([string]$slug, [string]$plain)
   $secure = ConvertTo-SecureString $plain -AsPlainText -Force
   $enc = $secure | ConvertFrom-SecureString
   $pf = Join-Path $env:USERPROFILE ".claude\.vault-backup-pass-$slug"


### PR DESCRIPTION
## What

Adds `scripts/psscriptanalyzer.sh`, run from two callers: a step in the `lint` job, and section (c2) of `scripts/ci.sh`. Completes the `.ps1` half of the syntax-check-only gap.

## Why

`shellcheck.sh` closed this for `*.sh`; `ruff-gate.sh` closed it for `*.py` last week. `.ps1` still had an **encoding** check (UTF-8 BOM, no em dash) and a **parse** check, and nothing semantic — on the Windows install path, the platform with the fewest local eyes on it.

## Why a curated rule list and not a severity floor

This is the part worth reviewing. Inheriting `shellcheck.sh`'s shape would have been wrong. shellcheck gates at `-S warning` because shellcheck's warning tier is mostly correctness. PSScriptAnalyzer's is not, and the numbers are not close — measured over the 17 tracked `.ps1`:

| Severity | Findings |
|---|---|
| Warning | **317** (251 of them `PSAvoidUsingWriteHost`) |
| Information | 18 |
| Error | 1 |

A `-Severity Warning` gate lands **318 findings red on day one**, and its single largest rule is *wrong for this repo*: these are installers and CLIs whose job is talking to a human, so `Write-Host` is the correct call, not a defect. A gate that lands red only teaches bypass.

So the contract is an explicit list of **21 security and real-bug rules** — `PSAvoidUsingInvokeExpression`, `PSPossibleIncorrectUsageOfAssignmentOperator` (`if ($a = $b)`), `PSPossibleIncorrectUsageOfRedirectionOperator` (`if ($a > $b)`, which silently creates a file), `PSPossibleIncorrectComparisonWithNull`, the credential rules — every one green on this tree. That is auditable in a way a severity floor is not: you can read exactly what is enforced, and adding a file cannot silently change it.

**Every rule name is verified to resolve before the scan runs.** A renamed or removed rule would otherwise sit in the list matching nothing while the gate still reported clean. That path exits 2 (UNEVALUATED), not 0.

**Parse errors are still caught.** An `-IncludeRule` list does not suppress `ParseError` findings, so a syntax error reds the gate even though the contract names no syntax rule. That property has its own negative control, because the whole curated-list design depends on it.

## The one Error, adjudicated at the source

`vault-backup.ps1`'s `Store-Passphrase` tripped `PSAvoidUsingConvertToSecureStringWithPlainText`. The code is **correct**: the passphrase arrives as a plain string because the user just typed it, and this is the only API path into DPAPI — the next line, `ConvertFrom-SecureString`, produces the encrypted blob that actually reaches disk. Suppressed there with a `Justification` rather than by dropping the rule, so any *other* file that genuinely leaks a plaintext secret still reds this gate.

## Review-risky areas

- The second commit fixes a defect in the first, found by doubt-passing my own diff: the helper ran the scan unguarded, and an uncaught terminating error exits `1` — which the caller maps to "found issues." A **crashed** analyzer was being reported as **bad code**. It still went red, so nothing could ship unverified, but it erased the three-state distinction the script exists to preserve. Now wrapped to exit `3` (UNEVALUATED), with its own control.
- The module install has no `|| true`. A gate that cannot run must not report clean — same reasoning as the existing ruff install.

## Verification

- Self-test: **9 negative controls** green — clean, findings, unresolvable rule, analyzer error, SIGKILL, SIGTERM, empty enumeration, plus two real-`pwsh` cases (a syntax error reds the gate despite the curated list; a tracked-but-missing file classifies as UNEVALUATED, not findings).
- The new control is **proven non-vacuous**: against the pre-fix helper it fails with `tracked-but-missing *.ps1 exited 1, expected 2` — the bug itself — and passes after.
- A planted `Invoke-Expression` is caught and named, tree restored byte-identical.
- A stale rule name (`PSSA_INCLUDE_EXTRA=PSThisRuleWasRenamedInV2`) exits 2 rather than passing clean.
- `lint.yml` parses with PyYAML; `ci.sh` passes `bash -n`; shellcheck green over all 230 tracked `*.sh`.
- Full canonical gate green: 403 `py_compile` + 139 integration tests + 31 `scripts/` + 31 `hooks/tests` suites + shellcheck + **powershell** + phase-doc python + repo python + utf8 + block-protocol + vault-root + home-hook + subprocess decode + py3.9 parity + ps1 encoding.

An earlier run of this same commit went red with a `FileNotFoundError`. That was MYC-3391 — the worktree was deleted mid-gate — not this diff. Re-run from a scratchpad worktree on the identical SHA is green.

## Scope

Completes MYC-572 together with #631 (the `.py` half). The ticket's docs-wiring item landed separately in the skills repo and the vault.

Drafted with Claude Code; gate run and doubt-pass completed before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
