### PR TITLE
graphify: review Part A.5's typed edges instead of stranding them

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,20 @@ description: What's new in AI Brain Starter — plain English, no jargon
 
 ---
 
+## 2026-09-02: /graphify can now show you what its typed edges would do, before they do it
+
+**Who this affects:** anyone running `/graphify` on a vault with frontmatter and wikilinks — so, anyone whose graph is built from notes rather than code.
+
+There is a step in the graph build (Part A.5) that reads real relationships straight out of your notes: who attended what, who works where, which journal entry is about which person. It writes them to a file. Then nothing happens to that file. It exists only to stop the model re-deriving the same edges later, and the relationships never reach your graph.
+
+The obvious fix — merge them automatically — is the one thing that isn't safe. Node names in the graph are invented per entity while it builds, so a wikilink like `[[Duplicate]]` can land on no node, one node, or two different notes that happen to share a title. And four of the edge types are already in your graph pointing the other way: the build writes *person → journal entry*, while the raw reading of a wikilink is *journal entry → person*. Merging as-is wouldn't add relationships, it would argue with the ones already there.
+
+So there's a new Step 4b that writes a report instead. It sorts every edge into what it can resolve unambiguously, what's genuinely ambiguous and needs you to pick, and what points at notes that don't exist — the same read-it-then-apply-it shape as the wikilink gaps report you already get. It never writes to your graph. You read it and say which rows to apply.
+
+If a wikilink target shows up over and over under "dst not found", that's usually worth a look on its own: it means you keep linking to a note you never made.
+
+---
+
 ## 2026-09-01: the journal names your floor for you
 
 **Who this affects:** everyone who journals. This changes what the skill asks you at the end of an entry.

--- a/scripts/test_review_typed_edges.py
+++ b/scripts/test_review_typed_edges.py
@@ -91,7 +91,7 @@ def run_review(tmp: Path):
     proc = subprocess.run(
         [sys.executable, str(REVIEW), "--graph", str(graph_path),
          "--edges", str(edges_path), "--output", str(report_path)],
-        capture_output=True, text=True,
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
     )
     return proc, graph_path, report_path, before
 
@@ -148,7 +148,7 @@ def main() -> int:
             [sys.executable, str(REVIEW), "--graph", str(tmp / "nope.json"),
              "--edges", str(tmp / "graphify-out" / ".graphify_typed_edges.jsonl"),
              "--output", str(tmp / "out.md")],
-            capture_output=True, text=True,
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
         )
         check("missing graph exits non-zero", missing.returncode != 0)
         check("missing graph explains itself", "ERROR" in missing.stderr)
@@ -162,4 +162,10 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't crash.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
     sys.exit(main())

