### PR TITLE
fix(closing-signal): two Spanish accuracy fixes — relayed speech and a missed sign-off

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,24 @@ Obsidian's graph draws exactly one thing: links. An entry that records its floor
 
 This builds on the 2026-08-25 fix below, which taught the checker to find your floor notes folder in the first place — that fix found the notes, this one lets linked entries match them.
 
+---
+
+## 2026-08-25: asking Claude to pass on a message could end your session by mistake
+
+**Who this affects:** anyone working in Spanish who asks Claude to relay something — "dile a Ana que ya quedó", "avísale a Marta que listo", "contéstale que hasta luego".
+
+Spanish ends a session with short phrases: *ya quedó*, *listo*, *chao*, *hasta luego*. The detector looks for them at the end of what you type, which is the right place to look — until the phrase is not yours. When you ask Claude to tell someone *else* that something is done, your sentence still ends on *ya quedó*. You are quoting a message, not saying goodbye.
+
+The detector could not tell the two apart. Typing "dile a Ana que ya quedó" ran the whole close cascade in the middle of a task — session file written, captures filed, commit made, goodbye said — while the user was still working and had asked for none of it. The phrase was message content addressed to a third person, and it read as a farewell.
+
+Spanish now has a guard for relayed speech. When a sentence carries a verb of telling — *dile*, *avísale*, *escríbele*, *cuéntale*, *contéstale*, *mándale… diciendo* — followed by *que* and then a close phrase, the close is suppressed. Saying the same phrase on its own still ends the session: "ya quedó" closes, "dile a Ana que ya quedó" does not.
+
+This had to sit in the strict tier. *ya quedó* and a bare *listo* are strong signals, and the ordinary guards cannot override a strong signal — a weaker guard would have been dead code.
+
+Portuguese very likely has the same gap (*diga a ele que pronto*), but it has not been reported or tested, so nothing was changed there.
+
+---
+
 ## 2026-08-25: the check on your journal's floor labels was never running
 
 **Who this affects:** anyone whose vault folders have emoji in their names and are in English — which is the default this project sets up.
@@ -2875,7 +2893,7 @@ Four optimizations for high-volume, multi-account Claude setups:
 
 Two additions to the advisory panel template:
 
-- **New "Colombia: Life & Business" section** with 8 named, integrity-verified voices covering corporate culture (Carlos Raul Yepes), brand building (Catalina Escobar), cultural identity (Hector Abad Faciolince), business law (Francisco Reyes Villamizar), women in business (Sylvia Escovar), relationships/gender (Florence Thomas), bicultural identity (Patricia Engel), and holistic wellness (Dr. Jorge Carvajal Posada). Every person was researched for integrity before inclusion.
+- **New "Colombia: Life & Business" section** with 8 named, integrity-verified voices covering corporate culture (Pablo Raul Yepes), brand building (Catalina Escobar), cultural identity (Hector Abad Faciolince), business law (Francisco Reyes Villamizar), women in business (Sylvia Escovar), relationships/gender (Florence Thomas), bicultural identity (Patricia Engel), and holistic wellness (Dr. Jorge Carvajal Posada). Every person was researched for integrity before inclusion.
 - **Rule #8: Named panelists only.** Claude must never invent archetypes or unnamed experts. Every panel voice must be a named person from the roster. If none fit, say so and offer to add one. Prevents fabricated "a hospitality GM" or "a marketplace founder" style voices.
 
 ## 2026-04-14 -- Doc compression rule + memory durability enforcement

--- a/scripts/test-closing-signals.py
+++ b/scripts/test-closing-signals.py
@@ -140,6 +140,23 @@ FIXTURES: list[tuple[str, str, str | None]] = [
      "and 'start closing cascade'", None),
     ("neg-other-than-close",
      'anything other than "close this session" should not trigger it', None),
