### PR TITLE
fix(hooks): two security hooks wrote their audit logs into their own git checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,12 @@ hooks/.secret-scan.lock
 # receiving substrate updates. Measured on the deployed checkout at
 # ~/.claude/skills/ai-brain-starter: untracked logs/ present, update blocked.
 /logs/
+
+# Same class as /logs/ above: a SHIPPED hook writing runtime state into whatever
+# directory it happens to run from, which on a real install is this repo's own
+# deployed checkout. scrub-session-jsonl-secrets.py now writes to
+# ~/.claude/hooks/ instead, but installs that already ran the old build carry the
+# stray file, and an untracked artifact here is reported as a hand-edit by the
+# deployed-hook-drift surfacer on every single session.
+hooks/scrub-log.jsonl
+hooks/secret-detection-log.jsonl

--- a/hooks/detect-secrets-in-bash-output.py
+++ b/hooks/detect-secrets-in-bash-output.py
@@ -43,7 +43,20 @@ sys.path.insert(0, str(HOOK_DIR))
 
 from _lib.secret_patterns import filter_tool_output_false_positives, scan  # noqa: E402
 
-LOG_PATH = HOOK_DIR / "secret-detection-log.jsonl"
+# NOT HOOK_DIR — same reason as scrub-session-jsonl-secrets.py, and the same
+# contradiction with this module's own docstring above, which places this log
+# at ~/.claude/hooks/. HOOK_DIR is where THIS COPY runs from, and the wired
+# copy on a real install is a GIT CHECKOUT of this repo, so an append-only
+# audit log accumulated inside it as an untracked file and was reported as a
+# hand-edit by the deployed-hook-drift surfacer on every session.
+#
+# It also SPLIT the audit trail: each deployed copy kept its own log, so the
+# record of what this detector caught depended on which copy happened to run.
+# One log per machine is the only version of an audit trail worth having.
+LOG_PATH = Path(
+    os.environ.get("SECRET_DETECTION_LOG_PATH")
+    or (Path.home() / ".claude" / "hooks" / "secret-detection-log.jsonl")
+)
 
 # Per the user's stated preference (2026-05-23): grep'ing her own .env.local /
 # admin.env / .zsh_secrets to verify what's stored is intentional, not a leak.
@@ -147,6 +160,7 @@ def main() -> int:
             {"pattern": n, "count": c, "reason": r} for n, c, r in fp_suppressed
         ]
     try:
+        LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
         with LOG_PATH.open("a", encoding="utf-8") as f:
             f.write(json.dumps(entry, separators=(",", ":")) + "\n")
     except OSError:

--- a/hooks/scrub-session-jsonl-secrets.py
+++ b/hooks/scrub-session-jsonl-secrets.py
@@ -36,7 +36,23 @@ sys.path.insert(0, str(HOOK_DIR))
 
 from _lib.secret_patterns import redact, scan  # noqa: E402
 
-SCRUB_LOG = HOOK_DIR / "scrub-log.jsonl"
+# NOT HOOK_DIR. HOOK_DIR is where THIS COPY of the hook lives, which is right
+# for importing the sibling _lib above and wrong for an audit log: the wired
+# copy on a real install is `~/.claude/skills/ai-brain-starter/hooks/`, a GIT
+# CHECKOUT, so the log accumulated as an untracked file inside the deployed
+# public repo. That contradicted this module's own docstring (which places it
+# at ~/.claude/hooks/) and made the deployed-hook-drift surfacer report a
+# hand-edit on every session — 108 false fires in one day, measured
+# 2026-09-01. A standing alarm that is always wrong is how a surfacer trains
+# itself into wallpaper, which is what MYC-683 exists to prevent.
+#
+# .gitignore covers the stray copies already on disk; this is the root fix.
+# One log per MACHINE is also the behaviour an audit trail wants — both
+# deployment copies now append to the same file instead of one each.
+SCRUB_LOG = Path(
+    os.environ.get("SCRUB_LOG_PATH")
+    or (Path.home() / ".claude" / "hooks" / "scrub-log.jsonl")
+)
 
 
 def _read_payload() -> dict:
@@ -101,6 +117,9 @@ def _scrub_file(path: Path) -> tuple[int, list[tuple[str, int]]]:
 
 def _log(summary: dict) -> None:
     try:
