### PR TITLE
daily-journal: read the user's self-chat voice notes first, gated on a new toggle

### DIFF
--- a/skills/daily-journal/SKILL.md
+++ b/skills/daily-journal/SKILL.md
@@ -193,6 +193,16 @@ If they opt in, set the toggles in the file in-session AND continue with those s
 
 Synthesize these into ONE dense paragraph that lands at the top of the saved entry as the `## Today` section (see Step 7 entry format). Concrete: PR numbers, test count deltas, file counts, hour totals, named events, named people. Inventory shape, not narrative.
 
+**0d-PRIMARY. Voice notes the user sent to their own self-chat (gated on `data_sources.self_chat_voice_notes: on`).** Some people dictate short voice notes to their own number during the day *specifically* as journal fuel. For them these are not background colour — they are the raw material of the entry, and they have to be pulled BEFORE the opener, not after. When the toggle is on, go through the live WhatsApp MCP directly rather than the on-demand reader in 0d: that reader digests text threads, and a self-chat's whole value is in the transcripts.
+
+1. `mcp__*whatsapp*__healthcheck` — confirm `auth_state: paired` and that `transcription` is present.
+2. `mcp__*whatsapp*__list_messages` on the self-chat JID (the user's own number, e.g. `<phone>@s.whatsapp.net`; the bridge may report it merged with a `@lid` JID — either works), `limit: 40`.
+3. Read every `type: "voice"` message since the last journal entry. Each carries a `voice_note_transcript` field — use it verbatim. If a note has no transcript yet, call `download_media` and note the gap.
+4. Extract mood, what happened, self-reported habits, people named, gratitudes the user already stated, and the floor language they used themselves. Build the interview and the `## Today` / `## Journal` sections on top of that.
+5. **Ask only about what the voice notes did NOT cover.** Open by reflecting back what you heard, then ask your follow-ups. Do not make the user re-narrate a day they already narrated into their phone.
+
+If the self-chat has no voice notes since the last entry, say so plainly and run the normal opener. Never skip this pull silently: with the toggle on, a `/journal` that didn't check the self-chat is broken.
+
 **0d. WhatsApp + iMessage since your last journal (gated on `data_sources.whatsapp_24h` / `imessage_24h`).** Prefer an MCP-INDEPENDENT on-demand reader over the live MCPs — a per-session stdio MCP for every channel adds memory pressure, and the journal should still get message context when those MCPs are not loaded. If a reader script exists in the vault (e.g. `Meta/scripts/journal-messages-fetch.py`), run it for the WHOLE gap since the last entry, not just 24h:
 
 ```

--- a/templates/journal-config.md
+++ b/templates/journal-config.md
@@ -13,6 +13,7 @@ data_sources:
   calendar: off               # today's calendar events (Google Workspace MCP) — opt-in
   imessage_24h: off           # iMessage threads with traffic in last 24h — opt-in (sees private conversations)
   whatsapp_24h: off           # WhatsApp threads with traffic in last 24h — opt-in (sees private conversations)
+  self_chat_voice_notes: off  # voice notes you send to your OWN number, read FIRST as the entry's raw material — opt-in (needs the WhatsApp MCP + transcription)
   body_health: off            # Step 0h: sleep/HRV/RHR/steps/workouts/recovery/cycle from health-mcp DuckDB — opt-in (most sensitive; local-only, never leaves your machine)
   email: off                  # email triage digest (Email Needs You.md) + a fresh gmail_search — opt-in (sees private mail)
   slack: off                  # on-disk Slack export + a fresh slack search — opt-in (sees private messages)


### PR DESCRIPTION
Some people dictate short voice notes to their own number during the day *specifically* as journal fuel — a midday one and an end-of-day one, recorded precisely so the journal has something to work from.

Today the skill has no place for that habit:

- **0d routes WhatsApp through the on-demand reader**, which digests text threads. It never surfaces `voice_note_transcript`, so the notes are invisible.
- **It runs alongside the other sources**, not before the opener. Even if the transcripts arrived, they would land after the first question.

The result is a `/journal` that opens cold and asks the user to re-narrate a day they already narrated into their phone. That is the failure that prompted this: the user had to stop the session and correct it.

## What this adds

`0d-PRIMARY`, placed before `0d`, opt-in via a new `data_sources.self_chat_voice_notes` toggle (default `off`, consistent with the other private-data sources).

When on, it:

1. Goes through the **live WhatsApp MCP** rather than the on-demand reader — the reader is right for text threads, but a self-chat’s whole value is in the transcripts.
2. Reads every `type: "voice"` message since the last entry and uses `voice_note_transcript` **verbatim**.
3. Builds the interview and the `## Today` / `## Journal` sections **on top of** what the user already said.
4. **Limits the questions to what the notes did not cover** — the assistant opens by reflecting back what it heard.

It fails loudly rather than silently: if the self-chat has no voice notes since the last entry, it says so and runs the normal opener.

## Files

- `skills/daily-journal/SKILL.md` — the `0d-PRIMARY` step
- `templates/journal-config.md` — the toggle, defaulted `off`

## Note for maintainers

This started as a local edit on one install and was **silently reverted by `scripts/sync-skills.py`**, which reported the file as "behind canonical" when the only difference was this local addition. Worth a look independently of this PR: the script appears to treat "has content canonical lacks" as "is outdated", and its "local customizations preserved" message only means it wrote a `.bak-` file, not that anything was merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)