### PR TITLE
fix(hooks): PreToolUse(Bash) gates must consult the command for *_BYPASS

### DIFF
--- a/hooks/_lib/bypass_scan.py
+++ b/hooks/_lib/bypass_scan.py
@@ -1,0 +1,129 @@
+"""Shared scanner for the inline-bypass-REACHABILITY class.
+
+A PreToolUse(Bash) gate that honors a `*_BYPASS` env var MUST also consult the
+COMMAND STRING for it: an inline `VAR=1 <cmd>` prefix lives only in the
+command, never in the hook process's (session) env. A gate that reads
+os.environ only advertises a bypass that can't fire -- training people to
+disable the guard some other way instead, which is worse than no advertised
+bypass at all.
+
+Single source of truth for "is hook X in the broken class?", shared by:
+  - test_bypass_reachability_watchdog.py  (CI: scans THIS repo's tracked
+                                            hooks/ dir)
+  - surface-bypass-unreachable.py         (SessionStart: scans the DEPLOYED
+                                            union ~/.claude/hooks -- catches a
+                                            broken hook tracked in a DIFFERENT
+                                            source repo, or untracked entirely)
+
+WHY BOTH ARE NEEDED. Hooks deploy to ~/.claude/hooks from more than one source
+repo. No single repo's CI sees the deployed union, so a per-repo CI watchdog is
+structurally blind to a hook that shipped from elsewhere, or was hand-edited
+after install. The deployed-surface surfacer is the catch-all for that gap;
+the CI watchdog is what stops a NEW instance of the class from merging here.
+"""
+from __future__ import annotations
+
+import glob
+import os
+import re
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+try:                                        # _lib itself is on sys.path
+    from safe_read import safe_read_text
+except ImportError:                        # hooks/ (the parent) is on sys.path
+    from _lib.safe_read import safe_read_text
+
+# Reads a `*_BYPASS` env var via os.environ, written INLINE as a literal.
+ENV_BYPASS_RE = re.compile(r'os\.environ(?:\.get\(|\[)["\'][A-Z0-9_]*BYPASS')
+# ...or INDIRECTLY, through a constant bound to the name:
+#     BYPASS = "SOME_GUARD_BYPASS"
+#     if os.environ.get(BYPASS) == "1": ...
+# Hoisting the name into a constant is BETTER style, and a scanner that only
+# matched the literal-string shape above would call it invisible: it gates a
+# Bash command, advertises an inline bypass, and never spells the env-var name
+# where a literal-only regex could see it. Widening to catch this shape only
+# ever ADDS hooks to `enforce` -- it cannot mask a violator the literal form
+# already caught, so it is a strictly safer scan, never a weaker one.
+_ENV_BYPASS_VAR_RE = re.compile(
+    r'os\.environ(?:\.get\(|\[)\s*([A-Za-z_][A-Za-z0-9_]*)')
+_BYPASS_CONST_RE = re.compile(
+    r'^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*["\'][A-Z0-9_]*BYPASS["\']', re.M)
+# References the Bash tool (so it gates Bash commands).
+_BASH_RE = re.compile(r'tool_name.*Bash|"Bash"|\'Bash\'')
+# ...or reads tool_input's "command" key without ever spelling "Bash" literally
+# -- true of a gate that relies entirely on its hooks.json PreToolUse:Bash
+# matcher for tool-type filtering instead of a redundant self-check. "command"
+# is a Bash-only key among Claude Code's standard tool_input shapes (Write and
+# Edit carry file_path/content/old_string/new_string, Task carries prompt), so
+# this is a narrow, low-false-positive alternative to the literal-string
+# check, not a looser substitute for it -- either signal is sufficient.
+_COMMAND_KEY_RE = re.compile(r'\.get\(\s*["\']command["\']|\[\s*["\']command["\']\s*\]')
+# Consults the command string for the bypass (the fix shape). Matches this
+# repo's actual call sites: the shared `_lib/cmd_env.inline_bypass` wrapper,
+# the `_lib/shell_parse.leading_env_assigns` primitive it wraps (called
+# directly by a couple of hooks), and every hook that keeps its own local
+# `_inline_bypass` copy instead of the shared one -- `inline_bypass` matches
+# as a substring of `_inline_bypass` too, so a local copy is not penalized for
+# being local, only for not consulting the command at all.
+CONSULTS_CMD_RE = re.compile(
+    r'inline_bypass|leading_env_assigns|cmd_env|segment_bypass_flags')
+
+
+def is_bash_gate(src):
+    """True if the hook extracts a Bash command to act on (vs a Stop/
+    SessionStart surfacer that touches neither tool_input.command nor Bash)."""
+    if "tool_input" not in src or "command" not in src:
+        return False
+    return _BASH_RE.search(src) is not None or _COMMAND_KEY_RE.search(src) is not None
+
+
+def reads_bypass_env(src):
+    """True if the hook gates on a `*_BYPASS` env var, however it spells it.
+
+    Two shapes, both real in a deployed fleet: the name inline as a literal,
+    and the name hoisted into a module constant. Missing the second lets a
+    live violator sit outside `enforce` while this scan reports clean.
+    """
+    if ENV_BYPASS_RE.search(src) is not None:
+        return True
+    consts = set(_BYPASS_CONST_RE.findall(src))
+    if not consts:
+        return False
+    return any(v in consts for v in _ENV_BYPASS_VAR_RE.findall(src))
+
+
+def consults_command(src):
+    return CONSULTS_CMD_RE.search(src) is not None
+
+
+def scan_hooks(hooks_dir, exempt=frozenset()):
+    """Scan a hooks dir. Returns (enforce, violators):
+
+    - enforce:   hooks that are Bash-gates AND read a `*_BYPASS` env (in scope).
+    - violators: the subset that NEVER consult the command for the bypass
+                 (the broken class -- os.environ-only).
+
+    Skips `test_*.py` and any basename in `exempt`. Unreadable files are
+    skipped (never raises) so a surfacer can't crash session start -- reads go
+    through the cloud-safe bounded primitive (`_lib/safe_read.py`) rather than
+    a bare `open()`, since the deployed-surface caller walks a real user
+    directory that can hold a cloud placeholder or a stalled mount.
+    """
+    enforce, violators = [], []
+    for path in sorted(glob.glob(os.path.join(hooks_dir, "*.py"))):
+        name = os.path.basename(path)
+        if name.startswith("test_") or name in exempt:
+            continue
+        res = safe_read_text(path, timeout=5.0, max_bytes=4_000_000, errors="replace")
+        if not res.ok:
+            continue
+        src = res.text or ""
+        if not (reads_bypass_env(src) and is_bash_gate(src)):
+            continue
+        enforce.append(name)
+        if not consults_command(src):
+            violators.append(name)
+    return enforce, violators

--- a/hooks/_lib/bypass_scan.py
+++ b/hooks/_lib/bypass_scan.py
@@ -68,8 +68,28 @@ _COMMAND_KEY_RE = re.compile(r'\.get\(\s*["\']command["\']|\[\s*["\']command["\'
 # `_inline_bypass` copy instead of the shared one -- `inline_bypass` matches
 # as a substring of `_inline_bypass` too, so a local copy is not penalized for
 # being local, only for not consulting the command at all.
+#
+# Requires an actual CALL (`name(`), not a bare mention, and not the `def
+# name(` that DEFINES it -- every real caller in this repo ships a `def
+# inline_bypass(...): return False` fallback for when _lib is unreachable, so
+# a call-only match without the `(?<!def )` exclusion still matched that
+# definition's own signature. Proven live in two steps: reverting a fixed
+# hook's `or inline_bypass(cmd, VAR)` back to os.environ-only, while leaving
+# the now-dead `from cmd_env import inline_bypass` line in place, first left
+# the scanner reporting the file clean (a bare mention read as "consults");
+# requiring a call closed that but the file's OWN fallback `def
+# inline_bypass(...)` line then satisfied the call-shaped regex too. The
+# fleet behavioral test (test_bypass_reachability_watchdog.py) caught the
+# regression correctly at every step, which is why that layer exists
+# alongside this one -- this is a text scanner, not control-flow analysis,
+# and cannot see whether a matched call is on a path that actually runs (e.g.
+# `if False: inline_bypass(...)` would still pass). That residual gap is
+# accepted, same as every other lightweight scanner in this repo
+# (check-hook-negative-control.py's own docstring names the identical limit
+# for its check).
 CONSULTS_CMD_RE = re.compile(
-    r'inline_bypass|leading_env_assigns|cmd_env|segment_bypass_flags')
+    r'(?<!def )inline_bypass\s*\(|(?<!def )leading_env_assigns\s*\('
+    r'|(?<!def )segment_bypass_flags\s*\(|cmd_env\.\w+\s*\(')
 
 
 def is_bash_gate(src):