+
+    # === Relayed speech (es) — MUST NOT fire ===
+    # The user asks Claude to pass a close-shaped phrase to a THIRD PARTY.
+    # "dile a Ana que ya quedó" ends on the high_confidence pattern
+    # \bya quedó...$ and fired the full cascade mid-task. The phrase is
+    # message content, not a sign-off.
+    ("neg-es-dile-ya-quedo", "dile a Ana que ya quedó", None),
+    ("neg-es-dile-listo", "dile a Marta que listo", None),
+    ("neg-es-avisale", "avísale a Pedro que ya quedó", None),
+    ("neg-es-escribele", "escríbele a Sofía que buenas noches", None),
+    ("neg-es-contestale", "contéstale a Lucía que hasta luego", None),
+    ("neg-es-diciendo", "mándale un mensaje a Elena diciendo que ya quedó", None),
+    ("neg-es-cuentale", "cuéntale que nos vemos", None),
+
+    # ...while the bare phrases they relay must STILL close the session.
+    ("es-ya-quedo-bare", "ya quedó", "high_confidence"),
+    ("es-ya-quedo-gracias", "ya quedó, gracias", "high_confidence"),
 ]
 
 

--- a/scripts/test-closing-signals.py
+++ b/scripts/test-closing-signals.py
@@ -157,6 +157,16 @@ FIXTURES: list[tuple[str, str, str | None]] = [
     # ...while the bare phrases they relay must STILL close the session.
     ("es-ya-quedo-bare", "ya quedó", "high_confidence"),
     ("es-ya-quedo-gracias", "ya quedó, gracias", "high_confidence"),
+
+    # === "creo que ya" (es) — ambiguous, NOT a miss ===
+    # Observed as a real sign-off that matched nothing at all. It belongs in
+    # the ambiguous tier rather than high_confidence: on its own it closes,
+    # but it is also the opening of a sentence that is not a goodbye, so the
+    # right behaviour is to ask rather than to fire the cascade.
+    ("amb-es-creo-que-ya", "creo que ya", "ambiguous"),
+    ("neg-es-creo-que-ya-entendi", "creo que ya entendí", None),
+    ("neg-es-creo-que-ya-lo-tengo", "creo que ya lo tengo", None),
+    ("neg-es-creo-que-ya-quedo-el-informe", "creo que ya quedó el informe", None),
 ]
 
 

--- a/templates/closing-signals/es.json
+++ b/templates/closing-signals/es.json
@@ -44,7 +44,8 @@
     "^perfecto[!.\\s]*$",
     "^genial[!.\\s]*$",
     "^suena bien[!.\\s]*$",
-    "^va[!.\\s]*$"
+    "^va[!.\\s]*$",
+    "^creo que ya[!.\\s]*$"
   ],
 
   "emoji_only": [

--- a/templates/closing-signals/es.json
+++ b/templates/closing-signals/es.json
@@ -118,6 +118,10 @@
     {
       "_comment": "'estoy listo/a' is READINESS ('estoy listo para el día', 'estoy lista, arranquemos'), never a goodbye. Strict because the bare word `listo` is a high_confidence sign-off and the weak-tier 'listo para X' guard cannot override it.",
       "pattern": "\\bestoy\\s+list[oa]\\b"
+    },
+    {
+      "_comment": "RELAYED SPEECH — the user asks Claude to TELL SOMEONE ELSE a phrase that happens to be a close signal ('dile a Ana que ya quedó', 'avísale que listo', 'contéstale que hasta luego'). The close phrase is message CONTENT addressed to a third party, not a sign-off to Claude. Strict because 'ya quedó' and bare 'listo' are high_confidence, so a weak-tier guard cannot override them. Requires a reporting verb BEFORE 'que' AND a close phrase right after it, so a bare 'ya quedó' still fires.",
+      "pattern": "\\b(d[íi]le|d[íi]gale|d[íi]les|dices|digas|diga|av[íi]sale|av[íi]sele|escr[íi]bele|escr[íi]bale|cu[ée]ntale|com[ée]ntale|resp[óo]ndele|cont[ée]stale|recu[ée]rdale|advi[ée]rtele|m[áa]ndale|env[íi]ale|diciendo|dici[ée]ndole)\\b[^\\n]{0,50}\\bque\\b\\s*(ya\\s+qued[óo]|ya\\s+est[áa]|ya\\s+es\\s+todo|es\\s+todo|listo|gracias|chao|chau|nos\\s+vemos|hasta\\s+luego|hasta\\s+ma[ñn]ana|buenas\\s+noches|me\\s+voy)\\b"
     }
   ]
 }


