### PR TITLE
fix(worktree): gate every reaper on the process table, so a busy session stops reading as a dead one

### DIFF
--- a/hooks/_lib/dev_repo_scan.py
+++ b/hooks/_lib/dev_repo_scan.py
@@ -46,6 +46,29 @@ except ImportError:  # loaded as a plain module (not a package), the common case
         def reclaim_stale_git_locks(_repo):
             return []
 
+# Fail-CLOSED process-liveness gate for the destructive tier (execute_reap).
+# Distinct from live_process_cwds() below, deliberately: that one is an ADVISORY
+# probe scoped to agent processes which reports "could not measure" and lets its
+# caller fall through to lock files. This one sees EVERY process (a detached
+# build or test runner holds no agent-shaped command line) and refuses when it
+# cannot answer. Resolved defensively so an older deployed sibling makes the
+# reaper refuse rather than fail to import and revert to the unguarded path.
+try:
+    from .worktree_safety import process_busy_reason as _process_busy_reason
+except Exception:  # pragma: no cover - depends on the deployed layout
+    try:
+        from _lib.worktree_safety import process_busy_reason as _process_busy_reason
+    except Exception:
+        _process_busy_reason = None  # type: ignore[assignment]
+
+
+def process_busy_reason_or_refuse(path: Path, cache: Optional[dict] = None):
+    """Why `path` must not be deleted, or None. An absent probe REFUSES."""
+    if _process_busy_reason is None:
+        return ("process-liveness helper unavailable in this deploy; "
+                "refusing every removal")
+    return _process_busy_reason(path, cache=cache)
+
 
 # ── client-safe configuration (MYC-2070) ─────────────────────────────────────
 # This module shipped assuming ONE operator's layout: a hardcoded ~/dev holding
@@ -1231,6 +1254,12 @@ def execute_reap(plan: ReapPlan, apply: bool = False) -> dict:
     remove is WITHOUT `--force` (git refuses if it somehow turned dirty between
     plan and apply — fail safe). The manifest is ALWAYS returned (even dry-run)
     so a caller can persist it before destruction.
+
+    A worktree with a LIVE PROCESS in it is skipped and recorded as `skipped`.
+    Merge-state says the CONTENT is safe; it says nothing about whether someone
+    is standing in the directory right now, and the plan may be minutes old by
+    the time this runs — so the probe is taken HERE, immediately before the
+    removals, and never reused from planning time.
     """
     manifest: dict = {
         "repo": str(plan.repo),
@@ -1239,11 +1268,17 @@ def execute_reap(plan: ReapPlan, apply: bool = False) -> dict:
         "worktrees": [],
         "stashes": [],
     }
+    probe_cache: dict = {}
     for wt in plan.reap_worktrees:
-        manifest["worktrees"].append(
-            {"path": str(wt.path), "branch": wt.branch, "sha": wt.sha}
-        )
+        entry = {"path": str(wt.path), "branch": wt.branch, "sha": wt.sha}
+        manifest["worktrees"].append(entry)
         if apply:
+            busy = process_busy_reason_or_refuse(wt.path, cache=probe_cache)
+            if busy:
+                entry["skipped"] = busy
+                print(f"dev_repo_scan: keeping {Path(wt.path).name} — {busy}",
+                      file=sys.stderr)
+                continue
             _ls_unregister_stale_bundles(wt.path)  # MYC-2626: before removal, not after
             _git(plan.repo, "worktree", "remove", str(wt.path))  # no --force
     for t in plan.reap_branches:

--- a/hooks/_lib/worktree_safety.py
+++ b/hooks/_lib/worktree_safety.py
@@ -110,6 +110,9 @@ RECOVERY_SCAN_DEADLINE_S = 30.0
 # letting "could not look" be mistaken for "nobody is here".
 PROCESS_PROBE_TIMEOUT = 15
 
+# Where the probe's own subprocesses stand. See _live_cwds for why this matters.
+PROBE_CWD = os.path.abspath(os.sep)
+
 # One probe per process by default. These callers are short-lived (a session
 # hook, a one-shot reclaim), and they ask once per worktree with dozens on disk.
 # A long-running caller that mutates in phases should pass its OWN dict and
@@ -136,6 +139,7 @@ def _own_process_chain() -> set:
                 ["ps", "-o", "ppid=", "-p", str(pid)],
                 capture_output=True,
                 timeout=5,
+                cwd=PROBE_CWD,  # same reason as _live_cwds: never stand in a worktree
             )
             pid = int(result.stdout.decode("utf-8", "replace").strip() or 0)
         except (OSError, ValueError, subprocess.SubprocessError):
@@ -150,10 +154,18 @@ def _live_cwds() -> list:
     empty list: "no process found" and "could not look" must not collapse into
     the same answer for a caller that deletes directories.
     """
+    # `cwd=PROBE_CWD` is LOAD-BEARING, not tidiness. A spawned child inherits
+    # our cwd, and lsof lists ITSELF -- so a sweep launched from inside the very
+    # tree it is retiring would observe its own probe standing in that tree and
+    # refuse to remove it, forever. That is the exact case the ancestor-chain
+    # exclusion exists to permit, defeated by a DESCENDANT we created one line
+    # earlier. Anchoring the probe at the filesystem root fixes it for lsof and
+    # for any helper lsof itself forks; no worktree is ever the root.
     result = subprocess.run(
         ["lsof", "-d", "cwd", "-F", "pn"],
         capture_output=True,
         timeout=PROCESS_PROBE_TIMEOUT,
+        cwd=PROBE_CWD,
     )
     text = result.stdout.decode("utf-8", "replace")
     if not text.strip():
@@ -200,14 +212,44 @@ def process_cwd_inside(worktree: Path, *, _cache: dict | None = None) -> bool:
     return any(c == root or c.startswith(prefix) for c in cwds)
 
 
+def probe_supported() -> bool:
+    """False only where no process-cwd probe EXISTS for the platform.
+
+    Fail-closed is the right answer for a probe that BROKE. It is the wrong
+    answer for a platform that never had one: refusing every reap forever would
+    not protect a Windows install, it would disable worktree cleanup there and
+    hand that user back the unbounded pileup these hooks exist to prevent.
+    Windows has no `lsof` and no stdlib route to another process's cwd, so the
+    gate reports UNSUPPORTED and the remaining (proxy) gates decide, exactly as
+    they did before this guard existed.
+
+    On POSIX a missing `lsof` is an ANOMALY, not a platform fact, so it stays
+    fail-closed and the operator sees the refusal and can install it.
+    """
+    return os.name != "nt" or shutil.which("lsof") is not None
+
+
+_UNSUPPORTED_NOTED = [False]
+
+
 def process_busy_reason(path: Path, *, cache: dict | None = None) -> str | None:
     """A reason to REFUSE deleting ``path``, or None when nothing is running in it.
 
     FAIL CLOSED. An unusable probe returns a refusal, never a green light. The
     reason string exists so the refusal is VISIBLE in whatever log the caller
     keeps: a permanently-broken probe must surface as a stated refusal, not as a
-    fleet that quietly stops being cleaned.
+    fleet that quietly stops being cleaned. The one exception is a platform with
+    no probe at all -- see probe_supported() -- which says so once and defers.
     """
+    if not probe_supported():
+        if not _UNSUPPORTED_NOTED[0]:
+            _UNSUPPORTED_NOTED[0] = True
+            _stderr_note(
+                "no process-cwd probe on this platform; worktree removals fall "
+                "back to session-lock and mtime gates, which cannot see a busy "
+                "session inside one long call"
+            )
+        return None
     if cache is None:
         cache = _PROBE_CACHE
     try:

--- a/hooks/_lib/worktree_safety.py
+++ b/hooks/_lib/worktree_safety.py
@@ -44,6 +44,7 @@ from datetime import datetime
 import shutil
 import sqlite3
 import subprocess
+import sys
 import time
 import uuid
 from dataclasses import dataclass
@@ -75,6 +76,153 @@ RECOVERY_MAX_FILE_BYTES = 64 * 1024 * 1024
 RECOVERY_MAX_TOTAL_BYTES = 128 * 1024 * 1024
 RECOVERY_MAX_CANDIDATES = 5_000
 RECOVERY_SCAN_DEADLINE_S = 30.0