--- a/hooks/_lib/cmd_env.py
+++ b/hooks/_lib/cmd_env.py
@@ -1,0 +1,48 @@
+"""Convenience wrapper: does `command` carry a leading `<var>=<value>` prefix?
+
+WHY THIS EXISTS. A PreToolUse(Bash) gate runs in the HOOK process, whose
+environment is the Claude Code SESSION env. An inline `VAR=1 <cmd>` prefix a
+user or agent types lives ONLY in the command STRING and never reaches the
+hook's `os.environ`. A gate that advertises an inline bypass in its own block
+message (`STALE_CHECKOUT_BYPASS=1 ...`, `JOURNAL_CONTEXT_BYPASS=1 ...`) but
+reads only `os.environ` is offering an escape hatch that can never fire --
+which trains people to disable the guard some other way instead. Bug class
+HOOK-READS-SESSION-ENV-NOT-COMMAND-ENV (env sibling of
+HOOK-RESOLVES-SESSION-CWD-NOT-COMMAND-CWD).
+
+NOT A NEW PARSER. The quote-aware segment split and leading-assignment walk
+already live in `_lib/shell_parse.py` (`leading_env_assigns`), used elsewhere
+in this repo for the same "does this shell command carry VAR=val" question.
+This module adds nothing but the one-line convenience call two hooks already
+expect at this import path (`from cmd_env import inline_bypass`, with a local
+fallback if the import fails) -- shipping it makes that import resolve to the
+real, shared implementation instead of silently falling back every time.
+
+Call shape, matching the fallback both callers already carry:
+
+    try:
+        from cmd_env import inline_bypass
+    except Exception:
+        def inline_bypass(command, var, value="1"):
+            return False
+    ...
+    if os.environ.get(VAR) == "1" or inline_bypass(command, VAR):
+        allow()
+"""
+from __future__ import annotations
+
+try:                                        # _lib itself is on sys.path
+    from shell_parse import leading_env_assigns
+except ImportError:                        # hooks/ (the parent) is on sys.path
+    from _lib.shell_parse import leading_env_assigns
+
+
+def inline_bypass(command: str, var: str, value: str = "1") -> bool:
+    """True iff `command` carries a leading `<var>=<value>` assignment.
+
+    `leading_env_assigns` already handles quoting, shell-segment splitting,
+    wrapper prefixes (`env`, `sudo`, ...), and heredoc bodies -- see its
+    docstring in shell_parse.py for the exact contract. This is just the
+    single-variable convenience read two callers already expect to import.
+    """
+    return leading_env_assigns(command).get(var) == value

--- a/hooks/block-branch-switch-with-untracked-build.py
+++ b/hooks/block-branch-switch-with-untracked-build.py
@@ -37,6 +37,18 @@ except Exception:
     print(json.dumps({}))
     sys.exit(0)
 
