### PR TITLE
docs(pii-gate): correct the stale "let the harden run propagate" instruction

### DIFF
--- a/.github/workflows/personal-pii-scrub.yml
+++ b/.github/workflows/personal-pii-scrub.yml
@@ -25,13 +25,28 @@ name: personal-pii-scrub
 #   line-by-line in Actions logs. The plaintext roster lives ONLY in the
 #   private generator vault and each managed repo secret store, never in
 #   any public artifact.
-# Adding/removing patterns: edit the private roster next to the generator
-# (in ⚙️ Meta/scripts/gh-harden-repos.sh) AND, for public-tier tokens,
-# this template, in the same commit, then let the harden run propagate.
-# The harden run must sync the SECRET to a repo BEFORE shipping this file
-# there: on a managed repo this gate fails closed when the secret is
-# missing, because a gate that shrugs off a broken secret sync is green
-# and vacuous exactly where it broke (auto-managed-gate-self-dos).
+# Adding/removing patterns TODAY (corrected 2026-09-05, closing a live gap --
+# a private name reached ai-brain-starter PR #281 through this exact hole):
+# the generator's render_personal_pii_scrub_workflow() in
+# ⚙️ Meta/scripts/gh-harden-repos.sh predates this tier split and does not
+# emit it -- it has no PII_PRIVATE_PATTERNS logic at all. DO NOT "let the
+# harden run propagate" a pattern change; on an already-migrated repo (this
+# one) that would silently overwrite this file with the generator's older,
+# pre-split, no-secret template, which is the exact GUARD-DISCLOSES-THE-
+# SECRET-IT-GUARDS regression MYC-3943 exists to prevent. Until the
+# generator is rewritten to own this tier split:
+#   PRIVATE-tier pattern -> update this repo's secret directly:
+#     gh secret set PII_PRIVATE_PATTERNS --repo <owner>/<repo>
+#     (one POSIX extended regex per line; wholesale replace, no append --
+#     read the current count first via a recent run's own "Positive control
+#     OK ... all N patterns" line, never overwrite blind).
+#   PUBLIC-tier pattern (rare -- only tokens already public by deliberate
+#     choice) -> hand-edit the three PUBLIC_PATTERNS arrays below directly,
+#     in this file, in both the source-file step and the archive step.
+# Either way: measure the new pattern against this repo's CURRENT tree
+# first (git grep -P, gate pathspecs) before shipping it -- a pattern that
+# already matches legitimate content turns this gate red on arrival
+# (auto-managed-gate-self-dos).
 # Hashing the roster instead was REJECTED: personal-name tokens have a
 # tiny preimage space, so a public salted-hash denylist is one dictionary
 # pass away from plaintext (operating rule: a hashed identifier is


### PR DESCRIPTION
## Summary

Closes a measured coverage gap in `.github/workflows/personal-pii-scrub.yml`: the deployed gate's private-tier vocabulary (the `PII_PRIVATE_PATTERNS` repo secret) was missing a pattern for a private name that reached this repo's `docs/` tree on PR #281 without being caught.

- Fixed directly on the repo secret (`gh secret set PII_PRIVATE_PATTERNS`), not in this file — the private roster is never inline (MYC-3943). Verified via a fresh `workflow_dispatch` run: the gate's own vocabulary-control self-test now covers 25 total patterns (was 19) / 22 private-tier (was 16), all three scan tiers still clean (no false positives introduced).
- This PR itself only corrects the header comment that told a future editor to add/remove patterns via the vault generator (`gh-harden-repos.sh`) and "let the harden run propagate." That generator predates the PUBLIC/PRIVATE tier split entirely (no `PII_PRIVATE_PATTERNS` logic anywhere in it) — running it against this already-migrated repo would silently overwrite this file with the older, pre-split, no-secret template, which is exactly the disclosure regression MYC-3943 exists to prevent. The corrected comment points at the real mechanism (`gh secret set`, measure-before-add).
- No trigger, job name, concurrency, or scan-logic change. Diff is comment-only.

## Test plan

- [x] `git grep -P` hit-count measured against `origin/main` (gate pathspecs) for every pattern added to the secret — 0 hits, no self-DoS risk.
- [x] Confirmed via live GitHub data that patterns matching the vault's own documented exclusion rationale (Onde, Colombia, Bogotá, High-Rise) still have real hits on this repo's published content today — left excluded, not touched.
- [x] Local negative control: a planted "Author: Nelly Ortiz" specimen is invisible to the pre-fix 16-pattern private roster and caught by the post-fix 22-pattern roster (same `scan_for` logic the gate uses).
- [x] Live fresh `workflow_dispatch` run on `main` post-fix: `scrub` job green, all three tiers ("source files" / "archives" / "markdown prose") report clean, vocabulary-control count increased 19→25 / 16→22 as expected.
- [x] `⚙️ Meta/scripts/pii-scrub-local.sh` run against this worktree: exit 0 (clean).
- [x] YAML re-parses (`python3 -c "import yaml; yaml.safe_load(...)"`) after the comment edit.
