### PR TITLE
fix(tests): survive a `python3` on PATH that refuses to run

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -174,8 +174,26 @@ cd "$REPO_ROOT"
 # bytecode cache to a temp dir instead of littering __pycache__/ across the repo.
 PYCACHE_TMP="$(mktemp -d)"
 export PYTHONPYCACHEPREFIX="$PYCACHE_TMP"
-cleanup() { rm -rf "$PYCACHE_TMP"; }
+cleanup() {
+  rm -rf "$PYCACHE_TMP"
+  if [ -n "${REAL_PYTHON_SHIM_DIR:-}" ]; then rm -rf "$REAL_PYTHON_SHIM_DIR"; fi
+}
 trap cleanup EXIT
+
+# A `python3` on PATH that refuses to run would fail every gate below AND all 103
+# python-invoking tests in section (b) — none of which is about the interpreter,
+# and all of which would report the shim's advice as their failure text. The
+# trailofbits/modern-python plugin ships exactly such a shim. Resolve one working
+# interpreter here, once, for the whole run: a no-op on CI and on any machine
+# without a shim. See tests/integration/lib/real_python.sh.
+_REAL_PYTHON_LIB="$SCRIPT_DIR/../tests/integration/lib/real_python.sh"
+if [ ! -f "$_REAL_PYTHON_LIB" ]; then
+  echo "::error::missing $_REAL_PYTHON_LIB — cannot guarantee a runnable python3"
+  exit 1
+fi
+# shellcheck source=tests/integration/lib/real_python.sh
+. "$_REAL_PYTHON_LIB"
+ensure_real_python || exit 1
 
 # Non-invasive git identity fallback - only when nothing is configured. Uses env
 # vars (not `git config --global`) so we never mutate the caller's global config.
@@ -538,6 +556,11 @@ INTEGRATION_TESTS=(
   # exit-0 the corporate profile was already built to route around, and never
   # reached the user-space Python/Node installers a few sections down.
   test_bootstrap_brewless_reaches_userspace
+  # A `python3` shim on PATH failed all 103 python-invoking tests at once, with
+  # the shim's advice standing in for every assertion. lib/real_python.sh defeats
+  # it; this proves the helper still works and still keeps its hands off a PATH
+  # that was already healthy.
+  test_real_python_shim
 )
 # ---- Gate-coverage invariant -------------------------------------------------
 # The list above is an explicit allow-list, and allow-lists rot: a new

--- a/tests/integration/lib/real_python.sh
+++ b/tests/integration/lib/real_python.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Guarantee that `python3` on PATH is an interpreter which actually runs.
+#
+# Some machines carry a `python3` shim that refuses a direct call and answers
+# with advice instead of running: the trailofbits/modern-python plugin ships one
+# that replies to every `python3 ...` with "Use `uv run python3 ...`". That is a
+# defensible default for interactive work and ruinous here — 103 test files in
+# this suite shell out to `python3`, so on a machine carrying the shim every one
+# of them fails, and the failure text is the shim's advice rather than anything
+# the test asserts. A whole red suite that says nothing about the code is worse
+# than a broken test, because it trains you to stop reading the output.
+#
+# Sandboxing HOME does not help: the shim sits on PATH by absolute path and
+# outlives the decoy home the suite installs.
+#
+# ensure_real_python is a no-op wherever `python3` already runs — CI, and most
+# contributor machines. Where it does not, it prepends a directory holding a
+# single `python3` symlink to a working interpreter. Only python3 is shadowed:
+# prepending the interpreter's own directory (/usr/bin, say) would reorder every
+# other tool on PATH for the rest of the run, which is a much larger promise than
+# this needs to make.
+#
+# ci.sh calls it once for the whole suite. A single test run by hand opts in the
+# same way:
+#
+#   . tests/integration/lib/real_python.sh && ensure_real_python
+#
+# On success PATH is exported and REAL_PYTHON_SHIM_DIR names the directory it
+# created — empty when nothing was needed — so the caller can clean it up.
+
+REAL_PYTHON_SHIM_DIR="${REAL_PYTHON_SHIM_DIR:-}"
+
+ensure_real_python() {
+    if python3 -c 'pass' >/dev/null 2>&1; then
+        return 0
+    fi
+
+    # Versioned names and absolute paths are what escape a shim: it only ever
+    # claims the bare `python3` and `python` names.
+    local cand resolved real=''
+    for cand in python3.14 python3.13 python3.12 python3.11 python3.10 python3.9 \
+                /opt/homebrew/bin/python3 /usr/local/bin/python3 /usr/bin/python3; do
+        resolved="$(command -v "$cand" 2>/dev/null)" || continue
+        [ -n "$resolved" ] || continue
+        if "$resolved" -c 'pass' >/dev/null 2>&1; then
+            real="$resolved"
+            break
+        fi
+    done
+
+    if [ -z "$real" ]; then
+        echo "ensure_real_python: \`python3\` on PATH does not execute, and no working" >&2
+        echo "  interpreter was found. Every test that shells out to python3 would fail" >&2
+        echo "  for that reason alone, saying nothing about the code under test." >&2
+        return 1
+    fi
+
+    REAL_PYTHON_SHIM_DIR="$(mktemp -d)" || return 1
+    ln -s "$real" "$REAL_PYTHON_SHIM_DIR/python3" || return 1
+    PATH="$REAL_PYTHON_SHIM_DIR:$PATH"
+    export PATH
+    echo "    note: \`python3\` on PATH does not execute (a shim); using $real for this run"
+}