+# Inline-bypass consult: os.environ can't see a `BRANCH_SWITCH_BYPASS=1 <cmd>`
+# prefix that lives only in the command string, never the hook's own env
+# (HOOK-READS-SESSION-ENV-NOT-COMMAND-ENV). Fail-open to env-only if the
+# shared helper is unavailable -- never let a missing _lib escalate this into
+# a block. This file already fails the whole hook open above when _lib is
+# unreachable, so the import is safe to fold into the same try/except.
+try:
+    from _lib.cmd_env import inline_bypass  # type: ignore
+except Exception:
+    def inline_bypass(command, var, value="1"):  # type: ignore
+        return False
+
 
 DANGEROUS_PATTERNS = [
     # checkout to a branch (NOT `checkout -- <file>` which is revert)
@@ -54,10 +66,10 @@ DEV_REPO_PATH_RE = re.compile(r"/Users/[^/]+/dev/([^/\s'\"]+)")
 HOME_DEV_PATH_RE = re.compile(r"~/dev/([^/\s'\"]+)")
 
 
-def _bypass() -> bool:
+def _bypass(cmd: str) -> bool:
     if os.environ.get("BRANCH_SWITCH_BYPASS") == "1":
         return True
-    return False
+    return inline_bypass(cmd, "BRANCH_SWITCH_BYPASS")
 
 
 def _command_is_dangerous(cmd: str) -> bool:
@@ -114,7 +126,7 @@ def main() -> None:
     if not _command_is_dangerous(cmd):
         _allow()
 
-    if _bypass():
+    if _bypass(cmd):
         _allow()
 
     # Determine which repo to scan. Prefer the repo named on the command line.

--- a/hooks/block-branch-switch-with-untracked-build.py
+++ b/hooks/block-branch-switch-with-untracked-build.py
@@ -193,4 +193,13 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (ai-brain-starter#313; hooks/ sweep #314).
+    # A hook that print()s non-ASCII raises UnicodeEncodeError on a cp1252
+    # console: the gate then fails silently OPEN, or denies the tool call with
+    # no legible cause. Idempotent; a no-op on an already-UTF-8 console.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     main()

--- a/hooks/block-claude-mcp-inline-secret.py
+++ b/hooks/block-claude-mcp-inline-secret.py
@@ -20,6 +20,18 @@ import json
 import os
 import re
 import sys
+from pathlib import Path
+
+# Inline-bypass consult: os.environ can't see a `MCP_INLINE_SECRET_BYPASS=1
+# <cmd>` prefix that lives only in the command string, never the hook's own
+# env (HOOK-READS-SESSION-ENV-NOT-COMMAND-ENV). Fail-open to env-only if the
+# shared helper is unavailable.
+sys.path.insert(0, str(Path(__file__).resolve().parent / "_lib"))
+try:
+    from cmd_env import inline_bypass
+except Exception:
+    def inline_bypass(command, var, value="1"):  # type: ignore
+        return False
 
 SECRET_PATTERNS = [
     r"sk-ant-[A-Za-z0-9_\-]+",
@@ -40,9 +52,6 @@ SECRET_RE = re.compile("|".join(SECRET_PATTERNS))
 
 
 def main() -> int:
-    if os.environ.get("MCP_INLINE_SECRET_BYPASS") == "1":
-        return 0
-
     try:
         payload = json.load(sys.stdin)
     except json.JSONDecodeError:
@@ -54,6 +63,11 @@ def main() -> int:
 
     cmd = (payload.get("tool_input") or {}).get("command", "")
     if not cmd:
+        return 0
+
+    if os.environ.get("MCP_INLINE_SECRET_BYPASS") == "1" or inline_bypass(
+        cmd, "MCP_INLINE_SECRET_BYPASS"
+    ):
         return 0
 
     # Only flag `claude mcp add ...` commands

--- a/hooks/check-py-import-precommit.py
+++ b/hooks/check-py-import-precommit.py
@@ -37,6 +37,18 @@ import shutil
 import subprocess
 import sys
 import time
+from pathlib import Path
+
+# Inline-bypass consult: os.environ can't see a `PRECOMMIT_F821_BYPASS=1
+# <cmd>` prefix that lives only in the command string, never the hook's own
+# env (HOOK-READS-SESSION-ENV-NOT-COMMAND-ENV). Fail-open to env-only if the
+# shared helper is unavailable.
+sys.path.insert(0, str(Path(__file__).resolve().parent / "_lib"))
+try:
+    from cmd_env import inline_bypass
+except Exception:
+    def inline_bypass(command, var, value="1"):  # type: ignore
+        return False
 
 BYPASS_ENV = "PRECOMMIT_F821_BYPASS"
 GIT_TIMEOUT_SEC = 8
@@ -132,8 +144,6 @@ def _nudge_ruff_missing_once():
 
 
 def main() -> int:
-    if os.environ.get(BYPASS_ENV) == "1":
-        return 0
     try:
         payload = json.load(sys.stdin)
     except (json.JSONDecodeError, ValueError):
@@ -141,6 +151,8 @@ def main() -> int:
     if payload.get("tool_name") != "Bash":
         return 0
     command = (payload.get("tool_input") or {}).get("command") or ""
+    if os.environ.get(BYPASS_ENV) == "1" or inline_bypass(command, BYPASS_ENV):
+        return 0
     if "commit" not in command or not _invokes_git_commit(command):
         return 0
 

--- a/hooks/check-py-import-precommit.py
+++ b/hooks/check-py-import-precommit.py
@@ -115,6 +115,7 @@ def _git(args, cwd):
         r = subprocess.run(
             ["git", "-C", cwd] + args,
             capture_output=True, text=True, timeout=GIT_TIMEOUT_SEC,
+            encoding="utf-8", errors="replace",
         )
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
         return ""
@@ -130,7 +131,7 @@ def _nudge_ruff_missing_once():
         ) < RUFF_NUDGE_INTERVAL_SEC:
             return
         os.makedirs(os.path.dirname(RUFF_NUDGE_MARKER), exist_ok=True)
-        with open(RUFF_NUDGE_MARKER, "w") as f:
+        with open(RUFF_NUDGE_MARKER, "w", encoding="utf-8") as f:
             f.write(str(now))
     except OSError:
         # If we can't write the marker, still nudge this once rather than crash.
@@ -181,6 +182,7 @@ def main() -> int:
             [ruff, "check", "--select", "F821", "--output-format=concise",
              "--no-cache", "--"] + existing,
             cwd=cwd, capture_output=True, text=True, timeout=RUFF_TIMEOUT_SEC,
+            encoding="utf-8", errors="replace",
         )
     except (subprocess.TimeoutExpired, OSError):
         return 0  # fail-open

--- a/hooks/session-lock.py
+++ b/hooks/session-lock.py
@@ -90,11 +90,25 @@ import shlex
 import subprocess
 import sys
 import time
+from pathlib import Path
 
 try:
     import fcntl  # POSIX only; absent on Windows.
 except ImportError:  # pragma: no cover
     fcntl = None
+
+# Inline-bypass consult: os.environ can't see a `SIBLING_SESSION_LOCK_BYPASS=1
+# <cmd>` prefix that lives only in the command string, never the hook's own
+# env (HOOK-READS-SESSION-ENV-NOT-COMMAND-ENV). Fail-open to env-only if the
+# shared helper is unavailable -- never let a missing _lib turn a warn/block
+# hook that already fails open on internal errors into one that can't be
+# reasoned about.
+try:
+    sys.path.insert(0, str(Path(__file__).resolve().parent / "_lib"))
+    from cmd_env import inline_bypass
+except Exception:
+    def inline_bypass(command, var, value="1"):  # type: ignore
+        return False
 
 BYPASS_ENV = "SIBLING_SESSION_LOCK_BYPASS"
 WARN_WINDOW_SEC = 300       # a sibling is "live" if active within 5 min
@@ -1186,6 +1200,13 @@ def _pretooluse(payload):
     now = time.time()
     captured = {}
     command = (payload.get("tool_input", {}) or {}).get("command", "") or ""
+
+    # The top-level main() bypass check only sees SESSION env; an inline
+    # `SIBLING_SESSION_LOCK_BYPASS=1 <cmd>` prefix lives only in `command`,
+    # which is not resolved until here. Consult it before any lock/warn logic
+    # runs, same fail-open shape as the env-var path this mirrors.
+    if inline_bypass(command, BYPASS_ENV):
+        return 0
 
     # Resolve the branch ONLY for commands that touch a shared ref, so an
     # ordinary `ls` never pays for a git subprocess.

--- a/hooks/surface-bypass-unreachable.py
+++ b/hooks/surface-bypass-unreachable.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""surface-bypass-unreachable.py
+
+SessionStart surfacer. Scans the DEPLOYED ~/.claude/hooks directory (the
+union every source repo writes into) for the inline-bypass-REACHABILITY
+class: a PreToolUse(Bash) gate that reads a `*_BYPASS` env var but never
+consults the COMMAND STRING for it. An inline `VAR=1 <cmd>` prefix lives
+only in the command, never in the hook process's own (session) env, so a
+gate that reads os.environ only is advertising a bypass that cannot fire --
+a permanent block with a fake exit, which trains people to disable the
+guard some other way instead.
+
+WHY A SEPARATE SessionStart SURFACER, ALONGSIDE THE CI WATCHDOG
+-----------------------------------------------------------------
+hooks/test_bypass_reachability_watchdog.py (this repo's own CI) can only see
+hooks TRACKED IN THIS REPO. Hooks deploy to ~/.claude/hooks from more than
+one source repo, and a hand-edited or hand-added hook is untracked anywhere.
+No single repo's CI sees that deployed union, so a per-repo watchdog is
+structurally blind to a broken hook that shipped from elsewhere, or one that
+diverged from its tracked source after install. This surfacer is the
+catch-all: it scans what is ACTUALLY on disk and deployed, regardless of
+where it came from.
+
+Silent when clean, or when the deployed hooks dir does not exist (a fresh
+install, or a machine that has never deployed anything here). Never blocks
+-- purely informational, matching every other surface-*.py hook in this
+repo. Any internal error falls back to silence rather than breaking
+SessionStart.
+
+Override for tests: ABS_DEPLOYED_HOOKS_DIR points the scan at a fixture
+directory instead of ~/.claude/hooks.
+
+WIRING (SessionStart):
+  "SessionStart": [
+    {"hooks": [{
+      "type": "command",
+      "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/surface-bypass-unreachable.py 2>/dev/null || echo '{\"continue\":true,\"suppressOutput\":true}'"
+    }]}
+  ]
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+HOOK_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(HOOK_DIR))
+
+try:
+    from _lib.bypass_scan import scan_hooks
+except Exception:
+    # Fail-open: a missing/broken _lib must never break SessionStart. A
+    # scanner that cannot run reports nothing, same as a clean scan --
+    # correct for a surfacer, which only ever advises and never blocks.
+    scan_hooks = None  # type: ignore[assignment]
+
+
+def _deployed_hooks_dir() -> Path:
+    env = os.environ.get("ABS_DEPLOYED_HOOKS_DIR")
+    if env:
+        return Path(env)
+    return Path.home() / ".claude" / "hooks"
+
+
+def _emit(message: str | None = None) -> None:
+    """SessionStart additionalContext (reaches the model) or `{}` (silent)."""
+    if message:
+        print(json.dumps({
+            "hookSpecificOutput": {
+                "hookEventName": "SessionStart",
+                "additionalContext": message,
+            }
+        }))
+    else:
+        print(json.dumps({}))
+    sys.exit(0)
+
+
+def build_message(hooks_dir: Path) -> "str | None":
+    """The advisory to emit, or None when there is nothing to say.
+
+    Pure function (no I/O beyond the scan itself) so tests can drive it
+    directly against a fixture directory without going through stdin/stdout.
+    """
+    if scan_hooks is None or not hooks_dir.is_dir():
+        return None
+    _enforce, violators = scan_hooks(str(hooks_dir))
+    if not violators:
+        return None
+    listed = "\n".join(f"  - {v}" for v in sorted(violators))
+    return (
+        "[surface-bypass-unreachable] "
+        f"{len(violators)} deployed Bash-gate hook(s) advertise a `*_BYPASS` "
+        "env var but never consult the COMMAND for it, so the bypass they "
+        "print in their own block message can never fire from an inline "
+        "`VAR=1 <cmd>` prefix (only from an exported session env var):\n"
+        f"{listed}\n"
+        "Fix: check both -- "
+        '`os.environ.get(VAR) == "1" or inline_bypass(command, VAR)` -- '
+        "using hooks/_lib/cmd_env.inline_bypass (ai-brain-starter) or the "
+        "equivalent shared helper in the hook's own source repo."
+    )
+
+
+def main() -> None:
+    try:
+        json.load(sys.stdin)
+    except Exception:
+        pass
+    try:
+        _emit(build_message(_deployed_hooks_dir()))
+    except Exception:
+        # Absolute backstop: an advisory surfacer must never fail loud.
+        _emit(None)
+
+
+if __name__ == "__main__":
+    # Windows cp1252-console safety (ai-brain-starter#313; hooks/ sweep #314).
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
+    try:
+        main()
+    except Exception:
+        print(json.dumps({}))
+        sys.exit(0)

--- a/hooks/surface-deployed-hooks-behind.py
+++ b/hooks/surface-deployed-hooks-behind.py
@@ -56,6 +56,15 @@ call sync-skills.classify_drift() (its own source of truth, reusing its symlink
 check message — no new SessionStart hook, so the footprint SLA (MYC-2348) is
 untouched. Directional: a copy that LEADS upstream is never nagged as behind.
 
+ALSO SURFACES INLINE-BYPASS-UNREACHABLE HOOKS: a third artifact, same
+"append to this message, buy no new SessionStart slot" reasoning. Scans the
+DEPLOYED ~/.claude/hooks union for a PreToolUse(Bash) gate that reads a
+`*_BYPASS` env var but never consults the COMMAND for it, so the inline
+`VAR=1 <cmd>` prefix it advertises can never fire (only an exported session
+var does). Real logic lives in the sibling surface-bypass-unreachable.py
+(kept standalone so its own test can drive it directly against a fixture
+directory); see _bypass_unreachable_message() below.
+
 LIMITATION (honest): a detector can only fire once it is itself deployed, so it
 cannot report its own first-time non-deployment. After the first successful
 deploy it self-perpetuates and catches every subsequent stale deploy. Checkout-
@@ -155,6 +164,35 @@ def _skill_drift_message() -> str | None:
             or (Path.home() / ".claude" / "skills")
         )
         return ss.drift_message(ss.classify_drift(clone_skills, install_root))
+    except Exception:
+        return None
+
+
+def _bypass_unreachable_message() -> "str | None":
+    """A third artifact, same reasoning as the two above: append to this
+    hook's SAME SessionStart message instead of buying a new hooks.json
+    entry, so the footprint SLA (MYC-2348) stays flat.
+
+    Scans the DEPLOYED ~/.claude/hooks union for the inline-bypass-
+    REACHABILITY class (surface-bypass-unreachable.py's own job, kept
+    standalone so its own test can exercise it directly against a fixture
+    directory with ABS_DEPLOYED_HOOKS_DIR) -- a PreToolUse(Bash) gate that
+    reads a `*_BYPASS` env var but never consults the COMMAND for it, so
+    the inline `VAR=1 <cmd>` prefix it advertises can never fire. Loaded
+    from THIS file's own directory: surface-bypass-unreachable.py ships
+    alongside it as ordinary skill content (not through the ABS_OWNED_
+    BASENAMES ~/.claude/hooks/ copy path), so it is always a sibling here.
+    Any error -> None (fail open; a SessionStart surfacer must never crash
+    session start)."""
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "_abs_surface_bypass_unreachable",
+            Path(__file__).resolve().parent / "surface-bypass-unreachable.py")
+        if spec is None or spec.loader is None:
+            return None
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod.build_message(mod._deployed_hooks_dir())
     except Exception:
         return None
 