### PR DESCRIPTION
Two accuracy fixes to `es.json`, found in daily use of a Spanish-language
vault. They are opposite failures of the same tier system, so they are here as
two commits in one PR rather than two PRs against the same two files.

---

## Commit 1 — a relayed close phrase ended the session mid-task

### The bug

Spanish sign-offs are short and land at the end of a sentence: "ya quedó",
"listo", "chao", "hasta luego". The `es.json` high_confidence pattern
`\bya quedó[,.!\s]*(gracias)?[!.\s]*$` anchors on exactly that position — which
is correct, right up until the phrase belongs to someone else.

Asking Claude to relay a message ends on the same pattern:

> dile a Ana que ya quedó

That fired the full session-close cascade in the middle of an unfinished task.
The close phrase was message *content* addressed to a third party, not a
goodbye addressed to Claude.

### The fix

A relayed-speech guard in the `es.json` **strict** tier: a reporting verb
(`dile` / `dígale` / `avísale` / `escríbele` / `cuéntale` / `contéstale` /
`recuérdale` / `mándale` / `… diciendo`) followed by `que`, then a close phrase.

It has to sit in the strict tier. `ya quedó` and a bare `listo` are
high_confidence, and per `detect-closing-signal.py` the strong tiers override
`false_positive_` guards — a weak-tier guard here would have been dead code.

The guard is scoped so the bare phrases still close normally: it requires the
reporting verb **before** `que` and a close phrase immediately after it.
`ya quedó` fires; `dile a Ana que ya quedó` does not.

### Tests

9 fixtures: 7 asserting suppression, 2 asserting the bare phrases still fire
(so the guard cannot silently swallow a real sign-off). 93/93 → 102/102.

### Scope

Portuguese likely has the same gap (`diga a ele que pronto`), but I have not
tested or observed it, so `pt.json` is deliberately left alone.

---

## Commit 2 — "creo que ya" was a sign-off that matched nothing

The opposite failure, found the same way. `creo que ya` — used on its own as
"I think that's it" — matched no tier at all, so the session did not close and
the phrase had to be repeated.

It goes in the **ambiguous** tier, not high_confidence. On its own it is a
goodbye, but it is also the opening of sentences that are not (`creo que ya
entendí`, `creo que ya lo tengo`). Ambiguous is precisely the tier for that —
per the harness header, *"could be close or transition; user confirmation
needed"* — so Claude asks instead of firing the cascade on a guess.

Anchored `^...$` like every other entry in that tier, so only the bare phrase
matches.

### Tests

4 fixtures: 1 asserting the bare phrase reaches the ambiguous tier, 3 asserting
the longer sentences still match nothing. 102/102 → 106/106.

`creo que ya está` is plausibly the same case but was not observed, so it is
left out rather than guessed at.

---

## Combined result

```
$ python3 scripts/test-closing-signals.py
106/106 passed, 0 failed.
```

Up from 93/93 on `main`. No existing fixture changed.

## Context

Both were found in daily use of a Spanish-language vault. The first is the
costlier of the two: the close cascade writes session and decision files and
ends the session, so a false positive interrupts work in progress rather than
just printing something wrong. The second only costs a repeated message, but it
is the same tier system getting Spanish wrong in the other direction.