+
+# ---------------------------------------------------------------------------
+# Process-table liveness — the only liveness signal here that cannot go stale.
+#
+# THE BUG CLASS: every other gate in this module is a PROXY for "is anyone
+# using this worktree", and every one of them reads a BUSY session as a dead
+# one.
+#
+#   * The session lock records `last_activity_at`, and the hook that refreshes
+#     it fires when a tool call STARTS. A session sitting inside ONE long call —
+#     a test suite, a build, a migration — emits no heartbeat for the whole run.
+#     Past the liveness window its entry is byte-identical to that of a session
+#     that exited, and past the lock's idle-expiry the entry is deleted outright.
+#     The lock's recorded pid cannot rescue this: it is the ephemeral hook
+#     process's pid, already dead when it is written.
+#   * `is_idle()` reads mtime, and "nothing written here for an hour" is also
+#     exactly what a long build whose output goes somewhere else looks like.
+#
+# So both proxies answer "gone" for a session that is merely BUSY: the harder a
+# worktree is being worked in, the deader it looks. Observed in the field: a
+# worktree was removed mid-test-run, several commits deep, by a sibling
+# session's start-up sweep; the commits survived only because they were already
+# in the shared object store.
+#
+# The process table knows nothing about heartbeats and cannot go stale, so it is
+# consulted before every deletion path in this package.
+#
+# Related but NOT the same primitive: `_lib/dev_repo_scan.live_process_cwds()`
+# is an ADVISORY liveness probe scoped to agent processes, which reports
+# "could not measure" and lets its caller fall through to lock files. This one
+# is a DELETION GATE: it sees every process, and it RAISES rather than ever
+# letting "could not look" be mistaken for "nobody is here".
+PROCESS_PROBE_TIMEOUT = 15
+
+# One probe per process by default. These callers are short-lived (a session
+# hook, a one-shot reclaim), and they ask once per worktree with dozens on disk.
+# A long-running caller that mutates in phases should pass its OWN dict and
+# refresh it immediately before deleting, never reuse a plan-time reading.
+_PROBE_CACHE: dict = {}
+
+
+def _own_process_chain() -> set:
+    """This process and its ancestors.
+
+    A session-end sweep is spawned BY the ending session, whose cwd is very
+    often the exact worktree being retired, so our own chain must never veto its
+    own cleanup. Descendants are deliberately NOT excluded: a detached gate
+    still running in the tree is precisely the thing worth protecting.
+    """
+    chain: set = set()
+    pid = os.getpid()
+    for _ in range(64):  # bounded: never trust a parent chain to terminate
+        if pid <= 1 or pid in chain:
+            break
+        chain.add(pid)
+        try:
+            result = subprocess.run(
+                ["ps", "-o", "ppid=", "-p", str(pid)],
+                capture_output=True,
+                timeout=5,
+            )
+            pid = int(result.stdout.decode("utf-8", "replace").strip() or 0)
+        except (OSError, ValueError, subprocess.SubprocessError):
+            break
+    return chain
+
+
+def _live_cwds() -> list:
+    """Resolved cwd of every live process, excluding our own ancestor chain.
+
+    Raises on any failure. A probe that cannot run reports UNKNOWN, never an
+    empty list: "no process found" and "could not look" must not collapse into
+    the same answer for a caller that deletes directories.
+    """
+    result = subprocess.run(
+        ["lsof", "-d", "cwd", "-F", "pn"],
+        capture_output=True,
+        timeout=PROCESS_PROBE_TIMEOUT,
+    )
+    text = result.stdout.decode("utf-8", "replace")
+    if not text.strip():
+        # lsof exits non-zero on a partially-unreadable process table, which is
+        # normal and still yields output. NO output at all means it did not run.
+        raise OSError("process probe returned no output")
+    mine = _own_process_chain()
+    cwds: list = []
+    current_pid = None
+    for line in text.splitlines():
+        if not line:
+            continue
+        tag, value = line[0], line[1:]
+        if tag == "p":
+            try:
+                current_pid = int(value)
+            except ValueError:
+                current_pid = None
+        elif tag == "n" and current_pid is not None and current_pid not in mine:
+            cwds.append(value)
+    return cwds
+
+
+def process_cwd_inside(worktree: Path, *, _cache: dict | None = None) -> bool:
+    """True if a live foreign process has its cwd at or under ``worktree``.
+
+    A subdirectory counts — a test runner sits in one. The trailing separator is
+    load-bearing: without it a sibling checkout named `<repo>-<slug>` would match
+    `<repo>` and one live session would lock the whole fleet.
+
+    Raises when the probe is unusable, so a destructive caller can fail closed.
+    """
+    if _cache is not None and "cwds" in _cache:
+        cwds = _cache["cwds"]
+    else:
+        cwds = _live_cwds()
+        if _cache is not None:
+            _cache["cwds"] = cwds
+    try:
+        root = str(worktree.resolve())
+    except OSError:
+        root = str(worktree)
+    prefix = root.rstrip("/") + "/"
+    return any(c == root or c.startswith(prefix) for c in cwds)
+
+
+def process_busy_reason(path: Path, *, cache: dict | None = None) -> str | None:
+    """A reason to REFUSE deleting ``path``, or None when nothing is running in it.
+
+    FAIL CLOSED. An unusable probe returns a refusal, never a green light. The
+    reason string exists so the refusal is VISIBLE in whatever log the caller
+    keeps: a permanently-broken probe must surface as a stated refusal, not as a
+    fleet that quietly stops being cleaned.
+    """
+    if cache is None:
+        cache = _PROBE_CACHE
+    try:
+        if process_cwd_inside(path, _cache=cache):
+            return "a live process has its cwd in it"
+    except Exception as exc:  # unusable probe -> UNKNOWN, never "empty"
+        return f"process probe unavailable ({exc})"
+    return None
+
+
+def _stderr_note(msg: str) -> None:
+    try:
+        print(f"worktree-safety: {msg}", file=sys.stderr)
+    except (OSError, ValueError, UnicodeEncodeError):
+        pass
 
 
 def find_main_repo(cwd: Path | None = None) -> Path | None:
@@ -528,7 +676,18 @@ def remove_worktree(main_repo: Path, worktree: Path, force: bool = True) -> bool
     at the worktree path a clean removal.
 
     Negative control: hooks/test_worktree_remove_verifies_side_effect.py
+    hooks/test_worktree_process_liveness.py pins the process gate below.
     """
+    # Process-table liveness, ahead of everything: a worktree someone is running
+    # code in is not ours to delete for any reason. Fail closed — an unusable
+    # probe refuses and SAYS SO in the shared cleanup log, so a broken probe
+    # surfaces as a refusal instead of silently paralysing cleanup.
+    reason = process_busy_reason(worktree)
+    if reason:
+        append_cleanup_log(
+            main_repo, f"REFUSE remove {worktree.name}: {reason}"
+        )
+        return False
     args = ["worktree", "remove"] + (["--force"] if force else []) + [str(worktree)]
     try:
         if git(main_repo, args, timeout=None).returncode != 0:
@@ -652,6 +811,13 @@ def _reclaim_disconnected_orphan(main_repo: Path, orphan: Path, slug: str) -> tu
     preserve the existing lifecycle behavior. This content boundary fails closed
     on read/Git uncertainty; it does not provide concurrent-writer exclusion.
     """
+    # Redundant with the gate in reclaim_orphan_dir (its only caller today) and
+    # kept deliberately: this function owns an `rmtree`, and a deletion path is
+    # guarded at the point it deletes, not at the point someone remembered to.
+    reason = process_busy_reason(orphan)
+    if reason:
+        append_cleanup_log(main_repo, f"REFUSE reclaim {orphan.name}: {reason}")
+        return ("kept-busy", 0)
     files = _bounded_recovery_files(orphan)
     if files is None:
         return ("kept-unsafe", 0)
@@ -681,10 +847,15 @@ def _reclaim_disconnected_orphan(main_repo: Path, orphan: Path, slug: str) -> tu
 def reclaim_orphan_dir(main_repo: Path, orphan: Path, idle_min: int = 60) -> tuple[str, int]:
     """Safely reclaim one orphan worktree dir. Returns (action, snapshotted).
 
-    action ∈ {removed, snapshot+removed, kept-active, kept-unsafe, kept-dangling,
-              relocation-orphan-removed, relocation-orphan+removed}.
+    action ∈ {removed, snapshot+removed, kept-active, kept-busy, kept-unsafe,
+              kept-dangling, relocation-orphan-removed, relocation-orphan+removed}.
+    Callers detect a removal with `"removed" in action`, so every keep verdict
+    must avoid that substring.
 
     Fast + fail-safe — never `rm -rf` a dir we can't reason about:
+      * process gate: a dir a live process has as its cwd (or an unusable probe)
+        is left. This runs FIRST because it is the only gate here that cannot go
+        stale, and the idle gate below reads a busy-but-quiet dir as abandoned.
       * idle gate: a dir touched < idle_min ago is left (a live/paused session).
       * `git -C <orphan> status` decides recoverability cheaply (uses the index):
           - clean       → rm (every file is committed/recoverable from a branch)
@@ -702,6 +873,10 @@ def reclaim_orphan_dir(main_repo: Path, orphan: Path, idle_min: int = 60) -> tup
     lease. Strong exclusion remains a runtime/upstream lifecycle dependency.
     """
     slug = orphan.name
+    reason = process_busy_reason(orphan)
+    if reason:
+        append_cleanup_log(main_repo, f"REFUSE reclaim {slug}: {reason}")
+        return ("kept-busy", 0)
     if not is_idle(orphan, idle_min):
         return ("kept-active", 0)
     try:

--- a/hooks/enforce-worktree-cap.py
+++ b/hooks/enforce-worktree-cap.py
@@ -35,10 +35,16 @@ Dead-idle gate: WORKTREE_DEAD_IDLE_MIN env (default 60, matching the cap reaper)
                 session must be absent from the lock's recency window before reclaim.
 Bypass:         WORKTREE_CAP_BYPASS=1.
 
-LIVENESS NOTE: per session-lock.py, the only trustworthy liveness signal is
+LIVENESS NOTE: per session-lock.py, the only trustworthy signal IN THE LOCK is
 `last_activity_at` recency (the recorded pid is the ephemeral hook pid, dead on
 arrival). live_session_cwds() therefore uses recency; this hook never reaps a cwd
 that is active in that window, nor the current session's worktree.
+
+That lock is a PROXY, and so is the mtime idle gate — both read a merely BUSY
+session as a dead one (the lock is refreshed when a tool call STARTS, so one long
+call emits nothing for its whole duration; mtime cannot tell a long build from an
+abandoned tree). So every removal path here is additionally gated on the PROCESS
+TABLE, which cannot go stale, and which fails CLOSED when it cannot be read.
 
 WIRING (SessionStart):
   "SessionStart": [
@@ -58,6 +64,7 @@ from pathlib import Path
 HOOK_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(HOOK_DIR))
 