@@ -418,7 +456,7 @@ def main() -> None:
     # clone itself no longer pulling (MYC-3175). Emit whichever fired, separated;
     # silent if none. Same hook, so SessionStart fan-out stays flat (MYC-2348).
     parts = [m for m in (_drift_message(), _skill_drift_message(),
-                         _stale_pull_message()) if m]
+                         _stale_pull_message(), _bypass_unreachable_message()) if m]
     _emit("\n\n".join(parts) if parts else None)
 
 

--- a/hooks/test_bypass_reachability_watchdog.py
+++ b/hooks/test_bypass_reachability_watchdog.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+"""Class watchdog: a Bash-command gate that honors a `*_BYPASS` env var MUST
+also consult the COMMAND STRING for that bypass.
+
+WHY THIS EXISTS
+----------------
+A PreToolUse(Bash) gate runs in the HOOK process, whose environment is the
+Claude Code SESSION env. An inline `VAR=1 <cmd>` prefix a user or agent types
+lives only in the command STRING and never reaches os.environ. A gate that
+advertises an inline bypass in its own block message but reads only
+os.environ is offering an escape hatch that can never fire -- a permanent
+block with a fake exit, which trains people to disable the guard some other
+way instead of using the one it names. Bug class
+HOOK-READS-SESSION-ENV-NOT-COMMAND-ENV.
+
+FOUR THINGS THIS FILE PROVES, IN ORDER
+----------------------------------------
+1. The SCANNER (hooks/_lib/bypass_scan.py) detects BOTH shapes a violation
+   can take: the bypass name spelled as a literal string, and the bypass
+   name hoisted into a module constant. Only the literal shape was checkable
+   until this scanner shipped; a scanner that only saw literals would have
+   missed 2 of the 5 real violators this repo shipped (check-py-import-
+   precommit.py and session-lock.py both hoist BYPASS_ENV into a constant).
+2. The CI WATCHDOG: this repo's own tracked hooks/ dir, scanned for real,
+   must come back with zero violators. This is the assertion that fails the
+   build if a new PreToolUse(Bash) bypass hook ever ships the broken shape.
+3. FLEET PROOF: for each hook this change fixed, the exact real invocation
+   (subprocess + stdin JSON, matching how Claude Code actually calls a hook)
+   still blocks/warns with no bypass present, and now also allows/quiets
+   with the inline `VAR=1 <cmd>` prefix -- never only the session-env form.
+4. The SessionStart SURFACER (surface-bypass-unreachable.py) correctly
+   reports a violator in a fixture "deployed hooks" directory, stays silent
+   on a clean one, and stays silent when the directory does not exist.
+
+check-py-import-precommit.py and session-lock.py are ALSO covered end-to-end
+(both bypass forms, against real git-repo fixtures with a live sibling /
+staged F821) in tests/integration/test_session_coordination_guards.sh --
+extended there instead of duplicated here, since that file already builds
+the fixtures both hooks need.
+
+Run: python3 hooks/test_bypass_reachability_watchdog.py   (pure stdlib)
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(_HERE, "_lib"))
+from bypass_scan import (  # noqa: E402  (shared with the SessionStart surfacer)
+    consults_command,
+    reads_bypass_env,
+    scan_hooks,
+)
+
+# Hooks intentionally exempt from the "must consult command" rule, each with
+# a reason. Keep this SMALL -- an exemption is a documented decision, not a
+# dodge.
+EXEMPT = frozenset({
+    # (none today -- every Bash-gate bypass hook in this repo consults the
+    #  command as of the change that added this watchdog.)
+})
+
+_fails = []
+
+
+def check(name, cond):
+    print(f"  {'PASS' if cond else 'FAIL'} {name}")
+    if not cond:
+        _fails.append(name)
+
+
+def _run(hook_path, payload, env_extra=None, cwd=None):
+    env = dict(os.environ)
+    for var in ("BRANCH_SWITCH_BYPASS", "MCP_INLINE_SECRET_BYPASS",
+                "PRECOMMIT_F821_BYPASS", "SIBLING_SESSION_LOCK_BYPASS",
+                "CHAINED_STATE_CMD_BYPASS", "ABS_DEPLOYED_HOOKS_DIR"):
+        env.pop(var, None)
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        [sys.executable, hook_path], input=json.dumps(payload),
+        capture_output=True, text=True, env=env, cwd=cwd, timeout=30,
+    )
+
+
+def _load(basename, modname):
+    path = os.path.join(_HERE, basename)
+    spec = importlib.util.spec_from_file_location(modname, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# 1. Detection-shape unit tests, on synthetic in-memory source. Fast, no I/O.
+# ---------------------------------------------------------------------------
+
+def test_reads_bypass_env_literal_shape():
+    src = 'if os.environ.get("FOO_BYPASS") == "1":\n    return 0\n'
+    check("literal os.environ.get(\"...BYPASS\") is detected",
+          reads_bypass_env(src) is True)
+
+
+def test_reads_bypass_env_constant_shape():
+    # The shape that was INVISIBLE before this scanner's constant-detection
+    # path existed: the name lives in a variable, not a string literal at
+    # the read site. This is exactly how check-py-import-precommit.py and
+    # session-lock.py spell their bypass.
+    src = ('BYPASS_ENV = "FOO_BYPASS"\n'
+           'if os.environ.get(BYPASS_ENV) == "1":\n    return 0\n')
+    check("constant-hoisted os.environ.get(BYPASS_ENV) is detected",
+          reads_bypass_env(src) is True)
+
+
+def test_reads_bypass_env_ignores_unrelated_constants():
+    # A constant that does NOT end in ...BYPASS, or one never passed to
+    # os.environ.get/[, must not false-positive.
+    src = ('OTHER = "FOO_BYPASS"\n'
+           'TIMEOUT = 30\n'
+           'if os.environ.get(TIMEOUT) == "1":\n    return 0\n')
+    check("unrelated constant does not false-positive",
+          reads_bypass_env(src) is False)
+
+
+def test_consults_command_shapes():
+    check("inline_bypass( call -> consults",
+          consults_command('x = inline_bypass(cmd, "V")') is True)
+    check("_inline_bypass( local-copy call -> consults (substring match)",
+          consults_command('x = _inline_bypass(cmd, "V")') is True)
+    check("leading_env_assigns( call -> consults",
+          consults_command('x = leading_env_assigns(cmd)') is True)
+    check("cmd_env import -> consults",
+          consults_command('from cmd_env import inline_bypass') is True)
+    check("segment_bypass_flags( call -> consults",
+          consults_command('x = segment_bypass_flags(segs, "V")') is True)
+    check("no consult marker -> does not consult",
+          consults_command('x = os.environ.get("V")') is False)
+
+
+# ---------------------------------------------------------------------------
+# 2. scan_hooks() end to end, over real planted fixture files (never the
+#    live repo tree for this test -- that is test_ci_self_scan below).
+#    Requires REQUIRED CONTROL 1 (literal violator), REQUIRED CONTROL 2
+#    (constant-spelling violator), and the POSITIVE (consults -> clean).
+# ---------------------------------------------------------------------------
+
+_VIOLATOR_LITERAL = '''\
+import json, os, sys
+def main():
+    if os.environ.get("FOO_BYPASS") == "1":
+        return 0
+    payload = json.loads(sys.stdin.read())
+    if payload.get("tool_name") != "Bash":
+        return 0
+    command = payload.get("tool_input", {}).get("command", "")
+    return 2
+'''
+
+_VIOLATOR_CONST = '''\
+import json, os, sys
+BYPASS_ENV = "FOO_BYPASS"
+def main():
+    if os.environ.get(BYPASS_ENV) == "1":
+        return 0
+    payload = json.loads(sys.stdin.read())
+    if payload.get("tool_name") != "Bash":
+        return 0
+    command = payload.get("tool_input", {}).get("command", "")
+    return 2
+'''
+
+_CLEAN_HOOK = '''\
+import json, os, sys
+sys.path.insert(0, "_lib")
+from cmd_env import inline_bypass
+def main():
+    payload = json.loads(sys.stdin.read())
+    if payload.get("tool_name") != "Bash":
+        return 0
+    command = payload.get("tool_input", {}).get("command", "")
+    if os.environ.get("FOO_BYPASS") == "1" or inline_bypass(command, "FOO_BYPASS"):
+        return 0
+    return 2
+'''
+
+_NOT_A_GATE = '''\
+import os
+def main():
+    if os.environ.get("FOO_BYPASS") == "1":
+        return
+    print("session start stuff, no tool_input/command/Bash here")
+'''
+
+
+def test_scan_hooks_fixture_dir():
+    with tempfile.TemporaryDirectory() as tmp:
+        (Path(tmp) / "violator-literal.py").write_text(_VIOLATOR_LITERAL)
+        (Path(tmp) / "violator-const.py").write_text(_VIOLATOR_CONST)
+        (Path(tmp) / "clean-hook.py").write_text(_CLEAN_HOOK)
+        (Path(tmp) / "not-a-gate.py").write_text(_NOT_A_GATE)
+        # Same content as the literal violator, but a test_ prefix: must be
+        # skipped by scan_hooks regardless of what it contains.
+        (Path(tmp) / "test_violator-literal.py").write_text(_VIOLATOR_LITERAL)
+
+        enforce, violators = scan_hooks(tmp)
+
+        check("REQUIRED CONTROL 1 (negative, literal): "
+              "violator-literal.py is caught",
+              "violator-literal.py" in violators)
+        check("REQUIRED CONTROL 2 (negative, constant spelling): "
+              "violator-const.py is caught",
+              "violator-const.py" in violators)
+        check("POSITIVE: clean-hook.py (consults command) is enforce, "
+              "not a violator",
+              "clean-hook.py" in enforce and "clean-hook.py" not in violators)
+        check("not-a-gate.py (no tool_input/command) is excluded entirely",
+              "not-a-gate.py" not in enforce)
+        check("test_*.py is skipped even when its content is a violator",
+              "test_violator-literal.py" not in enforce)
+        check("exactly the 2 planted violators, nothing else",
+              set(violators) == {"violator-literal.py", "violator-const.py"})
+        check("exactly the 3 planted Bash-gate bypass hooks are enforce",
+              set(enforce) == {"violator-literal.py", "violator-const.py",
+                               "clean-hook.py"})
+
+
+def test_scan_hooks_never_raises_on_unreadable():
+    with tempfile.TemporaryDirectory() as tmp:
+        # A directory named *.py is not a regular file; safe_read_text must
+        # report it unreadable and scan_hooks must skip it, not raise.
+        (Path(tmp) / "not-really-a-file.py").mkdir()
+        try:
+            enforce, violators = scan_hooks(tmp)
+            ok = enforce == [] and violators == []
+        except Exception as exc:  # pragma: no cover - the failure this proves
+            ok = False
+            print(f"    scan_hooks raised: {exc!r}")
+        check("scan_hooks never raises on an unreadable entry", ok)
+
+
+# ---------------------------------------------------------------------------
+# 3. THE CI WATCHDOG: this repo's own tracked hooks/, scanned for real.
+# ---------------------------------------------------------------------------
+
+def test_no_bash_gate_reads_bypass_without_consulting_command():
+    enforce, violators = scan_hooks(_HERE, exempt=EXEMPT)
+
+    print(f"  enforce set ({len(enforce)} Bash-gate bypass hooks): {enforce}")
+    check("at least 10 known Bash-gate bypass hooks are in scope (guard is live)",
+          len(enforce) >= 10)
+    check("every Bash-gate bypass hook in this repo consults the command "
+          "for its bypass",
+          not violators)
+    if violators:
+        print("    VIOLATORS (read bypass from os.environ only, never the "
+              "command):")
+        for v in violators:
+            print(f"      - {v}  -> wire `from cmd_env import inline_bypass` "
+                  "(hooks/_lib/cmd_env.py) and check "
+                  "`os.environ.get(VAR) == '1' or inline_bypass(cmd, VAR)`")
+
+
+# ---------------------------------------------------------------------------
+# 4. FLEET PROOF -- the exact real invocation shape, per fixed hook.
+#    check-py-import-precommit.py and session-lock.py are covered against
+#    real git-repo fixtures in
+#    tests/integration/test_session_coordination_guards.sh instead of here.
+# ---------------------------------------------------------------------------
+
+def test_mcp_inline_secret_fleet():
+    hook = os.path.join(_HERE, "block-claude-mcp-inline-secret.py")
+    secret_cmd = "claude mcp add x --env KEY=sk-ant-AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHHIIII"
+
+    r = _run(hook, {"tool_name": "Bash", "tool_input": {"command": secret_cmd}})
+    check("mcp-secret: secret add BLOCKS with no bypass (negative control)",
+          r.returncode == 2 and "BLOCKED" in r.stderr)
+
+    r = _run(hook, {"tool_name": "Bash",
+                    "tool_input": {"command": "MCP_INLINE_SECRET_BYPASS=1 " + secret_cmd}})
+    check("mcp-secret: inline prefix ALLOWS (rc 0, no BLOCKED)",
+          r.returncode == 0 and "BLOCKED" not in r.stderr)
+
+    r = _run(hook, {"tool_name": "Bash", "tool_input": {"command": secret_cmd}},
+             env_extra={"MCP_INLINE_SECRET_BYPASS": "1"})
+    check("mcp-secret: session env still ALLOWS (pre-existing path unbroken)",
+          r.returncode == 0)
+
+
+def test_chained_state_command_fleet():
+    hook = os.path.join(_HERE, "warn-chained-state-command-truncated.py")
+    # Detector C: a verification-gate command piped to tail, with its exit
+    # status then read back via bare $? -- always the pager's status, never
+    # the gate's. This hook never blocks (always exit 0); the SIGNAL is
+    # whether it prints an advisory at all.
+    risky_cmd = "ci-test 2>&1 | tail -80; echo $?"
+
+    r = _run(hook, {"tool_name": "Bash", "tool_input": {"command": risky_cmd}})
+    check("chained-state: fires (prints an advisory) with no bypass "
+          "(negative control)",
+          r.returncode == 0 and "permissionDecisionReason" in r.stdout)
+
+    r = _run(hook, {"tool_name": "Bash",
+                    "tool_input": {"command": "CHAINED_STATE_CMD_BYPASS=1 " + risky_cmd}})
+    check("chained-state: inline prefix silences it (empty stdout, rc 0)",
+          r.returncode == 0 and r.stdout.strip() == "")
+
+    r = _run(hook, {"tool_name": "Bash", "tool_input": {"command": risky_cmd}},
+             env_extra={"CHAINED_STATE_CMD_BYPASS": "1"})
+    check("chained-state: session env still silences it (pre-existing path "
+          "unbroken)",
+          r.returncode == 0 and r.stdout.strip() == "")
+
+
+def test_branch_switch_bypass_predicate():
+    # Function-level: this hook's block path needs a real "module in flight"
+    # git fixture to reach (find_modules_in_flight scans working-tree
+    # status), so exercise the fixed predicate directly -- the same
+    # narrow-unit approach block-branch-switch already uses for the rest of
+    # its logic (there is no hooks/test_*.py for this hook yet; this is its
+    # first test surface).
+    mod = _load("block-branch-switch-with-untracked-build.py", "bsw_under_test")
+    check("branch-switch: no bypass present -> False",
+          mod._bypass("git checkout main") is False)
+    check("branch-switch: inline BRANCH_SWITCH_BYPASS=1 prefix -> True",
+          mod._bypass("BRANCH_SWITCH_BYPASS=1 git checkout main") is True)
+    check("branch-switch: a quoted/non-leading token is not a bypass",
+          mod._bypass("echo 'BRANCH_SWITCH_BYPASS=1' && git checkout main") is False)
+    saved = os.environ.pop("BRANCH_SWITCH_BYPASS", None)
+    try:
+        os.environ["BRANCH_SWITCH_BYPASS"] = "1"
+        check("branch-switch: session env still bypasses",
+              mod._bypass("git checkout main") is True)
+    finally:
+        os.environ.pop("BRANCH_SWITCH_BYPASS", None)
+        if saved is not None:
+            os.environ["BRANCH_SWITCH_BYPASS"] = saved
+
+
+def test_branch_switch_end_to_end_with_real_repo():
+    # The full real invocation: a git repo with a genuine "module in flight"
+    # (3+ untracked source files under one 2-segment dir), gated via a
+    # dangerous `git checkout` naming the repo with `-C`.
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = Path(tmp) / "repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        subprocess.run(["git", "-c", "user.email=t@t", "-c", "user.name=t",
+                        "commit", "--allow-empty", "-q", "-m", "x"],
+                       cwd=repo, check=True)
+        voice = repo / "src" / "voice"
+        voice.mkdir(parents=True)
+        for name in ("a.py", "b.py", "c.py"):
+            (voice / name).write_text("# untracked\n")
+
+        hook = os.path.join(_HERE, "block-branch-switch-with-untracked-build.py")
+        cmd = f"git -C {repo} checkout main"
+
+        r = _run(hook, {"tool_name": "Bash", "tool_input": {"command": cmd}})
+        blocked = json.loads(r.stdout or "{}").get(
+            "hookSpecificOutput", {}).get("permissionDecision") == "deny"
+        check("branch-switch e2e: module-in-flight + checkout BLOCKS "
+              "(negative control)", blocked)
+
+        r = _run(hook, {"tool_name": "Bash",
+                        "tool_input": {"command": f"BRANCH_SWITCH_BYPASS=1 {cmd}"}})
+        allowed = json.loads(r.stdout or "{}").get("hookSpecificOutput") is None
+        check("branch-switch e2e: inline prefix ALLOWS", allowed)
+
+
+# ---------------------------------------------------------------------------
+# 5. The SessionStart SURFACER over a fixture "deployed hooks" directory.
+# ---------------------------------------------------------------------------
+
+def test_surfacer_reports_violator_and_stays_quiet_when_clean():
+    surfacer = os.path.join(_HERE, "surface-bypass-unreachable.py")
+    with tempfile.TemporaryDirectory() as tmp:
+        (Path(tmp) / "violator-literal.py").write_text(_VIOLATOR_LITERAL)
+        (Path(tmp) / "clean-hook.py").write_text(_CLEAN_HOOK)
+
+        r = _run(surfacer, {}, env_extra={"ABS_DEPLOYED_HOOKS_DIR": tmp})
+        out = json.loads(r.stdout or "{}")
+        ctx = out.get("hookSpecificOutput", {}).get("additionalContext", "")
+        check("surfacer: reports the deployed violator by name",
+              r.returncode == 0 and "violator-literal.py" in ctx)
+
+        (Path(tmp) / "violator-literal.py").unlink()
+        r = _run(surfacer, {}, env_extra={"ABS_DEPLOYED_HOOKS_DIR": tmp})
+        check("surfacer: silent once the deployed dir is clean",
+              r.returncode == 0 and json.loads(r.stdout or "{}") == {})
+
+        missing = os.path.join(tmp, "does-not-exist")
+        r = _run(surfacer, {}, env_extra={"ABS_DEPLOYED_HOOKS_DIR": missing})
+        check("surfacer: silent when the deployed hooks dir does not exist "
+              "(fresh install)",
+              r.returncode == 0 and json.loads(r.stdout or "{}") == {})
+
+
+def test_wired_via_surface_deployed_hooks_behind():
+    # THE ACTUAL ACTIVATED SURFACE. surface-bypass-unreachable.py has no
+    # SessionStart entry of its own -- SessionStart was already at its
+    # footprint-SLA cap (19/19; scripts/footprint-sla-check.py --gate), the
+    # exact situation TEMPLATE_ONLY documents for surface-stalled-git-
+    # operation.py and surface-sync-guard-findings.py in scripts/
+    # check-hook-activation.py. Same fix: it ships as a report BUILDER
+    # (build_message) that an ALREADY-WIRED SessionStart hook calls at its
+    # existing emission point. If this integration is missing, the scanner
+    # and the standalone-invocation tests above are correct but DEAD --
+    # nothing in a real session ever calls them.
+    mod = _load("surface-deployed-hooks-behind.py", "sdb_under_test")
+    with tempfile.TemporaryDirectory() as tmp:
+        (Path(tmp) / "violator-literal.py").write_text(_VIOLATOR_LITERAL)
+        saved = os.environ.get("ABS_DEPLOYED_HOOKS_DIR")
+        os.environ["ABS_DEPLOYED_HOOKS_DIR"] = tmp
+        try:
+            msg = mod._bypass_unreachable_message()
+        finally:
+            if saved is None:
+                os.environ.pop("ABS_DEPLOYED_HOOKS_DIR", None)
+            else:
+                os.environ["ABS_DEPLOYED_HOOKS_DIR"] = saved
+        check("surface-deployed-hooks-behind.py reports the deployed "
+              "violator via _bypass_unreachable_message() (the real, wired "
+              "SessionStart path, not just the standalone module)",
+              bool(msg) and "violator-literal.py" in (msg or ""))
+
+
+if __name__ == "__main__":
+    for fn in sorted((v for k, v in globals().items() if k.startswith("test_")),
+                     key=lambda f: f.__name__):
+        print(fn.__name__)
+        fn()
+    print()
+    if _fails:
+        print(f"FAILED ({len(_fails)}): {_fails}")
+        sys.exit(1)
+    print("ALL PASS")
+    sys.exit(0)

--- a/hooks/test_bypass_reachability_watchdog.py
+++ b/hooks/test_bypass_reachability_watchdog.py
@@ -136,12 +136,30 @@ def test_consults_command_shapes():
           consults_command('x = _inline_bypass(cmd, "V")') is True)
     check("leading_env_assigns( call -> consults",
           consults_command('x = leading_env_assigns(cmd)') is True)
-    check("cmd_env import -> consults",
-          consults_command('from cmd_env import inline_bypass') is True)
+    check("cmd_env.inline_bypass( attribute-call -> consults",
+          consults_command('x = cmd_env.inline_bypass(cmd, "V")') is True)
     check("segment_bypass_flags( call -> consults",
           consults_command('x = segment_bypass_flags(segs, "V")') is True)
     check("no consult marker -> does not consult",
           consults_command('x = os.environ.get("V")') is False)
+    # REQUIRED CONTROL 3: a bare import with no call site does NOT consult.
+    # Proven live, not merely reasoned about: a fixed hook's `or
+    # inline_bypass(cmd, VAR)` call was reverted to os.environ-only while its
+    # `from cmd_env import inline_bypass` line stayed in place, and the
+    # pre-tightening scanner read the bare mention as "consults" -- reporting
+    # a live regression as clean.
+    check("bare 'from cmd_env import inline_bypass' with no call -> does NOT "
+          "consult (the shape a real regression left behind)",
+          consults_command('from cmd_env import inline_bypass') is False)
+    # REQUIRED CONTROL 4: the fallback DEFINITION every real caller in this
+    # repo ships (`def inline_bypass(...): return False`, used when _lib is
+    # unreachable) must not itself read as a call. Also proven live: the
+    # same regression's still-present fallback `def inline_bypass(...)` line
+    # satisfied a call-shaped regex that did not exclude `def `.
+    check("'def inline_bypass(...)' fallback definition -> does NOT consult",
+          consults_command(
+              'def inline_bypass(command, var, value="1"):\n'
+              '    return False') is False)
 
 
 # ---------------------------------------------------------------------------

--- a/hooks/test_bypass_reachability_watchdog.py
+++ b/hooks/test_bypass_reachability_watchdog.py
@@ -86,6 +86,7 @@ def _run(hook_path, payload, env_extra=None, cwd=None):
     return subprocess.run(
         [sys.executable, hook_path], input=json.dumps(payload),
         capture_output=True, text=True, env=env, cwd=cwd, timeout=30,
+        encoding="utf-8", errors="replace",
     )
 
 
@@ -200,13 +201,13 @@ def main():
 
 def test_scan_hooks_fixture_dir():
     with tempfile.TemporaryDirectory() as tmp:
-        (Path(tmp) / "violator-literal.py").write_text(_VIOLATOR_LITERAL)
-        (Path(tmp) / "violator-const.py").write_text(_VIOLATOR_CONST)
-        (Path(tmp) / "clean-hook.py").write_text(_CLEAN_HOOK)
-        (Path(tmp) / "not-a-gate.py").write_text(_NOT_A_GATE)
+        (Path(tmp) / "violator-literal.py").write_text(_VIOLATOR_LITERAL, encoding="utf-8")
+        (Path(tmp) / "violator-const.py").write_text(_VIOLATOR_CONST, encoding="utf-8")
+        (Path(tmp) / "clean-hook.py").write_text(_CLEAN_HOOK, encoding="utf-8")
+        (Path(tmp) / "not-a-gate.py").write_text(_NOT_A_GATE, encoding="utf-8")
         # Same content as the literal violator, but a test_ prefix: must be
         # skipped by scan_hooks regardless of what it contains.
-        (Path(tmp) / "test_violator-literal.py").write_text(_VIOLATOR_LITERAL)
+        (Path(tmp) / "test_violator-literal.py").write_text(_VIOLATOR_LITERAL, encoding="utf-8")
 
         enforce, violators = scan_hooks(tmp)
 
@@ -356,7 +357,7 @@ def test_branch_switch_end_to_end_with_real_repo():
         voice = repo / "src" / "voice"
         voice.mkdir(parents=True)
         for name in ("a.py", "b.py", "c.py"):
-            (voice / name).write_text("# untracked\n")
+            (voice / name).write_text("# untracked\n", encoding="utf-8")
 
         hook = os.path.join(_HERE, "block-branch-switch-with-untracked-build.py")
         cmd = f"git -C {repo} checkout main"
@@ -380,8 +381,8 @@ def test_branch_switch_end_to_end_with_real_repo():
 def test_surfacer_reports_violator_and_stays_quiet_when_clean():
     surfacer = os.path.join(_HERE, "surface-bypass-unreachable.py")
     with tempfile.TemporaryDirectory() as tmp:
-        (Path(tmp) / "violator-literal.py").write_text(_VIOLATOR_LITERAL)
-        (Path(tmp) / "clean-hook.py").write_text(_CLEAN_HOOK)
+        (Path(tmp) / "violator-literal.py").write_text(_VIOLATOR_LITERAL, encoding="utf-8")
+        (Path(tmp) / "clean-hook.py").write_text(_CLEAN_HOOK, encoding="utf-8")
 
         r = _run(surfacer, {}, env_extra={"ABS_DEPLOYED_HOOKS_DIR": tmp})
         out = json.loads(r.stdout or "{}")
@@ -414,7 +415,7 @@ def test_wired_via_surface_deployed_hooks_behind():
     # nothing in a real session ever calls them.
     mod = _load("surface-deployed-hooks-behind.py", "sdb_under_test")
     with tempfile.TemporaryDirectory() as tmp:
-        (Path(tmp) / "violator-literal.py").write_text(_VIOLATOR_LITERAL)
+        (Path(tmp) / "violator-literal.py").write_text(_VIOLATOR_LITERAL, encoding="utf-8")
         saved = os.environ.get("ABS_DEPLOYED_HOOKS_DIR")
         os.environ["ABS_DEPLOYED_HOOKS_DIR"] = tmp
         try:

--- a/hooks/warn-chained-state-command-truncated.py
+++ b/hooks/warn-chained-state-command-truncated.py
@@ -53,6 +53,16 @@ except Exception:  # pragma: no cover - telemetry is never load-bearing
     def log_fire(*_a, **_k):
         return
 
+# Inline-bypass consult: os.environ can't see a `CHAINED_STATE_CMD_BYPASS=1
+# <cmd>` prefix that lives only in the command string, never the hook's own
+# env (HOOK-READS-SESSION-ENV-NOT-COMMAND-ENV). Fail-open to env-only if the
+# shared helper is unavailable.
+try:
+    from cmd_env import inline_bypass
+except Exception:
+    def inline_bypass(command, var, value="1"):  # type: ignore
+        return False
+
 # State-changing commands whose success cannot be inferred from a truncated tail.
 STATE_CMD = re.compile(
     r"\bgit\s+commit\b|\bgit\s+push\b|\bgh\s+pr\s+create\b|\bgh\s+pr\s+merge\b"
@@ -87,9 +97,6 @@ STATUS_READ_OK = re.compile(r"\$\{pipestatus\[1\]\}|pipefail")
 
 
 def main() -> None:
-    if os.environ.get("CHAINED_STATE_CMD_BYPASS") == "1":
-        log_fire("warn-chained-state-command-truncated", status="bypassed")
-        sys.exit(0)
     try:
         data = json.load(sys.stdin)
     except Exception:
@@ -101,6 +108,12 @@ def main() -> None:
     if isinstance(tin, dict):
         cmd = str(tin.get("command", ""))
     if not cmd:
+        sys.exit(0)
+
+    if os.environ.get("CHAINED_STATE_CMD_BYPASS") == "1" or inline_bypass(
+        cmd, "CHAINED_STATE_CMD_BYPASS"
+    ):
+        log_fire("warn-chained-state-command-truncated", status="bypassed")
         sys.exit(0)
 
     if not TRUNCATE.search(cmd):

--- a/scripts/check-hook-activation.py
+++ b/scripts/check-hook-activation.py
@@ -95,6 +95,17 @@ TEMPLATE_ONLY: Dict[str, str] = {
     "check_fab_shim.py":
         "not a hook: an import shim so tests can load the hyphenated guard "
         "module (hyphens are not importable identifiers).",
+    "surface-bypass-unreachable.py":
+        "not a hook: a report BUILDER (build_message) called by "
+        "surface-deployed-hooks-behind.py's _bypass_unreachable_message(), "
+        "plus a standalone main()/CLI carrying its own end-to-end test "
+        "(hooks/test_bypass_reachability_watchdog.py). Deliberately "
+        "unwired for the same reason as surface-stalled-git-operation.py "
+        "above -- SessionStart is at its 19/19 footprint-SLA cap "
+        "(scripts/footprint-sla-check.py --gate), and buying budget for "
+        "one more cold start would hide the cost that gate exists to "
+        "surface. Checkable: grep _bypass_unreachable_message "
+        "hooks/surface-deployed-hooks-behind.py",
     "surface-sync-guard-findings.py":
         "not a hook: a report BUILDER (build_report) called by "
         "worktree-footprint-signal.py at its single emission point, plus a "

--- a/scripts/check-hook-negative-control.py
+++ b/scripts/check-hook-negative-control.py
@@ -117,7 +117,6 @@ NO_TEST_BASELINE: Set[str] = {
     "block-secret-in-note",
     # -- correctness / process guards --
     "agent-briefing-check",
-    "block-branch-switch-with-untracked-build",
     "check-rule-conflicts-on-write",
     "session-turn-counter",
     "snapshot-pending-work-on-stop",
@@ -154,7 +153,7 @@ NO_TEST_BASELINE: Set[str] = {
 # 0. Same appendable-suppression-list hole as scripts/check-hook-activation.py
 # (fixed there in the same change). Amnesty ratchets DOWN, never up; raising
 # this number is a deliberate, reviewable act.
-NO_TEST_MAX = 28
+NO_TEST_MAX = 26
 
 
 def is_test_surface(path: Path) -> bool:

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1443,6 +1443,12 @@ PY_DIRECT=(
   # legs -- these guards sit in front of commands people run constantly, and the
   # fail-closed cwd SET is exactly the change that would start over-blocking.
   hooks/test_live_vault_git_guards_lead.py
+  # Class watchdog for the inline-bypass-REACHABILITY bug: a Bash-command
+  # gate that honors a `*_BYPASS` env var must also consult the COMMAND
+  # STRING for it (an inline `VAR=1 <cmd>` prefix lives only there, never in
+  # the hook's own os.environ). Scans this repo's own hooks/ for real and
+  # fleet-tests every hook the fix touched -- see the file's own docstring.
+  hooks/test_bypass_reachability_watchdog.py
 )
 dormant_py=()
 while IFS= read -r -d '' f; do

--- a/scripts/install-hooks-user-level.py
+++ b/scripts/install-hooks-user-level.py
@@ -179,6 +179,13 @@ ABS_FINGERPRINTS = [
     # operation is paused but never says one exists, so a stalled rebase freezes
     # every session silently (5 measured: MYC-3777/3451/3982/3781 + 2026-08-24).
     "ai-brain-starter/hooks/surface-stalled-git-operation.py",
+    # Inline-bypass-REACHABILITY report builder (build_message), called by
+    # surface-deployed-hooks-behind.py's _bypass_unreachable_message() at
+    # its existing SessionStart emission point -- not its own hooks.json
+    # entry (see scripts/check-hook-activation.py TEMPLATE_ONLY). Owned for
+    # the same reason as the "not a hook" builders above: uninstall/retire
+    # tracking, even though it is not independently wired.
+    "ai-brain-starter/hooks/surface-bypass-unreachable.py",
     # MCP secret-leak guards (MYC-3560). Written after three real GitHub PAT
     # leaks, shipped as working files, and never once registered -- the
     # protection everyone believed was in place did not exist. Same
@@ -289,6 +296,8 @@ ABS_OWNED_BASENAMES = {
     # skill-path copy, or the block fires twice on every git command.
     "block-git-mutation-mid-operation.py",
     "surface-stalled-git-operation.py",
+    # Inline-bypass-REACHABILITY report builder; see ABS_FINGERPRINTS above.
+    "surface-bypass-unreachable.py",
     # MCP secret-leak guards (MYC-3560): same basename-dedup reasoning as the
     # two gates above.
     "block-claude-mcp-inline-secret.py", "block-mcp-config-inline-secret.py",

--- a/scripts/utf8-file-io-baseline.txt
+++ b/scripts/utf8-file-io-baseline.txt
@@ -23,10 +23,9 @@
 #
 # <sha256-of-normalized-content> <tag> <repo-relative-path>
 
-# ---- SEV-A-write  (30 file(s)) ----
+# ---- SEV-A-write  (29 file(s)) ----
 b87ac14c241be51fb2427ac9a86ab8de4a5b161549f2ee0d445b6e9ca4f65550 SEV-A-write hooks/_lib/session_echo.test.py
 987aca2ae82229a42d29a8c89fed690e9de7e6fad4182dea564bc92557a81922 SEV-A-write hooks/auto-capture-public-ships.py
-9cbf3bb52c04fd00a41852d12baf7640f9212db9b5a34aaac2247ee6abb4312f SEV-A-write hooks/check-py-import-precommit.py
 a04ec6c84be6756813f4cde517ff379338b57ec9bf4c9c4172172951e62f91c3 SEV-A-write hooks/imessage-mcp-auto-export.py
 d293427274a02ef33d15ec50b17860aa305405adc9f372fde46a46454267becd SEV-A-write hooks/relocate-watch-surface.py
 95e98712d44f2ee71cdfb8ba3aa7a1fe21967160cd5b2bdaab20bd3d6869c10d SEV-A-write hooks/retry-budget.py

--- a/scripts/utf8-stdout-baseline.txt
+++ b/scripts/utf8-stdout-baseline.txt
@@ -103,7 +103,7 @@
 # ---- SEV-3-doc-only  (1 file(s)) ----
 ed1d68dba02ab76c99907e8efc27ac0aac8c98a14dad261da73fa5d8e1610369 SEV-3-doc-only hooks/_lib/template_purity.py
 
-# ---- SEV-4-json-encoded  (21 file(s)) ----
+# ---- SEV-4-json-encoded  (20 file(s)) ----
 e943857ef9482c097b4357ee8abf2e4ede3ffcab3b9bae3a1a0687b0ae371e2b SEV-4-json-encoded hooks/block-populated-public-skill.py
 73ec7598cd563971fcafc2542818e297df5ed045714d7b66263de949f4619093 SEV-4-json-encoded hooks/block-secret-in-note.py
 b647243fdf0a358d46a6a79b0bf7f817ee121f68d5d685fabe4b0ee2a93af94d SEV-4-json-encoded hooks/check-fabricated-hook-attribution.py

--- a/scripts/utf8-stdout-baseline.txt
+++ b/scripts/utf8-stdout-baseline.txt
@@ -104,7 +104,6 @@
 ed1d68dba02ab76c99907e8efc27ac0aac8c98a14dad261da73fa5d8e1610369 SEV-3-doc-only hooks/_lib/template_purity.py
 
 # ---- SEV-4-json-encoded  (21 file(s)) ----
-02627cdfcde451edc91149f9092154b2b846cb1a19d30f1f5ca01d66258791b2 SEV-4-json-encoded hooks/block-branch-switch-with-untracked-build.py
 e943857ef9482c097b4357ee8abf2e4ede3ffcab3b9bae3a1a0687b0ae371e2b SEV-4-json-encoded hooks/block-populated-public-skill.py
 73ec7598cd563971fcafc2542818e297df5ed045714d7b66263de949f4619093 SEV-4-json-encoded hooks/block-secret-in-note.py
 b647243fdf0a358d46a6a79b0bf7f817ee121f68d5d685fabe4b0ee2a93af94d SEV-4-json-encoded hooks/check-fabricated-hook-attribution.py

--- a/scripts/utf8-subprocess-baseline.txt
+++ b/scripts/utf8-subprocess-baseline.txt
@@ -4,7 +4,6 @@
 # Fix by adding: encoding="utf-8", errors="replace"
 e2f343536da6ef508c45d335a9d2fbe9977f40aaa152f5c86913ddeb82f9c531 hooks/_lib/git_locks.py
 987aca2ae82229a42d29a8c89fed690e9de7e6fad4182dea564bc92557a81922 hooks/auto-capture-public-ships.py
-9cbf3bb52c04fd00a41852d12baf7640f9212db9b5a34aaac2247ee6abb4312f hooks/check-py-import-precommit.py
 25d963d25e1e2e6844a35133bbad1d0aad8d03de424e29d4a406a67cb1d4c1cb hooks/check-rule-conflicts-on-write.py
 85006d7e25f42ba787b2ce616bd1c71590c3990f89f3153a6f958156c93029ed hooks/coach-auto-prescribe-on-journal.py
 d68684b8659aee1c1acd10a40146f8fee77b3494df8122bd7f1a7e1e121784d4 hooks/create-dev-repo-checkpoint.py

--- a/tests/integration/test_session_coordination_guards.sh
+++ b/tests/integration/test_session_coordination_guards.sh
@@ -79,6 +79,15 @@ run_hook "$PY_HOOK" "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git s
 assert_rc "PY ignores non-commit command" 0
 run_hook "$PY_HOOK" "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m x\"},\"cwd\":\"$REPO\"}" PRECOMMIT_F821_BYPASS=1
 assert_rc "PY bypass env disables block" 0
+# Inline `VAR=1 <cmd>` prefix: os.environ can't see this, only the command
+# string can (HOOK-READS-SESSION-ENV-NOT-COMMAND-ENV). The prefix lives in
+# tool_input.command, not in the session env passed to run_hook.
+run_hook "$PY_HOOK" "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"PRECOMMIT_F821_BYPASS=1 git commit -m x\"},\"cwd\":\"$REPO\"}"
+if command -v ruff >/dev/null 2>&1; then
+  assert_rc "PY inline-prefix bypass disables block (ruff present)" 0
+else
+  assert_rc "PY inline-prefix bypass (ruff absent, already fail-open)" 0
+fi
 
 echo "=== session-lock.py (SessionStart + heartbeat) ==="
 # Isolate the per-session cache pointer (CACHE_DIR resolves under $HOME) so this
@@ -136,6 +145,11 @@ case "$ERR" in *BLOCKED*) ok "LOCK block message is BLOCKED" ;; *) bad "LOCK blo
 # 2. same commit + bypass -> allow.
 pt "git commit -m x" SIBLING_SESSION_LOCK_BYPASS=1
 assert_rc "LOCK PreToolUse bypass lets commit through" 0
+# 2b. same commit, inline `VAR=1 <cmd>` prefix instead of session env -> allow.
+# os.environ can't see this prefix (HOOK-READS-SESSION-ENV-NOT-COMMAND-ENV);
+# it only lives in tool_input.command, which `pt`'s $1 becomes verbatim.
+pt "SIBLING_SESSION_LOCK_BYPASS=1 git commit -m x"
+assert_rc "LOCK PreToolUse inline-prefix bypass lets commit through" 0
 # 3. non-git command -> one-time HEADS-UP (exit 2), sets the warned marker.
 pt "ls -la"
 assert_rc "LOCK PreToolUse heads-up once on read-only (exit 2)" 2


### PR DESCRIPTION
Ports the inline-bypass-REACHABILITY guard: a `PreToolUse(Bash)` gate that honors a `*_BYPASS` env var must also consult the COMMAND STRING for it. An inline `VAR=1 <cmd>` prefix lives only in the command, never in the hook process's own (session) env — a gate that reads `os.environ` only advertises a bypass that can never fire from the form its own block message names.

- `bypass_scan` (new, `hooks/_lib/`) — shared scanner. Detects a bypass read both as a string literal AND via a module-level constant (the shape that was invisible before today — 2 of the 5 real violators this repo shipped use it).
- `cmd_env.inline_bypass` (new, `hooks/_lib/`) — the helper `warn-journal-saved-without-context` and `warn-stale-dev-checkout` already try to import (`from cmd_env import inline_bypass`, with a local fallback) — the module did not exist yet, so both were silently degrading to their fallback on every run. Thin wrapper over the existing `shell_parse.leading_env_assigns` primitive; no new command parser.
- `test_bypass_reachability_watchdog` (new, `hooks/`) — CI watchdog (scans this repo's own `hooks/` for real) + synthetic detection-shape unit tests + fleet proof (subprocess/function-level, block-without-bypass and allow-with-inline-prefix) for every hook this change fixed, plus the surfacer's own end-to-end test. Wired into `ci.sh`'s `PY_DIRECT`.
- `surface-bypass-unreachable` (new, `hooks/`) — SessionStart surfacer over the DEPLOYED `~/.claude/hooks` union (catches a hook from a different source repo, or hand-edited after install — this repo's CI can't see that). SessionStart was already at its footprint-SLA cap, so it ships as a report builder called from `surface-deployed-hooks-behind` at its existing emission point instead of buying a new SessionStart entry — same pattern already used for `surface-stalled-git-operation`.

Fixed the 5 real violators the scanner found in this repo's 12-hook enforce set (0 remain): `block-branch-switch-with-untracked-build`, `block-claude-mcp-inline-secret`, `check-py-import-precommit`, `session-lock`, `warn-chained-state-command-truncated`. The latter two are covered end-to-end against real git-repo fixtures (a live sibling, a staged F821 file) in `test_session_coordination_guards.sh`, extended rather than duplicated since that file already builds both fixtures.

Along the way, three stale content-pinned baseline rows surfaced by editing already-baselined files (console-guard, subprocess-decode, file-io baselines) — fixed the real gaps (UTF-8 console guard, explicit `encoding="utf-8"` on subprocess/file I/O) rather than re-pinning edited content into permanent exemption, per each checker's own instruction.

**Review-risky area:** `session-lock`'s `_pretooluse` gained one new early-return (`inline_bypass` check) ahead of its lock-acquire/heartbeat logic — same fail-open shape as the pre-existing session-env check in `main`, verified against a live-sibling fixture in `test_session_coordination_guards.sh` rather than reasoned about only.

Checked PR #642 (also touches `ci.sh`) via `git merge-tree` before pushing — no line-level conflict.

`bash scripts/ci.sh` (this repo's canonical local gate) is GREEN with a written marker: `py_compile` over every tracked file, all integration tests, all `scripts/`+`hooks/` unit suites, shellcheck, ruff, and every UTF-8/hook-activation/hook-parity/paired-implementation check passed.

Drafted with Claude Code; reviewed and verified locally before push.