--- a/tests/integration/test_real_python_shim.sh
+++ b/tests/integration/test_real_python_shim.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# test_real_python_shim.sh
+#
+# lib/real_python.sh exists because a `python3` shim on PATH turns the whole
+# suite red for a reason no test asserts. Every check below is a NEGATIVE
+# control: the shim is planted and the helper must defeat it, or no shim exists
+# and the helper must leave PATH alone. A helper that has never faced the thing
+# it defeats is unproven, and one that meddles when nothing is wrong is a new
+# hazard of its own.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB="$SCRIPT_DIR/lib/real_python.sh"
+
+FAILED=0
+pass() { printf '  PASS: %s\n' "$1"; }
+fail() { printf '  FAIL: %s\n' "$1"; FAILED=1; }
+
+echo "test_real_python_shim"
+
+[ -f "$LIB" ] || { echo "  FAIL: $LIB not found"; exit 1; }
+
+# A stand-in for the real plugin shim: named python3, on PATH, refuses to run.
+plant_shim() {
+    local d; d="$(mktemp -d)"
+    cat > "$d/python3" <<'SH'
+#!/bin/sh
+echo "ERROR: Use \`uv run python3\` instead of \`python3\`" >&2
+exit 1
+SH
+    chmod +x "$d/python3"
+    printf '%s' "$d"
+}
+
+# A python3 that works, for the leg where the helper must do nothing.
+plant_working() {
+    local d r c; d="$(mktemp -d)"
+    for c in python3.14 python3.13 python3.12 python3.11 python3.10 python3.9 \
+             /usr/bin/python3 /opt/homebrew/bin/python3; do
+        r="$(command -v "$c" 2>/dev/null)" || continue
+        [ -n "$r" ] || continue
+        if "$r" -c 'pass' >/dev/null 2>&1; then ln -s "$r" "$d/python3"; printf '%s' "$d"; return 0; fi
+    done
+    rm -rf "$d"; return 1
+}
+
+# --- 1. defeats a refusing shim ---------------------------------------------
+SHIMDIR="$(plant_shim)"
+out=$(
+    PATH="$SHIMDIR:$PATH"
+    if python3 -c 'pass' >/dev/null 2>&1; then echo "FIXTURE_INERT"; exit 0; fi
+    # shellcheck source=tests/integration/lib/real_python.sh
+    . "$LIB"
+    ensure_real_python >/dev/null 2>&1 || { echo "HELPER_FAILED"; exit 0; }
+    python3 -c 'print("ran")' 2>&1
+)
+case "$out" in
+  ran)           pass "a refusing python3 shim on PATH is defeated" ;;
+  FIXTURE_INERT) fail "fixture never shadowed python3 — this control proves nothing" ;;
+  HELPER_FAILED) fail "helper found no working interpreter to fall back to" ;;
+  *)             fail "helper did not yield a runnable python3: $out" ;;
+esac
+rm -rf "$SHIMDIR"
+
+# --- 2. shadows python3 ONLY, not the interpreter's whole bin dir ------------
+# Prepending /usr/bin would reorder git, sed, and everything else for the rest of
+# the run — a far larger change than the defect warrants.
+SHIMDIR="$(plant_shim)"
+out=$(
+    PATH="$SHIMDIR:$PATH"
+    # shellcheck source=tests/integration/lib/real_python.sh
+    . "$LIB"
+    ensure_real_python >/dev/null 2>&1 || { echo "HELPER_FAILED"; exit 0; }
+    ls "$REAL_PYTHON_SHIM_DIR" | tr '\n' ' '
+)
+if [ "$(printf '%s' "$out" | tr -d ' ')" = "python3" ]; then
+    pass "the prepended dir holds python3 and nothing else"
+else
+    fail "prepended dir was not surgical, it holds: $out"
+fi
+rm -rf "$SHIMDIR"
+
+# --- 3. no-op when python3 already runs -------------------------------------
+if WORKDIR="$(plant_working)"; then
+    out=$(
+        PATH="$WORKDIR:$PATH"
+        # shellcheck source=tests/integration/lib/real_python.sh
+    . "$LIB"
+        before="$PATH"
+        ensure_real_python >/dev/null 2>&1
+        [ "$PATH" = "$before" ] && echo UNCHANGED || echo CHANGED
+    )
+    [ "$out" = "UNCHANGED" ] && pass "leaves PATH untouched when python3 already runs" \
+                             || fail "meddled with PATH on a healthy machine ($out)"
+    rm -rf "$WORKDIR"
+else
+    fail "could not find any working interpreter to build the no-op control"
+fi
+
+[ $FAILED -eq 0 ] && echo "OK" || echo "FAILURES"
+exit $FAILED