--- a/scripts/test_review_typed_edges.py
+++ b/scripts/test_review_typed_edges.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""
+Negative-control tests for graphify's typed-edges review report (Step 4b).
+
+Guards the bug class BLIND-MERGE-CORRUPTS-A-LIVE-GRAPH: Part A.5
+(wire_typed_relationships.py) computes real typed edges from frontmatter and
+wikilinks, but its output is only ever an LLM skip-list -- nothing merges it
+into graph.json. Two things make an automatic merge unsafe:
+
+1. Node IDs in graph.json are LLM-improvised per entity (Part B), not a
+   deterministic function of the file path. A wikilink's raw text can resolve
+   to zero, one, or several nodes.
+2. The four wikilink-derived types (mentions, journaled_about, attended,
+   investor_for) already exist in graph.json via Part B with an
+   entity -> document direction. Part A.5 reads them the other way
+   (document -> wikilink target), so merging as-emitted would contradict the
+   existing convention rather than extend it.
+
+review_typed_edges.py resolves what it safely can and buckets the rest for a
+human. These tests pin the two properties that make it safe to run on a vault:
+graph.json is never written, and only unambiguous, non-duplicate, correctly
+oriented edges reach the "ready to merge" bucket.
+
+Run: python3 scripts/test_review_typed_edges.py
+"""
+
+from __future__ import annotations  # PEP 604 annotations; gate pins Python 3.9
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPTS = REPO / "skills" / "graphify" / "scripts"
+REVIEW = SCRIPTS / "review_typed_edges.py"
+
+FAILURES = []
+
+
+def check(name, cond, detail=""):
+    print(f"  {'PASS' if cond else 'FAIL'}  {name}" + (f"  -- {detail}" if detail and not cond else ""))
+    if not cond:
+        FAILURES.append(name)
+
+
+GRAPH = {
+    "nodes": [
+        {"id": "ada_lovelace", "label": "Ada Lovelace", "source_file": "people/Ada Lovelace.md"},
+        {"id": "acme_corp", "label": "Acme Corp", "source_file": "companies/Acme Corp.md"},
+        {"id": "journal_entry", "label": "A Tuesday", "source_file": "journal/2026-01-05.md"},
+        {"id": "dup_one", "label": "Dup One", "source_file": "a/Duplicate.md"},
+        {"id": "dup_two", "label": "Dup Two", "source_file": "b/Duplicate.md"},
+        {"id": "meeting_note", "label": "Board Meeting", "source_file": "meetings/Board Meeting.md"},
+    ],
+    # Part B already wrote this one, in the entity -> document direction.
+    "links": [
+        {"source": "ada_lovelace", "target": "journal_entry", "relation": "journaled_about"},
+    ],
+}
+
+EDGES = [
+    # Already covered: Part A.5 emits document -> entity; after the flip this is
+    # exactly the link Part B already wrote.
+    {"src": "2026-01-05", "dst": "Ada Lovelace", "edge_type": "journaled_about", "confidence": "medium"},
+    # Ready, and must be flipped: wikilink-derived.
+    {"src": "Board Meeting", "dst": "Ada Lovelace", "edge_type": "attended", "confidence": "medium"},
+    # Ready, and must NOT be flipped: frontmatter-derived.
+    {"src": "Ada Lovelace", "dst": "Acme Corp", "edge_type": "works_at", "confidence": "high"},
+    # Ambiguous: two notes share the stem "Duplicate".
+    {"src": "Board Meeting", "dst": "Duplicate", "edge_type": "mentions", "confidence": "low"},
+    # dst has no node in the graph.
+    {"src": "Board Meeting", "dst": "Ghost Note", "edge_type": "mentions", "confidence": "low"},
+    # src has no node in the graph.
+    {"src": "Missing File", "dst": "Acme Corp", "edge_type": "mentions", "confidence": "low"},
+]
+
+
+def run_review(tmp: Path):
+    out = tmp / "graphify-out"
+    out.mkdir(parents=True, exist_ok=True)
+    graph_path = out / "graph.json"
+    edges_path = out / ".graphify_typed_edges.jsonl"
+    report_path = out / "TYPED_EDGES_REVIEW.md"
+
+    graph_path.write_text(json.dumps(GRAPH), encoding="utf-8")
+    edges_path.write_text("\n".join(json.dumps(e) for e in EDGES) + "\n", encoding="utf-8")
+    before = graph_path.read_bytes()
+
+    proc = subprocess.run(
+        [sys.executable, str(REVIEW), "--graph", str(graph_path),
+         "--edges", str(edges_path), "--output", str(report_path)],
+        capture_output=True, text=True,
+    )
+    return proc, graph_path, report_path, before
+
+
+def main() -> int:
+    print("review_typed_edges.py — negative controls")
+
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        proc, graph_path, report_path, before = run_review(tmp)
+
+        check("exits 0", proc.returncode == 0, proc.stderr.strip())
+        check("writes the report", report_path.is_file())
+
+        # The invariant the whole design rests on.
+        check("graph.json is byte-identical afterwards",
+              graph_path.read_bytes() == before,
+              "the review step wrote to the live graph")
+
+        report = report_path.read_text(encoding="utf-8") if report_path.is_file() else ""
+        stdout = proc.stdout
+
+        check("counts every bucket", all(
+            f"{name}: {n}" in stdout
+            for name, n in (("ready", 2), ("ambiguous", 1), ("duplicate", 1),
+                            ("dst_unresolved", 1), ("src_unresolved", 1))
+        ), stdout.strip())
+
+        # Direction: wikilink-derived flips, frontmatter-derived does not.
+        check("wikilink-derived edge is flipped to entity -> document",
+              "ada_lovelace -> meeting_note" in report,
+              "attended should resolve as entity -> document")
+        check("frontmatter-derived edge keeps its direction",
+              "ada_lovelace -> acme_corp" in report,
+              "works_at should stay src -> dst")
+        check("flip is disclosed in the report",
+              "direction flipped to match existing convention" in report)
+
+        # Nothing unsafe reaches "ready".
+        ready_section = report.split("## Ready to merge — sample")[-1].split("## Ambiguous")[0]
+        check("ambiguous target stays out of ready", "Duplicate" not in ready_section)
+        check("unresolved dst stays out of ready", "Ghost Note" not in ready_section)
+        check("unresolved src stays out of ready", "Missing File" not in ready_section)
+        check("edge already written by Part B is not re-listed as ready",
+              "journaled_about" not in ready_section,
+              "duplicate detection must run AFTER the direction flip")
+
+        # The ambiguous bucket has to show the human both candidates to pick from.
+        check("ambiguous row lists both candidate nodes",
+              "dup_one" in report and "dup_two" in report)
+
+        # Missing inputs fail loudly instead of writing a half-empty report.
+        missing = subprocess.run(
+            [sys.executable, str(REVIEW), "--graph", str(tmp / "nope.json"),
+             "--edges", str(tmp / "graphify-out" / ".graphify_typed_edges.jsonl"),
+             "--output", str(tmp / "out.md")],
+            capture_output=True, text=True,
+        )
+        check("missing graph exits non-zero", missing.returncode != 0)
+        check("missing graph explains itself", "ERROR" in missing.stderr)
+
+    print()
+    if FAILURES:
+        print(f"FAILED ({len(FAILURES)}): {', '.join(FAILURES)}")
+        return 1
+    print("All checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/graphify/SKILL.md
+++ b/skills/graphify/SKILL.md
@@ -234,6 +234,8 @@ Pattern source: [garrytan/gbrain](https://github.com/garrytan/gbrain) — zero-L
 
 If `graphify-out/.graphify_typed_edges.jsonl` exists after this step, Part B's dispatch must pass the path to each subagent so they honor the skip list. Cost savings only materialize if the skip list is honored — otherwise this pass just duplicates work.
 
+This JSONL is a skip list for Part B, nothing merges it into the graph automatically. After Step 4 builds `graph.json`, run Step 4b to generate a human-reviewable report of which of these edges can be safely merged.
+
 #### Part B - Semantic extraction (parallel subagents)
 
 **Fast path:** If detection found zero docs, papers, and images (code-only corpus), skip Part B entirely and go straight to Part C. AST handles code - there is nothing for semantic subagents to do.
@@ -563,6 +565,21 @@ python3 "{SKILL_DIR}/scripts/graphify_report_sanitize.py" graphify-out/GRAPH_REP
 If this step prints `ERROR: Graph is empty`, stop and tell the user what happened - do not proceed to labeling or visualization.
 
 Replace INPUT_PATH with the actual path.
+
+#### Step 4b - Review Part A.5's typed edges (if Part A.5 ran)
+
+Part A.5's typed edges are NOT auto-merged into `graph.json` — see the "Part A.5" section above for why: node IDs from Part B are LLM-improvised per entity (not a deterministic function of the source file), so a wikilink target can match zero, one, or several nodes, and the wikilink-derived edge types (`mentions`, `journaled_about`, `attended`, `investor_for`) already appear in `graph.json` via Part B with an entity-points-at-document direction that Part A.5's raw file-points-at-wikilink reading contradicts unless flipped. Blind-merging risks corrupting a graph the user relies on.
+
+If `graphify-out/.graphify_typed_edges.jsonl` exists, run the review script instead:
+
+```bash
+$(cat graphify-out/.graphify_python) "{SKILL_DIR}/scripts/review_typed_edges.py" \
+    --graph graphify-out/graph.json \
+    --edges graphify-out/.graphify_typed_edges.jsonl \
+    --output graphify-out/TYPED_EDGES_REVIEW.md
+```
+
+This resolves what it safely can (unique src/dst match, not already present, direction corrected for the wikilink types) into a "ready to merge" table, and buckets the rest as ambiguous / dst-not-found / src-not-found — mirroring the review-then-apply shape of `WIKILINK_GAPS.md`. Tell the user the report is ready and summarize the bucket counts; do not write anything into `graph.json` without the user reviewing `TYPED_EDGES_REVIEW.md` and saying which rows to apply.
 
 ### Step 5 - Label communities
 

--- a/skills/graphify/scripts/review_typed_edges.py
+++ b/skills/graphify/scripts/review_typed_edges.py
@@ -71,10 +71,15 @@ def _existing_pairs(graph: dict) -> set[tuple[str, str, str]]:
 def _load_jsonl(path: Path) -> list[dict]:
     edges = []
     with path.open(encoding="utf-8") as f:
-        for line in f:
+        for lineno, line in enumerate(f, start=1):
             line = line.strip()
-            if line:
+            if not line:
+                continue
+            try:
                 edges.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                print(f"ERROR: malformed edge at {path}:{lineno}: {exc}", file=sys.stderr)
+                sys.exit(2)
     return edges
 
 

--- a/skills/graphify/scripts/review_typed_edges.py
+++ b/skills/graphify/scripts/review_typed_edges.py
@@ -1,0 +1,218 @@
+"""Human-review report for graphify's typed-edges output (Part A.5).
+
+Part A.5 (``wire_typed_relationships.py``) computes real typed edges from
+frontmatter + wikilinks, but graphify's build pipeline never reads that
+output — it's only ever used as an LLM skip-list (see SKILL.md). This script
+does NOT auto-merge the data into graph.json. Two things make a blind merge
+unsafe on a real vault:
+
+1. Node IDs in graph.json are LLM-improvised per entity (Part B), not a
+   deterministic function of the file path — resolving a wikilink's raw text
+   to the right node needs a lookup, and some files produce more than one
+   entity node, so a file-stem match can be ambiguous.
+2. The existing wikilink-derived edge types (``mentions``, ``journaled_about``,
+   ``attended``, ``investor_for``) already appear in graph.json via Part B,
+   with a consistent direction: entity --relation--> document (the mentioned
+   thing points at what mentions it). Part A.5 naturally reads the other way
+   (document -> wikilink target). Merging without reversing would contradict
+   the existing convention instead of extending it.
+
+So this script resolves what it safely can, flags what it can't, and writes
+a Markdown report (``graphify-out/TYPED_EDGES_REVIEW.md``, same review-then-apply
+shape as graphify's own WIKILINK_GAPS.md) for a human to read before anything
+touches the live graph. Nothing here writes to graph.json.
+
+Usage:
+    python3 review_typed_edges.py [--graph graphify-out/graph.json]
+                                   [--edges graphify-out/.graphify_typed_edges.jsonl]
+                                   [--output graphify-out/TYPED_EDGES_REVIEW.md]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+# The four wikilink-derived types below are exactly the ones
+# wire_typed_relationships.py emits from wikilinks, and Part B already writes
+# them into graph.json with an entity->document direction. Part A.5 reads them
+# the other way (document -> wikilink target), so they get flipped here.
+# The frontmatter-derived types (works_at, floor_at, governs, created_on) have
+# no existing precedent in graph.json to contradict, so their direction is left
+# as Part A.5 emitted it (src->dst).
+_REVERSE_FOR_CONVENTION = {"mentions", "journaled_about", "attended", "investor_for"}
+
+_CONFIDENCE_MAP = {"high": ("EXTRACTED", 1.0), "medium": ("INFERRED", 0.6), "low": ("AMBIGUOUS", 0.3)}
+
+
+def _stem_index(graph: dict) -> dict[str, list[dict]]:
+    index: dict[str, list[dict]] = defaultdict(list)
+    for node in graph.get("nodes", []):
+        sf = node.get("source_file")
+        if not sf:
+            continue
+        stem = Path(sf).stem.lower()
+        index[stem].append(node)
+    return index
+
+
+def _existing_pairs(graph: dict) -> set[tuple[str, str, str]]:
+    pairs: set[tuple[str, str, str]] = set()
+    for link in graph.get("links", []):
+        s, t, r = link.get("source"), link.get("target"), link.get("relation")
+        if s and t and r:
+            pairs.add((s, t, r))
+    return pairs
+
+
+def _load_jsonl(path: Path) -> list[dict]:
+    edges = []
+    with path.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                edges.append(json.loads(line))
+    return edges
+
+
+def _classify(edges: list[dict], index: dict[str, list[dict]], existing: set) -> dict:
+    buckets: dict[str, list[dict]] = {
+        "ready": [], "ambiguous": [], "dst_unresolved": [], "src_unresolved": [], "duplicate": [],
+    }
+    for e in edges:
+        src_candidates = index.get(e["src"].lower(), [])
+        dst_candidates = index.get(e["dst"].lower(), [])
+
+        if not src_candidates:
+            buckets["src_unresolved"].append(e)
+            continue
+        if not dst_candidates:
+            buckets["dst_unresolved"].append(e)
+            continue
+        if len(src_candidates) > 1 or len(dst_candidates) > 1:
+            buckets["ambiguous"].append({**e, "_src_candidates": src_candidates, "_dst_candidates": dst_candidates})
+            continue
+
+        src_id = src_candidates[0]["id"]
+        dst_id = dst_candidates[0]["id"]
+        reverse = e["edge_type"] in _REVERSE_FOR_CONVENTION
+        final_source, final_target = (dst_id, src_id) if reverse else (src_id, dst_id)
+
+        if (final_source, final_target, e["edge_type"]) in existing:
+            buckets["duplicate"].append(e)
+            continue
+
+        conf_label, conf_score = _CONFIDENCE_MAP.get(e["confidence"], ("AMBIGUOUS", 0.3))
+        buckets["ready"].append({
+            **e,
+            "_final_source": final_source, "_final_target": final_target,
+            "_reversed": reverse, "_confidence_label": conf_label, "_confidence_score": conf_score,
+        })
+    return buckets
+
+
+def _write_report(buckets: dict, output: Path, total: int) -> None:
+    lines = []
+    lines.append("---")
+    lines.append("type: report")
+    lines.append("---")
+    lines.append("")
+    lines.append("# Typed Edges Review")
+    lines.append("")
+    lines.append(f"Part A.5 computed {total} typed edges. Nothing here has touched graph.json —")
+    lines.append("this is a review report only, matching graphify's own WIKILINK_GAPS.md pattern.")
+    lines.append("")
+    lines.append("| Bucket | Count | Meaning |")
+    lines.append("|---|---|---|")
+    lines.append(f"| Ready to merge | {len(buckets['ready'])} | Both endpoints resolve to exactly one node, not already in graph.json |")
+    lines.append(f"| Ambiguous | {len(buckets['ambiguous'])} | src or dst matches more than one node (same-titled files) — needs a human pick |")
+    lines.append(f"| Already covered | {len(buckets['duplicate'])} | Same edge (after direction fix) already exists via Part B |")
+    lines.append(f"| dst not found | {len(buckets['dst_unresolved'])} | Wikilink/frontmatter target has no matching note in the graph |")
+    lines.append(f"| src not found | {len(buckets['src_unresolved'])} | Source file has no node in the graph (renamed/moved/excluded since Part A.5 ran) |")
+    lines.append("")
+
+    by_type = Counter(e["edge_type"] for e in buckets["ready"])
+    if by_type:
+        lines.append("## Ready to merge, by type")
+        lines.append("")
+        for et, count in by_type.most_common():
+            reversed_note = " (direction flipped to match existing convention)" if et in _REVERSE_FOR_CONVENTION else ""
+            lines.append(f"- **{et}**: {count}{reversed_note}")
+        lines.append("")
+
+    lines.append("## Ready to merge — sample")
+    lines.append("")
+    lines.append("| src | dst | type | confidence | final edge (source -> target) |")
+    lines.append("|---|---|---|---|---|")
+    for e in buckets["ready"][:200]:
+        arrow = f"{e['_final_source']} -> {e['_final_target']}"
+        lines.append(f"| {e['src']} | {e['dst']} | {e['edge_type']} | {e['_confidence_label']} | {arrow} |")
+    if len(buckets["ready"]) > 200:
+        lines.append(f"| ... | ... | ... | ... | ({len(buckets['ready']) - 200} more, truncated) |")
+    lines.append("")
+
+    if buckets["ambiguous"]:
+        lines.append("## Ambiguous — needs a human pick")
+        lines.append("")
+        lines.append("| src | dst | type | src candidates | dst candidates |")
+        lines.append("|---|---|---|---|---|")
+        for e in buckets["ambiguous"][:100]:
+            src_ids = ", ".join(n["id"] for n in e["_src_candidates"])
+            dst_ids = ", ".join(n["id"] for n in e["_dst_candidates"])
+            lines.append(f"| {e['src']} | {e['dst']} | {e['edge_type']} | {src_ids} | {dst_ids} |")
+        if len(buckets["ambiguous"]) > 100:
+            lines.append(f"| ... | ... | ... | ... | ({len(buckets['ambiguous']) - 100} more, truncated) |")
+        lines.append("")
+
+    dst_gap = Counter(e["dst"] for e in buckets["dst_unresolved"])
+    if dst_gap:
+        lines.append("## dst not found — most frequent missing targets")
+        lines.append("")
+        lines.append("| target | times referenced |")
+        lines.append("|---|---|")
+        for target, count in dst_gap.most_common(40):
+            lines.append(f"| {target} | {count} |")
+        lines.append("")
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--graph", default="graphify-out/graph.json")
+    parser.add_argument("--edges", default="graphify-out/.graphify_typed_edges.jsonl")
+    parser.add_argument("--output", default="graphify-out/TYPED_EDGES_REVIEW.md")
+    args = parser.parse_args(argv)
+
+    graph_path = Path(args.graph).expanduser()
+    edges_path = Path(args.edges).expanduser()
+    output_path = Path(args.output).expanduser()
+
+    if not graph_path.is_file():
+        print(f"ERROR: graph not found: {graph_path}", file=sys.stderr)
+        return 2
+    if not edges_path.is_file():
+        print(f"ERROR: typed edges not found: {edges_path}", file=sys.stderr)
+        return 2
+
+    graph = json.loads(graph_path.read_text(encoding="utf-8"))
+    edges = _load_jsonl(edges_path)
+    index = _stem_index(graph)
+    existing = _existing_pairs(graph)
+    buckets = _classify(edges, index, existing)
+
+    _write_report(buckets, output_path, len(edges))
+
+    print(f"{len(edges)} typed edges reviewed:")
+    for name in ("ready", "ambiguous", "duplicate", "dst_unresolved", "src_unresolved"):
+        print(f"  {name}: {len(buckets[name])}")
+    print(f"report: {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Part A.5 (`wire_typed_relationships.py`) computes real typed edges from frontmatter and wikilinks, writes them to `.graphify_typed_edges.jsonl` — and nothing ever reads that file again except as an LLM skip-list. On a notes vault those are the most reliable relationships in the corpus (`attended`, `works_at`, `journaled_about`, `governs`), and none of them reach the graph.

## Why not just merge them

Two things make a blind merge unsafe, and both are properties of how graphify already works:

1. **Node IDs are LLM-improvised per entity in Part B**, not a deterministic function of the source path. A wikilink target can resolve to zero nodes, one node, or two notes that share a title.
2. **Four of the types already exist in `graph.json`, pointing the other way.** Part B writes `mentions` / `journaled_about` / `attended` / `investor_for` as entity → document. Part A.5 naturally reads document → wikilink target. Merging as emitted contradicts the existing convention rather than extending it.

So this doesn't merge. It reports.

## What this adds

- **Step 4b** in `SKILL.md`, after the graph build, plus one line at Part A.5 saying where the JSONL actually goes.
- **`skills/graphify/scripts/review_typed_edges.py`** — resolves what it safely can into a "ready to merge" table (unique src/dst match, not already present, direction corrected for the four wikilink types) and buckets the rest as ambiguous / already-covered / dst-not-found / src-not-found. Writes `TYPED_EDGES_REVIEW.md`, the same review-then-apply shape as `WIKILINK_GAPS.md`. **Never writes to `graph.json`.** Stdlib only.
- **`scripts/test_review_typed_edges.py`** — picked up by the `scripts/test_*.py` glob, so it can't go dormant.

The `dst not found` bucket turned out to be useful on its own: a target that keeps appearing there is a note you keep linking to and never wrote.

## Tests are negative controls

Emptying `_REVERSE_FOR_CONVENTION` fails 4 of the 14 checks, including the one that matters: an edge Part B already wrote stops being detected as a duplicate, so it would get re-merged backwards into the user's live graph. The suite also pins the invariant that `graph.json` is byte-identical after a run.

## Gate

`scripts/ci.sh` — `py_compile` clean, and all 33 `scripts/test_*.py` suites pass including the new one.

One unrelated pre-existing failure on this branch's base: `tests/integration/test_preflight_git_and_it_request.sh` fails identically on a clean `upstream/main` at 567eb67 (`IT-request block header missing when git is broken` — pattern `Copy-paste request for your IT team` not found). Untouched here, flagging it rather than fixing it in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)