+        # The directory may not exist when the hook runs from the skills
+        # checkout on an install that has no ~/.claude/hooks of its own.
+        SCRUB_LOG.parent.mkdir(parents=True, exist_ok=True)
         with SCRUB_LOG.open("a", encoding="utf-8") as f:
             f.write(json.dumps(summary, separators=(",", ":")) + "\n")
     except OSError:

--- a/hooks/test_scrub_log_location.py
+++ b/hooks/test_scrub_log_location.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""A shipped hook must not write runtime state into the directory it RUNS from.
+
+scrub-session-jsonl-secrets.py resolved its audit log as `HOOK_DIR /
+"scrub-log.jsonl"`. HOOK_DIR is correct for importing the sibling `_lib`, and
+wrong for a log: the copy wired on a real install is
+`~/.claude/skills/ai-brain-starter/hooks/`, a GIT CHECKOUT of this repo. So the
+log accumulated as an untracked file inside the deployed public repo, the
+deployed-hook-drift surfacer reported it as a hand-edit, and it fired 108 times
+in a single day (measured 2026-09-01) — against a file the hook itself wrote.
+A standing alarm that is always wrong is how a surfacer becomes wallpaper.
+
+Two legs: the BEHAVIOUR (run the hook from a copied checkout, assert the log
+lands outside it) and the CLASS (no hook assigns a runtime-state path relative
+to its own __file__), so the next hook cannot reintroduce it.
+
+Run: python3 hooks/test_scrub_log_location.py
+"""
+from __future__ import annotations
+
+import ast
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HOOKS = Path(__file__).resolve().parent
+failures: list[str] = []
+
+
+def check(cond: bool, msg: str) -> None:
+    if not cond:
+        failures.append(msg)
+
+
+# --- BEHAVIOUR: reproduce the incident shape -----------------------------
+# A copy of hooks/ standing in for the deployed skills checkout, a sandboxed
+# HOME so the real one is never touched, and a real session JSONL to scrub.
+with tempfile.TemporaryDirectory() as td:
+    tmp = Path(td)
+    # Stand up the fake checkout WITHOUT a recursive copy. copytree is a
+    # recursive reader, which scripts/check-cloud-safe-file-walkers.py forbids
+    # without the shared safe_read primitive -- rightly: an unbounded recursive
+    # read blocks forever on a cloud placeholder or a FIFO. Nothing here needs
+    # recursion. The hook file is COPIED (so its Path(__file__).resolve().parent
+    # lands in this directory, which is the whole point of the fixture) and
+    # _lib is SYMLINKED, which reads nothing at all.
+    checkout = tmp / "skills" / "ai-brain-starter" / "hooks"
+    checkout.mkdir(parents=True)
+    shutil.copy2(HOOKS / "scrub-session-jsonl-secrets.py",
+                 checkout / "scrub-session-jsonl-secrets.py")
+    (checkout / "_lib").symlink_to(HOOKS / "_lib", target_is_directory=True)
+    home = tmp / "home"
+    (home / ".claude").mkdir(parents=True)
+
+    sess = tmp / "session.jsonl"
+    sess.write_text(json.dumps({"x": "nothing secret here"}) + "\n", encoding="utf-8")
+
+    before = {p.name for p in checkout.iterdir()}
+    assert before == {"scrub-session-jsonl-secrets.py", "_lib"}, before
+    proc = subprocess.run(
+        [sys.executable, str(checkout / "scrub-session-jsonl-secrets.py")],
+        input=json.dumps({"transcript_path": str(sess)}),
+        capture_output=True, text=True, encoding="utf-8",
+        env=dict(os.environ, HOME=str(home), USERPROFILE=str(home)),
+    )
+    after = {p.name for p in checkout.iterdir()}
+
+    # The hook is fail-open by design; a non-zero exit would make every
+    # assertion below vacuous (nothing ran, so nothing was written either).
+    check(proc.returncode == 0,
+          f"the hook did not run: rc={proc.returncode} {proc.stderr[-300:]}")
+    check("scrub-log.jsonl" not in after,
+          "the audit log landed INSIDE the running checkout — that untracked "
+          "file is what the drift surfacer reports as a hand-edit every session")
+    check(after == before,
+          f"the hook wrote {sorted(after - before)} into its own directory; a "
+          f"shipped hook's directory is a git checkout, not a state dir")
+    check((home / ".claude" / "hooks" / "scrub-log.jsonl").is_file(),
+          "the audit log did not land at ~/.claude/hooks/ either — it must move "
+          "OUT of the checkout, not disappear (the log is the evidence trail "
+          "that the secret-scrub pipeline is running at all)")
+
+    # POSITIVE CONTROL: the leg above passes trivially if the hook never logs.
+    # It logs unconditionally, so a populated file proves the path was exercised.
+    # Read defensively: against the PRE-FIX hook this file does not exist at all,
+    # and a suite that raises there reports a traceback instead of the finding —
+    # the negative control has to read as a clean FAIL, not a crash.
+    canonical = home / ".claude" / "hooks" / "scrub-log.jsonl"
+    logged = canonical.read_text(encoding="utf-8") if canonical.is_file() else ""
+    check(logged.strip().startswith("{"),
+          f"the audit log is empty/malformed/absent ({logged[:80]!r}) — the "
+          f"location assertions above would pass on a hook that never wrote")
+
+# --- CLASS: no hook resolves runtime state against its own __file__ -------
+# Extensions that are unambiguously runtime state. `.json` is deliberately out:
+# a bundled config read from the hook dir is legitimate.
+STATE_SUFFIXES = (".jsonl", ".log", ".state", ".db")
+offenders: list[str] = []
+for py in sorted(HOOKS.glob("*.py")):
+    try:
+        tree = ast.parse(py.read_text(encoding="utf-8", errors="replace"))
+    except SyntaxError:
+        continue
+    # names bound to a directory derived from __file__ (HOOK_DIR = ...parent)
+    dir_names = {"HOOK_DIR", "HERE", "HOOKS", "SCRIPT_DIR"}
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div)):
+            continue
+        left, right = node.left, node.right
+        if not (isinstance(right, ast.Constant) and isinstance(right.value, str)):
+            continue
+        if not right.value.endswith(STATE_SUFFIXES):
+            continue
+        rooted_at_file = (
+            (isinstance(left, ast.Name) and left.id in dir_names)
+            or "__file__" in ast.dump(left)
+        )
+        if rooted_at_file:
+            offenders.append(f"{py.name}:{node.lineno} -> {right.value}")
+
+check(not offenders,
+      "hook(s) resolve runtime state against their own __file__, so the file "
+      "lands in whichever deployed copy runs — on a real install that is a git "
+      f"checkout of this repo: {offenders}")
+
+if failures:
+    print("FAILED — scrub-log location (a hook's directory is not a state dir):")
+    for f in failures:
+        print(f"  ✗ {f}")
+    sys.exit(1)
+print("OK - the audit log lands outside the running checkout, the hook writes "
+      "nothing into its own directory, and no hook roots runtime state at __file__")

--- a/scripts/check-hook-negative-control.py
+++ b/scripts/check-hook-negative-control.py
@@ -115,7 +115,6 @@ SKIP_PARTS = {".git", "node_modules", "__pycache__", ".venv"}
 NO_TEST_BASELINE: Set[str] = {
     # -- secret / data-exposure guards (highest stakes) --
     "block-secret-in-note",
-    "scrub-session-jsonl-secrets",
     # -- correctness / process guards --
     "agent-briefing-check",
     "block-branch-switch-with-untracked-build",

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1154,6 +1154,13 @@ echo "==> (e10) exit contract: $PY scripts/check-exit-contract.py"
 echo "==> (e2b) hook activation: $PY scripts/check-hook-activation.py"
 "$PY" scripts/check-hook-activation.py --selftest >/dev/null
 "$PY" scripts/check-hook-activation.py
+# lint.yml runs this and scripts/ci.sh did not, so `ci-test` reported GREEN on a
+# commit CI then rejected — the local gate was silently narrower than the
+# required check it stands in for. It is a 0.2s pure-Python scan with a
+# self-test, so there was no cost reason to leave it out; the omission was the
+# bug. Caught the honest way: a push of this very commit went red on it.
+"$PY" scripts/check-hook-negative-control.py --selftest >/dev/null
+"$PY" scripts/check-hook-negative-control.py
 
 # ---- (e3) Naive VAULT_ROOT reads -------------------------------------------
 # scripts/check-vault-root-reads.py fails code that reads the VAULT_ROOT env var
@@ -1319,6 +1326,14 @@ PY_DIRECT=(
   # coverage at all while the condenser silently dropped every render
   # section after the first.
   hooks/test_standing_report.py
+  # Two SECURITY hooks resolved their append-only audit logs as `HOOK_DIR /
+  # "...jsonl"`. HOOK_DIR is where the running COPY lives, and the wired copy on
+  # a real install is this repo's own deployed checkout — so the logs accumulated
+  # as untracked files inside it (108 drift-surfacer false fires in one day) AND
+  # the audit trail split per copy. Carries the CLASS check: no hook may root
+  # runtime state at its own __file__. That check found the second hook; only the
+  # first was known.
+  hooks/test_scrub_log_location.py
   hooks/test_claim_surface_honesty.py
   hooks/test_narrow_refspec_falsealarm.py
   # session-lock resolves the repo identity its whole mechanism keys off with


### PR DESCRIPTION
`HOOK_DIR = Path(__file__).resolve().parent` is right for importing the sibling `_lib` and wrong for a log file. The copy wired on a real install is `~/.claude/skills/ai-brain-starter/hooks/` — a git checkout of **this repo** — so two security hooks appended runtime state inside it, contradicting their own docstrings, which place these logs at `~/.claude/hooks/`.

## Two live consequences

**A standing alarm that is always wrong.** The untracked file reads as a hand-edit to the deployed public checkout, so the deployed-hook-drift surfacer fired on it **every session — 108 times in one day** (measured 2026-09-01), against a file the hook itself had written. That is how a surfacer trains itself into wallpaper, and the next fire, for a *real* hand-edit, would read exactly the same.

**A split audit trail.** Measured on this machine:

| | |
|---|---|
| hooks wired from `~/.claude/hooks` | 156 |
| hooks wired from the skills checkout | 45 |
| `scrub-log.jsonl` in `~/.claude/hooks` | 4,780 entries |
| `scrub-log.jsonl` in the skills checkout | 1 entry |

Both copies are live, so the record of what the secret detector caught depended on which one happened to run. That is the one property an audit trail cannot trade away.

## The fix

Both logs now resolve to `~/.claude/hooks/<name>.jsonl` as documented, with an env override (`SCRUB_LOG_PATH`, `SECRET_DETECTION_LOG_PATH`) so a test can pin them instead of reading and polluting real machine state, and a `mkdir(parents=True)` **inside the existing `try`** so the fail-open contract is unchanged — a log that cannot be written still never breaks the hook. Logs already at the old locations stay there, readable; nothing is migrated or deleted.

`.gitignore` covers both filenames too. That is belt-and-suspenders, not the fix: installs that already ran the old build carry the stray file. `/logs/` a few lines above documents the same class for `worktree-prune.sh`.

## The class leg found the second hook

`hooks/test_scrub_log_location.py` (registered in `PY_DIRECT`) has two legs:

- **behaviour** — copy the hook into a temp dir standing in for the deployed checkout, sandbox `HOME`, run it for real, assert the log lands *outside* the copy and that the copy's file list is unchanged
- **class** — no hook assigns a `.jsonl`/`.log`/`.state`/`.db` path relative to its own `__file__` (`.json` deliberately excluded: a bundled config read from the hook dir is legitimate)

Only `scrub-session-jsonl-secrets.py` was known, from the drift alarm. The class leg immediately flagged `detect-secrets-in-bash-output.py` with the identical defect and the identical contradiction with its own docstring. Nothing had surfaced it.

**Negative control:** against the pre-fix revision the suite exits 1 with all five legs failing, each naming what it saw, and the class leg listing both offenders. The positive control reads the canonical path defensively — pre-fix that file does not exist, and a suite that raises there reports a traceback instead of a finding.

## One note on the fixture

The gate caught this test on its first run: the fixture used `shutil.copytree`, a recursive reader, which this repo's cloud-safe-walker ratchet rejects without the shared `safe_read` primitive. That is the ratchet working — an unbounded recursive read blocks forever on a cloud placeholder or a FIFO, and a test is not exempt. Nothing here needed recursion, so the fixture is now a single-file copy plus a symlinked `_lib`.

`ci-test` GREEN (canon), marker written for `814e8c08`. No `CI_PARITY_*` bypass was used; the run was slow only because the box was carrying ~16 concurrent sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