### PR DESCRIPTION
## The problem

103 of this suite's test files shell out to `python3`. On a machine carrying the [trailofbits/modern-python](https://github.com/trailofbits) plugin, its shim answers every one of those calls with `ERROR: Use \`uv run python3 ...\`` and exits 1.

The result is a **fully red suite where no failure says anything about the code**. Each one prints the shim's advice where an assertion should be:

```
FAIL: missed direct-form broken dep (rc=1): ERROR: Use `uv run python3 ...`
FAIL: missed python sibling import (rc=1): ERROR: Use `uv run python3 ...`
```

That is worse than a broken test. A suite that is red for a reason none of its tests assert trains you to stop reading it.

Sandboxing HOME does not help — the shim sits on PATH by absolute path and outlives the decoy home the suite installs.

## The fix

`tests/integration/lib/real_python.sh` adds `ensure_real_python`:

- **No-op** wherever `python3` already runs — CI, and most contributor machines
- Otherwise prepends a directory holding **a single `python3` symlink** to a working interpreter

Only `python3` is shadowed. Prepending the interpreter's own directory (`/usr/bin`, say) would reorder `git`, `sed` and every other tool for the rest of the run — a much larger promise than this needs to make.

`ci.sh` resolves it once, before its own first `python3` call, so all 103 files **and** the script's own gates are covered without editing either. `cleanup()` drops the temp dir on exit.

## Tests

`test_real_python_shim.sh`, three negative controls following the suite's convention:

| Control | Guards against |
|---|---|
| Plants a refusing shim; helper must defeat it | A helper that has never faced the thing it defeats is unproven |
| Prepended dir holds `python3` and nothing else | Silently reordering the rest of PATH |
| PATH untouched when `python3` already runs | **Trading an old hazard for a new one** — meddling on a healthy machine |

Registered in `INTEGRATION_TESTS` (the gate rejects any unlisted `test_*.sh`).

## Verification

On a machine with the live shim, `test_clobbered_vault_scripts` went from **8 failures to 8 passes** with no manual PATH surgery.

Full local gate green: **141 integration tests**, 413 `py_compile`, and `scripts/shellcheck.sh` clean at `-S warning` over 233 tracked files — with the two new files staged, since `git ls-files` skips untracked ones and would otherwise have passed vacuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