+from _lib import worktree_safety as _ws  # noqa: E402
 from _lib.worktree_safety import (  # noqa: E402
     append_cleanup_log,
     current_worktree,
@@ -73,7 +80,41 @@ from _lib.worktree_safety import (  # noqa: E402
     snapshot_unrecoverable,
 )
 
+# Process-table liveness. EVERY liveness gate this hook had was a proxy that
+# reads a BUSY session as a dead one: `live_session_cwds()` is refreshed when a
+# tool call STARTS, so a session inside one long call stops emitting; `is_idle()`
+# reads mtime, and "nothing written for an hour" is also what a long gate whose
+# output goes elsewhere looks like. The cap loop below then force-removes on the
+# mtime gate ALONE. The process table cannot go stale, so it is consulted before
+# every removal path in this file. Resolved by getattr so an older deployed _lib
+# makes this hook REFUSE removals rather than fail to load and quietly revert to
+# the unguarded behaviour.
+process_busy_reason = getattr(_ws, "process_busy_reason", None)
+
+# One probe for the whole sweep, not one per worktree. This hook runs to
+# completion in seconds, so a single reading stays current for all of it.
+_PROBE_CACHE: dict = {}
+
 DEFAULT_CAP = 12
+
+
+def _process_busy(main_repo: Path, path: Path) -> bool:
+    """True if a live process is in `path` OR we could not find out.
+
+    Fail-closed. "No process found" and "could not look" must never be the same
+    answer to a caller that runs `git worktree remove --force`. A missing or
+    broken probe is LOGGED rather than silently disabling cleanup, so paralysis
+    surfaces instead of masquerading as a quiet fleet.
+    """
+    if process_busy_reason is None:
+        _log(main_repo, "process-liveness helper unavailable in this _lib "
+                        "deploy; refusing every removal this run")
+        return True
+    reason = process_busy_reason(path, cache=_PROBE_CACHE)
+    if reason:
+        _log(main_repo, f"keep {path.name}: {reason}")
+        return True
+    return False
 
 
 def _log(main_repo: Path, msg: str) -> None:
@@ -148,6 +189,8 @@ def _per_session_backstop(main_repo: Path, cur_path: Path | None) -> tuple[list[
                     continue  # deliberate feature-branch worktree
                 if not is_idle(wt, idle_min=dead_idle):
                     continue  # touched recently — let it settle / SessionEnd handle it
+                if _process_busy(main_repo, wt):
+                    continue  # a live process is running in it, or we could not tell
                 slug = wt.name
                 snapped, _r, all_safe = snapshot_unrecoverable(main_repo, wt, slug)
                 if not all_safe:
@@ -167,6 +210,8 @@ def _per_session_backstop(main_repo: Path, cur_path: Path | None) -> tuple[list[
                     continue
             except OSError:
                 continue
+            if _process_busy(main_repo, od):
+                continue  # a live process is running in it, or we could not tell
             action, snapped = reclaim_orphan_dir(main_repo, od, idle_min=dead_idle)
             swept[od.name] = action
             if "removed" in action:
@@ -241,6 +286,8 @@ def main() -> int:
             continue  # never auto-remove a deliberate worktree
         if not is_idle(wt, idle_min=60):
             continue
+        if _process_busy(main_repo, wt):
+            continue  # a live process is running in it, or we could not tell
         slug = wt.name
         snapped, _recoverable, all_safe = snapshot_unrecoverable(main_repo, wt, slug)
         if not all_safe:

--- a/hooks/remove-ended-worktree.py
+++ b/hooks/remove-ended-worktree.py
@@ -45,6 +45,7 @@ from pathlib import Path
 HOOK_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(HOOK_DIR))
 
+from _lib import worktree_safety as _ws  # noqa: E402
 from _lib.worktree_safety import (  # noqa: E402
     append_cleanup_log,
     current_worktree,
@@ -53,6 +54,19 @@ from _lib.worktree_safety import (  # noqa: E402
     remove_worktree,
     snapshot_unrecoverable,
 )
+
+# Fail-closed process-liveness gate. Resolved by getattr, not by a hard import,
+# so an older deployed _lib copy makes this hook REFUSE removals rather than
+# fail to load and silently revert to the unguarded behaviour.
+process_busy_reason = getattr(_ws, "process_busy_reason", None)
+
+
+def _busy_reason(path: Path) -> str | None:
+    """Why `path` must not be deleted, or None. A missing helper refuses."""
+    if process_busy_reason is None:
+        return ("process-liveness helper unavailable in this _lib deploy; "
+                "refusing every removal")
+    return process_busy_reason(path)
 
 
 def _log(main_repo: Path, msg: str) -> None:
@@ -93,6 +107,17 @@ def main() -> int:
         return _done()
     if not branch.startswith("claude/"):
         _log(main_repo, f"keep {slug}: branch {branch!r} is not claude/* scratch")
+        return _done()
+
+    # The session is over by definition at SessionEnd — a DETACHED CHILD of it
+    # is not. This hook targets whatever worktree the hook PROCESS's cwd is in,
+    # so a background gate the session launched (a test suite, a build) is still
+    # standing in the tree we are about to unlink. Our own ancestor chain is
+    # excluded by the probe, so anything it still reports here is foreign.
+    # Checked BEFORE the recovery scan: no point walking a tree we will keep.
+    busy = _busy_reason(worktree)
+    if busy:
+        _log(main_repo, f"REFUSE remove {slug}: {busy}. Worktree kept.")
         return _done()
 
     snapped, recoverable, all_safe = snapshot_unrecoverable(main_repo, worktree, slug)

--- a/hooks/test_worktree_process_liveness.py
+++ b/hooks/test_worktree_process_liveness.py
@@ -1,0 +1,845 @@
+#!/usr/bin/env python3
+"""No reaper may delete a worktree that has a LIVE PROCESS in it.
+
+THE BUG CLASS. Every liveness gate these tools had was a PROXY, and every proxy
+reads a BUSY session as a dead one:
+
+  * the session lock records `last_activity_at`, refreshed when a tool call
+    STARTS -- so a session sitting inside ONE long call (a test suite, a build,
+    a migration) emits nothing for the whole run. Past the liveness window its
+    entry is byte-identical to that of a session that exited, and past
+    idle-expiry the entry is deleted outright. The lock's recorded pid cannot
+    rescue it: that is the ephemeral hook process's pid, dead when written.
+  * `is_idle()` / idle-days read mtime, and "nothing written here for an hour"
+    is also exactly what a long build whose output goes elsewhere looks like.
+
+So the harder a worktree is being worked in, the deader it looks. Observed in
+the field: a worktree removed mid-test-run, several commits deep, by a sibling
+session's start-up sweep.
+
+WHAT EACH TOOL'S BLOCK PINS. These are CALL-SITE controls, not helper controls:
+a correct helper that nothing calls is precisely the failure worth catching, so
+every guarded remover gets its own four legs.
+
+  [positive]      the same fixture IS deleted when nothing is running. Without
+                  it a negative control passes for the wrong reason -- a tool
+                  broken into never deleting anything would look perfect.
+  [negative]      a real child process whose cwd is a SUBDIRECTORY of the
+                  worktree (a test runner sits in one, not at the root) makes
+                  the tool refuse. Its readiness wait reads the process table
+                  DIRECTLY, never through the code under test: routing it
+                  through the probe would let a broken probe fail the HELPER
+                  instead of the assertion that matters.
+  [fail-closed]   an unusable probe refuses. "No process found" and "could not
+                  look" must never be the same answer to a caller that deletes.
+  [importable]    the probe actually resolved in this layout. A None probe
+                  refuses forever, which is safe but paralyses cleanup, so it
+                  has to be a test failure rather than a quiet fleet.
+
+Every fixture lives inside the test's own TemporaryDirectory, and every artifact
+path these tools resolve (snapshot roots, cleanup logs, reclaim manifests) is
+redirected there in setUp -- a suite that writes into the real recovery store is
+indistinguishable from a real rescued worktree exactly when someone is looking
+for one.
+
+Run: python3 hooks/test_worktree_process_liveness.py
+"""
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+HOOK_DIR = Path(__file__).resolve().parent
+REPO_DIR = HOOK_DIR.parent
+sys.path.insert(0, str(HOOK_DIR))
+
+from _lib import dev_repo_scan as drs  # noqa: E402
+from _lib import worktree_safety as ws  # noqa: E402
+
+CHILD_READY_TIMEOUT_S = 15
+CHILD_LIFETIME_S = 300  # outlives the suite; killed in cleanup either way
+
+
+def _load(path: Path, name: str):
+    """Import a hyphenated hook/script by path so its call sites can be driven."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+ended = _load(HOOK_DIR / "remove-ended-worktree.py", "remove_ended_worktree")
+cap = _load(HOOK_DIR / "enforce-worktree-cap.py", "enforce_worktree_cap")
+reclaim = _load(REPO_DIR / "scripts" / "worktree-reclaim.py", "worktree_reclaim")
+prune = _load(REPO_DIR / "scripts" / "dev-worktree-prune.py", "dev_worktree_prune")
+build = _load(REPO_DIR / "scripts" / "dev-build-reclaim.py", "dev_build_reclaim")
+
+
+class _Fake:
+    """A git result. `git()` here captures bytes, so stdout is bytes."""
+
+    def __init__(self, returncode: int = 0, stdout: bytes = b""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = b""
+
+
+class Base(unittest.TestCase):
+    """Containment + a real busy child. Nothing here touches a real vault."""
+
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+
+        # Every artifact root these tools resolve, redirected into this test's
+        # own dir. Read at CALL time, so patching here is enough.
+        env = mock.patch.dict(
+            os.environ,
+            {
+                "WORKTREE_ARTIFACT_ROOT": str(self.root / "artifacts"),
+                "DEV_BUILD_RECLAIM_LOG_DIR": str(self.root / "reclaim-logs"),
+                "DEV_WORKTREE_SNAPSHOT_ROOT": str(self.root / "wt-snapshots"),
+            },
+            clear=False,
+        )
+        env.start()
+        self.addCleanup(env.stop)
+        # Read at IMPORT time in dev-worktree-prune, so the env var above cannot
+        # reach it; patch the resolved constant too.
+        snap = mock.patch.object(prune, "SNAPSHOT_ROOT", self.root / "wt-snapshots")
+        snap.start()
+        self.addCleanup(snap.stop)
+        # Belt: no cleanup-log line may escape even if a root resolves oddly.
+        log = mock.patch.object(ws, "append_cleanup_log")
+        log.start()
+        self.addCleanup(log.stop)
+
+        # The process-table reading must not survive between tests. A reading
+        # taken before a child was spawned would make the negative control fail
+        # for a reason that has nothing to do with the code under test.
+        ws._PROBE_CACHE.clear()
+        self.addCleanup(ws._PROBE_CACHE.clear)
+
+    def make_worktree(self, name: str = "victim") -> Path:
+        wt = self.root / name
+        (wt / "nested").mkdir(parents=True)
+        return wt
+
+    def busy_child(self, cwd: Path) -> subprocess.Popen:
+        """A real process parked in `cwd`, proven live by the OS itself.
+
+        The readiness wait deliberately does NOT call process_cwd_inside: a
+        broken probe must fail the assertion under test, not this helper.
+        """
+        proc = subprocess.Popen(
+            [sys.executable, "-c", f"import time; time.sleep({CHILD_LIFETIME_S})"],
+            cwd=str(cwd),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+        def _stop() -> None:
+            proc.kill()
+            proc.wait(timeout=10)
+
+        self.addCleanup(_stop)
+
+        target = str(cwd.resolve())
+        deadline = time.time() + CHILD_READY_TIMEOUT_S
+        while time.time() < deadline:
+            out = subprocess.run(
+                ["lsof", "-d", "cwd", "-F", "n", "-p", str(proc.pid)],
+                capture_output=True,
+                text=True,
+            ).stdout
+            if any(ln[1:] == target for ln in out.splitlines() if ln[:1] == "n"):
+                return proc
+            time.sleep(0.1)
+        self.fail(f"the OS never reported the child's cwd as {target}")
+
+    def broken_probe(self):
+        """Patch the ONE primitive every consumer funnels through."""
+        return mock.patch.object(
+            ws, "process_cwd_inside", side_effect=OSError("lsof unavailable")
+        )
+
+    @staticmethod
+    @contextlib.contextmanager
+    def quiet():
+        """These CLIs print a full report; keep the gate log readable."""
+        with contextlib.redirect_stdout(io.StringIO()), \
+                contextlib.redirect_stderr(io.StringIO()):
+            yield
+
+
+# ---------------------------------------------------------------------------
+# The primitive itself.
+# ---------------------------------------------------------------------------
+class ProbeSemanticsTest(Base):
+    def test_a_subdirectory_counts_as_inside(self) -> None:
+        wt = self.make_worktree()
+        self.assertFalse(
+            ws.process_cwd_inside(wt, _cache={}),
+            "nothing is running in a freshly-made fixture",
+        )
+        self.busy_child(wt / "nested")
+        self.assertTrue(
+            ws.process_cwd_inside(wt, _cache={}),
+            "a test runner sits in a SUBDIRECTORY; that must count as in-use",
+        )
+
+    def test_a_sibling_sharing_a_path_prefix_does_not_count(self) -> None:
+        """Without the separator one live session locks the whole fleet."""
+        wt = self.make_worktree("repo-slug")
+        sibling = self.root / "repo"  # a prefix of "repo-slug" by construction
+        sibling.mkdir()
+        self.busy_child(wt / "nested")
+        cache: dict = {}
+        self.assertTrue(ws.process_cwd_inside(wt, _cache=cache))
+        self.assertFalse(
+            ws.process_cwd_inside(sibling, _cache=cache),
+            "`repo` must not match a process sitting in `repo-slug`",
+        )
+
+    def test_our_own_ancestor_chain_is_excluded(self) -> None:
+        """A session-end sweep must still be able to retire its own tree.
+
+        Deterministic by construction: we park OUR OWN process in a directory
+        nothing else on the machine can be in, so the only occupant is us.
+        """
+        chain = ws._own_process_chain()
+        self.assertIn(os.getpid(), chain, "our own pid must be in our own chain")
+        self.assertGreater(len(chain), 1, "the chain must reach at least a parent")
+
+        mine = self.root / "only-us"
+        mine.mkdir()
+        origin = Path.cwd()
+        self.addCleanup(os.chdir, str(origin))
+        os.chdir(str(mine))
+
+        with mock.patch.object(ws, "_own_process_chain", return_value=set()):
+            unfiltered = ws.process_cwd_inside(mine, _cache={})
+        self.assertTrue(
+            unfiltered,
+            "control: with no exclusion the dir IS occupied -- so the False "
+            "below is the exclusion working, not an empty process table",
+        )
+        self.assertFalse(
+            ws.process_cwd_inside(mine, _cache={}),
+            "our own chain must never veto the cleanup of the tree we run in",
+        )
+
+    def test_the_probe_does_not_observe_its_own_probe_process(self) -> None:
+        """A spawned child inherits our cwd, and lsof lists ITSELF.
+
+        Left unanchored the probe sees its own `lsof` standing in the tree, and
+        a sweep launched from inside the tree it is retiring refuses forever --
+        the ancestor-chain exclusion defeated by a descendant created one line
+        earlier. Anchoring the probe at the filesystem root is the fix, and this
+        pins it: nothing but us is ever in this directory.
+        """
+        mine = self.root / "probe-anchor"
+        mine.mkdir()
+        origin = Path.cwd()
+        self.addCleanup(os.chdir, str(origin))
+        os.chdir(str(mine))
+        self.assertFalse(
+            ws.process_cwd_inside(mine, _cache={}),
+            "the probe reported its own subprocess as an occupant",
+        )
+
+    def test_descendants_are_NOT_excluded(self) -> None:
+        """A detached gate still running is exactly what needs protecting."""
+        wt = self.make_worktree("gated")
+        self.busy_child(wt / "nested")  # our own direct child
+        self.assertTrue(
+            ws.process_cwd_inside(wt, _cache={}),
+            "a child of ours holding the tree must still veto its deletion",
+        )
+
+    def test_no_output_is_UNKNOWN_and_raises_rather_than_empty(self) -> None:
+        with mock.patch.object(
+            ws.subprocess, "run", return_value=_Fake(0, b"")
+        ), self.assertRaises(OSError):
+            ws._live_cwds()
+
+    def test_the_cache_makes_it_one_probe_per_sweep(self) -> None:
+        cache: dict = {}
+        with mock.patch.object(ws, "_live_cwds", return_value=[]) as spy:
+            ws.process_cwd_inside(self.root / "a", _cache=cache)
+            ws.process_cwd_inside(self.root / "b", _cache=cache)
+            ws.process_cwd_inside(self.root / "c", _cache=cache)
+        self.assertEqual(spy.call_count, 1, "one lsof per sweep, not per worktree")
+
+    def test_reason_wrapper_fails_closed_on_an_unusable_probe(self) -> None:
+        wt = self.make_worktree()
+        self.assertIsNone(
+            ws.process_busy_reason(wt, cache={}), "positive control: clean tree"
+        )
+        with self.broken_probe():
+            reason = ws.process_busy_reason(wt, cache={})
+        self.assertIsNotNone(reason, "an unusable probe must REFUSE, not allow")
+        self.assertIn("unavailable", reason)
+
+    def test_a_platform_with_no_probe_defers_instead_of_refusing_forever(self) -> None:
+        """Fail-closed protects a BROKEN probe; it must not disable a platform.
+
+        Windows has no `lsof` and no stdlib route to another process's cwd.
+        Refusing every reap there would hand that user back the unbounded
+        worktree pileup these hooks exist to prevent -- so an UNSUPPORTED
+        platform says so once and lets the remaining gates decide. A missing
+        `lsof` on POSIX stays an anomaly, and stays fail-closed.
+        """
+        wt = self.make_worktree()
+        ws._UNSUPPORTED_NOTED[0] = False
+        self.addCleanup(lambda: ws._UNSUPPORTED_NOTED.__setitem__(0, False))
+        with mock.patch.object(ws.os, "name", "nt"), \
+                mock.patch.object(ws.shutil, "which", return_value=None), \
+                self.broken_probe():
+            self.assertFalse(ws.probe_supported())
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                self.assertIsNone(ws.process_busy_reason(wt, cache={}))
+            self.assertIn("no process-cwd probe", err.getvalue(),
+                          "an unsupported platform must say so, not go quiet")
+        with mock.patch.object(ws.os, "name", "posix"), \
+                mock.patch.object(ws.shutil, "which", return_value=None):
+            self.assertTrue(
+                ws.probe_supported(),
+                "on POSIX a missing lsof is an anomaly the probe must refuse over",
+            )
+            with self.broken_probe():
+                self.assertIsNotNone(ws.process_busy_reason(wt, cache={}))
+
+
+# ---------------------------------------------------------------------------
+# _lib/worktree_safety.py -- remove_worktree()
+# ---------------------------------------------------------------------------
+class RemoveWorktreeTest(Base):
+    """The discriminator is whether `git worktree remove` was ISSUED.
+
+    The helper reports the side effect (is the dir gone), so with a faked git
+    the return value cannot distinguish "refused" from "ran and the dir stayed".
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.calls: list = []
+
+        def fake_git(repo, args, timeout=ws.GIT_TIMEOUT):
+            self.calls.append(list(args))
+            return _Fake(0)
+
+        g = mock.patch.object(ws, "git", side_effect=fake_git)
+        g.start()
+        self.addCleanup(g.stop)
+
+    def test_positive_control_issues_the_removal_when_nothing_runs(self) -> None:
+        wt = self.make_worktree()
+        ws.remove_worktree(self.root, wt)
+        self.assertTrue(
+            any(a[:2] == ["worktree", "remove"] for a in self.calls),
+            "a clean worktree must still be removable",
+        )
+
+    def test_never_removes_a_worktree_with_a_live_process(self) -> None:
+        wt = self.make_worktree()
+        self.busy_child(wt / "nested")
+        got = ws.remove_worktree(self.root, wt)
+        self.assertEqual(self.calls, [], "no git command may be issued at all")
+        self.assertFalse(got, "and it must not report a removal")
+
+    def test_probe_failure_fails_closed(self) -> None:
+        wt = self.make_worktree()
+        with self.broken_probe():
+            got = ws.remove_worktree(self.root, wt)
+        self.assertEqual(self.calls, [])
+        self.assertFalse(got)
+
+    def test_probe_is_importable(self) -> None:
+        self.assertIsNotNone(getattr(ws, "process_cwd_inside", None))
+        self.assertIsNotNone(getattr(ws, "process_busy_reason", None))
+
+
+# ---------------------------------------------------------------------------
+# _lib/worktree_safety.py -- reclaim_orphan_dir() / _reclaim_disconnected_orphan()
+# ---------------------------------------------------------------------------
+class ReclaimOrphanDirTest(Base):
+    def setUp(self) -> None:
+        super().setUp()
+        # A clean status: every file is recoverable, so the dir is reclaimable.
+        g = mock.patch.object(ws, "git", return_value=_Fake(0, b""))
+        g.start()
+        self.addCleanup(g.stop)
+        i = mock.patch.object(ws, "is_idle", return_value=True)
+        i.start()
+        self.addCleanup(i.stop)
+
+    def test_positive_control_removes_a_clean_idle_orphan(self) -> None:
+        orphan = self.make_worktree("orphan")
+        action, _ = ws.reclaim_orphan_dir(self.root, orphan)
+        self.assertIn("removed", action)
+        self.assertFalse(orphan.exists(), "the orphan dir must actually be gone")
+
+    def test_never_removes_an_orphan_with_a_live_process(self) -> None:
+        orphan = self.make_worktree("orphan")
+        self.busy_child(orphan / "nested")
+        action, _ = ws.reclaim_orphan_dir(self.root, orphan)
+        self.assertEqual(action, "kept-busy")
+        self.assertTrue(orphan.exists())
+        self.assertNotIn(
+            "removed", action, "callers detect a removal with `'removed' in action`"
+        )
+
+    def test_disconnected_orphan_path_is_guarded_at_its_own_rmtree(self) -> None:
+        """Its only caller is guarded too; a deletion path is gated where it deletes."""
+        orphan = self.make_worktree("reloc")
+        self.busy_child(orphan / "nested")
+        action, _ = ws._reclaim_disconnected_orphan(self.root, orphan, "reloc")
+        self.assertEqual(action, "kept-busy")
+        self.assertTrue(orphan.exists())
+
+    def test_probe_failure_fails_closed(self) -> None:
+        orphan = self.make_worktree("orphan")
+        with self.broken_probe():
+            action, _ = ws.reclaim_orphan_dir(self.root, orphan)
+        self.assertEqual(action, "kept-busy")
+        self.assertTrue(orphan.exists())
+
+
+# ---------------------------------------------------------------------------
+# hooks/remove-ended-worktree.py (SessionEnd)
+# ---------------------------------------------------------------------------
+class RemoveEndedWorktreeTest(Base):
+    """The session is over by definition at SessionEnd. A DETACHED CHILD of it
+    is not, and this hook targets whatever tree the hook process's cwd is in.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.wt = self.make_worktree("ended")
+        self.removed: list = []
+
+    def _run(self) -> None:
+        self.removed.clear()
+
+        def _remove(main_repo, worktree, force=True):
+            self.removed.append(Path(worktree).name)
+            return True
+
+        with mock.patch.dict(os.environ, {}, clear=False), \
+                mock.patch.object(ended, "current_worktree",
+                                  return_value=(self.wt, "ended")), \
+                mock.patch.object(ended, "find_main_repo", return_value=self.root), \
+                mock.patch.object(ended, "git",
+                                  return_value=_Fake(0, b"claude/ended")), \
+                mock.patch.object(ended, "snapshot_unrecoverable",
+                                  return_value=(0, 0, True)), \
+                mock.patch.object(ended, "remove_worktree", side_effect=_remove), \
+                mock.patch.object(ended, "_log"), \
+                mock.patch.object(ended, "_done", return_value=0), \
+                mock.patch.object(os, "chdir"):
+            ended.main()
+
+    def test_positive_control_removes_when_nothing_is_running(self) -> None:
+        self._run()
+        self.assertEqual(self.removed, ["ended"])
+
+    def test_never_removes_a_worktree_with_a_live_process(self) -> None:
+        self.busy_child(self.wt / "nested")
+        self._run()
+        self.assertEqual(
+            self.removed, [], "a detached child of the ended session still holds it"
+        )
+
+    def test_probe_failure_fails_closed(self) -> None:
+        with self.broken_probe():
+            self._run()
+        self.assertEqual(self.removed, [])
+
+    def test_probe_is_importable(self) -> None:
+        self.assertIsNotNone(
+            ended.process_busy_reason,
+            "probe unresolved -> this hook refuses forever and cleanup stops",
+        )
+
+
+# ---------------------------------------------------------------------------
+# hooks/enforce-worktree-cap.py (SessionStart) -- all three removal paths
+# ---------------------------------------------------------------------------
+class EnforceWorktreeCapTest(Base):
+    def setUp(self) -> None:
+        super().setUp()
+        self.repo = self.root / "repo"
+        (self.repo / ".claude" / "worktrees").mkdir(parents=True)
+        self.wts = []
+        for name in ("alpha", "beta", "gamma"):
+            wt = self.repo / ".claude" / "worktrees" / name
+            (wt / "nested").mkdir(parents=True)
+            self.wts.append(wt)
+        self.removed: list = []
+        self.reclaimed: list = []
+        cap._PROBE_CACHE.clear()
+        self.addCleanup(cap._PROBE_CACHE.clear)
+
+    def _remove(self, main_repo, worktree, force=True):
+        self.removed.append(Path(worktree).name)
+        return True
+
+    def _reclaim(self, main_repo, orphan, idle_min=60):
+        self.reclaimed.append(Path(orphan).name)
+        return ("removed", 0)
+
+    def _drive(self, *, live_cwds, orphans, cap_max):
+        """Every gate but the process probe forced OPEN, so only it can refuse."""
+        self.removed.clear()
+        self.reclaimed.clear()
+        with mock.patch.dict(os.environ, {"WORKTREE_MAX": str(cap_max)}, clear=False), \
+                mock.patch.object(cap, "find_main_repo", return_value=self.repo), \
+                mock.patch.object(cap, "current_worktree", return_value=None), \
+                mock.patch.object(cap, "list_worktrees", return_value=list(self.wts)), \
+                mock.patch.object(cap, "is_scratch_worktree", return_value=True), \
+                mock.patch.object(cap, "_branch", side_effect=lambda p: "claude/x"), \
+                mock.patch.object(cap, "is_idle", return_value=True), \
+                mock.patch.object(cap, "live_session_cwds", return_value=live_cwds), \
+                mock.patch.object(cap, "list_orphan_dirs", return_value=orphans), \
+                mock.patch.object(cap, "reclaim_orphan_dir", side_effect=self._reclaim), \
+                mock.patch.object(cap, "snapshot_unrecoverable",
+                                  return_value=(0, 0, True)), \
+                mock.patch.object(cap, "remove_worktree", side_effect=self._remove), \
+                mock.patch.object(cap, "_log"), \
+                mock.patch.object(cap, "_emit", return_value=0):
+            cap.main()
+
+    # -- path 1: the dead-session backstop -----------------------------------
+    def test_backstop_positive_control(self) -> None:
+        self._drive(live_cwds=set(), orphans=[], cap_max=99)
+        self.assertTrue(self.removed, "a dead-session worktree must be reclaimable")
+
+    def test_backstop_never_reaps_a_busy_worktree(self) -> None:
+        self.busy_child(self.wts[0] / "nested")
+        self._drive(live_cwds=set(), orphans=[], cap_max=99)
+        self.assertNotIn(self.wts[0].name, self.removed)
+
+    # -- path 2: the orphan-dir sweep ----------------------------------------
+    def test_orphan_sweep_positive_control(self) -> None:
+        orphan = self.repo / ".claude" / "worktrees" / "orphan"
+        (orphan / "nested").mkdir(parents=True)
+        self._drive(live_cwds=set(), orphans=[orphan], cap_max=99)
+        self.assertIn("orphan", self.reclaimed)
+
+    def test_orphan_sweep_never_reclaims_a_busy_dir(self) -> None:
+        orphan = self.repo / ".claude" / "worktrees" / "orphan"
+        (orphan / "nested").mkdir(parents=True)
+        self.busy_child(orphan / "nested")
+        self._drive(live_cwds=set(), orphans=[orphan], cap_max=99)
+        self.assertEqual(self.reclaimed, [])
+
+    # -- path 3: the count cap (the one that force-removes) -------------------
+    def test_cap_loop_positive_control(self) -> None:
+        self._drive(live_cwds=None, orphans=[], cap_max=1)
+        self.assertTrue(self.removed, "over-cap idle worktrees must be reclaimable")
+
+    def test_cap_loop_never_removes_a_busy_worktree(self) -> None:
+        self.busy_child(self.wts[0] / "nested")
+        self._drive(live_cwds=None, orphans=[], cap_max=1)
+        self.assertNotIn(
+            self.wts[0].name,
+            self.removed,
+            "the cap loop force-removes; a live process must veto it",
+        )
+
+    def test_probe_failure_blocks_every_removal_path(self) -> None:
+        orphan = self.repo / ".claude" / "worktrees" / "orphan"
+        (orphan / "nested").mkdir(parents=True)
+        with self.broken_probe():
+            self._drive(live_cwds=set(), orphans=[orphan], cap_max=1)
+        self.assertEqual(self.removed, [], "an unusable probe must fail CLOSED")
+        self.assertEqual(self.reclaimed, [])
+
+    def test_probe_is_importable(self) -> None:
+        self.assertIsNotNone(cap.process_busy_reason)
+
+
+# ---------------------------------------------------------------------------
+# scripts/worktree-reclaim.py -- both destructive paths
+# ---------------------------------------------------------------------------
+class WorktreeReclaimTest(Base):
+    def setUp(self) -> None:
+        super().setUp()
+        self.repo = self.root / "repo"
+        (self.repo / ".claude" / "worktrees").mkdir(parents=True)
+        self.wt = self.repo / ".claude" / "worktrees" / "alpha"
+        (self.wt / "nested").mkdir(parents=True)
+        self.orphan = self.repo / ".claude" / "worktrees" / "orphan"
+        (self.orphan / "nested").mkdir(parents=True)
+        self.removed: list = []
+        self.reclaimed: list = []
+        reclaim._PROBE_CACHE.clear()
+        self.addCleanup(reclaim._PROBE_CACHE.clear)
+
+    def _drive(self) -> None:
+        self.removed.clear()
+        self.reclaimed.clear()
+
+        def _remove(main_repo, worktree, force=True):
+            self.removed.append(Path(worktree).name)
+            return True
+
+        def _reclaim(main_repo, orphan, idle_min):
+            self.reclaimed.append(Path(orphan).name)
+            return ("removed", 0)
+
+        argv = ["worktree-reclaim.py", "--repo", str(self.repo), "--cap", "0"]
+        with mock.patch.object(sys, "argv", argv), \
+                mock.patch.object(reclaim, "current_worktree", return_value=None), \
+                mock.patch.object(reclaim, "list_worktrees", return_value=[self.wt]), \
+                mock.patch.object(reclaim, "is_scratch_worktree", return_value=True), \
+                mock.patch.object(reclaim, "_branch",
+                                  side_effect=lambda p: "claude/x"), \
+                mock.patch.object(reclaim, "is_idle", return_value=True), \
+                mock.patch.object(reclaim, "list_orphan_dirs",
+                                  return_value=[self.orphan]), \
+                mock.patch.object(reclaim, "snapshot_unrecoverable",
+                                  return_value=(0, 0, True)), \
+                mock.patch.object(reclaim, "remove_worktree", side_effect=_remove), \
+                mock.patch.object(reclaim, "reclaim_orphan_dir",
+                                  side_effect=_reclaim), \
+                mock.patch.object(reclaim, "git", return_value=_Fake(0, b"")):
+            with self.quiet():
+                reclaim.main()
+
+    def test_positive_control_removes_and_reclaims(self) -> None:
+        self._drive()
+        self.assertEqual(self.removed, ["alpha"])
+        self.assertEqual(self.reclaimed, ["orphan"])
+
+    def test_never_removes_a_busy_registered_worktree(self) -> None:
+        self.busy_child(self.wt / "nested")
+        self._drive()
+        self.assertEqual(self.removed, [])
+        self.assertEqual(
+            self.reclaimed, ["orphan"], "and the unaffected path still works"
+        )
+
+    def test_never_reclaims_a_busy_orphan_dir(self) -> None:
+        self.busy_child(self.orphan / "nested")
+        self._drive()
+        self.assertEqual(self.reclaimed, [])
+        self.assertEqual(self.removed, ["alpha"])
+
+    def test_probe_failure_fails_closed(self) -> None:
+        with self.broken_probe():
+            self._drive()
+        self.assertEqual(self.removed, [])
+        self.assertEqual(self.reclaimed, [])
+
+    def test_probe_is_importable(self) -> None:
+        self.assertIsNotNone(reclaim.process_busy_reason)
+
+
+# ---------------------------------------------------------------------------
+# _lib/dev_repo_scan.py -- execute_reap() (the engine behind dev-repo-reaper.py)
+# ---------------------------------------------------------------------------
+class ExecuteReapTest(Base):
+    """Merge-state says the CONTENT is safe. It says nothing about whether
+    someone is standing in the directory right now.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.wt = self.make_worktree("merged")
+        self.calls: list = []
+
+        def fake_git(repo, *args, **kwargs):
+            self.calls.append(list(args))
+            return (0, "", "")
+
+        g = mock.patch.object(drs, "_git", side_effect=fake_git)
+        g.start()
+        self.addCleanup(g.stop)
+        ls = mock.patch.object(drs, "_ls_unregister_stale_bundles")
+        ls.start()
+        self.addCleanup(ls.stop)
+
+    def _plan(self):
+        return drs.ReapPlan(
+            repo=self.root,
+            reap_worktrees=[
+                drs.WorktreeTarget(path=self.wt, branch="claude/x", sha="deadbee")
+            ],
+        )
+
+    def _removals(self) -> list:
+        return [a for a in self.calls if a[:2] == ["worktree", "remove"]]
+
+    def test_positive_control_reaps_when_nothing_runs(self) -> None:
+        manifest = drs.execute_reap(self._plan(), apply=True)
+        self.assertTrue(self._removals(), "a merged clean worktree must be reapable")
+        self.assertNotIn("skipped", manifest["worktrees"][0])
+
+    def test_never_reaps_a_worktree_with_a_live_process(self) -> None:
+        self.busy_child(self.wt / "nested")
+        manifest = drs.execute_reap(self._plan(), apply=True)
+        self.assertEqual(self._removals(), [])
+        self.assertIn(
+            "skipped",
+            manifest["worktrees"][0],
+            "the manifest must record WHY, not silently drop the entry",
+        )
+
+    def test_probe_failure_fails_closed(self) -> None:
+        with self.broken_probe():
+            drs.execute_reap(self._plan(), apply=True)
+        self.assertEqual(self._removals(), [])
+
+    def test_probe_is_importable(self) -> None:
+        self.assertIsNotNone(drs._process_busy_reason)
+
+
+# ---------------------------------------------------------------------------
+# scripts/dev-worktree-prune.py -- remove()
+# ---------------------------------------------------------------------------
+class DevWorktreePruneTest(Base):
+    def setUp(self) -> None:
+        super().setUp()
+        self.wt = self.make_worktree("repo-slug")
+        self.calls: list = []
+
+        def fake_git(cwd, *args, timeout=20):
+            self.calls.append(list(args))
+            return (0, "", "")
+
+        g = mock.patch.object(prune, "_git", side_effect=fake_git)
+        g.start()
+        self.addCleanup(g.stop)
+        m = mock.patch.object(prune, "main_checkout_of", return_value=self.root)
+        m.start()
+        self.addCleanup(m.stop)
+
+    def _removals(self) -> list:
+        return [a for a in self.calls if a[:2] == ["worktree", "remove"]]
+
+    def test_positive_control_removes_when_nothing_runs(self) -> None:
+        ok, note = prune.remove(self.wt, True, {})
+        self.assertTrue(ok, note)
+        self.assertTrue(self._removals())
+
+    def test_never_removes_a_worktree_with_a_live_process(self) -> None:
+        self.busy_child(self.wt / "nested")
+        ok, note = prune.remove(self.wt, True, {})
+        self.assertFalse(ok)
+        self.assertEqual(self._removals(), [], "no git removal may be issued")
+        self.assertIn("live process", note)
+
+    def test_probe_failure_fails_closed(self) -> None:
+        with self.broken_probe():
+            ok, note = prune.remove(self.wt, True, {})
+        self.assertFalse(ok)
+        self.assertEqual(self._removals(), [])
+        self.assertIn("unavailable", note)
+
+    def test_probe_is_importable(self) -> None:
+        self.assertIsNotNone(prune._process_busy_reason)
+
+
+# ---------------------------------------------------------------------------
+# scripts/dev-build-reclaim.py -- plan time AND apply time
+# ---------------------------------------------------------------------------
+class DevBuildReclaimTest(Base):
+    """Its bottom pressure rung sets the idle threshold to zero days, which
+    every worktree passes -- so this gate and the session lock are all that
+    stand between an actively-compiling tree and losing its build cache.
+
+    The probe reads the WORKTREE, never the artifact dir: a compiler sits in the
+    source root and writes into `target/`, so probing `target/` would answer
+    "nobody home" for exactly the build worth protecting.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.wt = self.root / "repo-slug"
+        (self.wt / "nested").mkdir(parents=True)
+        (self.wt / "src").mkdir()
+        (self.wt / "src" / "a.py").write_text("x = 1\n", encoding="utf-8")
+        self.artifact = self.wt / "node_modules"
+        (self.artifact / "pkg").mkdir(parents=True)
+        (self.artifact / "pkg" / "index.js").write_text("//\n", encoding="utf-8")
+        lock = mock.patch.object(build, "has_live_session_lock", return_value=False)
+        lock.start()
+        self.addCleanup(lock.stop)
+
+    # -- plan time ------------------------------------------------------------
+    def test_plan_positive_control_lists_the_artifact(self) -> None:
+        items, _ = build.plan(self.root, 0.0, time.time())
+        self.assertEqual([Path(i["path"]) for i in items], [self.artifact])
+
+    def test_plan_skips_a_worktree_with_a_live_process(self) -> None:
+        self.busy_child(self.wt / "nested")
+        items, skipped = build.plan(self.root, 0.0, time.time())
+        self.assertEqual(items, [], "a compiling worktree keeps its build cache")
+        self.assertTrue(
+            any("live process" in s for s in skipped),
+            "and it is reported, never silently dropped",
+        )
+
+    def test_plan_fails_closed(self) -> None:
+        with self.broken_probe():
+            items, skipped = build.plan(self.root, 0.0, time.time())
+        self.assertEqual(items, [])
+        self.assertTrue(any("unavailable" in s for s in skipped))
+
+    # -- apply time (re-probed, never reusing the plan-time reading) ----------
+    def _drive_apply(self) -> list:
+        deleted: list = []
+        items = [{"worktree": str(self.wt), "path": str(self.artifact),
+                  "idle_days": 9.0}]
+        argv = ["dev-build-reclaim.py", "--apply", "--dev-root", str(self.root)]
+        with mock.patch.object(sys, "argv", argv), \
+                mock.patch.object(build, "plan", return_value=(list(items), [])), \
+                mock.patch.object(build, "ladder_idle_days", return_value=0.0), \
+                mock.patch.object(build, "dir_size_mb", return_value=1), \
+                mock.patch.object(build, "remove_artifact",
+                                  side_effect=lambda p: deleted.append(Path(p).name)):
+            with self.quiet():
+                build.main()
+        return deleted
+
+    def test_apply_positive_control_deletes_when_nothing_runs(self) -> None:
+        self.assertEqual(self._drive_apply(), ["node_modules"])
+
+    def test_apply_never_deletes_from_a_busy_worktree(self) -> None:
+        """A build can START between planning and applying: sizing hundreds of
+        gigabytes takes minutes, so the apply loop takes its own reading."""
+        self.busy_child(self.wt / "nested")
+        self.assertEqual(self._drive_apply(), [])
+
+    def test_apply_fails_closed(self) -> None:
+        with self.broken_probe():
+            self.assertEqual(self._drive_apply(), [])
+
+    def test_probe_is_importable(self) -> None:
+        self.assertIsNotNone(build._process_busy_reason)
+
+
+if __name__ == "__main__":
+    # Windows cp1252-console safety (ai-brain-starter#313): this file's
+    # docstrings and assertion messages carry non-ASCII, and printing that on a
+    # cp1252 console raises UnicodeEncodeError -- a control that dies before it
+    # can report is the one failure a control must not have.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
+    unittest.main(verbosity=2)

--- a/hooks/test_worktree_process_liveness.py
+++ b/hooks/test_worktree_process_liveness.py
@@ -160,7 +160,10 @@ class Base(unittest.TestCase):
             out = subprocess.run(
                 ["lsof", "-d", "cwd", "-F", "n", "-p", str(proc.pid)],
                 capture_output=True,
-                text=True,
+                # encoding pinned: bare text=True decodes with the locale
+                # encoding, which raises UnicodeDecodeError the moment a path
+                # carries a non-ASCII byte on a non-UTF-8 console.
+                text=True, encoding="utf-8", errors="replace",
             ).stdout
             if any(ln[1:] == target for ln in out.splitlines() if ln[:1] == "n"):
                 return proc

--- a/scripts/check-hook-negative-control.py
+++ b/scripts/check-hook-negative-control.py
@@ -121,7 +121,6 @@ NO_TEST_BASELINE: Set[str] = {
     "check-rule-conflicts-on-write",
     "session-turn-counter",
     "snapshot-pending-work-on-stop",
-    "remove-ended-worktree",
     "list-wip-stashes-on-session-start",
     "retry-budget",
     "permission-denied",
@@ -154,7 +153,12 @@ NO_TEST_BASELINE: Set[str] = {
 # 0. Same appendable-suppression-list hole as scripts/check-hook-activation.py
 # (fixed there in the same change). Amnesty ratchets DOWN, never up; raising
 # this number is a deliberate, reviewable act.
-NO_TEST_MAX = 28
+#
+# 28 -> 26: `remove-ended-worktree` gained a real test surface, so its amnesty
+# was withdrawn. The cap follows the list down to the new length rather than
+# keeping the freed slot as slack -- slack is silently re-appendable, which is
+# the exact hole the ratchet closed.
+NO_TEST_MAX = 26
 
 
 def is_test_surface(path: Path) -> bool:

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1345,6 +1345,17 @@ PY_DIRECT=(
   hooks/test_live_session_reap.py
   hooks/test_relocation_orphan_reclaim.py
   hooks/test_worktree_remove_verifies_side_effect.py
+  # Every liveness gate the reapers had was a PROXY that reads a BUSY session as
+  # a dead one: the session lock is refreshed when a tool call STARTS, so one
+  # long call emits nothing for its whole duration, and mtime cannot tell a long
+  # build from an abandoned tree. So the harder a worktree is worked in, the
+  # deader it looks -- and one was removed mid-test-run, several commits deep.
+  # Call-site controls for the process-table gate on every remover: a real child
+  # process in a SUBDIRECTORY must veto the delete, an unusable probe must fail
+  # CLOSED, and a positive control proves the same fixture is still deleted when
+  # nothing runs (without which a tool broken into never deleting looks perfect).
+  # 21 of its legs fail against the pre-fix revision.
+  hooks/test_worktree_process_liveness.py
   hooks/test_secret_patterns_fp_filter.py
   hooks/test_secret_patterns_nvidia.py
   hooks/test_secret_patterns_anthropic.py

--- a/scripts/dev-build-reclaim.py
+++ b/scripts/dev-build-reclaim.py
@@ -125,6 +125,31 @@ except ImportError as exc:
           file=sys.stderr)
     sys.exit(2)
 
+# Fail-CLOSED process-liveness gate, resolved defensively so an older deployed
+# _lib makes this tool REFUSE deletions rather than fail to import and quietly
+# revert to the unguarded path.
+try:
+    from _lib.worktree_safety import process_busy_reason as _process_busy_reason
+except Exception:  # pragma: no cover - depends on the deployed layout
+    _process_busy_reason = None  # type: ignore[assignment]
+
+
+def worktree_busy(wt: Path, cache: dict | None = None) -> str | None:
+    """Why `wt`'s build output must not be reclaimed, or None.
+
+    Probes the WORKTREE, never the artifact directory: a compiler does not sit
+    in `target/`, it sits in the source root and writes into it. Probing the
+    artifact dir would answer "nobody home" for exactly the build this exists to
+    protect. An absent or broken probe REFUSES — the bottom pressure rung sets
+    the idle threshold to zero days, which every worktree passes, so this gate
+    and the session lock are all that stand between an actively-compiling tree
+    and losing its cache.
+    """
+    if _process_busy_reason is None:
+        return ("process-liveness helper unavailable in this _lib deploy; "
+                "refusing every deletion")
+    return _process_busy_reason(wt, cache=cache)
+
 
 # Directory names that are ALWAYS regenerable build output.
 ALWAYS = {"node_modules", ".venv", ".next", ".turbo"}
@@ -296,6 +321,10 @@ def plan(dev_root: Path, min_idle: float, now: float) -> tuple[list, list]:
     """(reclaimable artifacts, skipped-worktree notes). Never silently drops one."""
     out: list = []
     skipped: list = []
+    # One process-table reading for the whole planning pass. The apply loop takes
+    # its OWN, because sizing every candidate can take minutes and a build can
+    # start in that window.
+    probe_cache: dict = {}
     if not dev_root.is_dir():
         return out, skipped
     try:
@@ -318,6 +347,14 @@ def plan(dev_root: Path, min_idle: float, now: float) -> tuple[list, list]:
             continue
         if has_live_session_lock(wt, now):
             skipped.append(f"{entry}: live session lock, preserved")
+            continue
+        # The session lock is a PROXY and fails OPEN: it depends on a writer that
+        # stops emitting during one long call, and its own probe falls through to
+        # lock files when it cannot measure. A running compiler is direct
+        # evidence and fails CLOSED.
+        busy = worktree_busy(wt, probe_cache)
+        if busy:
+            skipped.append(f"{entry}: {busy}, preserved")
             continue
         for art in find_artifacts(wt):
             out.append({"worktree": str(wt), "path": str(art),
@@ -430,8 +467,18 @@ def main() -> int:
         # cloud-safe-walker gate proves write-only from `open(path, MODE)` and
         # cannot see the mode when it is Path.open's first argument, so the
         # append would read to it as a recursive content read.
+        # A FRESH probe, not plan()'s. Sizing every candidate above walks hundreds
+        # of gigabytes and can take minutes; on a shared machine a liveness
+        # reading has a shelf life measured in minutes, so it is re-taken here,
+        # immediately before the first deletion.
+        apply_probe_cache: dict = {}
         with open(manifest, "a", encoding="utf-8") as mf:
             for it in items:
+                busy = worktree_busy(Path(it["worktree"]), apply_probe_cache)
+                if busy:
+                    skipped.append(f"{os.path.basename(it['worktree'])}: "
+                                   f"{busy} at apply time, preserved")
+                    continue
                 try:
                     remove_artifact(Path(it["path"]))
                     deleted += 1

--- a/scripts/dev-worktree-prune.py
+++ b/scripts/dev-worktree-prune.py
@@ -83,6 +83,22 @@ except ImportError as exc:
           file=sys.stderr)
     sys.exit(2)
 
+# Fail-CLOSED process-liveness gate, resolved defensively so an older deployed
+# _lib makes this tool REFUSE removals rather than fail to import and quietly
+# revert to the unguarded path.
+try:
+    from _lib.worktree_safety import process_busy_reason as _process_busy_reason
+except Exception:  # pragma: no cover - depends on the deployed layout
+    _process_busy_reason = None  # type: ignore[assignment]
+
+
+def _busy(path: Path, cache: dict | None = None) -> str | None:
+    """Why `path` must not be removed, or None. An absent probe REFUSES."""
+    if _process_busy_reason is None:
+        return ("process-liveness helper unavailable in this _lib deploy; "
+                "refusing every removal")
+    return _process_busy_reason(path, cache=cache)
+
 DEFAULT_IDLE_DAYS = 7.0
 # Overridable so a test never writes into the operator's real snapshot store —
 # a test fixture sitting in the recovery directory is indistinguishable from a
@@ -300,11 +316,22 @@ def snapshot(worktree: Path, paths: list, apply: bool):
     return dest, failed
 
 
-def remove(worktree: Path, apply: bool) -> tuple:
+def remove(worktree: Path, apply: bool, probe_cache: dict | None = None) -> tuple:
     """`git worktree remove` via the OWNING checkout, never `rm -rf`, so git's
-    own bookkeeping stays consistent. --force only after a snapshot exists."""
+    own bookkeeping stays consistent. --force only after a snapshot exists.
+
+    Last gate before the unlink: the PROCESS TABLE. Every other input to the
+    classify/remove decision is a proxy that reads a busy tree as an abandoned
+    one — the idle-days threshold is mtime, and the session-lock probe depends
+    on a writer that stops emitting during one long call. This one observes,
+    fails closed, and is taken HERE rather than at classify time, because on a
+    shared machine a classification is minutes stale by the time it is acted on.
+    """
     if not apply:
         return True, "dry-run"
+    busy = _busy(worktree, probe_cache)
+    if busy:
+        return False, busy
     main = main_checkout_of(worktree)
     if main is None:
         return False, "no main checkout"
@@ -339,10 +366,21 @@ def main() -> int:
     verdicts = [classify(w, args.idle_days, now_ts) for w in find_candidates(dev_root)]
 
     reaped, snapped, failed = [], [], []
+    # One process-table reading for the whole apply pass, built at the first
+    # removal — deliberately NOT at classify time, which can be minutes earlier.
+    probe_cache: dict = {}
     for v in verdicts:
         if v["verdict"] not in (REAP, SNAPSHOT_REAP):
             continue
         wt = Path(v["path"])
+        # Ahead of the snapshot: no point walking a tree we are going to keep,
+        # and a dry run must report the same refusal an apply would hit.
+        busy = _busy(wt, probe_cache)
+        if busy:
+            v["removed"] = False
+            v["note"] = busy
+            failed.append(v)
+            continue
         if v["verdict"] == SNAPSHOT_REAP:
             paths, known = dirty_paths(wt)
             if not known:
@@ -360,7 +398,7 @@ def main() -> int:
                 failed.append(v)
                 continue
             snapped.append(v)
-        ok, note = remove(wt, args.apply)
+        ok, note = remove(wt, args.apply, probe_cache)
         v["removed"] = ok
         v["note"] = note
         (reaped if ok else failed).append(v)

--- a/scripts/worktree-reclaim.py
+++ b/scripts/worktree-reclaim.py
@@ -52,6 +52,7 @@ for _cand in (_HERE.parent / "hooks", _HERE):
         sys.path.insert(0, str(_cand))
         break
 
+from _lib import worktree_safety as _ws  # noqa: E402
 from _lib.worktree_safety import (  # noqa: E402
     current_worktree,
     find_main_repo,
@@ -64,6 +65,29 @@ from _lib.worktree_safety import (  # noqa: E402
     remove_worktree,
     snapshot_unrecoverable,
 )
+
+# Process-table liveness. The idle gate below is a PROXY: "nothing written in
+# --idle-min minutes" is also exactly what a long build or test run whose output
+# goes elsewhere looks like, so the busier a worktree is, the more reclaimable it
+# looks. Resolved by getattr so an older deployed _lib makes this tool REFUSE
+# removals rather than fail to load and quietly revert to the unguarded path.
+process_busy_reason = getattr(_ws, "process_busy_reason", None)
+
+# One probe for the whole apply pass. Built lazily at the first removal, never at
+# classify time — on a shared machine a plan-time reading has a shelf life.
+_PROBE_CACHE: dict = {}
+
+
+def _busy(path: Path) -> str | None:
+    """Why `path` must not be deleted, or None. Fail-closed and LOUD.
+
+    A missing or broken probe refuses AND prints, so a permanently-dead probe
+    surfaces as a stated refusal instead of a fleet that quietly stops shrinking.
+    """
+    if process_busy_reason is None:
+        return ("process-liveness helper unavailable in this _lib deploy; "
+                "refusing every removal")
+    return process_busy_reason(path, cache=_PROBE_CACHE)
 
 
 def _branch(wt: Path) -> str:
@@ -124,6 +148,11 @@ def main() -> int:
         if not is_idle(wt, args.idle_min):
             report["registered_kept"].append(f"{wt.name}: active")
             continue
+        busy = _busy(wt)
+        if busy:
+            report["registered_kept"].append(f"{wt.name}: {busy}")
+            print(f"worktree-reclaim: keeping {wt.name} — {busy}", file=sys.stderr)
+            continue
         if args.dry_run:
             report["registered_removed"].append(f"{wt.name}: would-remove")
             removed += 1
@@ -144,6 +173,12 @@ def main() -> int:
     for od in orphans:
         if cur_path and od.resolve() == cur_path:
             report["orphans"][od.name] = "kept-current"
+            continue
+        busy = _busy(od)
+        if busy:
+            report["orphans"][od.name] = f"kept-busy ({busy})"
+            print(f"worktree-reclaim: keeping orphan {od.name} — {busy}",
+                  file=sys.stderr)
             continue
         if args.dry_run:
             if not is_idle(od, args.idle_min):


### PR DESCRIPTION
## The bug

Every liveness gate in the worktree reapers was a **proxy**, and every proxy reads a **busy** session as a dead one.

- The session lock records `last_activity_at`, refreshed when a tool call **starts**. A session sitting inside **one long call** — a test suite, a build, a migration — emits no heartbeat for the whole run. Past the liveness window its entry is byte-identical to that of a session that exited; past idle-expiry the entry is deleted outright. The lock's recorded pid cannot rescue it: that is the ephemeral hook process's pid, already dead when written.
- The mtime idle gate cannot tell a long build whose output goes elsewhere from an abandoned tree.

So the harder a worktree is being worked in, the deader it looks. Observed in the field: a worktree removed mid-test-run, several commits deep, by a sibling session's start-up sweep. It survived only because the commits were already in the shared object store.

## The fix

`process_cwd_inside()` in `hooks/_lib/worktree_safety.py` — one `lsof -d cwd` per sweep, cached.

- **Subdirectories count.** A test runner sits in one, not at the worktree root.
- **A sibling sharing a path prefix does not.** Without the separator, `repo` would match `repo-slug` and one live session would lock the whole fleet.
- **Our own ancestor chain is excluded**, so a session-end sweep can still retire the tree it was launched from. **Descendants are not** — a detached gate still running is exactly what needs protecting.
- **It raises when it cannot run.** "No process found" and "could not look" must never be the same answer to a caller that deletes directories.

Every destructive path is gated on it and **fails closed**, logging a visible refusal so a dead probe surfaces as a stated refusal rather than a fleet that quietly stops being cleaned:

| File | Guarded paths |
|---|---|
| `hooks/_lib/worktree_safety.py` | `remove_worktree`, `reclaim_orphan_dir`, `_reclaim_disconnected_orphan` |
| `hooks/remove-ended-worktree.py` | the SessionEnd removal |
| `hooks/enforce-worktree-cap.py` | dead-session reap, orphan sweep, count-cap loop |
| `scripts/worktree-reclaim.py` | registered trim, orphan sweep |
| `hooks/_lib/dev_repo_scan.py` | `execute_reap` (the engine behind `dev-repo-reaper.py`) |
| `scripts/dev-worktree-prune.py` | `remove()` |
| `scripts/dev-build-reclaim.py` | plan time **and** apply time |

The long-running tools **re-probe immediately before mutating** rather than reusing a plan-time reading — sizing hundreds of gigabytes takes minutes, and a build can start in that window. `dev-build-reclaim` probes the **worktree**, never the artifact dir: a compiler sits in the source root and writes into `target/`, so probing `target/` would answer "nobody home" for exactly the build this protects.

## Two defects the tests found

1. **The probe observed itself.** A spawned child inherits our cwd and `lsof` lists itself, so a sweep launched from inside the tree it was retiring saw its own probe standing there and refused — the ancestor-chain exclusion defeated by a descendant created one line earlier. That is the SessionEnd remover's *normal* case, so its cleanup would have stopped working entirely. Fixed by anchoring the probe's subprocesses at the filesystem root, which also covers any helper `lsof` forks.
2. **Fail-closed would have disabled Windows.** There is no `lsof` and no stdlib route to another process's cwd there, so every reap would have refused forever and handed that user back the unbounded worktree pileup these hooks exist to prevent. An unsupported *platform* now says so once on stderr and defers to the remaining gates; a missing `lsof` on POSIX is an anomaly, not a platform fact, and stays fail-closed.

## Tests

`hooks/test_worktree_process_liveness.py`, 49 legs, registered in the gate's `PY_DIRECT` list so it cannot sit dormant. These are **call-site** controls, not helper controls — a correct helper that nothing calls is exactly the failure worth catching — so every guarded remover carries four legs:

- a **positive control** proving the same fixture is still deleted when nothing runs (without it, a tool broken into never deleting anything looks perfect);
- a **negative control** with a real `subprocess.Popen` child whose cwd is a **subdirectory** of the worktree, whose readiness wait reads the process table **directly** rather than through the code under test (routed through the probe, a broken probe would fail the helper instead of the assertion that matters);
- a **fail-closed** leg on an unusable probe;
- an **importability** leg — a `None` probe is safe but paralyses cleanup, so it must be a test failure rather than a quiet fleet.

Mutation-checked: with the guards neutered, **21 of 21** negative and fail-closed legs fail. Zero survivors. Every fixture and artifact root stays inside the test's own `TemporaryDirectory`.

## Also

`remove-ended-worktree` gained a real test surface, so the negative-control gate correctly demanded its `NO_TEST_BASELINE` amnesty be withdrawn. `NO_TEST_MAX` follows the list down 28 → 26 rather than keeping the freed slot as slack — slack on a shrinking ratchet is silently re-appendable, which is the hole that cap was added to close.

## Note on the pre-existing probe

`_lib/dev_repo_scan.live_process_cwds()` already existed and is deliberately left alone. It is an **advisory** probe scoped to agent-shaped processes that reports "could not measure" and lets its caller fall through to lock files. This one is a **deletion gate**: it sees every process (a detached build or test runner carries no agent-shaped command line) and refuses when it cannot answer. Both are cross-referenced in comments so the pair reads as deliberate rather than as drift.

## Field note

While this branch was being gated, the worktree it was running in **was itself deleted mid-run** by a sweep on this machine — the exact incident class above. Nothing was lost only because the commits had already been pushed.
